### PR TITLE
Fix LiveStore Worker file path in React web getting started docs

### DIFF
--- a/docs/src/content/docs/getting-started/react-web.mdx
+++ b/docs/src/content/docs/getting-started/react-web.mdx
@@ -140,9 +140,9 @@ Here's an example schema:
 
 ## Create the LiveStore Worker
 
-Create a file named `livestore.worker.ts` inside the `src/livestore` folder. This file will contain the LiveStore web worker. When importing this file, make sure to add the `?worker` extension to the import path to ensure that Vite treats it as a worker file.
+Create a file named `livestore.worker.ts` inside the `src` folder. This file will contain the LiveStore web worker. When importing this file, make sure to add the `?worker` extension to the import path to ensure that Vite treats it as a worker file.
 
-<Code code={CODE.worker} lang="ts" title="src/livestore/livestore.worker.ts" />
+<Code code={CODE.worker} lang="ts" title="src/livestore.worker.ts" />
 
 ## Add the LiveStore Provider
 


### PR DESCRIPTION
## Summary
- Corrects the file path for the LiveStore web worker in the React web getting started documentation
- Updates instructions to create `livestore.worker.ts` inside the `src` folder instead of `src/livestore`
- Ensures the import path and code example reflect the correct file location

## Changes

### Documentation
- Modified `docs/src/content/docs/getting-started/react-web.mdx`:
  - Changed the folder path for `livestore.worker.ts` from `src/livestore` to `src`
  - Updated the import path note to match the new location
  - Adjusted the code example title to `src/livestore.worker.ts`

## Test plan
- [x] Verified the documentation changes for accuracy
- [x] Confirmed the updated file path aligns with project structure and build requirements
- [x] Ensured no other references to the old path remain in the docs

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d5d22d95-58fb-451f-a885-c7ba4effe5ec