### PR TITLE
Add --clean flag to mono ts command

### DIFF
--- a/scripts/mono.ts
+++ b/scripts/mono.ts
@@ -218,8 +218,19 @@ const tsCommand = Cli.Command.make(
   'ts',
   {
     watch: Cli.Options.boolean('watch').pipe(Cli.Options.withDefault(false)),
+    clean: Cli.Options.boolean('clean').pipe(
+      Cli.Options.withDefault(false),
+      Cli.Options.withDescription('Clean build artifacts before compilation'),
+    ),
   },
-  Effect.fn(function* ({ watch }) {
+  Effect.fn(function* ({ watch, clean }) {
+    if (clean) {
+      yield* cmd(
+        'find {examples,packages,tests,docs} -path "*node_modules*" -prune -o \\( -name "dist" -type d -o -name "*.tsbuildinfo" \\) -exec rm -rf {} +',
+        { cwd, shell: true },
+      )
+    }
+
     if (watch) {
       yield* cmd('tsc --build tsconfig.dev.json --watch', { cwd })
     } else {


### PR DESCRIPTION
## Summary
- Adds a new `--clean` flag to the `mono ts` CLI command
- Removes build artifacts before TypeScript compilation when flag is used
- Cleans `dist` directories and `*.tsbuildinfo` files from `examples`, `packages`, `tests`, and `docs` directories
- Preserves `node_modules` directories during cleanup

## Test plan
- [ ] Test `mono ts --clean` removes build artifacts and compiles
- [ ] Test `mono ts --clean --watch` works in watch mode
- [ ] Verify existing `mono ts` and `mono ts --watch` behavior unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)