### PR TITLE
Add Terragon Nix development environment setup script

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Terragon Development Environment Setup ==="
+
+# Install Nix using DeterminateSystems installer
+echo "Installing Nix..."
+if ! command -v nix &> /dev/null; then
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+  
+  # Source nix daemon for current session
+  if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+  fi
+else
+  echo "Nix is already installed"
+fi
+
+# Install direnv
+echo "Installing direnv..."
+if ! command -v direnv &> /dev/null; then
+  nix-env -i direnv
+else
+  echo "direnv is already installed"
+fi
+
+# Setup direnv shell hook
+echo "Setting up direnv shell hooks..."
+
+# Detect shell and add appropriate hook
+SHELL_NAME=$(basename "$SHELL")
+case "$SHELL_NAME" in
+  bash)
+    SHELL_RC="$HOME/.bashrc"
+    HOOK_CMD='eval "$(direnv hook bash)"'
+    ;;
+  zsh)
+    SHELL_RC="$HOME/.zshrc"
+    HOOK_CMD='eval "$(direnv hook zsh)"'
+    ;;
+  fish)
+    SHELL_RC="$HOME/.config/fish/config.fish"
+    HOOK_CMD='direnv hook fish | source'
+    ;;
+  *)
+    echo "Warning: Unsupported shell '$SHELL_NAME'. Please manually add direnv hook."
+    SHELL_RC=""
+    ;;
+esac
+
+if [ -n "$SHELL_RC" ]; then
+  if ! grep -q "direnv hook" "$SHELL_RC" 2>/dev/null; then
+    echo "" >> "$SHELL_RC"
+    echo "# Added by Terragon setup" >> "$SHELL_RC"
+    echo "$HOOK_CMD" >> "$SHELL_RC"
+    echo "direnv hook added to $SHELL_RC"
+  else
+    echo "direnv hook already exists in $SHELL_RC"
+  fi
+  
+  # Load direnv for current session
+  eval "$HOOK_CMD"
+fi
+
+# Run direnv allow if .envrc exists
+if [ -f ".envrc" ]; then
+  echo "Running direnv allow..."
+  direnv allow
+else
+  echo "No .envrc file found in current directory"
+fi
+
+echo ""
+echo "=== Setup Complete ==="
+echo "Please restart your shell or run: source $SHELL_RC"
+echo "Then navigate to your project directory and run: direnv allow"


### PR DESCRIPTION
## Summary
- Introduces a new setup script `terragon-setup.sh` for configuring the Terragon development environment
- Automates installation of Nix package manager using DeterminateSystems installer
- Installs and configures `direnv` for environment variable management
- Adds shell hooks for `direnv` based on the user's shell (bash, zsh, fish)
- Automatically runs `direnv allow` if a `.envrc` file is present in the current directory

## Changes

### terragon-setup.sh
- Checks if Nix is installed; installs it if missing
- Sources the Nix daemon environment for the current session
- Installs `direnv` via Nix if not already installed
- Detects the user's shell and adds the appropriate `direnv` hook to the shell configuration file
- Loads the `direnv` hook in the current session
- Runs `direnv allow` if `.envrc` exists in the current directory
- Provides user guidance to restart the shell or source the shell config file after setup

## Test plan
- [x] Run the script on a clean environment without Nix and verify Nix installation
- [x] Confirm `direnv` installation and shell hook addition
- [x] Verify that running the script again detects existing installations and skips redundant steps
- [x] Check that `direnv allow` runs successfully when `.envrc` is present
- [x] Validate shell hook is added only once and appropriate messages are displayed

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8ffe5b69-beaf-4154-a7e7-de7e05b478e9