### PR TITLE
Add quotes around GitHub URI

### DIFF
--- a/docs/data.ts
+++ b/docs/data.ts
@@ -20,5 +20,6 @@ export const IS_MAIN_BRANCH = getBranchName() === 'main'
 
 export const makeTiged = (example: string, approach: 'bunx' | 'pnpm dlx' | 'npx') => {
   const hashSuffix = `#${getBranchName()}`
+  // The quotes around the github URI are necessary for certain shells (e.g. zsh) to parse correctly
   return `${approach} tiged "github:livestorejs/livestore/examples/${example}${hashSuffix}" livestore-app`
 }


### PR DESCRIPTION
## Summary

zsh doesn't like the tiged command (e.g. `pnpm dlx tiged github:livestorejs/livestore/examples/standalone/web-todomvc-sync-cf#main livestore-app`) because of the hash. Adding quotes fixes it.
