### PR TITLE
Revert "chore: update import path for WaSqliteFactory in mod.node.ts"

### DIFF
--- a/packages/@livestore/sqlite-wasm/src/load-wasm/mod.node.ts
+++ b/packages/@livestore/sqlite-wasm/src/load-wasm/mod.node.ts
@@ -1,5 +1,6 @@
 import * as WaSqlite from '@livestore/wa-sqlite'
-import WaSqliteFactory from '@livestore/wa-sqlite/dist/wa-sqlite.mjs'
+// @ts-expect-error TODO fix types in wa-sqlite
+import WaSqliteFactory from '@livestore/wa-sqlite/dist/wa-sqlite.node.mjs'
 
 export const loadSqlite3Wasm = async () => {
   const module = await WaSqliteFactory()


### PR DESCRIPTION
## Summary

This reverts commit a23087d2e82e024ae2d6f14cb22905065441e25c. That change causes the following error by importing the web version of `wa-sqlite`. The web version uses `fetch` with the `file://` protocol, which is incompatible with Node.js’ `undici` implementation of `fetch`.

```
node:internal/deps/undici/undici:13510
      Error.captureStackTrace(err);
            ^

TypeError: fetch failed
    at node:internal/deps/undici/undici:13510:13 {
  [cause]: Error: not implemented... yet...
      at makeNetworkError (node:internal/deps/undici/undici:9277:35)
      at schemeFetch (node:internal/deps/undici/undici:10673:34)
      at node:internal/deps/undici/undici:10522:26
      at mainFetch (node:internal/deps/undici/undici:10541:11)
      at fetching (node:internal/deps/undici/undici:10489:7)
      at fetch (node:internal/deps/undici/undici:10358:20)
      at fetch (node:internal/deps/undici/undici:13508:10)
      at fetch (node:internal/bootstrap/web/exposed-window-or-worker:72:12)
      at instantiateAsync (file:///home/runner/work/livestore/livestore/node_modules/.pnpm/@livestore+wa-sqlite@1.0.5/node_modules/@livestore/wa-sqlite/dist/wa-sqlite.mjs:9:5198)
      at createWasm (file:///home/runner/work/livestore/livestore/node_modules/.pnpm/@livestore+wa-sqlite@1.0.5/node_modules/@livestore/wa-sqlite/dist/wa-sqlite.mjs:9:6253)
}
```

## How to test

Run the command `mono test integration misc` before and after the revert to see the error and then fix in action.
