### PR TITLE
Modified the Solid.js integration to work through useQuery and useStore hooks

### DIFF
--- a/packages/@livestore/solid/src/LiveStoreContext.ts
+++ b/packages/@livestore/solid/src/LiveStoreContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "solid-js";
+import type { Store, LiveStoreSchema } from "@livestore/livestore";
+
+export type LiveStoreContextValue = {
+  store: Store<LiveStoreSchema>;
+};
+
+export const LiveStoreContext = createContext<LiveStoreContextValue>();
+
+export function useLiveStore(): Store<LiveStoreSchema> {
+  const context = useContext(LiveStoreContext);
+  if (!context) {
+    throw new Error("useLiveStore must be used within a <LiveStoreProvider>");
+  }
+  return context.store;
+}

--- a/packages/@livestore/solid/src/LiveStoreProvider.tsx
+++ b/packages/@livestore/solid/src/LiveStoreProvider.tsx
@@ -1,0 +1,199 @@
+import {
+  createSignal,
+  createEffect,
+  onCleanup,
+  Switch,
+  Match,
+  type JSX,
+  type ParentComponent,
+} from "solid-js";
+import {
+  type Store,
+  type CreateStoreOptions,
+  type LiveStoreSchema,
+  createStore,
+  makeShutdownDeferred,
+  StoreInterrupted,
+  type ShutdownDeferred,
+  type LiveStoreContext as StoreContext_,
+  type IntentionalShutdownCause,
+  type BootStatus,
+} from "@livestore/livestore";
+import {
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Logger,
+  LogLevel,
+  Scope,
+} from "@livestore/utils/effect";
+import { provideOtel } from "@livestore/common";
+import { LiveStoreContext } from "./LiveStoreContext.ts";
+
+type LiveStoreProviderProps = {
+  schema: LiveStoreSchema;
+  adapter: CreateStoreOptions<any>["adapter"];
+  storeId?: string;
+  loadingState?: (status: BootStatus) => JSX.Element;
+  errorState?: (error: unknown) => JSX.Element;
+  shutdownState?: (
+    cause: IntentionalShutdownCause | StoreInterrupted,
+  ) => JSX.Element;
+};
+
+export const LiveStoreProvider: ParentComponent<LiveStoreProviderProps> = (
+  props,
+) => {
+  const [contextValue, setContextValue] = createSignal<
+    StoreContext_ | BootStatus
+  >({
+    stage: "loading",
+  });
+
+  const lifecycle = {
+    shutdownDeferred: undefined as ShutdownDeferred | undefined,
+    componentScope: undefined as Scope.CloseableScope | undefined,
+    cancelEffect: () => {},
+  };
+
+  createEffect(() => {
+    const previousShutdownDeferred = lifecycle.shutdownDeferred;
+
+    const interrupt = (
+      scope: Scope.CloseableScope,
+      deferred: ShutdownDeferred,
+      reason: StoreInterrupted,
+    ) =>
+      Effect.gen(function* () {
+        yield* Scope.close(scope, Exit.fail(reason));
+        yield* Deferred.fail(deferred, reason);
+      }).pipe(Effect.runFork);
+
+    const lifecycleEffect = Effect.gen(function* () {
+      if (previousShutdownDeferred) {
+        yield* Effect.logDebug(
+          "A prop changed. Waiting for previous store to shut down...",
+        );
+        yield* Deferred.await(previousShutdownDeferred).pipe(Effect.exit);
+        yield* Effect.logDebug(
+          "Previous store shut down. Initializing new store.",
+        );
+      }
+
+      const componentScope = yield* Scope.make();
+      const shutdownDeferred = yield* makeShutdownDeferred;
+
+      lifecycle.componentScope = componentScope;
+      lifecycle.shutdownDeferred = shutdownDeferred;
+
+      yield* Effect.gen(function* () {
+        const store = yield* createStore({
+          schema: props.schema,
+          adapter: props.adapter,
+          storeId: props.storeId ?? "default",
+          onBootStatus: (status) => {
+            if (
+              contextValue().stage === "running" ||
+              contextValue().stage === "error"
+            )
+              return;
+            setContextValue(status);
+          },
+        }).pipe(
+          Effect.tapErrorCause((cause) =>
+            Deferred.failCause(shutdownDeferred, cause),
+          ),
+        );
+
+        setContextValue({ stage: "running", store });
+      }).pipe(Effect.forkIn(componentScope));
+
+      const shutdownContext = (
+        cause: IntentionalShutdownCause | StoreInterrupted,
+      ) => Effect.sync(() => setContextValue({ stage: "shutdown", cause }));
+
+      yield* Deferred.await(shutdownDeferred).pipe(
+        Effect.catchTag("LiveStore.IntentionalShutdownCause", (cause) =>
+          shutdownContext(cause),
+        ),
+        Effect.catchTag("LiveStore.StoreInterrupted", (cause) =>
+          shutdownContext(cause),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() => setContextValue({ stage: "error", error })),
+        ),
+        Effect.tapDefect((defect) =>
+          Effect.sync(() => setContextValue({ stage: "error", error: defect })),
+        ),
+        Effect.exit,
+      );
+    }).pipe(
+      Effect.scoped,
+      Effect.withSpan("@livestore/solid:LiveStoreProvider"),
+      provideOtel({}),
+      Effect.tapCauseLogPretty,
+      Logger.withMinimumLogLevel(LogLevel.Debug),
+    );
+
+    const cancelEffect = Effect.runCallback(lifecycleEffect);
+    lifecycle.cancelEffect = cancelEffect;
+
+    onCleanup(() => {
+      // Reset the UI to loading for the next run
+      setContextValue({ stage: "loading" });
+
+      if (lifecycle.componentScope && lifecycle.shutdownDeferred) {
+        interrupt(
+          lifecycle.componentScope,
+          lifecycle.shutdownDeferred,
+          new StoreInterrupted({
+            reason: "component unmounted or props changed",
+          }),
+        );
+      }
+
+      lifecycle.cancelEffect();
+    });
+  });
+
+  return (
+    <Switch>
+      <Match when={contextValue().stage === "loading"}>
+        {props.loadingState ? (
+          props.loadingState(contextValue() as BootStatus)
+        ) : (
+          <div>Loading Store...</div>
+        )}
+      </Match>
+
+      <Match when={contextValue().stage === "error"}>
+        {props.errorState ? (
+          props.errorState((contextValue() as { error: unknown }).error)
+        ) : (
+          <div>Error initializing store. Check the console.</div>
+        )}
+      </Match>
+
+      <Match when={contextValue().stage === "shutdown"}>
+        {props.shutdownState ? (
+          props.shutdownState(
+            (
+              contextValue() as {
+                cause: IntentionalShutdownCause | StoreInterrupted;
+              }
+            ).cause,
+          )
+        ) : (
+          <div>Store has been shut down.</div>
+        )}
+      </Match>
+
+      <Match when={contextValue().stage === "running"}>
+        <LiveStoreContext.Provider value={contextValue()}>
+          {props.children}
+        </LiveStoreContext.Provider>
+      </Match>
+    </Switch>
+  );
+};

