### PR TITLE
Prevent attempting to connect to otel if no backend is available

### DIFF
--- a/packages/@livestore/utils-dev/src/node/mod.ts
+++ b/packages/@livestore/utils-dev/src/node/mod.ts
@@ -3,7 +3,7 @@ import { performance } from 'node:perf_hooks'
 import * as OtelNodeSdk from '@effect/opentelemetry/NodeSdk'
 import { IS_BUN, isNonEmptyString, isNotUndefined, shouldNeverHappen } from '@livestore/utils'
 import type { CommandExecutor, PlatformError, Tracer } from '@livestore/utils/effect'
-import { Command, Config, Effect, identity, Layer, OtelTracer } from '@livestore/utils/effect'
+import { Command, Config, Effect, FetchHttpClient, FiberRef, HttpClient, HttpClientResponse, identity, Layer, LogLevel, OtelTracer } from '@livestore/utils/effect'
 import { OtelLiveDummy } from '@livestore/utils/node'
 import * as otel from '@opentelemetry/api'
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
@@ -50,6 +50,17 @@ export const OtelLiveHttp = ({
     }
 
     const config = configRes.value
+    const exporterUrl = `${config.exporterUrl}/v1/traces`
+
+    // Test the connection to the OpenTelemetry exporter to ensure the backend
+    // is available before setting up the corresponding layers
+    const isOtelAvailable = yield* Effect.isSuccess(HttpClient.options(config.exporterUrl))
+
+    // Return a dummy layer if the OpenTelemetry backend is unavailable
+    if (!isOtelAvailable) {
+      const RootSpanLive = Layer.span('DummyRoot', {})
+      return RootSpanLive.pipe(Layer.provide(OtelLiveDummy))
+    }
 
     const resource = { serviceName: config.serviceName }
 
@@ -62,10 +73,10 @@ export const OtelLiveHttp = ({
       resource,
       metricReader,
       spanProcessor: new BatchSpanProcessor(
-        new OTLPTraceExporter({ url: `${config.exporterUrl}/v1/traces`, headers: {} }),
+        new OTLPTraceExporter({ url: exporterUrl, headers: {} }),
         { scheduledDelayMillis: 50 },
       ),
-    }))
+    })).pipe(Layer.locally(FiberRef.currentMinimumLogLevel, LogLevel.None))
 
     const RootSpanLive = Layer.span(config.rootSpanName, {
       attributes: { config, ...rootSpanAttributes },
@@ -108,7 +119,10 @@ export const OtelLiveHttp = ({
     }
 
     return layer
-  }).pipe(Layer.unwrapScoped) as any
+  }).pipe(
+    Layer.unwrapScoped,
+    Layer.provide(FetchHttpClient.layer),
+  ) as any
 
 export const logTraceUiUrlForSpan = (printMsg?: (url: string) => string) => (span: otel.Span) =>
   getTracingBackendUrl(span).pipe(
@@ -152,10 +166,10 @@ export const cmd: (
   commandInput: string | (string | undefined)[],
   options?:
     | {
-        cwd?: string
-        shell?: boolean
-        env?: Record<string, string | undefined>
-      }
+      cwd?: string
+      shell?: boolean
+      env?: Record<string, string | undefined>
+    }
     | undefined,
 ) => Effect.Effect<CommandExecutor.ExitCode, PlatformError.PlatformError, CommandExecutor.CommandExecutor> = Effect.fn(
   'cmd',


### PR DESCRIPTION
## Summary

This PR ensures that the OTEL backend is available before attempting to connect, preventing `ECONNREFUSED` logs from leaking out of the layer constructor.

## Related issues

- #515
