### PR TITLE
chore: add GitHub issue templates to improve issue quality

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,36 +47,12 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
+  - type: input
     id: package
     attributes:
       label: Which package(s) are affected?
-      description: Select all that apply
-      options:
-        - label: "**Core**"
-        - label: "@livestore/livestore"
-        - label: "@livestore/common"
-        - label: "@livestore/react"
-        - label: "@livestore/solid"
-        - label: "**Adapters**"
-        - label: "@livestore/adapter-cloudflare"
-        - label: "@livestore/adapter-expo"
-        - label: "@livestore/adapter-node"
-        - label: "@livestore/adapter-web"
-        - label: "**Sync Providers**"
-        - label: "@livestore/sync-cf"
-        - label: "@livestore/sync-electric"
-        - label: "**Other Packages**"
-        - label: "@livestore/cli"
-        - label: "@livestore/common-cf"
-        - label: "@livestore/devtools-expo"
-        - label: "@livestore/devtools-web-common"
-        - label: "@livestore/graphql"
-        - label: "@livestore/sqlite-wasm"
-        - label: "@livestore/utils"
-        - label: "@livestore/wa-sqlite"
-        - label: "@livestore/webmesh"
-        - label: "Other (specify in description)"
+      description: List the affected packages (e.g., @livestore/react, @livestore/adapter-web)
+      placeholder: e.g., @livestore/react, @livestore/adapter-web
 
   - type: textarea
     id: environment

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -50,38 +50,12 @@ body:
         - Are there existing workarounds?
         - What are the trade-offs of different approaches?
 
-  - type: checkboxes
+  - type: input
     id: package
     attributes:
       label: Which package(s) would this affect?
-      description: Select all that apply
-      options:
-        - label: "**Core**"
-        - label: "@livestore/livestore"
-        - label: "@livestore/common"
-        - label: "@livestore/react"
-        - label: "@livestore/solid"
-        - label: "**Adapters**"
-        - label: "@livestore/adapter-cloudflare"
-        - label: "@livestore/adapter-expo"
-        - label: "@livestore/adapter-node"
-        - label: "@livestore/adapter-web"
-        - label: "**Sync Providers**"
-        - label: "@livestore/sync-cf"
-        - label: "@livestore/sync-electric"
-        - label: "**Other Packages**"
-        - label: "@livestore/cli"
-        - label: "@livestore/common-cf"
-        - label: "@livestore/devtools-expo"
-        - label: "@livestore/devtools-web-common"
-        - label: "@livestore/graphql"
-        - label: "@livestore/sqlite-wasm"
-        - label: "@livestore/utils"
-        - label: "@livestore/wa-sqlite"
-        - label: "@livestore/webmesh"
-        - label: "New package"
-        - label: "Documentation"
-        - label: "Other (specify in description)"
+      description: List the affected packages, or specify "New package" or "Documentation"
+      placeholder: e.g., @livestore/react, @livestore/adapter-web, or "New package"
 
   - type: dropdown
     id: priority


### PR DESCRIPTION
## Summary
- Add structured bug report form with mandatory minimal reproduction
- Add feature request template with problem/solution structure  
- Add simplified config.yml to redirect questions to discussions/Discord
- Use simple text input for package selection
- Disable blank issues to ensure all issues use templates

## Problem
We're getting low-quality issues that lack context and don't provide actionable information for maintainers.

## Solution
- **Bug reports** now require minimal reproduction (StackBlitz/CodeSandbox/repo link)
- **Feature requests** structured with problem/solution format
- **Questions** automatically redirected to GitHub Discussions and Discord
- **Package selection** uses simple text input for flexibility
- **Blank issues** disabled to force template usage
- **Simplified contact links** with three main channels: Discussions, Docs, Discord

This should significantly improve issue quality and reduce maintenance overhead while directing questions to appropriate channels.

🤖 Generated with [Claude Code](https://claude.ai/code)