### PR TITLE
feat: add Bun export conditions for improved local development

### DIFF
--- a/packages/@livestore/common/package.json
+++ b/packages/@livestore/common/package.json
@@ -5,6 +5,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },

--- a/packages/@livestore/utils-dev/package.json
+++ b/packages/@livestore/utils-dev/package.json
@@ -7,14 +7,17 @@
   ],
   "exports": {
     "./node": {
+      "bun": "./src/node/mod.ts",
       "types": "./dist/node/mod.d.ts",
       "default": "./dist/node/mod.js"
     },
     "./node-vitest": {
+      "bun": "./src/node-vitest/mod.ts",
       "types": "./dist/node-vitest/mod.d.ts",
       "default": "./dist/node-vitest/mod.js"
     },
     "./node-vitest-polyfill": {
+      "bun": "./src/node-vitest/polyfill.ts",
       "types": "./dist/node-vitest/polyfill.d.ts",
       "default": "./dist/node-vitest/polyfill.js"
     }

--- a/packages/@livestore/utils/package.json
+++ b/packages/@livestore/utils/package.json
@@ -7,28 +7,34 @@
   ],
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
     "./cuid": {
+      "bun": "./src/cuid/cuid.node.ts",
       "types": "./dist/cuid/cuid.node.d.ts",
       "node": "./dist/cuid/cuid.node.js",
       "browser": "./dist/cuid/cuid.browser.js",
       "react-native": "./dist/cuid/cuid.browser.js"
     },
     "./nanoid": {
+      "bun": "./src/nanoid/index.ts",
       "types": "./dist/nanoid/index.d.ts",
       "default": "./dist/nanoid/index.js"
     },
     "./effect": {
+      "bun": "./src/effect/index.ts",
       "types": "./dist/effect/index.d.ts",
       "default": "./dist/effect/index.js"
     },
     "./node": {
+      "bun": "./src/node/mod.ts",
       "types": "./dist/node/mod.d.ts",
       "default": "./dist/node/mod.js"
     },
     "./bun": {
+      "bun": "./src/bun/mod.ts",
       "types": "./dist/bun/mod.d.ts",
       "default": "./dist/bun/mod.js"
     }

--- a/packages/@livestore/webmesh/package.json
+++ b/packages/@livestore/webmesh/package.json
@@ -5,10 +5,12 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "bun": "./src/mod.ts",
       "types": "./dist/mod.d.ts",
       "default": "./dist/mod.js"
     },
     "./websocket-server": {
+      "bun": "./src/websocket-server.ts",
       "types": "./dist/websocket-server.d.ts",
       "default": "./dist/websocket-server.js"
     }

--- a/scripts/mono.ts
+++ b/scripts/mono.ts
@@ -1,17 +1,18 @@
 import fs from 'node:fs'
 
 import { liveStoreVersion } from '@livestore/common'
+import { shouldNeverHappen } from '@livestore/utils'
 import { Effect, Layer, Logger, LogLevel } from '@livestore/utils/effect'
 import { Cli, PlatformNode } from '@livestore/utils/node'
 import { cmd, cmdText, OtelLiveHttp } from '@livestore/utils-dev/node'
 import * as integrationTests from '@local/tests-integration/run-tests'
-
 import { copyTodomvcSrc } from './examples/copy-examples.js'
 import { command as deployExamplesCommand } from './examples/deploy-examples.js'
 import * as generateExamples from './examples/generate-examples.js'
 import { deployToNetlify } from './shared/netlify.js'
 
-const cwd = process.env.WORKSPACE_ROOT
+const cwd =
+  process.env.WORKSPACE_ROOT ?? shouldNeverHappen(`WORKSPACE_ROOT is not set. Make sure to run 'direnv allow'`)
 const isGithubAction = process.env.GITHUB_ACTIONS === 'true'
 
 // GitHub actions log groups


### PR DESCRIPTION
## Summary
- Add `"bun"` export conditions to @livestore packages pointing to TypeScript source files
- Enables faster local development workflow with Bun (no build step required)
- Maintains compatibility with external consumers and published packages

## Changes
- **@livestore/common**: Added `"bun"` condition to main export
- **@livestore/utils**: Added `"bun"` conditions to all exports (main, effect, node, etc.)
- **@livestore/utils-dev**: Added `"bun"` conditions to node exports
- **@livestore/webmesh**: Added `"bun"` conditions to main and websocket-server exports

## Benefits
- Faster local development with Bun (direct TypeScript execution)
- No build step needed during development
- Maintains backward compatibility (other tools ignore unknown conditions)
- External consumers and Expo apps still use compiled JavaScript

## Test plan
- [x] Verify Bun can execute scripts that import these packages
- [x] Confirm other tools ignore the `"bun"` condition and use default exports
- [ ] Test published packages work correctly for external consumers
- [ ] Verify Expo compatibility remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)