### PR TITLE
docs: clarify clientId vs userId distinction and identity concepts

### DIFF
--- a/docs/src/content/docs/misc/FAQ.md
+++ b/docs/src/content/docs/misc/FAQ.md
@@ -33,3 +33,11 @@ No, LiveStore is designed to be self-hosted or be used with a 3rd party sync bac
 Not currently. LiveStore is built around the idea of event-sourcing which separates reads and writes. This means LiveStore isn't syncing your database directly but only the events that are used to materialize the database making sure it's kept in sync across clients.
 
 However, we might provide support for this in the future depending on demand.
+
+### What's the difference between clientId, sessionId, and userId?
+
+- **sessionId**: Identifies a single LiveStore instance within a client (e.g., a browser tab). Sessions can persist (e.g., across tab reloads in web).
+- **clientId**: A randomly generated identifier managed by LiveStore that identifies a client instance. Each client has its own unique clientId and can have one or multiple sessions.
+- **userId**: Not a LiveStore concept. User identity must be handled at the application level through your events and application logic.
+
+A single user might have multiple clients (e.g., using different browsers or devices), each with its own clientId. User identification should be modeled within your application domain.

--- a/docs/src/content/docs/patterns/auth.md
+++ b/docs/src/content/docs/patterns/auth.md
@@ -87,3 +87,28 @@ The above example uses [`jose`](https://www.npmjs.com/package/jose), a popular J
 The `validatePayload` function receives the `authToken`, checks if the payload exists, and verifies that it's valid and hasn't expired. If all checks pass, sync continues as normal. If any check fails, the server rejects the sync.
 
 The client app still works as expected, but saves data locally. If the user re-authenticates or refreshes the token later, LiveStore syncs any local changes made while the user was unauthenticated.
+
+## Client Identity vs User Identity
+
+LiveStore's `clientId` identifies a client instance, while user identity is an application-level concern that must be modeled through your application's events and logic.
+
+### Key Points
+- `clientId`: Automatically managed by LiveStore, identifies a client instance
+- User identity: Managed by your application through events and syncPayload
+
+### Using syncPayload for Authentication
+
+The `syncPayload` is primarily intended for authentication purposes:
+
+```tsx
+<LiveStoreProvider
+  schema={schema}
+  storeId={storeId}
+  syncPayload={{
+    authToken: user.jwt, // Authentication credentials
+    // Additional auth-related data as needed
+  }}
+>
+```
+
+User identification and semantic data (like user IDs) should typically be handled through your event payloads and application state rather than relying solely on the sync payload.

--- a/docs/src/content/docs/reference/concepts.md
+++ b/docs/src/content/docs/reference/concepts.md
@@ -13,10 +13,16 @@ sidebar:
   - An adapter can instantiate a client session for a given platform (e.g. web, Expo)
 - Client
   - A logical group of client sessions
+  - Identified by a `clientId` - a randomly generated 6-char nanoid
+  - Each client has at least one client session
+  - Sessions within a client share local data
   - Client session
+    - An instance within a client
+    - Identified by a `sessionId`
+    - In web: sessionId can persist across tab reloads
+    - Multiple sessions can exist within a single client (e.g., multiple browser tabs)
     - Store
     - Reactivity graph
-    - Responsible for leader election
 - [Devtools](/reference/devtools)
 - [Events](/reference/events)
   - Event definition
@@ -68,4 +74,11 @@ LiveStore is designed to be pluggable in various ways:
 - Platform adapters
 - Sync providers
 - Framework integrations
+
+## Important Notes on Identity
+
+- LiveStore does not have built-in concepts of "users" or "devices"
+- User identity must be modeled within your application domain through events and application logic
+- The `clientId` identifies a client instance, not a user
+- Multiple clients can represent the same user (e.g., different browsers or devices)
 

--- a/docs/src/content/docs/reference/syncing/index.mdx
+++ b/docs/src/content/docs/reference/syncing/index.mdx
@@ -42,15 +42,18 @@ The sync backend acts as the global authority and determines the total order of 
 
 ## Clients
 
-- Each client initialy chooses a random `clientId` as its globally unique ID
+- Each client initially chooses a random `clientId` as its globally unique ID
   - LiveStore uses a 6-char nanoid
 	- In the unlikely event of a collision which is detected by the sync backend the first time a client tries to push, the client chooses a new random `clientId`, patches the local events with the new `clientId`, and tries again.
 
-### Local syncing across client sessions
+### Client Sessions
 
-- For adapters which support multiple client sessions (e.g. web), LiveStore also supports local syncing across client sessions (e.g. across browser tabs or worker threads).
-- LiveStore does this by electing a leader thread which is responsible for syncing and persiting data locally.
-- Client session events are not synced to the sync backend.
+- Each client has at least one client session
+- Client sessions within the same client share local data
+- In web adapters: multiple tabs/windows can be different sessions within the same client
+- Sessions are identified by a `sessionId` which can persist (e.g., across tab reloads in web)
+- For adapters which support multiple client sessions (e.g. web), LiveStore also supports local syncing across client sessions (e.g. across browser tabs or worker threads)
+- Client session events are not synced to the sync backend
 
 ## Auth (Authentication & Authorization)
 


### PR DESCRIPTION
## Summary

• Enhanced identity concepts documentation across multiple files
• Clarified the distinction between clientId (LiveStore-managed) vs userId (application-managed)
• Added comprehensive explanations of client/session hierarchy and persistence
• Added FAQ entry to address common confusion about identity concepts

## Key Changes

**Enhanced Concepts Page** (`concepts.md`):
- Updated Client section with detailed `clientId` and session explanations
- Added "Important Notes on Identity" section clarifying LiveStore has no built-in user/device concepts

**Updated Auth Documentation** (`auth.md`):
- Added "Client Identity vs User Identity" section
- Clarified that `syncPayload` is primarily for authentication
- Explained user identification should be handled through events/application state

**Enhanced Syncing Documentation** (`syncing/index.mdx`):
- Expanded Client Sessions section with hierarchy details
- Clarified sessionId persistence (e.g., across tab reloads)

**Added FAQ Entry** (`FAQ.md`):
- Comprehensive explanation of sessionId, clientId, and userId differences
- Examples of multi-device scenarios

## Problem Addressed

Previously, the system was setting `clientId = userId`, which violates LiveStore's design principles. This documentation clarifies:
- `clientId` should identify device/app instances, not users
- Multiple devices/tabs from the same user should have different `clientId`s
- User identification should be handled separately in the sync payload and application events

🤖 Generated with [Claude Code](https://claude.ai/code)