--- a/packages/@livestore/solid/src/mod.ts
+++ b/packages/@livestore/solid/src/mod.ts
@@ -1,2 +1,7 @@
-export { query } from './query.ts'
-export { getStore } from './store.ts'
+// old funtions
+export { getStore } from "./store.ts";
+export { query } from "./query.ts";
+
+// new functions
+export { useStore } from "./useStore.ts";
+export { useQuery } from "./useQuery.ts";

--- a/packages/@livestore/solid/src/useQuery.ts
+++ b/packages/@livestore/solid/src/useQuery.ts
@@ -1,0 +1,103 @@
+import {
+  createStore,
+  reconcile,
+  type Store as SolidStore,
+} from "solid-js/store";
+import type { LiveQueries } from "@livestore/livestore/internal";
+import * as Solid from "solid-js";
+import { useLiveStore } from "./LiveStoreContext.ts";
+import { type LiveQuery, type Store } from "@livestore/livestore";
+
+type LiveQueryOptions = {
+  store?: Store;
+  primaryKey?: string;
+};
+
+const activeQueries = new Map<
+  string,
+  { store: SolidStore<any>; count: number; unsubscribe: () => void }
+>();
+
+/**
+ * A SolidJS hook for subscribing to a LiveQuery and receiving its results
+ * as a reactive Solid store.
+ *
+ * @param queryDef The LiveQuery definition object that specifies the data to fetch.
+ * @param [options={}] Optional configuration for the hook.
+ * @param [options.store] An explicit `livestore` instance to use. If not provided,
+ *   the hook will search for one in the SolidJS context.
+ * @param [options.primaryKey="id"] The name of the key that is unique across returned rows
+ *  (i.e. the primary key of the queried table), defaults to "id"
+ */
+export function useQuery<TQuery extends LiveQueries.LiveQueryDef.Any>(
+  queryDef: TQuery,
+  options: LiveQueryOptions = {}, // Default to empty options
+): SolidStore<LiveQueries.GetResult<TQuery>> {
+  const livestore = options.store ?? useLiveStore();
+  const key = options.primaryKey ?? "id";
+
+  if (!livestore) {
+    throw new Error(
+      "useLiveQuery: No store was provided via options, and no store was found in context. " +
+        "Make sure this hook is used inside a <LiveStoreProvider>.",
+    );
+  }
+
+  const queryKey = `${livestore.storeId}_${livestore.clientId}_${livestore.sessionId}_${queryDef.hash}`;
+
+  const existing = activeQueries.get(queryKey);
+  if (existing) {
+    existing.count++;
+    Solid.onCleanup(() => {
+      existing.count--;
+      if (existing.count === 0) {
+        existing.unsubscribe();
+        activeQueries.delete(queryKey);
+      }
+    });
+    return existing.store;
+  }
+
+  const query = queryDef.make(livestore.reactivityGraph.context!);
+  const query$ = query.value as LiveQuery<LiveQueries.GetResult<TQuery>>;
+  const getInitialResult = () => {
+    try {
+      return query$.run({});
+    } catch (cause: any) {
+      console.error("[@livestore/react:useQuery] Error running query", cause);
+      throw new Error(
+        `\
+  [@livestore/solid:useLiveQuery] Error running query: ${cause.name}
+
+  Query: ${query$.label}
+
+  Stack trace:
+  `,
+        { cause },
+      );
+    }
+  };
+
+  const [solidStore, setSolidStore] = createStore(getInitialResult());
+
+  const unsubscribe = livestore.subscribe(queryDef, {
+    onUpdate: (newResult: LiveQueries.GetResult<TQuery>) => {
+      if (newResult) {
+        setSolidStore(reconcile(newResult, { merge: true, key }));
+      }
+    },
+  });
+
+  const newQuery = { store: solidStore, count: 1, unsubscribe };
+  activeQueries.set(queryKey, newQuery);
+
+  Solid.onCleanup(() => {
+    newQuery.count--;
+    if (newQuery.count === 0) {
+      newQuery.unsubscribe();
+      activeQueries.delete(queryKey);
+    }
+  });
+
+  return solidStore;
+}

