### PR TITLE
Run Effect language service patch during prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build:clean": "bash -c \"find {examples,packages,tests,docs} -path '*node_modules*' -prune -o \\( -name 'dist' -type d -o -name '*.tsbuildinfo' \\) -exec rm -rf {} +\"",
     "build:ts": "tsc --build tsconfig.dev.json",
     "pack:tmp": "pnpm --filter '@livestore/*' exec -- pnpm pack --out tmp/pack.tgz",
-    "prepare": "husky",
+    "prepare": "effect-language-service patch && husky",
     "test": "CI=1 pnpm --parallel run test",
     "update-lockfile": "CI=1 pnpm install --lockfile-only"
   }


### PR DESCRIPTION
## Problem
- The monorepo did not automatically apply the Effect language service patch during dependency installs, so editors would miss the enhanced typings.

## Solution
- Update the root prepare script to run `effect-language-service patch` before installing Husky hooks so the patch is always applied.

## Testing
- pnpm exec tsc --build tsconfig.dev.json
- pnpm exec biome check .

------
https://chatgpt.com/codex/tasks/task_e_68edfdc34f1c8329bc5b2067f0fc7dac