### PR TITLE
refactor: migrate `store.commit` to Effect

### DIFF
--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -21,29 +21,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
       },
     },
     {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
       "attributes": {
         "batch": "undefined",
@@ -63,17 +40,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -128,6 +94,45 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
 }
 `;
 
+exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
 {
   "_name": "createStore",
@@ -149,29 +154,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       },
     },
     {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
       "attributes": {
         "batch": "undefined",
@@ -191,17 +173,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -256,6 +227,45 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
 }
 `;
 
+exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
 {
   "_name": "createStore",
@@ -275,52 +285,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
-    },
-    {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -349,26 +313,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -449,6 +393,79 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
 }
 `;
 
+exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`otel > otel 3`] = `
 {
   "_name": "createStore",
@@ -470,29 +487,6 @@ exports[`otel > otel 3`] = `
       },
     },
     {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
       "attributes": {
         "batch": "undefined",
@@ -512,17 +506,6 @@ exports[`otel > otel 3`] = `
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -565,6 +548,45 @@ exports[`otel > otel 3`] = `
     },
   ],
 }
+`;
+
+exports[`otel > otel 4`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
 `;
 
 exports[`otel > with thunks 1`] = `
@@ -760,29 +782,6 @@ exports[`otel > with thunks 7`] = `
       },
     },
     {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
       "attributes": {
         "batch": "undefined",
@@ -802,17 +801,6 @@ exports[`otel > with thunks 7`] = `
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -863,6 +851,45 @@ exports[`otel > with thunks 7`] = `
 }
 `;
 
+exports[`otel > with thunks 8`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`otel > with thunks with query builder and without labels 3`] = `
 {
   "_name": "createStore",
@@ -884,29 +911,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       },
     },
     {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "todo.created": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
       "attributes": {
         "batch": "undefined",
@@ -926,17 +930,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "todo.created",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -985,4 +978,43 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
     },
   ],
 }
+`;
+
+exports[`otel > with thunks with query builder and without labels 4`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
 `;

--- a/packages/@livestore/livestore/src/live-queries/db-query.test.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.test.ts
@@ -6,7 +6,7 @@ import { expect } from 'vitest'
 
 import * as RG from '../reactive.ts'
 import { events, makeTodoMvc, tables } from '../utils/tests/fixture.ts'
-import { getSimplifiedRootSpan } from '../utils/tests/otel.ts'
+import { getAllSimplifiedRootSpans, getSimplifiedRootSpan } from '../utils/tests/otel.ts'
 import { computed } from './computed.ts'
 import { queryDb } from './db-query.ts'
 
@@ -83,7 +83,8 @@ Vitest.describe('otel', () => {
       Effect.tap(({ exporter, provider }) =>
         Effect.promise(async () => {
           await provider.forceFlush()
-          expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+          expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+          expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
           await provider.shutdown()
         }),
       ),
@@ -139,7 +140,8 @@ Vitest.describe('otel', () => {
       Effect.tap(({ exporter, provider }) =>
         Effect.promise(async () => {
           await provider.forceFlush()
-          expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+          expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+          expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
           await provider.shutdown()
         }),
       ),
@@ -183,7 +185,8 @@ Vitest.describe('otel', () => {
       Effect.tap(({ exporter, provider }) =>
         Effect.promise(async () => {
           await provider.forceFlush()
-          expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+          expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+          expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
           await provider.shutdown()
         }),
       ),
@@ -228,7 +231,8 @@ Vitest.describe('otel', () => {
       Effect.tap(({ exporter, provider }) =>
         Effect.promise(async () => {
           await provider.forceFlush()
-          expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+          expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+          expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
           await provider.shutdown()
         }),
       ),
@@ -283,7 +287,8 @@ Vitest.describe('otel', () => {
       Effect.tap(({ exporter, provider }) =>
         Effect.promise(async () => {
           await provider.forceFlush()
-          expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+          expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+          expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
           await provider.shutdown()
         }),
       ),
@@ -324,7 +329,8 @@ Vitest.describe('otel', () => {
       Effect.tap(({ exporter, provider }) =>
         Effect.promise(async () => {
           await provider.forceFlush()
-          expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+          expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+          expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
           await provider.shutdown()
         }),
       ),

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -21,60 +21,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "UserInfoSet": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "UserInfoSet": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
       "attributes": {
         "batch": "undefined",
@@ -101,17 +47,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "UserInfoSet",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -129,16 +64,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
                 "sql.cached": false,
                 "sql.query": "SELECT 1 FROM 'UserInfo' WHERE id = ?",
                 "sql.rowsCount": 0,
-              },
-            },
-            {
-              "_name": "LiveStore:commit",
-              "attributes": {
-                "livestore.commitLabel": "UserInfo.set:u1",
-                "livestore.eventTags": [
-                  "UserInfoSet",
-                ],
-                "livestore.eventsCount": 1,
               },
             },
             {
@@ -256,6 +181,82 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }
 `;
 
+exports[`useClientDocument > otel > should update the data based on component key strictMode={ strictMode: false } 2`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.commitLabel": "UserInfo.set:u1",
+      "livestore.eventTags": "[
+  "UserInfoSet"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "UserInfoSet"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`useClientDocument > otel > should update the data based on component key strictMode={ strictMode: true } 1`] = `
 {
   "_name": "createStore",
@@ -275,60 +276,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
-    },
-    {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "UserInfoSet": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-              },
-            },
-          ],
-        },
-      ],
-    },
-    {
-      "_name": "client-session-sync-processor:push",
-      "attributes": {
-        "batchSize": 1,
-        "eventCounts": "{
-  "UserInfoSet": 1
-}",
-        "mergeResultTag": "advance",
-      },
-      "children": [
-        {
-          "_name": "client-session-sync-processor:materialize-event",
-          "children": [
-            {
-              "_name": "livestore.in-memory-db:execute",
-              "attributes": {
-                "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-              },
-            },
-          ],
-        },
-      ],
     },
     {
       "_name": "@livestore/common:LeaderSyncProcessor:push",
@@ -357,17 +304,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     {
       "_name": "LiveStore:commits",
-      "children": [
-        {
-          "_name": "LiveStore:commit",
-          "attributes": {
-            "livestore.eventTags": [
-              "UserInfoSet",
-            ],
-            "livestore.eventsCount": 1,
-          },
-        },
-      ],
     },
     {
       "_name": "LiveStore:queries",
@@ -385,16 +321,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
                 "sql.cached": false,
                 "sql.query": "SELECT 1 FROM 'UserInfo' WHERE id = ?",
                 "sql.rowsCount": 0,
-              },
-            },
-            {
-              "_name": "LiveStore:commit",
-              "attributes": {
-                "livestore.commitLabel": "UserInfo.set:u1",
-                "livestore.eventTags": [
-                  "UserInfoSet",
-                ],
-                "livestore.eventsCount": 1,
               },
             },
             {
@@ -448,6 +374,82 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
   ],
 }
+`;
+
+exports[`useClientDocument > otel > should update the data based on component key strictMode={ strictMode: true } 2`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.commitLabel": "UserInfo.set:u1",
+      "livestore.eventTags": "[
+  "UserInfoSet"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "UserInfoSet"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
 `;
 
 exports[`useClientDocument > should update the data based on component key 1`] = `

--- a/packages/@livestore/react/src/useClientDocument.test.tsx
+++ b/packages/@livestore/react/src/useClientDocument.test.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/a11y/useValidAriaRole: not needed for testing */
 /** biome-ignore-all lint/a11y/noStaticElementInteractions: not needed for testing */
 import * as LiveStore from '@livestore/livestore'
-import { getSimplifiedRootSpan } from '@livestore/livestore/internal/testing-utils'
+import { getAllSimplifiedRootSpans, getSimplifiedRootSpan } from '@livestore/livestore/internal/testing-utils'
 import { Effect, ReadonlyRecord, Schema } from '@livestore/utils/effect'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 import * as otel from '@opentelemetry/api'
@@ -323,7 +323,8 @@ Vitest.describe('useClientDocument', () => {
           })
         }
 
-        expect(getSimplifiedRootSpan(exporter, mapAttributes)).toMatchSnapshot()
+        expect(getSimplifiedRootSpan(exporter, 'createStore', mapAttributes)).toMatchSnapshot()
+        expect(getAllSimplifiedRootSpans(exporter, 'LiveStore:commit', mapAttributes)).toMatchSnapshot()
 
         await provider.shutdown()
       },

--- a/packages/@livestore/utils/src/NoopTracer.ts
+++ b/packages/@livestore/utils/src/NoopTracer.ts
@@ -9,6 +9,7 @@ export const makeNoopSpan = () => {
     setAttribute: () => null,
     setAttributes: () => null,
     addEvent: () => null,
+    addLink: () => null,
     setStatus: () => null,
     updateName: () => null,
     recordException: () => null,

--- a/packages/@livestore/utils/src/effect/OtelTracer.ts
+++ b/packages/@livestore/utils/src/effect/OtelTracer.ts
@@ -1,0 +1,11 @@
+import { makeExternalSpan } from '@effect/opentelemetry/Tracer'
+import type { Link as OtelSpanLink } from '@opentelemetry/api'
+import type { SpanLink as EffectSpanLink } from 'effect/Tracer'
+
+export * from '@effect/opentelemetry/Tracer'
+
+export const makeSpanLink = (otelSpanLink: OtelSpanLink): EffectSpanLink => ({
+  _tag: 'SpanLink',
+  span: makeExternalSpan(otelSpanLink.context),
+  attributes: otelSpanLink.attributes ?? {},
+})

--- a/packages/@livestore/utils/src/effect/index.ts
+++ b/packages/@livestore/utils/src/effect/index.ts
@@ -1,6 +1,5 @@
 import '../global.ts'
 
-export * as OtelTracer from '@effect/opentelemetry/Tracer'
 export {
   Command,
   CommandExecutor,
@@ -114,6 +113,7 @@ export type { Serializable, SerializableWithResult } from 'effect/Schema'
 export * as SchemaAST from 'effect/SchemaAST'
 export * as BucketQueue from './BucketQueue.ts'
 export * as Logger from './Logger.ts'
+export * as OtelTracer from './OtelTracer.ts'
 export * as Schema from './Schema/index.ts'
 export * as Stream from './Stream.ts'
 export * as Subscribable from './Subscribable.ts'


### PR DESCRIPTION
This migrates `store.commit()` to Effect to make it easier to instrument it with OpenTelemetry.

> [!CAUTION]
> **DO NOT MERGE!**
>
> This is a stacked PR. To preserve logical order, and a clean commit history, these must be merged from the bottom upwards. I'll handle the merges and rebases myself, as it can be [tricky to do properly](https://stackoverflow.com/a/70994400).
> 
> Merge order:
> 1. [refactor: migrate `ClientSessionSyncProcessor.push()` to Effect #375](https://github.com/livestorejs/livestore/pull/375) (base)
> 2. [refactor: migrate `ClientSessionSyncProcessor`’s `materializeEvent()` to Effect #376](https://github.com/livestorejs/livestore/pull/376)
> 3. [refactor: migrate `store.commit` to Effect #381](https://github.com/livestorejs/livestore/pull/381) (top)

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
