### PR TITLE
Add direnv hook configuration for automatic environment loading

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "hooks": {
+    "on-startup-hook": "[ -z \"$WORKSPACE_ROOT\" ] && [ -f .envrc ] && direnv allow || true",
+    "on-cwd-change-hook": "[ -z \"$WORKSPACE_ROOT\" ] && [ -f .envrc ] && direnv allow || true"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ _tmp*
 .output
 
 scripts/.completions
+
+# Claude directory - ignore everything except settings
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## Summary
- Add Claude Code hooks to automatically run `direnv allow` when WORKSPACE_ROOT is not set
- Configure gitignore to track .claude/settings.json while ignoring other Claude files
- Hooks run on startup and directory changes to ensure environment variables are loaded

## Test plan
- [ ] Verify hooks trigger when Claude Code starts in a directory without WORKSPACE_ROOT set
- [ ] Confirm .claude/settings.json is tracked while other Claude files are ignored
- [ ] Test that direnv allow runs automatically when needed

🤖 Generated with [Claude Code](https://claude.ai/code)