### PR TITLE
Disable proxies when starting node-sync tests

### DIFF
--- a/tests/integration/src/tests/node-sync/disable-proxy-env.ts
+++ b/tests/integration/src/tests/node-sync/disable-proxy-env.ts
@@ -1,0 +1,24 @@
+import { afterAll } from 'vitest'
+
+const PROXY_ENV_VARS = ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy', 'ALL_PROXY', 'all_proxy'] as const
+
+type ProxyEnvVar = (typeof PROXY_ENV_VARS)[number]
+
+const removedProxyEnv: Partial<Record<ProxyEnvVar, string>> = {}
+
+for (const key of PROXY_ENV_VARS) {
+  const value = process.env[key]
+  if (value !== undefined) {
+    removedProxyEnv[key] = value
+    delete process.env[key]
+  }
+}
+
+afterAll(() => {
+  for (const key of PROXY_ENV_VARS) {
+    const value = removedProxyEnv[key]
+    if (value !== undefined) {
+      process.env[key] = value
+    }
+  }
+})

--- a/tests/integration/src/tests/node-sync/node-sync.test.ts
+++ b/tests/integration/src/tests/node-sync/node-sync.test.ts
@@ -1,3 +1,4 @@
+import './disable-proxy-env.ts'
 import './thread-polyfill.ts'
 
 import * as ChildProcess from 'node:child_process'


### PR DESCRIPTION
## Summary
- add a test helper that clears loopback proxy environment variables before the node-sync suite boots Wrangler and restores them afterwards
- import the helper at the top of the node-sync integration test so the Wrangler readiness probe never tunnels through CI proxies

## Testing
- WORKSPACE_ROOT=$PWD CI=1 pnpm vitest run tests/integration/src/tests/node-sync/node-sync.test.ts --reporter verbose --testNamePattern "create 4 todos"


------
https://chatgpt.com/codex/tasks/task_e_68ceb264a2508329bd12963280087af7