### PR TITLE
fix: allow a broader range of react

### DIFF
--- a/packages/@livestore/react/package.json
+++ b/packages/@livestore/react/package.json
@@ -50,7 +50,7 @@
   ],
   "license": "Apache-2.0",
   "peerDependencies": {
-    "react": "~19.0.0"
+    "react": "^19.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This lets people use react 19.1.x

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
