### PR TITLE
feat: enable dev-only persistence reset for Cloudflare adapter

### DIFF
--- a/packages/@livestore/adapter-cloudflare/src/make-client-durable-object.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-client-durable-object.ts
@@ -45,6 +45,7 @@ export type CreateStoreDoOptions<TSchema extends LiveStoreSchema = LiveStoreSche
   durableObjectId: string
   bindingName: string
   livePull?: boolean
+  resetPersistence?: boolean
 }
 
 export const createStoreDo = <TSchema extends LiveStoreSchema = LiveStoreSchema.Any>({
@@ -57,6 +58,7 @@ export const createStoreDo = <TSchema extends LiveStoreSchema = LiveStoreSchema.
   durableObjectId,
   bindingName,
   livePull = false,
+  resetPersistence = false,
 }: CreateStoreDoOptions<TSchema>) =>
   Effect.gen(function* () {
     const scope = yield* Scope.make()
@@ -65,6 +67,7 @@ export const createStoreDo = <TSchema extends LiveStoreSchema = LiveStoreSchema.
       clientId,
       sessionId,
       storage,
+      resetPersistence,
       syncOptions: {
         backend: makeDoRpcSync({
           syncBackendStub: syncBackendDurableObject,


### PR DESCRIPTION
## Summary
- add an optional `resetPersistence` flag to the Cloudflare Durable Object adapter and clear LiveStore-managed tables before opening the databases
- plumb the flag through `createStoreDo` and document how to gate the reset flow behind development-only routes or parameters

## Testing
- pnpm biome check packages/@livestore/adapter-cloudflare/src/make-adapter.ts packages/@livestore/adapter-cloudflare/src/make-client-durable-object.ts docs/src/content/docs/reference/platform-adapters/cloudflare-durable-object-adapter.md

------
https://chatgpt.com/codex/tasks/task_e_68ceb578f2448329a5cc58d130cce819