--- a/packages/@livestore/solid/src/useStore.ts
+++ b/packages/@livestore/solid/src/useStore.ts
@@ -1,0 +1,24 @@
+import type { LiveStoreSchema, Store } from "@livestore/livestore";
+import { useLiveStore } from "./LiveStoreContext.ts";
+
+/**
+ * A SolidJS function for accessing a Livestore instance.
+ *
+ * @param [options={}] Optional configuration for the hook.
+ * @param [options.store] An explicit `livestore` instance to use. If not provided,
+ *   the hook will search for one in the SolidJS context.
+ **/
+export function useStore(
+  options: { store?: Store } = {},
+): Store<LiveStoreSchema> {
+  const livestore = options.store ?? useLiveStore();
+
+  if (!livestore) {
+    throw new Error(
+      "useLiveQuery: No store was provided via options, and no store was found in context. " +
+        "Make sure this hook is used inside a <LiveStoreProvider>.",
+    );
+  } else {
+    return livestore;
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the functions `useQuery` and `useStore`, as well as the appropriate LiveStore context and provider code to update the Solid integration to match the existing React functionality. 

It switches to using Solid stores (with reconcile) instead of a coarse signal of the previous implementation. It also allows for using multiple stores instead of the singleton pattern enforced by the previous `getStore` function.

The Effect code to manage the store lifecycle within the provider is written with help from Gemini 2.5 Pro. The query caching in `useQuery` was adapted from the React version of useQuery.

Note: I will update the examples and docs in a future PR if these new methods prove acceptable.
