### PR TITLE
fix: export SqliteTableDefForInput to resolve TS error

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/table-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/table-def.ts
@@ -177,7 +177,7 @@ export namespace FromColumns {
   export type InsertRowDecoded<TColumns extends SqliteDsl.Columns> = SqliteDsl.FromColumns.InsertRowDecoded<TColumns>
 }
 
-type SqliteTableDefForInput<
+export type SqliteTableDefForInput<
   TName extends string,
   TColumns extends SqliteDsl.Columns | SqliteDsl.ColumnDefinition<any, any>,
 > = SqliteDsl.TableDefinition<TName, PrettifyFlat<ToColumns<TColumns>>>


### PR DESCRIPTION
Resolve https://github.com/livestorejs/livestore/issues/336 by exporting type for TS inference.

### Checklist
- [√] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [√] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
