### PR TITLE
ci(node-sync): debug CI-only failure with env overrides + extra diagnostics

### DIFF
--- a/debug/CLEANUP.md
+++ b/debug/CLEANUP.md
@@ -1,0 +1,16 @@
+Cleanup checklist (post-investigation)
+
+Code flags and debug-only changes
+- tests/integration/src/tests/node-sync/node-sync.test.ts
+  - Remove or document `NODE_SYNC_DEBUG` env override block.
+- packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+  - Remove extra ServerAheadError diagnostics if too verbose.
+- packages/@livestore/sync-cf/src/cf-worker/durable-object.ts
+  - Remove extra mismatch diagnostics if not needed.
+
+CI/workflows
+- Ensure no new workflow files were added.
+
+Docs
+- Consolidate hypothesis docs into a summary; keep or remove `debug/` folder as appropriate.
+

--- a/debug/HYPOTHESES.md
+++ b/debug/HYPOTHESES.md
@@ -1,0 +1,23 @@
+Investigation: CI-only failure in node-sync integration tests
+
+Owner: Codex CLI agent
+
+Status
+- Active hypotheses are tracked in per-file docs under `debug/hypotheses/`.
+- Test loop uses env-driven overrides to keep CI iterations fast.
+
+Index
+- H001: ServerAheadError push/pull deadlock
+- H002: Wrangler dev/inspector and orphaned processes
+- H003: Resource limits (ulimit/memory/CPU)
+- H004: Logger RPC port collision
+- H005: Version drift (wrangler/workerd/node/bun)
+
+Quick Repro (CI-like)
+- CI mode, 1 run, default debug params:
+  CI=1 DEBUGGER_ACTIVE=0 NODE_SYNC_DEBUG=1 mono test integration node-sync
+
+Where to look
+- Node-sync logs: `tests/integration/tmp/logs/*.log` (uploaded as CI artifact)
+- CI job env summary in `.github/workflows/ci.yml` > Debug environment info
+

--- a/debug/hypotheses/hypothesis-001-serverahead-deadlock.md
+++ b/debug/hypotheses/hypothesis-001-serverahead-deadlock.md
@@ -1,0 +1,30 @@
+Hypothesis H001: ServerAheadError push/pull deadlock
+
+Statement
+- The leader thread’s background pushing fiber returns `Effect.never` on parent/head mismatch and expects pulling to interrupt/restart it. If pulling only advances (no rebase), pushing may never resume, causing a hang in CI.
+
+Why likely
+- CI or CI-like local runs can show repeated parent/head mismatch with static `minimumExpectedNum` and slowly increasing `providedNum`, suggesting a mismatch loop.
+- Pushing path explicitly returns `Effect.never` on error and relies on restart; pulling may not always trigger it on advance.
+
+Signals to collect
+- Frequency and pattern of parent/head mismatch in DO logs.
+- Whether pulling reports rebase vs advance around the time of error.
+- Whether pushing restarts after advance events.
+
+Reproduction
+- Local CI-like run:
+  CI=1 DEBUGGER_ACTIVE=0 NODE_SYNC_DEBUG=1 mono test integration node-sync
+- Stress case:
+  CI=1 DEBUGGER_ACTIVE=0 NODE_SYNC_DEBUG=1 NODE_SYNC_TODO_A=300 NODE_SYNC_TODO_B=300 NODE_SYNC_COMMIT_BATCH_SIZE=10 NODE_SYNC_LEADER_PUSH_BATCH_SIZE=100 mono test integration node-sync
+
+Acceptance criteria (to confirm/falsify)
+- Confirmed if CI logs show pushing stuck while pulling advances without rebase.
+- Falsified if pushing reliably restarts after advance or if hangs occur with zero mismatch logs.
+
+Minimal fix (gated experiment)
+- Provide a way to resume pushing on `advance` (not only on `rebase`). Keep behind an env flag for A/B validation.
+
+Cleanup plan
+- Remove experimental flag and verbose logs after root cause is fixed.
+

--- a/debug/hypotheses/hypothesis-002-wrangler-inspector-orphans.md
+++ b/debug/hypotheses/hypothesis-002-wrangler-inspector-orphans.md
@@ -1,0 +1,16 @@
+Hypothesis H002: Wrangler inspector / orphaned processes cause CI stalls
+
+Statement
+- Wrangler dev server or workerd subprocesses (or inspector port) behave differently in CI, leaving orphaned processes or blocked readiness that stalls the test.
+
+Signals to collect
+- Process snapshots before/after tests (`ps -eo pid,ppid,cmd | egrep "wrangler|workerd|vitest|bunx"`).
+- Wrangler stdout readiness lines and any EPIPE issues.
+
+Acceptance criteria
+- Confirmed if wrangler readiness fails or zombie processes persist after tests correlating with the hang.
+- Falsified if wrangler readiness is timely and processes are cleaned up while hang still occurs.
+
+Remediation
+- Increase startup timeout; ensure stdout drain coverage; add post-test cleanup.
+

