### PR TITLE
Add project-specific Claude configuration for direnv tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,5 @@
 {
-  "hooks": {}
+  "hooks": {
+    "on-startup-hook": "[ -z \"$WORKSPACE_ROOT\" ] && [ -f .envrc ] && direnv allow || true"
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Project-Specific Instructions for Claude
+
+## Tooling
+
+- When tools are not directly available in `$PATH`, prefix commands with `direnv exec .` (e.g. `direnv exec . tsc`, `direnv exec . biome check`)


### PR DESCRIPTION
## Summary
- Added CLAUDE.md with instructions to use 'direnv exec .' prefix for commands when tools are not directly available in PATH
- Added on-startup-hook to automatically run 'direnv allow' when workspace doesn't have WORKSPACE_ROOT set
- This ensures proper access to project tools through direnv environment

## Test plan
- Verify that the CLAUDE.md file is properly formatted
- Confirm that Claude can now use direnv-prefixed commands when needed
- Test that the on-startup-hook works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)