### PR TITLE
pass through event with clientId to materializers

### DIFF
--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -63,6 +63,7 @@ export const getExecStatementsFromMaterializer = ({
       query,
       // TODO properly implement this
       currentFacts: new Map(),
+      event: event.decoded ?? event.encoded!,
     }),
   )
 

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -1,4 +1,4 @@
-import { isDevEnv, isReadonlyArray } from '@livestore/utils'
+import { isDevEnv, isNil, isReadonlyArray } from '@livestore/utils'
 import { Hash, Option, Schema } from '@livestore/utils/effect'
 
 import type { SqliteDb } from './adapter-types.ts'
@@ -39,8 +39,9 @@ export const getExecStatementsFromMaterializer = ({
         }
       : event.decoded
 
-  const eventArgsEncoded =
-    event.decoded === undefined ? event.encoded!.args : Schema.encodeUnknownSync(eventDef.schema)(event.decoded.args)
+  const eventArgsEncoded = isNil(event.decoded?.args)
+    ? undefined
+    : Schema.encodeUnknownSync(eventDef.schema)(event.decoded!.args)
 
   const query: MaterializerContextQuery = (
     rawQueryOrQueryBuilder:

--- a/packages/@livestore/common/src/schema/EventDef.ts
+++ b/packages/@livestore/common/src/schema/EventDef.ts
@@ -193,7 +193,7 @@ export type Materializer<TEventDef extends EventDef.AnyWithoutFn = EventDef.AnyW
     /** Can be used to query the current state */
     query: MaterializerContextQuery
     /** The full LiveStore event with clientId, sessionId, etc. */
-    event: LiveStoreEvent.AnyDecoded | LiveStoreEvent.AnyEncoded
+    event: LiveStoreEvent.AnyDecoded
   },
 ) => SingleOrReadonlyArray<MaterializerResult>
 

--- a/packages/@livestore/common/src/schema/EventDef.ts
+++ b/packages/@livestore/common/src/schema/EventDef.ts
@@ -4,6 +4,7 @@ import { Schema } from '@livestore/utils/effect'
 
 import type { BindValues } from '../sql-queries/sql-queries.ts'
 import type { ParamsObject } from '../util.ts'
+import type * as LiveStoreEvent from './LiveStoreEvent.ts'
 import type { QueryBuilder } from './state/sqlite/query-builder/mod.ts'
 
 export type EventDefMap = {
@@ -191,6 +192,8 @@ export type Materializer<TEventDef extends EventDef.AnyWithoutFn = EventDef.AnyW
     eventDef: TEventDef
     /** Can be used to query the current state */
     query: MaterializerContextQuery
+    /** The full LiveStore event with clientId, sessionId, etc. */
+    event: LiveStoreEvent.AnyDecoded | LiveStoreEvent.AnyEncoded
   },
 ) => SingleOrReadonlyArray<MaterializerResult>
 

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
@@ -50,6 +50,7 @@ describe('client document table', () => {
         currentFacts: new Map(),
         query: {} as any, // unused
         eventDef: Doc[ClientDocumentTableDefSymbol].derived.setEventDef,
+        event: {} as any, // unused in this test
       })
     }
 


### PR DESCRIPTION
## Summary

This passes through the full event as recommended in https://github.com/livestorejs/livestore/pull/485#discussion_r2233889459

```typescript
import { Events, makeSchema, Schema, State } from '@livestore/common/schema'

const events = {
  messageCreated: Events.synced({
    name: 'messageCreated',
    schema: Schema.Struct({
      id: Schema.String,
      content: Schema.String,
    }),
  }),
}

const messages = State.SQLite.table({
  name: 'messages',
  columns: {
    id: State.SQLite.text({ primaryKey: true }),
    content: State.SQLite.text(),
    createdBy: State.SQLite.text(), // Store the clientId here
  },
})

const materializers = State.SQLite.materializers(events, {
  messageCreated: ({ id, content }, context) => {

    const clientId = context.event.clientId;

    return messages.insert({
      id,
      content,
      createdBy: clientId,
    })
  },
})
```