### PR TITLE
fix: update example readme urls and fix readme command

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,4 +5,4 @@
 
 ## For contributors
 
-- Please use the `pnpm -w generate:examples:standalone` command to keep the `src`, `patches` and `standalone` directories in sync.
+- Please use the `mono examples sync --direction src-to-standalone` command to keep the `src`, `patches` and `standalone` directories in sync.

--- a/examples/src/web-linearlite/README.md
+++ b/examples/src/web-linearlite/README.md
@@ -1,0 +1,3 @@
+# Linearlite Example
+
+[Demo](https://web-linearlite.livestore.dev/)

--- a/examples/src/web-todomvc-custom-elements/README.md
+++ b/examples/src/web-todomvc-custom-elements/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/src/web-todomvc-experimental/README.md
+++ b/examples/src/web-todomvc-experimental/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/src/web-todomvc-sync-cf/README.md
+++ b/examples/src/web-todomvc-sync-cf/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc-sync-cf.livestore.dev)
 
 ## Running locally
 

--- a/examples/src/web-todomvc-sync-electric/README.md
+++ b/examples/src/web-todomvc-sync-electric/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/src/web-todomvc/README.md
+++ b/examples/src/web-todomvc/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc.livestore.dev)
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-custom-elements/README.md
+++ b/examples/standalone/web-todomvc-custom-elements/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-experimental/README.md
+++ b/examples/standalone/web-todomvc-experimental/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-sync-cf/README.md
+++ b/examples/standalone/web-todomvc-sync-cf/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc-sync-cf.livestore.dev)
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-sync-electric/README.md
+++ b/examples/standalone/web-todomvc-sync-electric/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc/README.md
+++ b/examples/standalone/web-todomvc/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc.livestore.dev)
 
 ## Running locally
 


### PR DESCRIPTION
### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.

Hello,

As I explored the examples I noticed the demo links in some README files were broken.
I found the correct links in the docs so this:

- fixes the ones that could be fixed.
- adds a default pointing to the example docs page for those that are not deployed yet.
- adds a README for the linearlite example with a link to the demo.

Also I was not able to run `pnpm -w generate:examples:standalone`. I found the correct command in the docs so I replaced it in this PR.

Thank you for open sourcing LiveStore :tada: 