### PR TITLE
Bypass proxies when verifying Wrangler dev server readiness

### DIFF
--- a/packages/@livestore/utils-dev/src/wrangler/WranglerDevServer.ts
+++ b/packages/@livestore/utils-dev/src/wrangler/WranglerDevServer.ts
@@ -194,10 +194,7 @@ const verifyHttpConnectivity = ({
     yield* withRetries(client.get(url))
   })
 
-const loopbackConnectivityAttempt = (
-  url: URL,
-  connectTimeout: Duration.DurationInput,
-): Effect.Effect<void, unknown> =>
+const loopbackConnectivityAttempt = (url: URL, connectTimeout: Duration.DurationInput): Effect.Effect<void, unknown> =>
   Effect.tryPromise({
     try: () => {
       const protocol = url.protocol


### PR DESCRIPTION
## Summary
- avoid tunneling wrangler dev server health checks through HTTP(S)_PROXY by detecting loopback hosts and making direct requests
- add loopback helpers that normalize 0.0.0.0/:: to localhost for readiness checks

## Testing
- pnpm --filter @livestore/utils-dev exec tsc --noEmit --pretty false
- pnpm --filter @livestore/utils-dev exec vitest run src/wrangler/WranglerDevServer.test.ts --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68cdc341facc8329b604b00eaf657f3e