### PR TITLE
Fix typo in sync-cf package in the docs installation guide

### DIFF
--- a/docs/src/content/docs/getting-started/react-web.mdx
+++ b/docs/src/content/docs/getting-started/react-web.mdx
@@ -35,7 +35,7 @@ export const manualInstallDepsStr = [
   '@livestore/adapter-web' + versionNpmSuffix,
   '@livestore/react' + versionNpmSuffix,
   '@livestore/peer-deps' + versionNpmSuffix,
-  '@livestore/sync-cf/client' + versionNpmSuffix,
+  '@livestore/sync-cf' + versionNpmSuffix,
   '@livestore/devtools-vite' + versionNpmSuffix,
 ].join(' ')
 


### PR DESCRIPTION
Noticed it when tried to install the latest release version, only `sync-cf` package failed to install

<img width="1576" height="202" alt="CleanShot 2025-10-05 at 22 25 46@2x" src="https://github.com/user-attachments/assets/12478efd-bef6-4d72-9ce2-30dfcf03788a" />
