### PR TITLE
fix: import Cloudflare Worker types

### DIFF
--- a/packages/@livestore/sync-cf/package.json
+++ b/packages/@livestore/sync-cf/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@livestore/sync-cf",
   "version": "0.3.1",
-  "type": "module",
+  "license": "Apache-2.0",
   "sideEffects": false,
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/sync-impl/mod.d.ts",
@@ -11,14 +12,15 @@
     "./cf-worker": {
       "types": "./dist/cf-worker/mod.d.ts",
       "default": "./dist/cf-worker/mod.js"
+    },
+    "./cf-worker/durable-object": {
+      "types": "./dist/cf-worker/durable-object.d.ts",
+      "default": "./dist/cf-worker/durable-object.js"
+    },
+    "./cf-worker/worker": {
+      "types": "./dist/cf-worker/worker.d.ts",
+      "default": "./dist/cf-worker/worker.js"
     }
-  },
-  "dependencies": {
-    "@livestore/common": "workspace:*",
-    "@livestore/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250303.0"
   },
   "files": [
     "dist",
@@ -26,11 +28,17 @@
     "package.json",
     "README.md"
   ],
-  "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "@livestore/common": "workspace:*",
+    "@livestore/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250620.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/@livestore/sync-cf/package.json
+++ b/packages/@livestore/sync-cf/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@livestore/sync-cf",
   "version": "0.3.1",
-  "license": "Apache-2.0",
-  "sideEffects": false,
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/sync-impl/mod.d.ts",
@@ -12,15 +11,14 @@
     "./cf-worker": {
       "types": "./dist/cf-worker/mod.d.ts",
       "default": "./dist/cf-worker/mod.js"
-    },
-    "./cf-worker/durable-object": {
-      "types": "./dist/cf-worker/durable-object.d.ts",
-      "default": "./dist/cf-worker/durable-object.js"
-    },
-    "./cf-worker/worker": {
-      "types": "./dist/cf-worker/worker.d.ts",
-      "default": "./dist/cf-worker/worker.js"
     }
+  },
+  "dependencies": {
+    "@livestore/common": "workspace:*",
+    "@livestore/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250303.0"
   },
   "files": [
     "dist",
@@ -28,17 +26,11 @@
     "package.json",
     "README.md"
   ],
-  "scripts": {
-    "test": "echo 'No tests yet'"
-  },
-  "dependencies": {
-    "@livestore/common": "workspace:*",
-    "@livestore/utils": "workspace:*"
-  },
-  "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250620.0"
-  },
+  "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "test": "echo 'No tests yet'"
   }
 }

--- a/packages/@livestore/sync-cf/package.json
+++ b/packages/@livestore/sync-cf/package.json
@@ -26,7 +26,7 @@
     "@livestore/utils": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250620.0"
+    "@cloudflare/workers-types": "^4.20250702.0"
   },
   "files": [
     "dist",

--- a/packages/@livestore/sync-cf/package.json
+++ b/packages/@livestore/sync-cf/package.json
@@ -11,14 +11,22 @@
     "./cf-worker": {
       "types": "./dist/cf-worker/mod.d.ts",
       "default": "./dist/cf-worker/mod.js"
-    }
+    },
+    "./cf-worker/durable-object": {
+      "types": "./dist/cf-worker/durable-object.d.ts",
+      "default": "./dist/cf-worker/durable-object.js"
+    },
+    "./cf-worker/worker": {
+      "types": "./dist/cf-worker/worker.d.ts",
+      "default": "./dist/cf-worker/worker.js"
+    }  
   },
   "dependencies": {
     "@livestore/common": "workspace:*",
     "@livestore/utils": "workspace:*"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250303.0"
+    "@cloudflare/workers-types": "^4.20250620.0"
   },
   "files": [
     "dist",

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -189,16 +189,5 @@ export const handleWebSocket = <
       })
     }
 
-    return yield* Effect.promise(() =>
-      durableObject.fetch(request.url, {
-        method: request.method,
-        body: request.body,
-        cf: request.cf,
-        fetcher: request.fetcher,
-        headers: request.headers,
-        integrity: request.integrity,
-        redirect: request.redirect,
-        signal: request.signal,
-      }),
-    )
+    return yield* Effect.promise(() => durableObject.fetch(request as any))
   }).pipe(Effect.tapCauseLogPretty, Effect.runPromise) as unknown as Promise<CFResponse>

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -189,5 +189,16 @@ export const handleWebSocket = <
       })
     }
 
-    return yield* Effect.promise(() => durableObject.fetch(request as any))
+    return yield* Effect.promise(() =>
+      durableObject.fetch(request.url, {
+        method: request.method,
+        body: request.body,
+        cf: request.cf,
+        fetcher: request.fetcher,
+        headers: request.headers,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        signal: request.signal,
+      }),
+    )
   }).pipe(Effect.tapCauseLogPretty, Effect.runPromise) as unknown as Promise<CFResponse>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,7 +400,7 @@ importers:
         version: 5.8.3
       wrangler:
         specifier: ^4.14.4
-        version: 4.15.1
+        version: 4.15.1(@cloudflare/workers-types@4.20250702.0)
 
   examples/src/node-effect-cli:
     dependencies:
@@ -861,7 +861,7 @@ importers:
         version: 6.3.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1)
       wrangler:
         specifier: ^4.14.4
