### PR TITLE
fix(docs): bad indentation for <Steps>

### DIFF
--- a/website/src/content/docs/getting-started/react-web.mdx
+++ b/website/src/content/docs/getting-started/react-web.mdx
@@ -98,6 +98,8 @@ For existing projects, see [Existing project setup](#existing-project-setup).
 
 ### Option B: Existing project setup
 
+<Steps>
+
 1. **Install dependencies**
 
    <Tabs syncKey="package-manager">
@@ -139,6 +141,7 @@ For existing projects, see [Existing project setup](#existing-project-setup).
      },
    })
    ```
+</Steps>
 
 ## Define your schema
 


### PR DESCRIPTION
This fixes the failing website build. The steps weren't properly indented which was causing the website to fail.

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
