### PR TITLE
feat: chunk Cloudflare sync responses within websocket limits

### DIFF
--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -6,10 +6,21 @@ import {
   UnexpectedError,
 } from '@livestore/common'
 import { type CfTypes, emitStreamResponse } from '@livestore/common-cf'
-import { Effect, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
+import { Chunk, Effect, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
 import { SyncMessage } from '../../common/mod.ts'
-import { type Env, type MakeDurableObjectClassOptions, type StoreId, WebSocketAttachmentSchema } from '../shared.ts'
+import {
+  type Env,
+  MAX_PULL_EVENTS_PER_MESSAGE,
+  MAX_WS_MESSAGE_BYTES,
+  type MakeDurableObjectClassOptions,
+  type StoreId,
+  WebSocketAttachmentSchema,
+} from '../shared.ts'
 import { DoCtx } from './layer.ts'
+import { splitChunkBySize } from './ws-chunking.ts'
+
+const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
+type PullBatchItem = SyncMessage.PullResponse['batch'][number]
 
 export const makePush =
   ({
@@ -75,40 +86,69 @@ export const makePush =
       yield* Effect.gen(function* () {
         const connectedClients = ctx.getWebSockets()
 
-        // Dual broadcasting: WebSocket + RPC clients
-        const pullRes = SyncMessage.PullResponse.make({
-          batch: pushRequest.batch.map((eventEncoded) => ({
-            eventEncoded,
-            metadata: Option.some(SyncMessage.SyncMetadata.make({ createdAt })),
-          })),
-          pageInfo: SyncBackend.pageInfoNoMore,
-          backendId,
-        })
+        // Preparing chunks of responses to make sure we don't exceed the WS message size limit.
+        const responses = Chunk.fromIterable(pushRequest.batch).pipe(
+          splitChunkBySize({
+            maxItems: MAX_PULL_EVENTS_PER_MESSAGE,
+            maxBytes: MAX_WS_MESSAGE_BYTES,
+            encode: (items) =>
+              encodePullResponse(
+                SyncMessage.PullResponse.make({
+                  batch: items.map(
+                    (eventEncoded): PullBatchItem => ({
+                      eventEncoded,
+                      metadata: Option.some(SyncMessage.SyncMetadata.make({ createdAt })),
+                    }),
+                  ),
+                  pageInfo: SyncBackend.pageInfoNoMore,
+                  backendId,
+                }),
+              ),
+          }),
+          Chunk.map((eventsChunk) => {
+            const batchWithMetadata = Chunk.toReadonlyArray(eventsChunk).map((eventEncoded) => ({
+              eventEncoded,
+              metadata: Option.some(SyncMessage.SyncMetadata.make({ createdAt })),
+            }))
 
-        const pullResEnc = Schema.encodeSync(SyncMessage.PullResponse)(pullRes)
+            const response = SyncMessage.PullResponse.make({
+              batch: batchWithMetadata,
+              pageInfo: SyncBackend.pageInfoNoMore,
+              backendId,
+            })
+
+            return {
+              response,
+              encoded: Schema.encodeSync(SyncMessage.PullResponse)(response),
+            }
+          }),
+        )
+
+        // Dual broadcasting: WebSocket + RPC clients
 
         // Broadcast to WebSocket clients
         if (connectedClients.length > 0) {
-          // Only calling once for now.
-          if (options?.onPullRes) {
-            yield* Effect.tryAll(() => options.onPullRes!(pullRes)).pipe(UnexpectedError.mapToUnexpectedError)
-          }
+          for (const { response, encoded } of responses) {
+            // Only calling once for now.
+            if (options?.onPullRes) {
+              yield* Effect.tryAll(() => options.onPullRes!(response)).pipe(UnexpectedError.mapToUnexpectedError)
+            }
 
-          // NOTE we're also sending the pullRes to the pushing ws client as a confirmation
-          for (const conn of connectedClients) {
-            // conn.send(pullResEnc)
-            const attachment = Schema.decodeSync(WebSocketAttachmentSchema)(conn.deserializeAttachment())
+            // NOTE we're also sending the pullRes chunk to the pushing ws client as confirmation
+            for (const conn of connectedClients) {
+              const attachment = Schema.decodeSync(WebSocketAttachmentSchema)(conn.deserializeAttachment())
 
-            // We're doing something a bit "advanced" here as we're directly emitting Effect RPC-compatible
-            // response messsages on the Effect RPC-managed websocket connection to the WS client.
-            // For this we need to get the RPC `requestId` from the WebSocket attachment.
-            for (const requestId of attachment.pullRequestIds) {
-              const res: RpcMessage.ResponseChunkEncoded = {
-                _tag: 'Chunk',
-                requestId,
-                values: [pullResEnc],
+              // We're doing something a bit "advanced" here as we're directly emitting Effect RPC-compatible
+              // response messsages on the Effect RPC-managed websocket connection to the WS client.
+              // For this we need to get the RPC `requestId` from the WebSocket attachment.
+              for (const requestId of attachment.pullRequestIds) {
+                const res: RpcMessage.ResponseChunkEncoded = {
+                  _tag: 'Chunk',
+                  requestId,
+                  values: [encoded],
+                }
+                conn.send(JSON.stringify(res))
               }
-              conn.send(JSON.stringify(res))
             }
           }
 
@@ -117,17 +157,16 @@ export const makePush =
 
         // RPC broadcasting would require reconstructing client stubs from clientIds
         if (rpcSubscriptions.size > 0) {
-          yield* Effect.forEach(
-            rpcSubscriptions.values(),
-            (subscription) =>
-              emitStreamResponse({
+          for (const subscription of rpcSubscriptions.values()) {
+            for (const { encoded } of responses) {
+              yield* emitStreamResponse({
                 callerContext: subscription.callerContext,
                 env,
                 requestId: subscription.requestId,
-                values: [pullResEnc],
-              }).pipe(Effect.tapCauseLogPretty, Effect.exit),
-            { concurrency: 'unbounded' },
-          )
+                values: [encoded],
+              }).pipe(Effect.tapCauseLogPretty, Effect.exit)
+            }
+          }
 
           yield* Effect.logDebug(`Broadcasted to ${rpcSubscriptions.size} RPC clients`)
         }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/ws-chunking.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/ws-chunking.ts
@@ -1,0 +1,76 @@
+import { Chunk } from '@livestore/utils/effect'
+
+const textEncoder = new TextEncoder()
+
+/**
+ * Configuration describing how to break a chunk into smaller payload-safe chunks.
+ */
+export interface ChunkingOptions<A> {
+  /** Maximum number of items that may appear in any emitted chunk. */
+  readonly maxItems: number
+  /** Maximum encoded byte size allowed for any emitted chunk. */
+  readonly maxBytes: number
+  /**
+   * Callback that produces a JSON-serialisable structure whose byte size should
+   * fit within {@link maxBytes}. This lets callers control framing overhead.
+   */
+  readonly encode: (items: ReadonlyArray<A>) => unknown
+}
+
+/**
+ * Derives a function that splits an input chunk into sub-chunks confined by
+ * both item count and encoded byte size limits. Designed for transports with
+ * strict frame caps (e.g. Cloudflare hibernated WebSockets).
+ */
+export const splitChunkBySize =
+  <A>(options: ChunkingOptions<A>) =>
+  (chunk: Chunk.Chunk<A>): Chunk.Chunk<Chunk.Chunk<A>> => {
+    const maxItems = Math.max(1, options.maxItems)
+    const maxBytes = Math.max(1, options.maxBytes)
+    const encode = options.encode
+
+    const measure = (items: ReadonlyArray<A>) => {
+      const encoded = encode(items)
+      return textEncoder.encode(JSON.stringify(encoded)).byteLength
+    }
+
+    const items = Chunk.toReadonlyArray(chunk)
+    if (items.length === 0) {
+      return Chunk.fromIterable<Chunk.Chunk<A>>([])
+    }
+
+    const result: Array<Chunk.Chunk<A>> = []
+    let current: Array<A> = []
+
+    const flushCurrent = () => {
+      if (current.length > 0) {
+        result.push(Chunk.fromIterable(current))
+        current = []
+      }
+    }
+
+    for (const item of items) {
+      current.push(item)
+      const exceedsLimit = current.length > maxItems || measure(current) > maxBytes
+
+      if (exceedsLimit) {
+        // remove the item we just added and emit the previous chunk if it exists
+        const last = current.pop()!
+        flushCurrent()
+
+        if (last !== undefined) {
+          current = [last]
+          const singleItemTooLarge = measure(current) > maxBytes
+          if (singleItemTooLarge || current.length > maxItems) {
+            // Emit the oversized item on its own; downstream can decide how to handle it.
+            result.push(Chunk.of(last))
+            current = []
+          }
+        }
+      }
+    }
+
+    flushCurrent()
+
+    return Chunk.fromIterable(result)
+  }

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -61,7 +61,12 @@ export const getSyncRequestSearchParams = (request: CfTypes.Request): Option.Opt
   return paramsResult
 }
 
-export const PULL_CHUNK_SIZE = 100
+export const MAX_PULL_EVENTS_PER_MESSAGE = 100
+
+// Cloudflare hibernated WebSocket frames begin failing just below 1MB. Keep our
+// payloads comfortably beneath that ceiling so we don't rely on implementation
+// quirks of local dev servers.
+export const MAX_WS_MESSAGE_BYTES = 900_000
 
 // RPC subscription storage (TODO refactor)
 export type RpcSubscription = {


### PR DESCRIPTION
## Summary
- rename the Cloudflare DO limits to `MAX_PULL_EVENTS_PER_MESSAGE` and add a byte ceiling to guard hibernated websocket frames (packages/@livestore/sync-cf/src/cf-worker/shared.ts#L64)
- add a `splitChunkBySize` helper that splits encoded pull batches by item and byte thresholds before transport (packages/@livestore/sync-cf/src/cf-worker/do/ws-chunking.ts#L1)
- pipe Cloudflare pull/push flows through the new chunker so websocket and RPC broadcasts stay under the limits (packages/@livestore/sync-cf/src/cf-worker/do/pull.ts#L40, packages/@livestore/sync-cf/src/cf-worker/do/push.ts#L89)

## Testing
- not run (pending CI)
