### PR TITLE
fix: handle optional fields without defaults in client documents (#487)

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import { tables } from '../../../__tests__/fixture.ts'
 import type * as LiveStoreEvent from '../../LiveStoreEvent.ts'
-import { ClientDocumentTableDefSymbol, clientDocument } from './client-document-def.ts'
+import { ClientDocumentTableDefSymbol, clientDocument, mergeDefaultValues } from './client-document-def.ts'
 
 describe('client document table', () => {
   test('set event', () => {
@@ -238,3 +238,91 @@ const patchId = (muationEvent: LiveStoreEvent.PartialAnyDecoded) => {
   const id = `00000000-0000-0000-0000-000000000000`
   return { ...muationEvent, id }
 }
+
+describe('mergeDefaultValues', () => {
+  test('merges values from both objects', () => {
+    const defaults = { a: 1, b: 2 }
+    const explicit = { a: 10, b: 20 }
+    const result = mergeDefaultValues(defaults, explicit)
+
+    expect(result).toEqual({ a: 10, b: 20 })
+  })
+
+  test('uses default values when explicit values are undefined', () => {
+    const defaults = { a: 1, b: 2 }
+    const explicit = { a: undefined, b: 20 } as any
+    const result = mergeDefaultValues(defaults, explicit)
+
+    expect(result).toEqual({ a: 1, b: 20 })
+  })
+
+  test('should preserve properties that are not in default values', () => {
+    const defaults = { a: 1, b: 2 }
+    const explicit = { a: 10, b: 20, c: 30 }
+    const result = mergeDefaultValues(defaults, explicit)
+
+    // Should include ALL properties from explicit, not just those in defaults
+    expect(result).toEqual({ a: 10, b: 20, c: 30 })
+    expect('c' in result).toBe(true)
+  })
+
+  test('issue #487 - should preserve optional fields not in defaults', () => {
+    const defaults = {
+      newTodoText: '',
+      filter: 'all' as const,
+    }
+    const userSet = {
+      newTodoText: '',
+      description: 'First attempt', // Optional field not in defaults
+      filter: 'all' as const,
+    }
+    const result = mergeDefaultValues(defaults, userSet)
+
+    // Should include the description field even though it's not in defaults
+    expect(result).toEqual({ 
+      newTodoText: '', 
+      description: 'First attempt',
+      filter: 'all' 
+    })
+    expect('description' in result).toBe(true)
+  })
+
+  test('handles non-object values', () => {
+    expect(mergeDefaultValues('default', 'explicit')).toBe('explicit')
+    expect(mergeDefaultValues(42, 100)).toBe(100)
+    expect(mergeDefaultValues(null, { a: 1 })).toEqual({ a: 1 })
+    expect(mergeDefaultValues({ a: 1 }, null)).toBe(null)
+  })
+
+  test('handles nested objects (current implementation does not deep merge)', () => {
+    const defaults = { a: { x: 1, y: 2 }, b: 3 }
+    const explicit = { a: { x: 10 }, b: 30 } as any
+    const result = mergeDefaultValues(defaults, explicit)
+
+    // Current implementation replaces entire nested object
+    expect(result).toEqual({ a: { x: 10 }, b: 30 })
+    // Note: 'y' is lost because the entire 'a' object is replaced
+  })
+
+  test('should handle mix of default and new properties', () => {
+    const defaults = { 
+      required1: 'default1',
+      required2: 'default2'
+    }
+    const userSet = {
+      required1: 'user1',      // Override default
+      required2: 'default2',   // Keep default  
+      optional1: 'new1',       // New field
+      optional2: 'new2'        // New field
+    }
+    const result = mergeDefaultValues(defaults, userSet)
+
+    expect(result).toEqual({
+      required1: 'user1',
+      required2: 'default2', 
+      optional1: 'new1',
+      optional2: 'new2'
+    })
+    expect(Object.keys(result).sort()).toEqual(['optional1', 'optional2', 'required1', 'required2'])
+  })
+})

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -121,7 +121,7 @@ export const clientDocument = <
   return clientDocumentTableDef
 }
 
-const mergeDefaultValues = <T>(defaultValues: T, explicitDefaultValues: T): T => {
+export const mergeDefaultValues = <T>(defaultValues: T, explicitDefaultValues: T): T => {
   if (
     typeof defaultValues !== 'object' ||
     typeof explicitDefaultValues !== 'object' ||
@@ -131,7 +131,13 @@ const mergeDefaultValues = <T>(defaultValues: T, explicitDefaultValues: T): T =>
     return explicitDefaultValues
   }
 
-  return Object.keys(defaultValues as any).reduce((acc, key) => {
+  // Get all unique keys from both objects
+  const allKeys = new Set([
+    ...Object.keys(defaultValues as any),
+    ...Object.keys(explicitDefaultValues as any)
+  ])
+
+  return Array.from(allKeys).reduce((acc, key) => {
     acc[key] = (explicitDefaultValues as any)[key] ?? (defaultValues as any)[key]
     return acc
   }, {} as any)

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -438,6 +438,12 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema, TContext =
 
       const sqlRes = query.asSql()
       const schema = getResultSchema(query)
+      
+      // Replace SessionIdSymbol in bind values before executing the query
+      if (sqlRes.bindValues) {
+        replaceSessionIdSymbol(sqlRes.bindValues, this.clientSession.sessionId)
+      }
+      
       const rawRes = this.sqliteDbWrapper.cachedSelect(sqlRes.query, sqlRes.bindValues as any as PreparedBindValues, {
         otelContext: options?.otelContext,
         queriedTables: new Set([query[QueryBuilderAstSymbol].tableDef.sqliteDef.name]),

--- a/tests/package-common/src/issue-487.test.ts
+++ b/tests/package-common/src/issue-487.test.ts
@@ -1,0 +1,80 @@
+import { makeAdapter } from '@livestore/adapter-node'
+import { makeSchema, State } from '@livestore/common/schema'
+import { createStore, SessionIdSymbol } from '@livestore/livestore'
+import { IS_CI } from '@livestore/utils'
+import { Effect, FetchHttpClient, Logger, LogLevel, Schema } from '@livestore/utils/effect'
+import { OtelLiveDummy, PlatformNode } from '@livestore/utils/node'
+import { OtelLiveHttp } from '@livestore/utils-dev/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { expect } from 'vitest'
+
+Vitest.describe('issue #487 - Optional fields without defaults cause errors', () => {
+  Vitest.scopedLive('reproduces livestore-optional-field-bug repo scenario', (test) =>
+    Effect.gen(function* () {
+      // Exact setup from https://github.com/rubywwwilde/livestore-optional-field-bug
+      const uiState = State.SQLite.clientDocument({
+        name: 'UiState',
+        schema: Schema.Struct({
+          newTodoText: Schema.String,
+          description: Schema.optional(Schema.String), // Optional field
+          filter: Schema.Literal('all', 'active', 'completed'),
+        }),
+        default: {
+          id: SessionIdSymbol,
+          value: {
+            newTodoText: '',
+            filter: 'all',
+            // No default for description - this is the issue
+          },
+        },
+      })
+
+      const tables = { uiState }
+      const state = State.SQLite.makeState({ tables, materializers: {} })
+      const schema = makeSchema({ state, events: { UiStateSet: uiState.set } })
+
+      // Create store with in-memory adapter
+      const adapter = makeAdapter({ storage: { type: 'in-memory' } })
+      const store = yield* createStore({
+        schema,
+        adapter,
+        storeId: 'test',
+      })
+
+      // This is what the user does:
+      // 1. Set a value including the optional field
+      store.commit(
+        uiState.set({
+          newTodoText: '',
+          description: 'First attempt', // Setting the optional field
+          filter: 'all',
+        }),
+      )
+
+      // 2. Query the value back - this should work but may fail without the fix
+      const result = store.query(uiState.get())
+
+      // User expects this to work:
+      expect(result).toBeDefined()
+      expect(result.newTodoText).toBe('')
+      expect(result.description).toBe('First attempt')
+      expect(result.filter).toBe('all')
+    }).pipe(withCtx(test)),
+  )
+})
+
+const otelLayer = IS_CI ? OtelLiveDummy : OtelLiveHttp({ serviceName: 'store-test', skipLogUrl: false })
+
+const withCtx =
+  (testContext: Vitest.TaskContext, { suffix }: { suffix?: string; skipOtel?: boolean } = {}) =>
+  <A, E, R>(self: Effect.Effect<A, E, R>) =>
+    self.pipe(
+      Effect.timeout(IS_CI ? 60_000 : 10_000),
+      Effect.provide(FetchHttpClient.layer),
+      Effect.provide(PlatformNode.NodeFileSystem.layer),
+      Logger.withMinimumLogLevel(LogLevel.Debug),
+      Effect.provide(Logger.prettyWithThread('test-main-thread')),
+      Effect.scoped,
+      Effect.withSpan(`${testContext.task.suite?.name}:${testContext.task.name}${suffix ? `:${suffix}` : ''}`),
+      Effect.provide(otelLayer),
+    )


### PR DESCRIPTION
## Summary
This PR fixes an issue where optional Schema fields in client documents without default values would be `undefined` when querying after being set.

## Problem
When using optional fields in client documents without providing default values, the fields would be lost when querying the document back, even after explicitly setting them. This was due to:
1. The `mergeDefaultValues` function only iterating over keys from the default values object
2. SessionIdSymbol not being replaced in synchronous `store.query()` calls

## Solution
1. **Fixed `mergeDefaultValues`** to preserve all keys from both default and explicit values
2. **Added SessionIdSymbol replacement** in the synchronous `store.query()` method
3. **Added comprehensive tests** to prevent regression

## Test Plan
- [x] Added unit tests for `mergeDefaultValues` function
- [x] Added integration test reproducing the exact scenario from issue #487
- [x] All existing tests pass

## Changes
- `packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts`: Fixed `mergeDefaultValues` to iterate over all keys
- `packages/@livestore/livestore/src/store/store.ts`: Added SessionIdSymbol replacement in query method
- `tests/package-common/src/issue-487.test.ts`: Added integration test
- `packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts`: Added unit tests

Fixes #487

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>