### PR TITLE
docs: add comprehensive Effect Atom integration documentation

### DIFF
--- a/docs/src/content/docs/patterns/effect.md
+++ b/docs/src/content/docs/patterns/effect.md
@@ -250,4 +250,13 @@ export const bulkUpdateAtom = runtimeAtom.fn<string[]>()(
 4. **Batch React updates**: Always provide `batchUpdates` for better performance
 5. **Label queries**: Add descriptive labels to queries for better debugging
 6. **Type safety**: Let TypeScript infer types from schemas rather than manual annotations
+
+### Real-World Example
+
+For a comprehensive example of LiveStore with Effect Atom in action, check out [Cheffect](https://github.com/tim-smart/cheffect) - a recipe management application that demonstrates:
+- Complete Effect service integration
+- AI-powered recipe extraction using Effect services
+- Complex query patterns with search and filtering
+- Worker-based persistence with OPFS
+- Production-ready error handling and logging
 ```

--- a/docs/src/content/docs/patterns/effect.md
+++ b/docs/src/content/docs/patterns/effect.md
@@ -33,12 +33,12 @@ LiveStore's reactive primitives (`LiveQueryDef` and `SignalDef`) implement Effec
 
 LiveStore integrates seamlessly with [Effect Atom](https://github.com/effect-atom/effect-atom) for reactive state management in React applications. This provides a powerful combination of Effect's functional programming capabilities with LiveStore's event sourcing and CQRS patterns.
 
-Effect Atom is an external package developed by [Tim Smart](https://github.com/tim-smart) (not by the LiveStore team) that provides a more Effect-idiomatic alternative to the `@livestore/react` package. While `@livestore/react` offers a straightforward React integration, Effect Atom leverages Effect's functional programming patterns throughout, making it a natural choice for applications already using Effect.
+Effect Atom is an external package developed by [Tim Smart](https://github.com/tim-smart) that provides a more Effect-idiomatic alternative to the `@livestore/react` package. While `@livestore/react` offers a straightforward React integration, Effect Atom leverages Effect API/patterns throughout, making it a natural choice for applications already using Effect.
 
 ### Installation
 
 ```bash
-npm install @effect-atom/atom-livestore @effect-atom/atom-react
+pnpm install @effect-atom/atom-livestore @effect-atom/atom-react
 ```
 
 ### Store Creation
@@ -46,6 +46,7 @@ npm install @effect-atom/atom-livestore @effect-atom/atom-react
 Create a LiveStore-backed atom store with persistence and worker support:
 
 ```ts
+// atoms.ts
 import { schema } from './schema'
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import { AtomLivestore } from '@effect-atom/atom-livestore'


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for using LiveStore with Effect Atom
- Document store creation, query atoms, and React component usage patterns
- Include advanced patterns and best practices

## Details
This PR extends the Effect documentation page to include detailed guidance on using LiveStore with Effect Atom, an external package by [Tim Smart](https://github.com/tim-smart) that provides a more Effect-idiomatic alternative to `@livestore/react`.

The documentation covers:
- Store creation with persistence and worker support
- Defining and using query atoms
- React component integration with hooks
- Integrating Effect services with LiveStore operations
- Advanced patterns (optimistic updates, derived state, batch operations)
- Best practices for type safety and performance

Based on real-world examples from the [cheffect](https://github.com/tim-smart/cheffect) repository.

## Test plan
- [x] Documentation builds successfully
- [x] All code examples are syntactically correct
- [x] Links to external resources are valid

🤖 Generated with [Claude Code](https://claude.ai/code)