### PR TITLE
Fix query builder method order to preserve where clauses

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
@@ -219,21 +219,27 @@ export const makeQueryBuilder = <TResult, TTableDef extends TableDefBase>(
     update: (values) => {
       const filteredValues = Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined))
 
+      // Preserve where clauses if coming from a SelectQuery
+      const whereClause = ast._tag === 'SelectQuery' ? ast.where : []
+
       return makeQueryBuilder(tableDef, {
         _tag: 'UpdateQuery',
         tableDef,
         values: filteredValues,
-        where: [],
+        where: whereClause,
         returning: undefined,
         resultSchema: Schema.Void,
       }) as any
     },
 
     delete: () => {
+      // Preserve where clauses if coming from a SelectQuery
+      const whereClause = ast._tag === 'SelectQuery' ? ast.where : []
+
       return makeQueryBuilder(tableDef, {
         _tag: 'DeleteQuery',
         tableDef,
-        where: [],
+        where: whereClause,
         returning: undefined,
         resultSchema: Schema.Void,
       }) as any


### PR DESCRIPTION
## Summary
- Fixed query builder to preserve where clauses when chaining methods in any order
- Both `.where().delete()` and `.delete().where()` now produce identical SQL
- Both `.where().update()` and `.update().where()` now produce identical SQL

## Problem
Previously, calling `.where().delete()` or `.where().update()` would lose the where clauses because these methods created brand new ASTs with empty where arrays.

```typescript
// This didn't work correctly (would delete ALL rows\!)
tables.reactions.where({ id: '123' }).delete()

// Only this pattern worked
tables.reactions.delete().where({ id: '123' })
```

## Solution
Modified the `delete()` and `update()` methods to preserve existing where clauses when transitioning from a SelectQuery AST.

## Changes
- Updated `delete()` method to check for and preserve where clauses from SelectQuery AST
- Updated `update()` method to check for and preserve where clauses from SelectQuery AST
- Added comprehensive tests verifying both patterns produce identical SQL
- Added tests for chaining multiple where clauses

## Test Results
All tests pass, confirming:
- ✅ Single where clause preservation
- ✅ Multiple where clause preservation
- ✅ Equivalence between both method orders
- ✅ TypeScript compilation successful
- ✅ Linting passed

## Impact
- **Backward Compatible**: Existing code continues to work unchanged
- **Developer Experience**: More intuitive API - method chaining order no longer matters
- **Safety**: Prevents accidental data loss from missing where clauses

🤖 Generated with [Claude Code](https://claude.ai/code)