### PR TITLE
fix: add netlify.toml to enable remote image transformations in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 
 test-results
 playwright-report
+.playwright-mcp
 
 .envrc.local
 

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,9 @@
+# Netlify configuration for docs deployment
+# This file configures Netlify's Image CDN to allow remote image transformations
+# from the hosted asset service used for example screenshots
+
+[images]
+# Allow image transformations from gitbucket.schickling.dev
+# This is needed for example screenshots to display properly in production
+# The domain is double-escaped as required by Netlify's regex configuration
+remote_images = ["https://gitbucket\\.schickling\\.dev/.*"]


### PR DESCRIPTION
## Summary

- Add `netlify.toml` configuration to allow image transformations from `gitbucket.schickling.dev`
- Fixes 400 "not an allowed pattern" errors for example screenshots in production
- Add `.playwright-mcp` to `.gitignore` for cleanup

## Problem

Example screenshots hosted on `gitbucket.schickling.dev` were not loading in the production docs deployment at `dev.docs.livestore.dev`. The error was:

```json
{
    "code": 400,
    "msg": "url (https://gitbucket.schickling.dev/api/get/7c3314ad88b842aa6454f8b8c28ddc91984badb86316dc27afa86a58fbfabc1d.png) is not an allowed pattern"
}
```

## Root Cause

While Astro's `image.domains` configuration allowed the domain, **Netlify's Image CDN requires a separate configuration** in `netlify.toml` to authorize remote image transformations. This is a two-layer security requirement:

1. ✅ Astro needs to allow the domain (already configured in `astro.config.mjs`)
2. ❌ Netlify's Image CDN needs to allow the domain (was missing)

## Solution

Created `/docs/netlify.toml` with:

```toml
[images]
# Allow image transformations from gitbucket.schickling.dev
remote_images = ["https://gitbucket\\.schickling\\.dev/.*"]
```

## Test plan

- [x] Verified all example screenshots now load correctly in production
- [x] Confirmed network requests return 200 status codes instead of 400 errors
- [x] Tested at: https://test-image-fix--livestore-docs-dev.netlify.app/examples/web-adapter/
- [x] All other page functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)