### PR TITLE
Fix lint errors and update biome schema in livestore

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
   // WORKAROUND: Biome 2.1.x nested root configuration issue
   // Prevents "Found a nested root configuration" errors in parent repo
   // Related issues: 

--- a/packages/@livestore/livestore/src/reactive.ts
+++ b/packages/@livestore/livestore/src/reactive.ts
@@ -211,8 +211,10 @@ export class ReactiveGraph<
 
   private refreshCallbacks: Set<() => void> = new Set()
 
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Used by uniqueNodeId method
   private nodeIdCounter = 0
   private uniqueNodeId = () => `node-${++this.nodeIdCounter}`
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: Used by uniqueRefreshInfoId method
   private refreshInfoIdCounter = 0
   private uniqueRefreshInfoId = () => `refresh-info-${++this.refreshInfoIdCounter}`
 

--- a/packages/@livestore/sqlite-wasm/src/node/NodeFS.ts
+++ b/packages/@livestore/sqlite-wasm/src/node/NodeFS.ts
@@ -16,7 +16,6 @@ interface NodeFsFile {
 
 export class NodeFS extends FacadeVFS {
   private mapIdToFile = new Map<number, NodeFsFile>()
-  private lastError: Error | null = null
   private readonly directory: string
   constructor(name: string, sqlite3: WaSqlite.SQLiteAPI, directory: string) {
     super(name, sqlite3)


### PR DESCRIPTION
## Summary
- Updated biome schema version to 2.1.2 to fix nested root configuration issues
- Added biome-ignore comments to suppress lint warnings for unused private class members in ReactiveGraph
- Removed unused private field `lastError` from NodeFS class

## Changes

### Configuration
- Updated `biome.jsonc` schema URL from 2.1.0 to 2.1.2 to address Biome 2.1.x nested root configuration errors

### Reactive Module
- Added `biome-ignore` lint comments to `nodeIdCounter` and `refreshInfoIdCounter` private fields in `ReactiveGraph` class to prevent lint errors about unused private members

### SQLite WASM NodeFS Module
- Removed unused private field `lastError` from `NodeFS` class to clean up code and fix lint error

## Test plan
- Verified no lint errors related to unused private members in `ReactiveGraph` after adding ignore comments
- Confirmed no lint errors after removing unused `lastError` field in `NodeFS`
- Ensured Biome configuration schema update does not cause lint or configuration errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/09ea0f85-985b-42c1-a97a-47a55a338346