### PR TITLE
feat: improve direnv setup for git worktrees

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -20,6 +20,11 @@ export VITE_GRAFANA_ENDPOINT="${GRAFANA_ENDPOINT}"
 # Needed until Corepack newest corepack version is released on nixpkgs
 export COREPACK_INTEGRITY_KEYS=0
 
+# Load .envrc.local files - check both parent (for git worktrees) and current directory
+# Parent directory takes precedence as base config, current directory can override
+if test -f ../.envrc.local; then
+  source_env ../.envrc.local
+fi
 if test -f ./.envrc.local; then
   source_env ./.envrc.local
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Project-Specific Instructions for Claude
 
+## Setup
+
+This repository uses [`direnv`](https://direnv.net) for automatic environment setup. Run `direnv allow` once, then direnv automatically runs the setup script which installs dependencies and builds TypeScript.
+
 ## Tooling
 
 - When tools are not directly available in `$PATH`, prefix commands with `direnv exec .` (e.g. `direnv exec . tsc`, `direnv exec . mono lint`)


### PR DESCRIPTION
## Summary
- Document direnv automatic environment setup in CLAUDE.md
- Support loading `.envrc.local` from parent directory for shared worktree configuration
- Allow local `.envrc.local` to override parent settings

## Context
This improves the developer experience when working with git worktrees by automatically loading shared configuration from the parent directory's `.envrc.local` file, while still allowing worktree-specific overrides.

## Changes
1. **Updated `.envrc`**: Now checks for `.envrc.local` in both parent and current directories
2. **Updated `CLAUDE.md`**: Added Setup section documenting direnv usage

## Test plan
- [x] Verified parent `.envrc.local` variables are loaded in worktree
- [x] Direnv reload works correctly with the changes
- [x] Documentation is clear and concise

🤖 Generated with [Claude Code](https://claude.ai/code)