### PR TITLE
chore(nix): add comment about flake.nix location

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -21,14 +21,16 @@ export VITE_GRAFANA_ENDPOINT="${GRAFANA_ENDPOINT}"
 export COREPACK_INTEGRITY_KEYS=0
 
 if test -f ./.envrc.local; then
-    source_env ./.envrc.local
+  source_env ./.envrc.local
 fi
 
 if command -v nix-shell &> /dev/null
 then
-    cd nix
-    use_flake
-    cd ..
+  # flake.nix is in nix/ to speed up Nix flake evaluation by limiting files hashed/copied to the Nix Store (self.outPath).
+  # Trade-off: Requires path spec (e.g., nix develop ./nix; this script handles it via direnv's 'use flake'.)
+  cd nix
+  use_flake
+  cd ..
 fi
 
 # Add LiveStore CLIs to PATH


### PR DESCRIPTION
## Summary
- Added a comment to .envrc explaining that flake.nix is located in the nix/ directory to speed up Nix flake evaluation

## Details
The comment clarifies the trade-off:
- **Benefit**: Limiting files hashed/copied to the Nix Store (self.outPath) speeds up evaluation
- **Trade-off**: Requires path specification (e.g., `nix develop ./nix`) which this script handles via direnv's `use flake`

🤖 Generated with [Claude Code](https://claude.ai/code)