### PR TITLE
feat: enforce S2 push limits with transport chunking

### DIFF
--- a/docs/src/content/_assets/code/reference/syncing/s2/api-proxy-implementation.ts
+++ b/docs/src/content/_assets/code/reference/syncing/s2/api-proxy-implementation.ts
@@ -62,24 +62,23 @@ export async function POST(request: Request) {
   await S2Helpers.ensureStream(s2Config, streamName)
 
   // Build push request with proper formatting
-  const {
-    url: pushUrl,
-    headers,
-    body,
-  } = S2Helpers.buildPushRequest({
+  const pushRequests = S2Helpers.buildPushRequests({
     config: s2Config,
     storeId: parsed.storeId,
     batch: parsed.batch,
   })
 
-  const res = await fetch(pushUrl, {
-    method: 'POST',
-    headers,
-    body,
-  })
+  for (const pushRequest of pushRequests) {
+    const res = await fetch(pushRequest.url, {
+      method: 'POST',
+      headers: pushRequest.headers,
+      body: pushRequest.body,
+    })
 
-  if (!res.ok) {
-    return S2Helpers.errorResponse('Push failed', 500)
+    if (!res.ok) {
+      return S2Helpers.errorResponse('Push failed', 500)
+    }
   }
+
   return S2Helpers.successResponse()
 }

--- a/packages/@livestore/common/package.json
+++ b/packages/@livestore/common/package.json
@@ -8,6 +8,7 @@
     "./sql-queries": "./src/sql-queries/index.ts",
     "./leader-thread": "./src/leader-thread/mod.ts",
     "./schema": "./src/schema/mod.ts",
+    "./sync": "./src/sync/index.ts",
     "./sync/next": "./src/sync/next/mod.ts",
     "./sync/next/test": "./src/sync/next/test/mod.ts",
     "./testing": "./src/testing/mod.ts"
@@ -37,6 +38,7 @@
       "./sql-queries": "./dist/sql-queries/index.js",
       "./leader-thread": "./dist/leader-thread/mod.js",
       "./schema": "./dist/schema/mod.js",
+      "./sync": "./dist/sync/index.js",
       "./sync/next": "./dist/sync/next/mod.js",
       "./sync/next/test": "./dist/sync/next/test/mod.js",
       "./testing": "./dist/testing/mod.js"

--- a/packages/@livestore/common/src/sync/index.ts
+++ b/packages/@livestore/common/src/sync/index.ts
@@ -1,4 +1,5 @@
 export * from './ClientSessionSyncProcessor.ts'
 export * from './mock-sync-backend.ts'
 export * from './sync.ts'
+export * from './transport-chunking.ts'
 export * from './validate-push-payload.ts'

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -1,8 +1,8 @@
 import { BackendIdMismatchError, InvalidPullError, SyncBackend, UnexpectedError } from '@livestore/common'
+import { splitChunkBySize } from '@livestore/common/sync'
 import { Chunk, Effect, Option, Schema, Stream } from '@livestore/utils/effect'
 import { MAX_PULL_EVENTS_PER_MESSAGE, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SyncMessage } from '../../common/mod.ts'
-import { splitChunkBySize } from '../../common/transport-chunking.ts'
 import { DoCtx } from './layer.ts'
 
 const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -5,11 +5,11 @@ import {
   SyncBackend,
   UnexpectedError,
 } from '@livestore/common'
+import { splitChunkBySize } from '@livestore/common/sync'
 import { type CfTypes, emitStreamResponse } from '@livestore/common-cf'
 import { Chunk, Effect, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
 import { MAX_PUSH_EVENTS_PER_REQUEST, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SyncMessage } from '../../common/mod.ts'
-import { splitChunkBySize } from '../../common/transport-chunking.ts'
 import { type Env, type MakeDurableObjectClassOptions, type StoreId, WebSocketAttachmentSchema } from '../shared.ts'
 import { DoCtx } from './layer.ts'
 

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -1,4 +1,5 @@
 import { InvalidPullError, InvalidPushError, SyncBackend, UnexpectedError } from '@livestore/common'
+import { splitChunkBySize } from '@livestore/common/sync'
 import { type CfTypes, layerProtocolDurableObject } from '@livestore/common-cf'
 import { omit, shouldNeverHappen } from '@livestore/utils'
 import {
@@ -19,7 +20,6 @@ import { MAX_DO_RPC_REQUEST_BYTES, MAX_PUSH_EVENTS_PER_REQUEST } from '../../com
 import { SyncDoRpc } from '../../common/do-rpc-schema.ts'
 import { SyncMessage } from '../../common/mod.ts'
 import type { SyncMetadata } from '../../common/sync-message-types.ts'
-import { splitChunkBySize } from '../../common/transport-chunking.ts'
 
 export interface SyncBackendRpcStub extends CfTypes.DurableObjectStub, SyncBackendRpcInterface {}
 

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -1,5 +1,6 @@
 import { InvalidPullError, InvalidPushError, SyncBackend, UnexpectedError } from '@livestore/common'
 import type { EventSequenceNumber } from '@livestore/common/schema'
+import { splitChunkBySize } from '@livestore/common/sync'
 import { omit } from '@livestore/utils'
 import {
   Chunk,
@@ -22,7 +23,6 @@ import { MAX_HTTP_REQUEST_BYTES, MAX_PUSH_EVENTS_PER_REQUEST } from '../../commo
 import { SyncHttpRpc } from '../../common/http-rpc-schema.ts'
 import { SearchParamsSchema } from '../../common/mod.ts'
 import type { SyncMetadata } from '../../common/sync-message-types.ts'
-import { splitChunkBySize } from '../../common/transport-chunking.ts'
 
 export interface HttpSyncOptions {
   /**

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -1,5 +1,6 @@
 import { InvalidPullError, InvalidPushError, IsOfflineError, SyncBackend, UnexpectedError } from '@livestore/common'
 import type { LiveStoreEvent } from '@livestore/common/schema'
+import { splitChunkBySize } from '@livestore/common/sync'
 import { omit } from '@livestore/utils'
 import {
   Chunk,
@@ -21,7 +22,6 @@ import {
 import { MAX_PUSH_EVENTS_PER_REQUEST, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SearchParamsSchema } from '../../common/mod.ts'
 import type { SyncMetadata } from '../../common/sync-message-types.ts'
-import { splitChunkBySize } from '../../common/transport-chunking.ts'
 import { SyncWsRpc } from '../../common/ws-rpc-schema.ts'
 
 export interface WsSyncOptions {

--- a/packages/@livestore/sync-cf/src/common/mod.ts
+++ b/packages/@livestore/sync-cf/src/common/mod.ts
@@ -1,10 +1,11 @@
+import { OversizeChunkItemError, splitChunkBySize } from '@livestore/common/sync'
 import { Schema } from '@livestore/utils/effect'
 
 export type { CfTypes } from '@livestore/common-cf'
 export * from './constants.ts'
 export { SyncHttpRpc } from './http-rpc-schema.ts'
 export * as SyncMessage from './sync-message-types.ts'
-export { splitChunkBySize } from './transport-chunking.ts'
+export { OversizeChunkItemError, splitChunkBySize }
 
 export const SearchParamsSchema = Schema.Struct({
   storeId: Schema.String,

--- a/packages/@livestore/sync-s2/src/limits.test.ts
+++ b/packages/@livestore/sync-s2/src/limits.test.ts
@@ -1,0 +1,42 @@
+import type { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
+import { describe, expect, it } from 'vitest'
+import {
+  chunkEventsForS2,
+  computeRecordMeteredBytes,
+  MAX_BATCH_METERED_BYTES,
+  MAX_RECORD_METERED_BYTES,
+  S2LimitExceededError,
+} from './limits.ts'
+
+const encoder = new TextEncoder()
+
+const makeEvent = (payloadLength: number, index = 0): LiveStoreEvent.AnyEncodedGlobal => ({
+  name: `event-${index}`,
+  args: { payload: 'x'.repeat(payloadLength) },
+  seqNum: index as EventSequenceNumber.GlobalEventSequenceNumber,
+  parentSeqNum: index as EventSequenceNumber.GlobalEventSequenceNumber,
+  clientId: 'client',
+  sessionId: 'session',
+})
+
+describe('S2 limits helpers', () => {
+  it('computes metered bytes for record bodies', () => {
+    const record = { body: JSON.stringify({ hello: 'world' }) }
+    const expected = 8 + encoder.encode(record.body ?? '').byteLength
+    expect(computeRecordMeteredBytes(record)).toBe(expected)
+  })
+
+  it('splits large batches while respecting metered byte limits', () => {
+    const events = [makeEvent(400_000, 1), makeEvent(400_000, 2), makeEvent(400_000, 3)]
+    const chunks = chunkEventsForS2(events)
+
+    expect(chunks).toHaveLength(2)
+    expect(chunks.map((chunk) => chunk.events.length)).toStrictEqual([2, 1])
+    expect(chunks.every((chunk) => chunk.meteredBytes <= MAX_BATCH_METERED_BYTES)).toBe(true)
+  })
+
+  it('throws when a single record exceeds the metered byte cap', () => {
+    const oversize = makeEvent(MAX_RECORD_METERED_BYTES, 1)
+    expect(() => chunkEventsForS2([oversize])).toThrow(S2LimitExceededError)
+  })
+})

--- a/packages/@livestore/sync-s2/src/limits.ts
+++ b/packages/@livestore/sync-s2/src/limits.ts
@@ -1,0 +1,135 @@
+import type { LiveStoreEvent } from '@livestore/common/schema'
+import { splitChunkBySize } from '@livestore/common/sync'
+import { Chunk, Effect, Schema } from '@livestore/utils/effect'
+
+const textEncoder = new TextEncoder()
+
+/**
+ * Maximum metered size of a single record (docs: https://s2.dev/docs/limits#records).
+ */
+export const MAX_RECORD_METERED_BYTES = 1_048_576 // 1 MiB
+
+/**
+ * Maximum combined metered size of a batch append (docs: https://s2.dev/docs/limits#records).
+ */
+export const MAX_BATCH_METERED_BYTES = 1_048_576 // 1 MiB
+
+/**
+ * Maximum number of records per append (docs: https://s2.dev/docs/limits#records).
+ */
+export const MAX_RECORDS_PER_BATCH = 1_000
+
+const LimitType = Schema.Literal('record-metered-bytes', 'batch-metered-bytes', 'batch-count')
+
+export class S2LimitExceededError extends Schema.TaggedError<S2LimitExceededError>()('S2LimitExceededError', {
+  limitType: LimitType,
+  max: Schema.Number,
+  actual: Schema.Number,
+  recordIndex: Schema.optional(Schema.Number),
+}) {}
+
+export interface AppendRecordBody {
+  readonly body?: string
+  readonly headers?: ReadonlyArray<{ readonly name: string; readonly value: string }>
+}
+
+// S2 measures bodies/headers in UTF‑8 bytes; centralising this helper keeps the
+// formula readable and consistent with the docs.
+const utf8ByteLength = (value: string): number => textEncoder.encode(value).byteLength
+
+export const computeRecordMeteredBytes = (record: AppendRecordBody): number => {
+  const headers = record.headers ?? []
+  const headerCount = headers.length
+  const headerBytes = headers.reduce(
+    (acc, header) => acc + utf8ByteLength(header.name) + utf8ByteLength(header.value),
+    0,
+  )
+  const bodyBytes = record.body === undefined ? 0 : utf8ByteLength(record.body)
+  return 8 + 2 * headerCount + headerBytes + bodyBytes
+}
+
+export const computeBatchMeteredBytes = (records: ReadonlyArray<AppendRecordBody>): number =>
+  records.reduce((acc, record) => acc + computeRecordMeteredBytes(record), 0)
+
+interface PreparedEvent {
+  readonly event: LiveStoreEvent.AnyEncodedGlobal
+  readonly record: AppendRecordBody
+  readonly meteredBytes: number
+  readonly index: number
+}
+
+export interface S2Chunk {
+  readonly events: ReadonlyArray<LiveStoreEvent.AnyEncodedGlobal>
+  readonly records: ReadonlyArray<AppendRecordBody>
+  readonly meteredBytes: number
+}
+
+// Pre-stringify events and pre-compute per-record metered bytes so we only pay
+// the JSON cost once when chunking large batches.
+const convertEventsToPrepared = (events: ReadonlyArray<LiveStoreEvent.AnyEncodedGlobal>): PreparedEvent[] =>
+  events.map((event, index) => {
+    const body = JSON.stringify(event)
+    const record: AppendRecordBody = { body }
+    const meteredBytes = computeRecordMeteredBytes(record)
+
+    if (meteredBytes > MAX_RECORD_METERED_BYTES) {
+      throw new S2LimitExceededError({
+        limitType: 'record-metered-bytes',
+        max: MAX_RECORD_METERED_BYTES,
+        actual: meteredBytes,
+        recordIndex: index,
+      })
+    }
+
+    return { event, record, meteredBytes, index }
+  })
+
+// Summarises a chunk’s metered bytes. Passed to splitChunkBySize so we enforce
+// S2 limits directly instead of relying on JSON size heuristics.
+const makeChunkMeasure = (items: ReadonlyArray<PreparedEvent>): number =>
+  items.reduce((acc, item) => acc + item.meteredBytes, 0)
+
+const mapPreparedChunks = (chunks: Chunk.Chunk<Chunk.Chunk<PreparedEvent>>): ReadonlyArray<S2Chunk> =>
+  Chunk.toReadonlyArray(chunks).map((chunk) => {
+    const chunkItems = Chunk.toReadonlyArray(chunk)
+    const events = chunkItems.map((item) => item.event)
+    const records = chunkItems.map((item) => item.record)
+    return {
+      events,
+      records,
+      meteredBytes: makeChunkMeasure(chunkItems),
+    }
+  })
+
+export const chunkEventsForS2 = (events: ReadonlyArray<LiveStoreEvent.AnyEncodedGlobal>): ReadonlyArray<S2Chunk> => {
+  if (events.length === 0) {
+    return []
+  }
+
+  const prepared = convertEventsToPrepared(events)
+
+  try {
+    const chunks = Chunk.fromIterable(prepared).pipe(
+      splitChunkBySize({
+        maxItems: MAX_RECORDS_PER_BATCH,
+        maxBytes: MAX_BATCH_METERED_BYTES,
+        encode: (items) => ({ records: items.map((item) => item.record) }),
+        measure: makeChunkMeasure,
+      }),
+      Effect.runSync,
+    )
+
+    return mapPreparedChunks(chunks)
+  } catch (error) {
+    if (error && typeof error === 'object' && (error as any)._tag === 'OversizeChunkItemError') {
+      const oversize = error as { size: number; maxBytes: number; _tag: string }
+      throw new S2LimitExceededError({
+        limitType: 'record-metered-bytes',
+        max: oversize.maxBytes,
+        actual: oversize.size,
+      })
+    }
+
+    throw error
+  }
+}

--- a/packages/@livestore/sync-s2/src/mod.ts
+++ b/packages/@livestore/sync-s2/src/mod.ts
@@ -1,5 +1,6 @@
 export * as ApiSchema from './api-schema.ts'
 export * as HttpClientGenerated from './http-client-generated.ts'
+export * from './limits.ts'
 export * from './make-s2-url.ts'
 export * from './s2-proxy-helpers.ts'
 export { makeSyncBackend, type SyncS2Options } from './sync-provider.ts'


### PR DESCRIPTION
## Summary
- Adds client-side enforcement of S2 record limits to prevent 413/422 errors during push operations
- Promotes transport chunking utility from `@livestore/sync-cf` to `@livestore/common/sync` for reuse across sync backends
- Implements proactive batch splitting in S2 sync provider to ensure compliance with S2's 1 MiB record limit and 1000 records per batch constraint

## Key Changes
- **S2 Limits Validation**: New `limits.ts` module with metered byte calculation and `S2LimitExceededError` for clear error reporting
- **Shared Transport Chunking**: Moved and enhanced chunking utility to `@livestore/common/sync` with optional custom measurement support
- **Batch Splitting**: Updated S2 sync provider to split oversized batches into compliant chunks before network calls
- **Error Handling**: Proper error propagation with informative `InvalidPushError` messages for limit violations
- **Example Updates**: Updated proxy examples and docs to handle multiple requests and surface S2 limit failures appropriately

## Test Plan
- [x] Unit tests for S2 metered byte calculation
- [x] Tests for batch chunking logic and oversize record detection
- [x] Verify transport chunking migration doesn't break Cloudflare sync backend
- [x] Ensure examples properly handle multiple push requests and error scenarios
- [x] TypeScript compilation and linting pass

🤖 Generated with [Claude Code](https://claude.ai/code)