### PR TITLE
chore: upgrade @livestore/wa-sqlite to 1.0.8-dev.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - chore: Update dependency management and Renovate configuration
 - chore: Clean up global type definitions and improve command debug output
 - chore: Update package.json exports structure and add workaround in biome.jsonc
+- chore: Update @livestore/wa-sqlite to version 1.0.8-dev.2
 - refactor: Update worker execution to use PlatformNode runtime
 - refactor: Restructure examples and make tsconfigs self-contained
 - refactor: Update Card component to improve accessibility

--- a/examples/web-linearlite/package.json
+++ b/examples/web-linearlite/package.json
@@ -9,7 +9,7 @@
     "@livestore/livestore": "0.3.2-dev.11",
     "@livestore/peer-deps": "0.3.2-dev.11",
     "@livestore/react": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@overengineering/fps-meter": "0.2.1",
     "@tailwindcss/forms": "0.5.10",
     "@tiptap/core": "3.0.7",

--- a/examples/web-todomvc-custom-elements/package.json
+++ b/examples/web-todomvc-custom-elements/package.json
@@ -7,7 +7,7 @@
     "@livestore/adapter-web": "0.3.2-dev.11",
     "@livestore/livestore": "0.3.2-dev.11",
     "@livestore/peer-deps": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "todomvc-app-css": "2.4.3"

--- a/examples/web-todomvc-experimental/package.json
+++ b/examples/web-todomvc-experimental/package.json
@@ -8,7 +8,7 @@
     "@livestore/livestore": "0.3.2-dev.11",
     "@livestore/peer-deps": "0.3.2-dev.11",
     "@livestore/react": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@overengineering/fps-meter": "0.2.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/examples/web-todomvc-solid/package.json
+++ b/examples/web-todomvc-solid/package.json
@@ -7,7 +7,7 @@
     "@livestore/livestore": "0.3.2-dev.11",
     "@livestore/peer-deps": "0.3.2-dev.11",
     "@livestore/solid": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "solid-js": "1.9.7",
     "todomvc-app-css": "2.4.3",
     "uuid": "11.1.0"

--- a/examples/web-todomvc-sync-cf/package.json
+++ b/examples/web-todomvc-sync-cf/package.json
@@ -9,7 +9,7 @@
     "@livestore/peer-deps": "0.3.2-dev.11",
     "@livestore/react": "0.3.2-dev.11",
     "@livestore/sync-cf": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@overengineering/fps-meter": "0.2.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/examples/web-todomvc-sync-electric/package.json
+++ b/examples/web-todomvc-sync-electric/package.json
@@ -10,7 +10,7 @@
     "@livestore/peer-deps": "0.3.2-dev.11",
     "@livestore/react": "0.3.2-dev.11",
     "@livestore/sync-electric": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@overengineering/fps-meter": "0.2.1",
     "@tanstack/react-start": "1.129.8",
     "react": "19.0.0",

--- a/examples/web-todomvc/package.json
+++ b/examples/web-todomvc/package.json
@@ -8,7 +8,7 @@
     "@livestore/livestore": "0.3.2-dev.11",
     "@livestore/peer-deps": "0.3.2-dev.11",
     "@livestore/react": "0.3.2-dev.11",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@overengineering/fps-meter": "0.2.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/packages/@livestore/sqlite-wasm/package.json
+++ b/packages/@livestore/sqlite-wasm/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@livestore/common": "workspace:*",
     "@livestore/utils": "workspace:*",
-    "@livestore/wa-sqlite": "1.0.5"
+    "@livestore/wa-sqlite": "1.0.8-dev.2"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.1",

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -5,7 +5,7 @@ export const EFFECT_VERSION = '3.17.2'
 export const REACT_VERSION = '19.0.0'
 export const MIN_NODE_VERSION = '23.0.0'
 
-export const LIVESTORE_WA_SQLITE_VERSION = '1.0.5'
+export const LIVESTORE_WA_SQLITE_VERSION = '1.0.8-dev.2'
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,8 +446,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/react
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@overengineering/fps-meter':
         specifier: 0.2.1
         version: 0.2.1(react@19.0.0)
@@ -588,8 +588,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/react
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@overengineering/fps-meter':
         specifier: 0.2.1
         version: 0.2.1(react@19.0.0)
@@ -634,8 +634,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/peer-deps
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -689,8 +689,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/react
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@overengineering/fps-meter':
         specifier: 0.2.1
         version: 0.2.1(react@19.0.0)
@@ -741,8 +741,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/solid
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       solid-js:
         specifier: 1.9.7
         version: 1.9.7