--- a/debug/hypotheses/hypothesis-003-resource-limits.md
+++ b/debug/hypotheses/hypothesis-003-resource-limits.md
@@ -1,0 +1,16 @@
+Hypothesis H003: Resource limits (ulimit/memory/CPU) trigger hidden timeouts
+
+Statement
+- CI’s open file limits, CPU quotas, or memory pressure cause intermittent networking or I/O failures that surface as sync stalls.
+
+Signals to collect
+- `ulimit -n`, `free -h`, `nproc` (already emitted in CI job).
+- Correlation between low limits and failure runs.
+
+Acceptance criteria
+- Confirmed if raising limits/staggering load eliminates failures with no code changes.
+- Falsified if failures persist under ample resources.
+
+Remediation
+- Raise limits in CI job, serialize heavy tests, or reduce concurrency locally to match CI constraints.
+

--- a/debug/hypotheses/hypothesis-004-logger-port-collision.md
+++ b/debug/hypotheses/hypothesis-004-logger-port-collision.md
@@ -1,0 +1,16 @@
+Hypothesis H004: Logger RPC port collisions across workers/tests
+
+Statement
+- File logger RPC server uses random ports (50k–60k). In CI parallelization, collisions/ephemeral port reuse cause logs to fail and mask underlying state.
+
+Signals to collect
+- Logger server startup messages include `LOGGER_SERVER_PORT` and path used.
+- Errors connecting to `http://localhost:<port>/rpc` in worker logs.
+
+Acceptance criteria
+- Confirmed if repeated port bind errors or connectivity failures occur during hangs.
+- Falsified if logs stream reliably while hang reproduces.
+
+Remediation
+- Track in-use ports and retry allocation; optionally serialize tests that share log sinks.
+

--- a/debug/hypotheses/hypothesis-005-version-drift.md
+++ b/debug/hypotheses/hypothesis-005-version-drift.md
@@ -1,0 +1,16 @@
+Hypothesis H005: Version drift (wrangler/workerd/node/bun/pnpm) affects behavior
+
+Statement
+- Version differences between local and CI environments change sync timing or protocol behavior.
+
+Signals to collect
+- CI prints versions of node/bun/pnpm/wrangler/workerd; compare with local.
+- Reproduce locally with the same versions and nix shell to match CI.
+
+Acceptance criteria
+- Confirmed if pinning versions to match local eliminates CI-only failures, or specific version change correlates with failures.
+- Falsified if failures persist across matched versions.
+
+Remediation
+- Pin or bump specific tool versions in Nix flake/lock and CI setup.
+

--- a/packages/@livestore/sync-cf/src/cf-worker/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/durable-object.ts
@@ -197,7 +197,15 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
                   requestId,
                 })
 
-                yield* Effect.logError(err)
+                // Extra diagnostics for CI-only flakiness
+                yield* Effect.logError(err).pipe(
+                  Effect.annotateLogs({
+                    minimumExpectedNum: String(currentHead),
+                    providedNum: String(firstEvent.parentSeqNum),
+                    batchFirstEventSeq: String(firstEvent.seqNum),
+                    batchSize: String(decodedMessage.batch.length),
+                  }),
+                )
 
                 yield* respond(err)
                 yield* this.pushSemaphore.release(1)


### PR DESCRIPTION
This PR adds:

- Env-driven debug overrides in node-sync tests (`NODE_SYNC_DEBUG=1`, plus knobs for counts/batches) to speed up CI iterations.
- Extra diagnostics for parent/head mismatch on the leader pushing path and Durable Object push handling.
- `debug/` folder with hypotheses and cleanup checklist so we can track this investigation methodically.

How to run a quick repro in CI mode locally:

```
CI=1 DEBUGGER_ACTIVE=0 NODE_SYNC_DEBUG=1 mono test integration node-sync
```

Tune parameters as needed:

```
NODE_SYNC_TODO_A=300 NODE_SYNC_TODO_B=300 NODE_SYNC_COMMIT_BATCH_SIZE=10 NODE_SYNC_LEADER_PUSH_BATCH_SIZE=100
```

We will iterate hypotheses one by one and keep notes in `debug/`.
