### PR TITLE
fix(ci): increase pnpm fetch retries to handle snapshot version propagation delays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,11 @@ jobs:
         # `github.sha` refers to a temporary commit SHA that can become inaccessible in some contexts.
         # See https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/
         run: pnpm dlx tiged github:${{ github.repository }}/${{ env.APP_PATH }}#${{ github.ref_name }} ${{ runner.temp }}/${{ env.APP_PATH }}
+      - name: Increase pnpm fetch retries
+        # Sometimes the snapshot version is not available immediately after publishing due to network propagation delays.
+        # We increase the fetch retries to mitigate this issue.
+        # See https://pnpm.io/settings#fetchretries
+        run: pnpm config set fetchRetries 3
       - name: Use snapshot version of workspace dependencies
         working-directory: ${{ runner.temp }}/${{ env.APP_PATH }}
         run: |


### PR DESCRIPTION
## Summary
- Increase pnpm `fetchRetries` to 3 (from 2) to handle [intermittent failures when snapshot versions are not immediately available after publishing](https://github.com/livestorejs/livestore/actions/runs/16861541788/job/47762673947?pr=549)
- This addresses network propagation delays that can cause CI failures

## Test plan
- [x] Verify CI passes with the new configuration
- [ ] Monitor for reduced intermittent failures in future runs

🤖 Generated with [Claude Code](https://claude.ai/code)