### PR TITLE
feat(adapter-web): archive state DB files after migration during dev

### DIFF
--- a/docs/src/content/docs/reference/platform-adapters/web-adapter.md
+++ b/docs/src/content/docs/reference/platform-adapters/web-adapter.md
@@ -86,6 +86,8 @@ const adapter = makeInMemoryAdapter({
 
 LiveStore currently only support OPFS to locally persist its data. In the future we might add support for other storage types (e.g. IndexedDB).
 
+During development (`NODE_ENV !== 'production'`), LiveStore automatically copies older state database files into `archive/` inside the OPFS directory for the store (e.g. `livestore-<storeId>@<version>/archive/`). The three most recent copies are retained so you can inspect pre-migration data; older archives are pruned. In production, we delete outdated state databases immediately.
+
 LiveStore also uses `window.sessionStorage` to retain the identity of a client session (e.g. tab/window) across reloads.
 
 ### Resetting local persistence

--- a/packages/@livestore/adapter-web/src/opfs-utils.ts
+++ b/packages/@livestore/adapter-web/src/opfs-utils.ts
@@ -17,14 +17,14 @@ export const rootHandlePromise =
       ) as never)
     : navigator.storage.getDirectory()
 
-export const getDirHandle = async (absDirPath: string | undefined) => {
+export const getDirHandle = async (absDirPath: string | undefined, options: { create?: boolean } = {}) => {
   const rootHandle = await rootHandlePromise
-  if (absDirPath === undefined) return rootHandle
+  if (absDirPath === undefined || absDirPath === '' || absDirPath === '/') return rootHandle
 
   let dirHandle = rootHandle
-  const directoryStack = absDirPath?.split('/').filter(Boolean)
+  const directoryStack = absDirPath.split('/').filter(Boolean)
   while (directoryStack.length > 0) {
-    dirHandle = await dirHandle.getDirectoryHandle(directoryStack.shift()!)
+    dirHandle = await dirHandle.getDirectoryHandle(directoryStack.shift()!, options)
   }
 
   return dirHandle

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -137,6 +137,7 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions }: WorkerOptions) =>
           yield* cleanupOldStateDbFiles({
             vfs: dbState.metadata.vfs,
             currentSchema: schema,
+            opfsDirectory: dbState.metadata.persistenceInfo.opfsDirectory,
           })
         }
 

--- a/tests/integration/src/tests/playwright/misc-tests.play.ts
+++ b/tests/integration/src/tests/playwright/misc-tests.play.ts
@@ -58,13 +58,23 @@ test(
         schema: Bridge.ResultMultipleMigrations,
       })
 
+      expect(exit._tag).toBe('Success')
+      if (exit._tag !== 'Success') throw new Error(`Expected success exit, received ${exit._tag}`)
+
+      const { migrationsCount, archivedStateDbFiles } = exit.value
+
       // Verify that after 22 migrations, we can still complete the process without running out of file handles
       // See packages/@livestore/sqlite-wasm/src/browser/opfs/AccessHandlePoolVFS.ts for default file handle pool size
-      expect(exit).toStrictEqual(
-        Exit.succeed({
-          migrationsCount: 22,
-        }),
-      )
+      expect(migrationsCount).toBe(22)
+
+      // Verify that we have 3 archived state DB files
+      // See packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts for default retention count
+      expect(archivedStateDbFiles.length).toBe(3)
+
+      // Verify that each archived file isn’t empty
+      archivedStateDbFiles.forEach((file) => {
+        expect(file.size).toBeGreaterThan(0)
+      })
     }),
   ),
 )

--- a/tests/integration/src/tests/playwright/unit-tests/bridge.ts
+++ b/tests/integration/src/tests/playwright/unit-tests/bridge.ts
@@ -24,6 +24,13 @@ export class ResultMultipleMigrations extends Schema.TaggedStruct('Bridge.Result
   exit: Schema.Exit({
     success: Schema.Struct({
       migrationsCount: Schema.Number,
+      archivedStateDbFiles: Schema.Array(
+        Schema.Struct({
+          name: Schema.String,
+          size: Schema.Number,
+          lastModified: Schema.Number,
+        }),
+      ),
     }),
     failure: UnexpectedError,
     defect: Schema.Defect,


### PR DESCRIPTION
## Summary

Implements bounded retention for old state databases during development to enable debugging while maintaining clean production behavior.

Resolves #570

## Changes

### Core Implementation
- **Archive directory management**: Creates `archive/` subdirectory in OPFS for development environments
- **Bounded retention**: Keeps 3 most recent archived state database files, automatically pruning older ones
- **Environment detection**: Uses `isDevEnv()` to distinguish between development and production environments
- **File archival**: Copies state DB files with timestamp prefix before deletion in development

### Key Components
- `archiveStateDbFile()`: Copies database files to archive with timestamp naming
- `pruneArchiveDirectory()`: Maintains bounded retention by removing oldest archived files
- `ensureArchiveDirectory()`: Creates archive directory structure in OPFS
- Enhanced `cleanupOldStateDbFiles()` with conditional archival logic

### Development Experience
- **Zero configuration**: Automatic detection and archival in development
- **Debugging support**: Retained files allow post-migration inspection
- **Enhanced logging**: Reports archived, retained, and deleted file counts
- **Storage efficiency**: Prevents OPFS pool exhaustion while preserving recent files

## Technical Details

### File Pool Management
- Maintains the 20-file OPFS access handle pool limit
- Transient archival operations use 1 additional file handle temporarily
- Archive files are stored outside the managed pool to avoid conflicts

### Archive Structure
```
livestore-<storeId>@<version>/
└── archive/
    ├── 1726502400000-state123.db
    ├── 1726502500000-state456.db
    └── 1726502600000-state789.db
```

### Environment Behavior
- **Development**: Archives 3 most recent state DBs before deletion
- **Production**: Immediate deletion (existing behavior)

## Testing

- ✅ Integration test verifies 3 archived files after 22 migrations
- ✅ Validates archive files have non-zero size
- ✅ Confirms migration process completes without handle exhaustion

## Documentation

Updated web adapter documentation to explain the development archival behavior and storage structure.