@@ -787,8 +787,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/sync-cf
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@overengineering/fps-meter':
         specifier: 0.2.1
         version: 0.2.1(react@19.0.0)
@@ -845,8 +845,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/sync-electric
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@overengineering/fps-meter':
         specifier: 0.2.1
         version: 0.2.1(react@19.0.0)
@@ -1267,8 +1267,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
     devDependencies:
       '@types/chrome':
         specifier: ^0.1.1
@@ -1489,8 +1489,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/utils-dev
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@local/shared':
         specifier: workspace:*
         version: link:../../packages/@local/shared
@@ -1590,8 +1590,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@livestore/utils-dev
       '@livestore/wa-sqlite':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.8-dev.2
+        version: 1.0.8-dev.2
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: 0.203.0
         version: 0.203.0(@opentelemetry/api@1.9.0)
@@ -2780,7 +2780,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.24.20':
     resolution: {integrity: sha512-uF1pOVcd+xizNtVTuZqNGzy7I6IJon5YMmQidsURds1Ww96AFDxrR/NEACqeATNAmY60m8wy1VZZpSg5zLNkpw==}
@@ -3360,8 +3360,8 @@ packages:
     peerDependencies:
       vite: ^7.0.6
 
-  '@livestore/wa-sqlite@1.0.5':
-    resolution: {integrity: sha512-OIxBEtl027kSl/z3772YgYf7ZlkE8aDWvLmm+O/hbPJO/lubv9+2EaDpXeoxsyg2xIIpkpXXSreEzFckkT1/QQ==}
+  '@livestore/wa-sqlite@1.0.8-dev.2':
+    resolution: {integrity: sha512-XwzW2sIyeXo0F9ZpG3Q2qx484fd8RYlxJygFqjWJ0aQazwJ8jIR8C3OV0kNIGp2HEgHFUSdPznxJQqQ9XbSIhQ==}
 
   '@mapbox/node-pre-gyp@2.0.0':
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
@@ -3560,7 +3560,6 @@ packages:
   '@oclif/screen@3.0.8':
     resolution: {integrity: sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==}
     engines: {node: '>=12.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oozcitak/dom@1.15.10':
     resolution: {integrity: sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==}
@@ -5928,7 +5927,6 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -8014,11 +8012,9 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
@@ -8338,7 +8334,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -9030,7 +9025,6 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -9687,7 +9681,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.6:
     resolution: {integrity: sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==}
@@ -10400,7 +10393,6 @@ packages:
 
   react-beautiful-dnd@13.1.1:
     resolution: {integrity: sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==}
-    deprecated: 'react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672'
     peerDependencies:
       react: ^16.8.5 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
@@ -10871,12 +10863,10 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@5.0.10:
@@ -11378,7 +11368,6 @@ packages:
 
   sudo-prompt@9.1.1:
     resolution: {integrity: sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
@@ -14882,7 +14871,7 @@ snapshots:
       '@livestore/utils': link:packages/@livestore/utils
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.8.0)
 
-  '@livestore/wa-sqlite@1.0.5': {}
+  '@livestore/wa-sqlite@1.0.8-dev.2': {}
 
   '@mapbox/node-pre-gyp@2.0.0':
     dependencies:

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -17,7 +17,7 @@
     "@livestore/sync-cf": "workspace:*",
     "@livestore/utils": "workspace:*",
     "@livestore/utils-dev": "workspace:*",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@local/shared": "workspace:*"
   },
   "devDependencies": {

--- a/tests/perf/package.json
+++ b/tests/perf/package.json
@@ -8,7 +8,7 @@
     "@livestore/react": "workspace:*",
     "@livestore/utils": "workspace:*",
     "@livestore/utils-dev": "workspace:*",
-    "@livestore/wa-sqlite": "1.0.5",
+    "@livestore/wa-sqlite": "1.0.8-dev.2",
     "@opentelemetry/exporter-trace-otlp-http": "0.203.0",
     "@opentelemetry/resources": "2.0.1",
     "@opentelemetry/sdk-trace-base": "2.0.1",


### PR DESCRIPTION
## Summary

- Update @livestore/wa-sqlite from 1.0.5 to 1.0.8-dev.2 across all packages
- Update version constant in CONSTANTS.ts
- Update pnpm lockfile with the new dependency version
- Add changelog entry to document the upgrade

## Test plan

- [x] TypeScript build passes (`mono ts`)
- [x] Linting passes (`mono lint`)
- [x] Pre-commit hooks passed during commit
- [x] All dependency validation checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)