### PR TITLE
Ensure finalizers are executed in the proper order

### DIFF
--- a/packages/@livestore/adapter-node/src/client-session/adapter.ts
+++ b/packages/@livestore/adapter-node/src/client-session/adapter.ts
@@ -215,7 +215,6 @@ const makeAdapterImpl = ({
       return clientSession
     }).pipe(
       Effect.withSpan('@livestore/adapter-node:adapter'),
-      Effect.parallelFinalizers,
       Effect.provide(PlatformNode.NodeFileSystem.layer),
       Effect.provide(FetchHttpClient.layer),
     )) satisfies Adapter
@@ -336,20 +335,6 @@ const makeWorkerLeaderThread = ({
       UnexpectedError.mapToUnexpectedError,
       Effect.tapErrorCause(shutdown),
       Effect.withSpan('@livestore/adapter-node:adapter:setupLeaderThread'),
-    )
-
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        // We first try to gracefully shutdown the leader worker and then forcefully terminate it
-        yield* Effect.raceFirst(
-          runInWorker(new WorkerSchema.LeaderWorkerInner.Shutdown()).pipe(Effect.andThen(() => nodeWorker.terminate())),
-
-          Effect.sync(() => {
-            console.warn('[@livestore/adapter-node:adapter] Worker did not gracefully shutdown in time, terminating it')
-            nodeWorker.terminate()
-          }).pipe(Effect.delay(1000)),
-        ).pipe(Effect.exit) // The disconnect is to prevent the interrupt to bubble out
-      }).pipe(Effect.withSpan('@livestore/adapter-node:adapter:shutdown'), Effect.tapCauseLogPretty, Effect.orDie),
     )
 
     const runInWorker = <TReq extends typeof WorkerSchema.LeaderWorkerInner.Request.Type>(


### PR DESCRIPTION
## Summary

Parallel finalization is almost _always_ an undesirable behavior given that it can result in non-deterministic behavior if finalizers depend on one another.

In addition, the `Shutdown` message being issued as a finalizer has been removed given there is no logic in the associated handler at this time. I will look into strategies for enabling specific shutdown behavior based upon state within the worker as a separate task.

## Related issues

- #449

## How to test
