### PR TITLE
refactor: migrate `ClientSessionSyncProcessor`’s `materializeEvent()` to Effect

### DIFF
--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -10,9 +10,16 @@ import {
 
 import type { ClientSessionLeaderThreadProxy } from './ClientSessionLeaderThreadProxy.ts'
 import type * as Devtools from './devtools/mod.ts'
-import type { IntentionalShutdownCause, SyncError, UnexpectedError } from './errors.ts'
+import type {
+  IntentionalShutdownCause,
+  MaterializerHashMismatchError,
+  SqliteError,
+  SyncError,
+  UnexpectedError,
+} from './errors.ts'
 import type { LiveStoreSchema } from './schema/mod.ts'
 import type { SqliteDb } from './sqlite-types.ts'
+import type { InvalidPullError, IsOfflineError } from './sync/index.js'
 
 export * as ClientSessionLeaderThreadProxy from './ClientSessionLeaderThreadProxy.ts'
 export * from './defs.ts'
@@ -27,7 +34,9 @@ export interface ClientSession {
   sessionId: string
   /** Status info whether current session is leader or not */
   lockStatus: SubscriptionRef.SubscriptionRef<LockStatus>
-  shutdown: (cause: Exit.Exit<IntentionalShutdownCause, UnexpectedError | SyncError>) => Effect.Effect<void>
+  shutdown: (
+    cause: Exit.Exit<IntentionalShutdownCause, UnexpectedError | SyncError | MaterializerHashMismatchError>,
+  ) => Effect.Effect<void>
   /** A proxy API to communicate with the leader thread */
   leaderThread: ClientSessionLeaderThreadProxy
   /** A unique identifier for the current instance of the client session. Used for debugging purposes. */
@@ -121,7 +130,12 @@ export interface AdapterArgs {
   devtoolsEnabled: boolean
   debugInstanceId: string
   bootStatusQueue: Queue.Queue<BootStatus>
-  shutdown: (exit: Exit.Exit<IntentionalShutdownCause, UnexpectedError | SyncError>) => Effect.Effect<void>
+  shutdown: (
+    exit: Exit.Exit<
+      IntentionalShutdownCause,
+      UnexpectedError | SyncError | MaterializerHashMismatchError | InvalidPullError | SqliteError | IsOfflineError
+    >,
+  ) => Effect.Effect<void>
   connectDevtoolsToStore: ConnectDevtoolsToStore
   /**
    * Payload that will be passed to the sync backend when connecting

--- a/packages/@livestore/common/src/errors.ts
+++ b/packages/@livestore/common/src/errors.ts
@@ -21,6 +21,16 @@ export class SyncError extends Schema.TaggedError<SyncError>()('LiveStore.SyncEr
   cause: Schema.Defect,
 }) {}
 
+export class MaterializerHashMismatchError extends Schema.TaggedError<MaterializerHashMismatchError>()(
+  'LiveStore.MaterializerHashMismatchError',
+  {
+    eventName: Schema.String,
+    note: Schema.optionalWith(Schema.String, {
+      default: () => 'Please make sure your event materializer is a pure function without side effects.',
+    }),
+  },
+) {}
+
 export class IntentionalShutdownCause extends Schema.TaggedError<IntentionalShutdownCause>()(
   'LiveStore.IntentionalShutdownCause',
   {

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -1,9 +1,14 @@
 import { shouldNeverHappen } from '@livestore/utils'
 import type { HttpClient, Schema, Scope } from '@livestore/utils/effect'
 import { Deferred, Effect, Layer, Queue, SubscriptionRef } from '@livestore/utils/effect'
-
-import type { BootStatus, MakeSqliteDb, SqliteDb, SqliteError } from '../adapter-types.ts'
-import { UnexpectedError } from '../adapter-types.ts'
+import {
+  type BootStatus,
+  type MakeSqliteDb,
+  type MaterializerHashMismatchError,
+  type SqliteDb,
+  type SqliteError,
+  UnexpectedError,
+} from '../adapter-types.ts'
 import type * as Devtools from '../devtools/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '../schema/mod.ts'
@@ -280,7 +285,7 @@ const bootLeaderThread = ({
   devtoolsOptions: DevtoolsOptions
 }): Effect.Effect<
   LeaderThreadCtx['Type']['initialState'],
-  UnexpectedError | SqliteError | IsOfflineError | InvalidPullError,
+  UnexpectedError | SqliteError | IsOfflineError | InvalidPullError | MaterializerHashMismatchError,
   LeaderThreadCtx | Scope.Scope | HttpClient.HttpClient
 > =>
   Effect.gen(function* () {

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -2,8 +2,16 @@ import { casesHandled } from '@livestore/utils'
 import { Effect, Queue } from '@livestore/utils/effect'
 
 import type { MigrationsReport } from '../defs.ts'
-import type { BootStatus, MigrationHooks, SqliteDb, SqliteError } from '../index.ts'
-import { migrateDb, rematerializeFromEventlog, UnexpectedError } from '../index.ts'
+import {
+  type BootStatus,
+  type MaterializerHashMismatchError,
+  type MigrationHooks,
+  migrateDb,
+  rematerializeFromEventlog,
+  type SqliteDb,
+  type SqliteError,
+  UnexpectedError,
+} from '../index.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { configureConnection } from './connection.ts'
 import type { MaterializeEvent } from './types.ts'
@@ -20,7 +28,10 @@ export const recreateDb = ({
   schema: LiveStoreSchema
   bootStatusQueue: Queue.Queue<BootStatus>
   materializeEvent: MaterializeEvent
-}): Effect.Effect<{ migrationsReport: MigrationsReport }, UnexpectedError | SqliteError> =>
+}): Effect.Effect<
+  { migrationsReport: MigrationsReport },
+  UnexpectedError | SqliteError | MaterializerHashMismatchError
+> =>
   Effect.gen(function* () {
     const migrationOptions = schema.state.sqlite.migrations
     let migrationsReport: MigrationsReport

--- a/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
+++ b/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
@@ -1,9 +1,25 @@
 import type { WebChannel } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
-import { IntentionalShutdownCause, SyncError, UnexpectedError } from '../index.ts'
+import {
+  IntentionalShutdownCause,
+  InvalidPullError,
+  IsOfflineError,
+  MaterializerHashMismatchError,
+  SqliteError,
+  SyncError,
+  UnexpectedError,
+} from '../index.ts'
 
-export class All extends Schema.Union(IntentionalShutdownCause, UnexpectedError, SyncError) {}
+export class All extends Schema.Union(
+  IntentionalShutdownCause,
+  UnexpectedError,
+  SyncError,
+  MaterializerHashMismatchError,
+  IsOfflineError,
+  InvalidPullError,
+  SqliteError,
+) {}
 
 /**
  * Used internally by an adapter to shutdown gracefully.

--- a/packages/@livestore/common/src/leader-thread/types.ts
+++ b/packages/@livestore/common/src/leader-thread/types.ts
@@ -13,7 +13,7 @@ import { Context, Schema } from '@livestore/utils/effect'
 import type { MeshNode } from '@livestore/webmesh'
 
 import type { MigrationsReport } from '../defs.ts'
-import type { SqliteError } from '../errors.ts'
+import type { MaterializerHashMismatchError, SqliteError } from '../errors.ts'
 import type {
   BootStatus,
   Devtools,
@@ -125,7 +125,7 @@ export type MaterializeEvent = (
     sessionChangeset: { _tag: 'sessionChangeset'; data: Uint8Array<ArrayBuffer>; debug: any } | { _tag: 'no-op' }
     hash: Option.Option<number>
   },
-  SqliteError | UnexpectedError
+  SqliteError | MaterializerHashMismatchError
 >
 
 export type InitialBlockingSyncContext = {

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -29,6 +29,19 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -59,14 +72,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
       ],
     },
@@ -152,6 +157,19 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -182,14 +200,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
       ],
     },
@@ -275,6 +285,19 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "client-session-sync-processor:push",
@@ -285,6 +308,19 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -322,14 +358,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
         {
           "_name": "LiveStore:commit",
@@ -339,14 +367,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
       ],
     },
@@ -458,6 +478,19 @@ exports[`otel > otel 3`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -488,14 +521,6 @@ exports[`otel > otel 3`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
       ],
     },
@@ -743,6 +768,19 @@ exports[`otel > with thunks 7`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -773,14 +811,6 @@ exports[`otel > with thunks 7`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
       ],
     },
@@ -862,6 +892,19 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -892,14 +935,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
         },
       ],
     },

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -5,8 +5,12 @@ import {
   type ClientSessionDevtoolsChannel,
   type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
+  type InvalidPullError,
+  type IsOfflineError,
+  type MaterializerHashMismatchError,
   type MigrationsReport,
   provideOtel,
+  type SqliteError,
   type SyncError,
   UnexpectedError,
 } from '@livestore/common'
@@ -217,7 +221,12 @@ export const createStore = <TSchema extends LiveStoreSchema = LiveStoreSchema.An
 
       const runtime = yield* Effect.runtime<Scope.Scope>()
 
-      const shutdown = (exit: Exit.Exit<IntentionalShutdownCause, UnexpectedError | SyncError>) =>
+      const shutdown = (
+        exit: Exit.Exit<
+          IntentionalShutdownCause,
+          UnexpectedError | MaterializerHashMismatchError | SyncError | InvalidPullError | SqliteError | IsOfflineError
+        >,
+      ) =>
         Effect.gen(function* () {
           yield* Scope.close(lifetimeScope, exit).pipe(
             Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -2,6 +2,10 @@ import type {
   ClientSession,
   ClientSessionSyncProcessorSimulationParams,
   IntentionalShutdownCause,
+  InvalidPullError,
+  IsOfflineError,
+  MaterializerHashMismatchError,
+  SqliteError,
   StoreInterrupted,
   SyncError,
   UnexpectedError,
@@ -28,11 +32,23 @@ export type LiveStoreContext =
 
 export type ShutdownDeferred = Deferred.Deferred<
   IntentionalShutdownCause,
-  UnexpectedError | SyncError | StoreInterrupted
+  | UnexpectedError
+  | SyncError
+  | StoreInterrupted
+  | MaterializerHashMismatchError
+  | InvalidPullError
+  | SqliteError
+  | IsOfflineError
 >
 export const makeShutdownDeferred: Effect.Effect<ShutdownDeferred> = Deferred.make<
   IntentionalShutdownCause,
-  UnexpectedError | SyncError | StoreInterrupted
+  | UnexpectedError
+  | SyncError
+  | StoreInterrupted
+  | MaterializerHashMismatchError
+  | InvalidPullError
+  | SqliteError
+  | IsOfflineError
 >()
 
 export type LiveStoreContextRunning = {

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -29,6 +29,23 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "client-session-sync-processor:push",
@@ -39,6 +56,23 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -76,18 +110,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-              },
-            },
-          ],
         },
       ],
     },
@@ -118,18 +140,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
                 ],
                 "livestore.eventsCount": 1,
               },
-              "children": [
-                {
-                  "_name": "livestore.in-memory-db:execute",
-                  "attributes": {
-                    "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-                  },
-                },
-              ],
             },
             {
               "_name": "db:SELECT * FROM 'UserInfo' WHERE id = ?",
@@ -275,6 +285,23 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "client-session-sync-processor:push",
@@ -285,6 +312,23 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
         "mergeResultTag": "advance",
       },
+      "children": [
+        {
+          "_name": "client-session-sync-processor:materialize-event",
+          "children": [
+            {
+              "_name": "livestore.in-memory-db:execute",
+              "attributes": {
+                "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+              },
+            },
+          ],
+        },
+      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -322,18 +366,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
             ],
             "livestore.eventsCount": 1,
           },
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-              },
-            },
-          ],
         },
       ],
     },
@@ -364,18 +396,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
                 ],
                 "livestore.eventsCount": 1,
               },
-              "children": [
-                {
-                  "_name": "livestore.in-memory-db:execute",
-                  "attributes": {
-                    "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-                  },
-                },
-              ],
             },
             {
               "_name": "db:SELECT * FROM 'UserInfo' WHERE id = ?",


### PR DESCRIPTION
This migrates `ClientSessionSyncProcessor`’s `materializeEvent()` to Effect to make it easier to instrument it with OpenTelemetry.

> [!CAUTION]
> **DO NOT MERGE!**
>
> This is a stacked PR. To preserve logical order, and a clean commit history, these must be merged from the bottom upwards. I'll handle the merges and rebases myself, as it can be [tricky to do properly](https://stackoverflow.com/a/70994400).
> 
> Merge order:
> 1. [refactor: migrate `ClientSessionSyncProcessor.push()` to Effect #375](https://github.com/livestorejs/livestore/pull/375) (base)
> 2. [refactor: migrate `ClientSessionSyncProcessor`’s `materializeEvent()` to Effect #376](https://github.com/livestorejs/livestore/pull/376)
> 3. [refactor: migrate `store.commit` to Effect #381](https://github.com/livestorejs/livestore/pull/381) (top)

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
