### PR TITLE
Set up husky pre-commit hook for linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+direnv exec . mono lint --fix

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "build:clean": "bash -c \"find {examples,packages} -path '*node_modules*' -prune -o \\( -name 'dist' -type d -o -name '*.tsbuildinfo' \\) -exec rm -rf {} +\"",
     "build:ts": "tsc --build tsconfig.dev.json",
     "pack:tmp": "pnpm --filter '@livestore/*' exec -- pnpm pack --out tmp/pack.tgz",
+    "prepare": "husky",
     "test": "CI=1 pnpm --parallel run test",
     "test:perf": "pnpm --filter '@local/tests-perf' test",
-    "update-lockfile": "CI=1 pnpm install --lockfile-only",
-    "prepare": "husky"
+    "update-lockfile": "CI=1 pnpm install --lockfile-only"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@effect/language-service": "^0.29.0",
     "@types/node": "catalog:",
     "@vitest/ui": "catalog:",
+    "husky": "^9.1.7",
     "madge": "^8.0.0",
     "syncpack": "^13.0.4",
     "typescript": "^5.8.3",
@@ -52,6 +53,7 @@
     "pack:tmp": "pnpm --filter '@livestore/*' exec -- pnpm pack --out tmp/pack.tgz",
     "test": "CI=1 pnpm --parallel run test",
     "test:perf": "pnpm --filter '@local/tests-perf' test",
-    "update-lockfile": "CI=1 pnpm install --lockfile-only"
+    "update-lockfile": "CI=1 pnpm install --lockfile-only",
+    "prepare": "husky"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@vitest/ui':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@5.8.3)
@@ -8258,6 +8261,11 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   hyperlinker@1.0.0:
     resolution: {integrity: sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==}
@@ -21450,6 +21458,8 @@ snapshots:
   httpxy@0.1.7: {}
 
   human-signals@5.0.0: {}
+
+  husky@9.1.7: {}
 
   hyperlinker@1.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add husky as dev dependency to enable Git hooks
- Configure pre-commit hook to run `mono lint --fix` before commits
- Ensure code quality is maintained automatically across the codebase

## Test plan
- [x] Install husky and initialize Git hooks
- [x] Create pre-commit hook with proper direnv context
- [x] Verify mono lint command works correctly
- [x] Test pre-commit hook triggers on actual commits (verified during this commit)

🤖 Generated with [Claude Code](https://claude.ai/code)