### PR TITLE
Inline Store.subscribe callback handling

### DIFF
--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -1,5 +1,92 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`otel > QueryBuilder subscription - async iterator 1`] = `
+{
+  "_name": "createStore",
+  "attributes": {
+    "debugInstanceId": "test",
+    "storeId": "default",
+  },
+  "children": [
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "
+      PRAGMA page_size=32768;
+      PRAGMA cache_size=10000;
+      PRAGMA synchronous='OFF';
+      PRAGMA temp_store='MEMORY';
+      PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
+    ",
+      },
+    },
+    {
+      "_name": "@livestore/common:LeaderSyncProcessor:push",
+      "attributes": {
+        "batch": "undefined",
+        "batchSize": 1,
+      },
+    },
+    {
+      "_name": "client-session-sync-processor:pull",
+      "attributes": {
+        "code.stacktrace": "<STACKTRACE>",
+        "span.label": "⚠︎ Interrupted",
+        "status.interrupted": true,
+      },
+    },
+    {
+      "_name": "LiveStore:sync",
+    },
+    {
+      "_name": "LiveStore:commits",
+    },
+    {
+      "_name": "LiveStore:queries",
+    },
+  ],
+}
+`;
+
+exports[`otel > QueryBuilder subscription - async iterator 2`] = `
+[
+  {
+    "_name": "LiveStore:commit",
+    "attributes": {
+      "livestore.eventTags": "[
+  "todo.created"
+]",
+      "livestore.eventsCount": 1,
+    },
+    "children": [
+      {
+        "_name": "client-session-sync-processor:push",
+        "attributes": {
+          "batchSize": 1,
+          "eventCounts": "{
+  "todo.created": 1
+}",
+          "mergeResultTag": "advance",
+        },
+        "children": [
+          {
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
 {
   "_name": "createStore",

--- a/packages/@livestore/livestore/src/mod.ts
+++ b/packages/@livestore/livestore/src/mod.ts
@@ -37,7 +37,13 @@ export {
 export { emptyDebugInfo, SqliteDbWrapper } from './SqliteDbWrapper.ts'
 export { type CreateStoreOptions, createStore, createStorePromise } from './store/create-store.ts'
 export { Store } from './store/store.ts'
-export type { OtelOptions, QueryDebugInfo, RefreshReason, Unsubscribe } from './store/store-types.ts'
+export type {
+  OtelOptions,
+  QueryDebugInfo,
+  RefreshReason,
+  SubscribeOptions,
+  Unsubscribe,
+} from './store/store-types.ts'
 export {
   type LiveStoreContext,
   type LiveStoreContextRunning,

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -14,6 +14,7 @@ import type { Effect, Runtime, Scope } from '@livestore/utils/effect'
 import { Deferred } from '@livestore/utils/effect'
 import type * as otel from '@opentelemetry/api'
 
+import type { LiveQuery } from '../live-queries/base-class.ts'
 import type { DebugRefreshReasonBase } from '../reactive.ts'
 import type { StackInfo } from '../utils/stack-info.ts'
 import type { Store } from './store.ts'
@@ -135,3 +136,12 @@ export type StoreEventsOptions<TSchema extends LiveStoreSchema> = {
 }
 
 export type Unsubscribe = () => void
+
+export type SubscribeOptions<TResult> = {
+  onSubscribe?: (query$: LiveQuery<TResult>) => void
+  onUnsubsubscribe?: () => void
+  label?: string
+  skipInitialRun?: boolean
+  otelContext?: otel.Context
+  stackInfo?: StackInfo
+}


### PR DESCRIPTION
## Problem
- `Store.subscribe` still delegated the callback branch through a private helper, making the stream-based overload bounce through an extra function.
- The async iterator overload needed a cast and manual `[Symbol.asyncIterator]` access that could be simplified.

## Solution
- Inline the callback subscription workflow directly inside `Store.subscribe` and have `subscribeStream` reuse it for stream emission.
- Return the iterator derived from `Stream.toAsyncIterable` while ensuring it advertises `[Symbol.asyncIterator]`, avoiding the previous type assertion.

## Testing
- `pnpm exec biome check --write packages/@livestore/livestore/src/store/store.ts`
- `pnpm exec vitest run packages/@livestore/livestore/src/live-queries/db-query.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68e4ecfa6ec8832981ef6532a3191865