### PR TITLE
Pass clientId as a parameter to materializers

### DIFF
--- a/packages/@livestore/common/src/schema/EventDef.ts
+++ b/packages/@livestore/common/src/schema/EventDef.ts
@@ -191,6 +191,8 @@ export type Materializer<TEventDef extends EventDef.AnyWithoutFn = EventDef.AnyW
     eventDef: TEventDef
     /** Can be used to query the current state */
     query: MaterializerContextQuery
+    /** The client ID that created this event */
+    clientId: string
   },
 ) => SingleOrReadonlyArray<MaterializerResult>
 

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
@@ -50,6 +50,7 @@ describe('client document table', () => {
         currentFacts: new Map(),
         query: {} as any, // unused
         eventDef: Doc[ClientDocumentTableDefSymbol].derived.setEventDef,
+        clientId: 'test-client-id',
       })
     }
 


### PR DESCRIPTION
Add `clientId` as a parameter to materializer context to enable attribution, audit logging, and presence use cases.

Changes:
- Add `clientId: string` to Materializer type in EventDef.ts
- Pass `clientId` through `getExecStatementsFromMaterializer`
- Update leader-thread and store to provide `clientId`
- Fix test to include required `clientId` parameter

Example usage:

```typescript
import { Events, makeSchema, Schema, State } from '@livestore/common/schema'

const events = {
  messageCreated: Events.synced({
    name: 'messageCreated',
    schema: Schema.Struct({
      id: Schema.String,
      content: Schema.String,
    }),
  }),
}

const messages = State.SQLite.table({
  name: 'messages',
  columns: {
    id: State.SQLite.text({ primaryKey: true }),
    content: State.SQLite.text(),
    createdBy: State.SQLite.text(), // Store the clientId here
  },
})

const materializers = State.SQLite.materializers(events, {
  messageCreated: ({ id, content }, { clientId }) => {
    return messages.insert({
      id,
      content,
      createdBy: clientId,
    })
  },
})

const schema = makeSchema({
  events,
  state: State.SQLite.makeState({ tables: { messages }, materializers }),
})

export { schema, events, messages }
```