-        version: 4.15.1
+        version: 4.15.1(@cloudflare/workers-types@4.20250702.0)
 
   examples/src/web-todomvc-sync-electric:
     dependencies:
@@ -1164,7 +1164,7 @@ importers:
         version: 5.8.3
       wrangler:
         specifier: ^4.14.4
-        version: 4.15.1
+        version: 4.15.1(@cloudflare/workers-types@4.20250702.0)
 
   examples/standalone/node-todomvc-sync-cf:
     dependencies:
@@ -1600,7 +1600,7 @@ importers:
         version: 6.3.4(@types/node@22.15.17)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1)
       wrangler:
         specifier: ^4.14.4
-        version: 4.15.1
+        version: 4.15.1(@cloudflare/workers-types@4.20250702.0)
 
   examples/standalone/web-todomvc-sync-electric:
     dependencies:
@@ -2068,8 +2068,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20250303.0
-        version: 4.20250303.0
+        specifier: ^4.20250702.0
+        version: 4.20250702.0
 
   packages/@livestore/sync-electric:
     dependencies:
@@ -2315,7 +2315,7 @@ importers:
         version: 3.1.2(@types/debug@4.1.12)(@types/node@22.15.17)(@vitest/ui@3.1.1)(jiti@2.4.2)(jsdom@26.0.0)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1)
       wrangler:
         specifier: ^4.14.4
-        version: 4.15.1
+        version: 4.15.1(@cloudflare/workers-types@4.20250702.0)
 
   tests/package-common:
     dependencies:
@@ -3146,8 +3146,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20250303.0':
-    resolution: {integrity: sha512-O7F7nRT4bbmwHf3gkRBLfJ7R6vHIJ/oZzWdby6obOiw2yavUfp/AIwS7aO2POu5Cv8+h3TXS3oHs3kKCZLraUA==}
+  '@cloudflare/workers-types@4.20250702.0':
+    resolution: {integrity: sha512-gUuWeVvb0Y6E8h83nI19Ay+69x+9Xjz99TdhX0JdZoNTtyVX9KcdQgGcRK+Tmt2WC0z2AQaPq/qVmNihAgS7iQ==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -3581,7 +3581,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.24.13':
     resolution: {integrity: sha512-2LSdbvYs+WmUljnplQXMCUyNzyX4H+F4l8uExfA1hud25Bl5kyaGrx1jjtgNxMTXmfmMjvgBdK798R50imEhkA==}
@@ -14784,7 +14784,7 @@ snapshots:
 
   '@babel/highlight@7.25.9':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
@@ -15346,7 +15346,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250508.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20250303.0': {}
+  '@cloudflare/workers-types@4.20250702.0': {}
 
   '@colors/colors@1.5.0': {}
 
@@ -29976,7 +29976,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250508.0
       '@cloudflare/workerd-windows-64': 1.20250508.0
 
-  wrangler@4.15.1:
+  wrangler@4.15.1(@cloudflare/workers-types@4.20250702.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@cloudflare/unenv-preset': 2.3.1(unenv@2.0.0-rc.15)(workerd@1.20250508.0)
@@ -29987,6 +29987,7 @@ snapshots:
       unenv: 2.0.0-rc.15
       workerd: 1.20250508.0
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20250702.0
       fsevents: 2.3.3
       sharp: 0.33.5
     transitivePeerDependencies:


### PR DESCRIPTION
tsconfig.compilerOptions.types does not declare the types, which means the consumer would get the wrong globalThis types and not Cloudflare Worker types. Consumer would have to bring in types and cast which feels awkward.

```ts
export class WebSocketServer extends makeDurableObject({
	onPush: async (message) => {
		console.log('onPush', message.batch);
	},
	onPull: async (message) => {
		console.log('onPull', message);
	}
}) {}

export default {
	fetch: async (request, env, ctx) => {
		console.log('WebSocketServer: request', request.url);
		return await livestoreWorker.fetch(request, env, ctx);
                                              // ^  globalThis.Response  
	}
} satisfies ExportedHandler<Env>;
```

Added generics and helper types to extract and fill in downstream generics. 

Helper type `ExtractDurableObjectKeys` to help with type safety if `TEnv extends Env` and has  `DurableObjectNamespace`.  

```ts
// app.d.ts
export interface PlatformEnv extends Env {
	WEBSOCKET_SERVER: DurableObjectNamespace<WebSocketServer>;
}

// worker.ts
export const livestoreWorker = makeWorker<PlatformEnv>({
	validatePayload: (payload: any) => {
		console.log('DURABLE OBJECT PAYLOAD:', payload);
		if (payload?.authToken !== 'insecure-token-change-me') {
			throw new Error('Invalid auth token');
		}
	},
	enableCORS: true,
        // (property) name?: "WEBSOCKET_SERVER" | undefined
	durableObject: { name: 'WEBSOCKET_SERVER' }
});
```

### Checklist
- [x] I grant to recipients of this Project distribution a perpetual,
non-exclusive, royalty-free, irrevocable copyright license to reproduce, prepare
derivative works of, publicly display, sublicense, and distribute this
Contribution and such derivative works.
- [x] I certify that I am legally entitled to grant this license, and that this
Contribution contains no content requiring a license from any third party.
