### PR TITLE
fix: use proper git reference in build-example-tiged workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,10 +246,10 @@ jobs:
             jq -r '.[0].dependencies | keys | join(" ")' \
           )" >> $GITHUB_ENV
       - name: Copy example app
-        # We use `github.ref_name` instead of `github.sha` because, when a workflow is triggered by a pull request,
-        # `github.sha` refers to a temporary commit SHA that can become inaccessible in some contexts.
+        # We use the PR head SHA (or push SHA) to ensure tiged can fetch the exact commit.
+        # In PR context, github.ref_name would be "123/merge" which isn't a valid git reference.
         # See https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/
-        run: pnpm dlx tiged github:${{ github.repository }}/${{ env.APP_PATH }}#${{ github.ref_name }} ${{ runner.temp }}/${{ env.APP_PATH }}
+        run: bunx tiged github:${{ github.repository }}/${{ env.APP_PATH }}#${{ github.event.pull_request.head.sha || github.sha }} ${{ runner.temp }}/${{ env.APP_PATH }}
       - name: Increase pnpm fetch retries
         # Sometimes the snapshot version is not available immediately after publishing due to network propagation delays.
         # We increase the fetch retries to mitigate this issue.


### PR DESCRIPTION
## Summary
- Fix CI failure in `build-example-tiged` workflow caused by invalid git reference
- Replace `pnpm dlx` with `bunx` for consistency

## Problem
The workflow was using `github.ref_name` which evaluates to `"123/merge"` in PR contexts - an invalid git reference that `tiged` cannot fetch from the repository. This caused the workflow to consistently fail on pull requests.

**Example failing CI run:** https://github.com/livestorejs/livestore/actions/runs/17386194093/job/49353595476#step:5:2

The specific error occurred in the "Copy example app" step where `tiged` could not fetch the repository using the invalid reference.

## Solution
- Use `github.event.pull_request.head.sha || github.sha` to provide the actual commit SHA that `tiged` can successfully fetch
- Replace `pnpm dlx` with `bunx` for consistency with project tooling preferences
- Update comment to accurately explain the approach

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Confirm `build-example-tiged` job completes without errors
- [ ] Test that both PR and push contexts work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)