### PR TITLE
chore: update CI workflow commands for example deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
       - uses: oven-sh/setup-bun@v2
       # TODO bring back once repo is public
-      # - run: bunx tiged --mode=git https://github.com/livestorejs/livestore/examples/todomvc#${{ github.sha }} example
+      # - run: bunx tiged https://github.com/livestorejs/livestore/examples/todomvc#${{ github.sha }} example
       - uses: actions/checkout@v4
         with:
           path: example-repo
@@ -233,7 +233,7 @@ jobs:
     steps:
       - uses: oven-sh/setup-bun@v2
       # TODO bring back once repo is public
-      # - run: bunx tiged --mode=git https://github.com/livestorejs/livestore/examples/linearlite#${{ github.sha }} example
+      # - run: bunx tiged https://github.com/livestorejs/livestore/examples/linearlite#${{ github.sha }} example
       - uses: actions/checkout@v4
         with:
           path: example-repo
@@ -263,7 +263,7 @@ jobs:
     steps:
       - uses: oven-sh/setup-bun@v2
       # TODO bring back once repo is public
-      # - run: bunx tiged --mode=git https://github.com/livestorejs/livestore/examples/expo-linearlite#${{ github.sha }} example
+      # - run: bunx tiged https://github.com/livestorejs/livestore/examples/expo-linearlite#${{ github.sha }} example
       - uses: actions/checkout@v4
         with:
           path: example-repo

--- a/docs/data.ts
+++ b/docs/data.ts
@@ -22,5 +22,5 @@ export const IS_MAIN_BRANCH = process.env.GITHUB_BRANCH_NAME
 
 export const makeTiged = (example: string, approach: 'bunx' | 'pnpm dlx' | 'npx') => {
   const hashSuffix = IS_MAIN_BRANCH ? '' : `#${getBranchName()}`
-  return `${approach} tiged --mode=git git@github.com:livestorejs/livestore/examples/standalone/${example}${hashSuffix} livestore-app`
+  return `${approach} tiged github:livestorejs/livestore/examples/standalone/${example}${hashSuffix} livestore-app`
 }


### PR DESCRIPTION
- Modified the command syntax in the CI workflow to remove the `--mode=git` option for `tiged` in multiple steps.
- Adjusted the `makeTiged` function to use the shorthand syntax for GitHub URLs in the generated command.
