### PR TITLE
Fix the livestore.worker.ts path in guides

### DIFF
--- a/docs/src/content/docs/getting-started/react-web.mdx
+++ b/docs/src/content/docs/getting-started/react-web.mdx
@@ -140,9 +140,9 @@ Here's an example schema:
 
 ## Create the LiveStore Worker
 
-Create a file named `livestore.worker.ts` inside the `src/livestore` folder. This file will contain the LiveStore web worker. When importing this file, make sure to add the `?worker` extension to the import path to ensure that Vite treats it as a worker file.
+Create a file named `livestore.worker.ts` inside the `src` folder. This file will contain the LiveStore web worker. When importing this file, make sure to add the `?worker` extension to the import path to ensure that Vite treats it as a worker file.
 
-<Code code={CODE.worker} lang="ts" title="src/livestore/livestore.worker.ts" />
+<Code code={CODE.worker} lang="ts" title="src/livestore.worker.ts" />
 
 ## Add the LiveStore Provider
 


### PR DESCRIPTION
Currently in the "Getting Started" guide for "React Web", the instructions tell you to create the `livestore.worker.ts` file into `src/livestore` directory, but the example files referenced in next steps have the `livestore.worker.ts` file in `src` directory instead.

Not sure which is the preferred location, but since it was easier to fix the "Getting Started" page instructions than the actual source code for the examples, I kept the `src` directory approach.

<img width="755" height="285" alt="Screenshot 2025-07-31 at 21 02 39" src="https://github.com/user-attachments/assets/f51140f9-91d3-4e74-bc3a-7eac435d6cbc" />
<img width="552" height="146" alt="Screenshot 2025-07-31 at 21 02 20" src="https://github.com/user-attachments/assets/e3899a77-d909-434c-94e1-cde191587735" />
