### PR TITLE
fix primary key error

### DIFF
--- a/examples/linearlite/src/components/LeftMenu.tsx
+++ b/examples/linearlite/src/components/LeftMenu.tsx
@@ -16,6 +16,8 @@ import AboutModal from './AboutModal'
 import IssueModal from './IssueModal'
 import ItemGroup from './ItemGroup'
 import ProfileMenu from './ProfileMenu'
+import { useQuery, useStore } from '@livestore/livestore/react'
+import { filterState$ } from '../domain/queries'
 
 // eslint-disable-next-line react-refresh/only-export-components
 function LeftMenu() {
@@ -24,6 +26,8 @@ function LeftMenu() {
   const [showAboutModal, setShowAboutModal] = useState(false)
   const [showIssueModal, setShowIssueModal] = useState(false)
   const { showMenu, setShowMenu } = useContext(MenuContext)!
+  const filterState = useQuery(filterState$)
+  const { store } = useStore()
   // const { connectivityState } = useConnectivityState()
   const connectivityState = 'connected'
 
@@ -93,12 +97,33 @@ function LeftMenu() {
 
         <div className="flex flex-col flex-shrink flex-grow overflow-y-auto mb-0.5 px-2">
           <ItemGroup title="Your Issues">
-            <Link to="/" className="flex items-center pl-6 rounded cursor-pointer group h-7 hover:bg-gray-100">
+            <Link
+              to="/"
+              onClick={() => {
+                store.applyEvent('upsertAppAtom', {
+                  id: 'filter_state',
+                  value: JSON.stringify({
+                    ...filterState,
+                    status: undefined,
+                  }),
+                })
+              }}
+              className="flex items-center pl-6 rounded cursor-pointer group h-7 hover:bg-gray-100"
+            >
               <IssuesIcon className="w-3.5 h-3.5 mr-2" />
               <span>All Issues</span>
             </Link>
             <Link
               to="/?status=todo,in_progress"
+              onClick={() => {
+                store.applyEvent('upsertAppAtom', {
+                  id: 'filter_state',
+                  value: JSON.stringify({
+                    ...filterState,
+                    status: ['todo', 'in_progress'],
+                  }),
+                })
+              }}
               className="flex items-center pl-6 rounded cursor-pointer h-7 hover:bg-gray-100"
             >
               <span className="w-3.5 h-6 mr-2 inline-block">
@@ -106,7 +131,19 @@ function LeftMenu() {
               </span>
               <span>Active</span>
             </Link>
-            <Link to="/?status=backlog" className="flex items-center pl-6 rounded cursor-pointer h-7 hover:bg-gray-100">
+            <Link
+              to="/?status=backlog"
+              onClick={() => {
+                store.applyEvent('upsertAppAtom', {
+                  id: 'filter_state',
+                  value: JSON.stringify({
+                    ...filterState,
+                    status: ['backlog'],
+                  }),
+                })
+              }}
+              className="flex items-center pl-6 rounded cursor-pointer h-7 hover:bg-gray-100"
+            >
               <BacklogIcon className="w-3.5 h-3.5 mr-2" />
               <span>Backlog</span>
             </Link>

--- a/examples/linearlite/src/components/TopFilter.tsx
+++ b/examples/linearlite/src/components/TopFilter.tsx
@@ -33,7 +33,7 @@ export default function TopFilter({ issues, hideSort, showSearch, title = 'All i
 
   const handleSearchInner = (query: string) => {
     store.applyEvent('upsertAppAtom', {
-      key: 'filter_state',
+      id: 'filter_state',
       value: JSON.stringify({
         ...filterState,
         query: query,
@@ -105,7 +105,7 @@ export default function TopFilter({ issues, hideSort, showSearch, title = 'All i
                 className="px-1 bg-gray-300 rounded-r cursor-pointer flex items-center"
                 onClick={() => {
                   store.applyEvent('upsertAppAtom', {
-                    key: 'filter_state',
+                    id: 'filter_state',
                     value: JSON.stringify({
                       ...filterState,
                       priority: undefined,
@@ -127,7 +127,7 @@ export default function TopFilter({ issues, hideSort, showSearch, title = 'All i
                 className="px-1 bg-gray-300 rounded-r cursor-pointer flex items-center"
                 onClick={() => {
                   store.applyEvent('upsertAppAtom', {
-                    key: 'filter_state',
+                    id: 'filter_state',
                     value: JSON.stringify({
                       ...filterState,
                       status: undefined,

--- a/examples/linearlite/src/components/ViewOptionMenu.tsx
+++ b/examples/linearlite/src/components/ViewOptionMenu.tsx
@@ -20,7 +20,7 @@ export default function ViewOptionMenu({ isOpen, onDismiss }: Props) {
 
   const handleOrderByChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     store.applyEvent('upsertAppAtom', {
-      key: 'filter_state',
+      id: 'filter_state',
       value: JSON.stringify({
         ...filterState,
         orderBy: e.target.value,
@@ -30,7 +30,7 @@ export default function ViewOptionMenu({ isOpen, onDismiss }: Props) {
 
   const handleOrderDirectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     store.applyEvent('upsertAppAtom', {
-      key: 'filter_state',
+      id: 'filter_state',
       value: JSON.stringify({
         ...filterState,
         orderDirection: e.target.value as 'asc' | 'desc',

--- a/examples/linearlite/src/components/contextmenu/FilterMenu.tsx
+++ b/examples/linearlite/src/components/contextmenu/FilterMenu.tsx
@@ -61,7 +61,7 @@ function FilterMenu({ id, button, className }: Props) {
       newPriority.push(priority)
     }
     store.applyEvent('upsertAppAtom', {
-      key: 'filter_state',
+      id: 'filter_state',
       value: JSON.stringify({
         ...filterState,
         priority: newPriority,
@@ -78,7 +78,7 @@ function FilterMenu({ id, button, className }: Props) {
       newStatus.push(status)
     }
     store.applyEvent('upsertAppAtom', {
-      key: 'filter_state',
+      id: 'filter_state',
       value: JSON.stringify({
         ...filterState,
         status: newStatus,

--- a/examples/linearlite/src/domain/queries.ts
+++ b/examples/linearlite/src/domain/queries.ts
@@ -1,9 +1,7 @@
 import { querySQL, sql } from '@livestore/livestore'
 import { FilterState } from './schema'
 
-export const filterState$ = querySQL<{ value: string }>(
-  (_) => sql`SELECT * FROM app_state WHERE "key" = 'filter_state'`,
-)
+export const filterState$ = querySQL<{ value: string }>((_) => sql`SELECT * FROM app_state WHERE "id" = 'filter_state'`)
   .getFirstRow({
     defaultValue: { value: '{}' },
   })

--- a/examples/linearlite/src/domain/schema.ts
+++ b/examples/linearlite/src/domain/schema.ts
@@ -48,7 +48,7 @@ const comment = DbSchema.table(
 
 // TODO: move filter state into its own table?
 const appState = DbSchema.table('app_state', {
-  key: DbSchema.text({ primaryKey: true }),
+  id: DbSchema.text({ primaryKey: true }),
   value: DbSchema.text(),
 })
 
@@ -149,8 +149,8 @@ export const schema = makeSchema({
     },
     upsertAppAtom: {
       statement: {
-        sql: sql`INSERT INTO app_state (key, value) VALUES ($key, $value)
-          ON CONFLICT (key) DO UPDATE SET value = $value`,
+        sql: sql`INSERT INTO app_state (id, value) VALUES ($id, $value)
+          ON CONFLICT (id) DO UPDATE SET value = $value`,
         writeTables: ['app_state'],
       },
     },

--- a/examples/linearlite/src/pages/Board/index.tsx
+++ b/examples/linearlite/src/pages/Board/index.tsx
@@ -7,7 +7,7 @@ import { filterStateToWhere } from '../../utils/filterState'
 import { AppState } from '../../domain/schema'
 import { useQuery } from '@livestore/livestore/react'
 
-const filterClause$ = querySQL<AppState>(`select * from app_state WHERE key = 'filter_state';`)
+const filterClause$ = querySQL<AppState>(`select * from app_state WHERE id = 'filter_state';`)
   // .getFirstRow({defaultValue: undefined })
   .pipe((filterStates) => {
     // TODO this handling should be improved (see https://github.com/livestorejs/livestore/issues/22)

--- a/examples/linearlite/src/pages/List/index.tsx
+++ b/examples/linearlite/src/pages/List/index.tsx
@@ -7,7 +7,7 @@ import { AppState } from '../../domain/schema'
 import { filterStateToOrder, filterStateToWhere } from '../../utils/filterState'
 import { useQuery } from '@livestore/livestore/react'
 
-const filterClause$ = querySQL<AppState>(`select * from app_state WHERE key = 'filter_state';`)
+const filterClause$ = querySQL<AppState>(`select * from app_state WHERE id = 'filter_state';`)
   // .getFirstRow({defaultValue: undefined })
   .pipe((filterStates) => {
     // TODO this handling should be improved (see https://github.com/livestorejs/livestore/issues/22)


### PR DESCRIPTION
columns not named `id` are unable to be primary keys as of the latest round of API changes.