### PR TITLE
Update expo getting started command to use https instead of ssh

### DIFF
--- a/website/src/content/docs/getting-started/expo.mdx
+++ b/website/src/content/docs/getting-started/expo.mdx
@@ -8,11 +8,8 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Steps>
 
-1.  Set up project via:
-	```
-	# .terminal
-	npx tiged --mode=git https://github.com/livestorejs/livestore/examples/expo-app my-app
-	```
+1.  Set up project via: `npx tiged --mode=git https://github.com/livestorejs/livestore/examples/expo-app my-app`
+
 	Replace `my-app` with the name of your app.
 
 2. Install dependencies


### PR DESCRIPTION
### Why
This method doesn't require SSH keys and often works right away. Also, provide a default app name, `my-app,` to prevent the command from failing after running without specifying a name for the folder.

### Test
I ran docs locally and ensured everything looked fine.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5c361c9f-90c7-45e1-bbc0-453295f30075">

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license and that this
Contribution contains no content requiring a license from any third party.
