### PR TITLE
Remove prettier references from eslint comments

### DIFF
--- a/packages/@livestore/devtools-expo/src/metro-config.cts
+++ b/packages/@livestore/devtools-expo/src/metro-config.cts
@@ -1,10 +1,10 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module, @typescript-eslint/consistent-type-imports, prettier/prettier
+// eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module, @typescript-eslint/consistent-type-imports
 const { Effect, Logger, LogLevel } =
   require('@livestore/utils/effect') as typeof import('@livestore/utils/effect', { with: {
     'resolution-mode': 'import',
   }})
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module, @typescript-eslint/consistent-type-imports, prettier/prettier
+// eslint-disable-next-line @typescript-eslint/no-require-imports, unicorn/prefer-module, @typescript-eslint/consistent-type-imports
 const { PlatformNode } = require('@livestore/utils/node') as typeof import('@livestore/utils/node', { with: {
   'resolution-mode': 'import',
 }})


### PR DESCRIPTION
## Summary
- Removes `prettier/prettier` rule references from eslint-disable comments in `metro-config.cts`
- Creates issue #617 to track future migration of examples from Prettier to Biome once React Native/Expo support is available

## Context
The monorepo now uses Biome for all formatting and linting. These comments referenced Prettier rules that are no longer relevant since we're not using Prettier/ESLint in the main codebase.

Examples still temporarily use Prettier until Biome has proper React Native/Expo support (tracked in #617).

## Test plan
- [x] Linting passes: `mono lint`
- [x] TypeScript builds: `mono ts`
- [x] No functional changes to code behavior

🤖 Generated with [Claude Code](https://claude.ai/code)