### PR TITLE
fix: handle Symbol values in QueryCache key generation

### DIFF
--- a/packages/@livestore/livestore/src/QueryCache.ts
+++ b/packages/@livestore/livestore/src/QueryCache.ts
@@ -1,5 +1,5 @@
 import type { Bindable } from '@livestore/common'
-import { BoundMap, BoundSet } from '@livestore/common'
+import { BoundMap, BoundSet, SessionIdSymbol } from '@livestore/common'
 
 type Opaque<BaseType, BrandType = unknown> = BaseType & {
   readonly [Symbols.base]: BaseType
@@ -27,13 +27,18 @@ export default class QueryCache {
       return sql as CacheKey
     }
 
+    const formatValue = (value: any) => (value === SessionIdSymbol ? 'SessionIdSymbol' : String(value))
+
     if (Array.isArray(bindValues)) {
-      return (sql + '\n' + bindValues.join('\n')) as CacheKey
+      return (sql + '\n' + bindValues.map(formatValue).join('\n')) as CacheKey
     }
 
-    return (sql + '\n' + Object.values(bindValues).join('\n')) as CacheKey
+    return (sql +
+      '\n' +
+      Object.entries(bindValues)
+        .map(([key, value]) => `${key}:${formatValue(value)}`)
+        .join('\n')) as CacheKey
   }
-
   get = (key: CacheKey) => {
     return this.#entries.get(key)
   }


### PR DESCRIPTION
Important:
I've changed formatting of Object entries from concatenation of values to concatenation of `key:value` and that might be not what you want! I wanted to clarify that in discord, but then decided that pull request might be a better place to discuss that.

## Summary

**What:** Convert Symbol values to strings before joining in getKey() 
**Why:** Fixes "Cannot convert a Symbol value to string" error that occcurs when using query builder with store.query() containing session symbols

## Related issues

#390 

## How to test

described in the issue 