### PR TITLE
Fix wa-sqlite test setup by removing problematic IIFE

### DIFF
--- a/tests/wa-sqlite/test/setup/database-setup.ts
+++ b/tests/wa-sqlite/test/setup/database-setup.ts
@@ -184,17 +184,6 @@ async function generateLargeTestDatabase(): Promise<void> {
     throw error
   }
 }
-// This runs as a Vitest setup file
-;(async () => {
-  try {
-    await ensureDirectoryExists(FIXTURES_DIR)
-    await generateLargeTestDatabase()
-  } catch (error) {
-    console.error('Setup failed:', error)
-    process.exit(1)
-  }
-})()
-
 export default async function setupDatabase() {
   await ensureDirectoryExists(FIXTURES_DIR)
   await generateLargeTestDatabase()


### PR DESCRIPTION
## Summary

Fixes CI failures in wa-sqlite tests by removing a problematic immediately invoked function expression (IIFE) from the database setup file.

## Problem

The `tests/wa-sqlite/test/setup/database-setup.ts` file contained an IIFE that:
- Executed immediately when the module was loaded
- Called `process.exit(1)` on errors, which terminated the test runner prematurely
- Interfered with Vitest's proper error handling mechanism

This caused CI tests to fail with assertion errors because the test runner was being terminated before tests could complete properly.

## Solution

- Removed the IIFE (lines 187-196) that was causing the issue
- Kept the exported `setupDatabase()` function which Vitest calls correctly as a setup file
- The setup functionality remains identical, but now works properly within Vitest's lifecycle

## Test Plan

- [x] Verified only one setup file had this issue (checked all vitest configs)
- [x] Confirmed other setup files use proper vitest hooks (`beforeAll`/`afterAll`)
- [x] The fix allows proper error handling without terminating the test runner

🤖 Generated with [Claude Code](https://claude.ai/code)