### PR TITLE
fix: use correct bun install command in example apps

### DIFF
--- a/examples/web-todomvc-custom-elements/README.md
+++ b/examples/web-todomvc-custom-elements/README.md
@@ -5,6 +5,6 @@ See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 ## Running locally
 
 ```bash
-bun
+bun install
 bun dev
 ```

--- a/examples/web-todomvc-experimental/README.md
+++ b/examples/web-todomvc-experimental/README.md
@@ -5,6 +5,6 @@ See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 ## Running locally
 
 ```bash
-bun
+bun install
 bun dev
 ```

--- a/examples/web-todomvc-sync-cf/README.md
+++ b/examples/web-todomvc-sync-cf/README.md
@@ -5,6 +5,6 @@
 ## Running locally
 
 ```bash
-bun
+bun install
 bun dev
 ```

--- a/examples/web-todomvc-sync-electric/README.md
+++ b/examples/web-todomvc-sync-electric/README.md
@@ -7,7 +7,7 @@ See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 Note you'll also need to run the Electric server locally for the app to work (see below).
 
 ```bash
-bun
+bun install
 bun dev
 ```
 


### PR DESCRIPTION
## Summary

Update the README in the example apps and suggest running `bun install` (which installs the dependencies)  instead of `bun` (which shows the usage).

## How to test

```
$ bunx tiged github:livestorejs/livestore/examples/standalone/web-todomvc-sync-cf#main livestore-app
> cloned livestorejs/livestore#main to livestore-app
$ cd livestore-app
$ bun
Bun is a fast JavaScript runtime, package manager, bundler, and test runner. (1.2.21+7c45ed97d)
Usage: bun <command> [...flags] [...args]
<snip>
$ bun install
bun install v1.2.21 (7c45ed97)
<snip>
185 packages installed [1.69s]
```