### PR TITLE
Add `enforceSuccess` option to `cmdText` to return `stderr` on failure

### DIFF
--- a/packages/@livestore/utils-dev/src/node/cmd.ts
+++ b/packages/@livestore/utils-dev/src/node/cmd.ts
@@ -14,7 +14,7 @@ import {
   identity,
   List,
   LogLevel,
-  PlatformError,
+  type PlatformError,
   Schema,
   Sink,
   Stream,
@@ -117,7 +117,7 @@ export const cmd: (
  * returns the `stdout` from the child process.
  *
  * If `options.enforceSuccess` is true, will check the command exit code prior
- * to emitting results. If the exit code is anything other than `0` (i.e. a 
+ * to emitting results. If the exit code is anything other than `0` (i.e. a
  * successful exit code), the `stderr` for the child process will be returned.
  */
 export const cmdText: (

--- a/packages/@livestore/utils-dev/src/node/cmd.ts
+++ b/packages/@livestore/utils-dev/src/node/cmd.ts
@@ -187,23 +187,15 @@ export const cmdOutput: (
     Stream.run(collectUint8Array),
     Effect.map((bytes) => decoder.decode(bytes)),
     Effect.forkScoped,
-    Effect.withSpan("cmdText:readStdout")
   )
   const readStderr = yield* childProcess.stderr.pipe(
     Stream.run(collectUint8Array),
     Effect.map((bytes) => decoder.decode(bytes)),
     Effect.forkScoped,
-    Effect.withSpan("cmdText:readStderr")
   )
-  const exitCode = yield* Effect.forkScoped(childProcess.exitCode).pipe(
-    Effect.withSpan("cmdText:exitCode")
-  )
+  const exitCode = yield* Effect.forkScoped(childProcess.exitCode)
 
-  return [
-    yield* Fiber.await(readStdout),
-    yield* Fiber.await(readStderr),
-    yield* Fiber.await(exitCode),
-  ]
+  return [yield* Fiber.join(readStdout), yield* Fiber.join(readStderr), yield* Fiber.join(exitCode)]
 }, Effect.scoped)
 
 export class CmdError extends Schema.TaggedError<CmdError>()('CmdError', {

--- a/packages/@livestore/utils-dev/src/node/cmd.ts
+++ b/packages/@livestore/utils-dev/src/node/cmd.ts
@@ -193,7 +193,7 @@ export const cmdOutput: (
   )
 
   return yield* Effect.all([readStdout, readStderr, childProcess.exitCode], {
-    concurrency: 2,
+    concurrency: 3,
   })
 }, Effect.scoped)
 

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -109,11 +109,9 @@ export const docsCommand = Cli.Command.make('docs').pipe(
         open: Cli.Options.boolean('open').pipe(Cli.Options.withDefault(false)),
       },
       ({ open }) =>
-        Effect.gen(function* () {
-          yield* cmd(['pnpm', 'astro', 'dev', open ? '--open' : undefined], {
-            cwd: docsPath,
-            logDir: `${docsPath}/logs`,
-          })
+        cmd(['pnpm', 'astro', 'dev', open ? '--open' : undefined], {
+          cwd: docsPath,
+          logDir: `${docsPath}/logs`,
         }),
     ),
     docsBuildCommand,
@@ -182,9 +180,10 @@ export const docsCommand = Cli.Command.make('docs').pipe(
         alias: Cli.Options.text('alias').pipe(Cli.Options.optional),
         site: Cli.Options.text('site').pipe(Cli.Options.optional),
         build: Cli.Options.boolean('build').pipe(Cli.Options.withDefault(false)),
-        purgeCdn: Cli.Options.boolean('purge-cdn')
-          .pipe(Cli.Options.withDefault(false))
-          .pipe(Cli.Options.withDescription('Purge the Netlify CDN cache after deploying')),
+        purgeCdn: Cli.Options.boolean('purge-cdn').pipe(
+          Cli.Options.withDefault(false),
+          Cli.Options.withDescription('Purge the Netlify CDN cache after deploying'),
+        ),
       },
       Effect.fn(
         function* ({ prod: prodOption, alias: aliasOption, site: siteOption, build: shouldBuild, purgeCdn }) {

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -157,9 +157,11 @@ export const testUnitCommand = Cli.Command.make(
         allPaths,
         (vitestPath) =>
           // TODO use this https://x.com/luxdav/status/1942532247833436656
-          cmdText(`vitest run ${vitestPath}`, { cwd, stderr: 'pipe' }).pipe(
-            Effect.tap((text) => console.log(`Output for ${vitestPath}:\n\n${text}\n\n`)),
-          ),
+          cmdText(`vitest run ${vitestPath}`, {
+            cwd,
+            stderr: 'pipe',
+            enforceSuccess: true,
+          }).pipe(Effect.tap((text) => console.log(`Output for ${vitestPath}:\n\n${text}\n\n`))),
         { concurrency: 'unbounded' },
       )
     }


### PR DESCRIPTION
<!-- Use a title that captures the problem and the approach, e.g. "Fix backlog replay flake by stabilizing event helper" -->

## Problem

See #683.

## Solution

Adds a `enforceSuccess` option to `cmdText` which checks the exit code of the child process and returns the accumulated stderr if the exit code is anything other than success.

## Validation

See #683 for repro / validation instructions.

### Demo (optional)

Share logs, screenshots, CLI output, or quick diagrams (Mermaid/ASCII) that illustrate the change when it helps reviewers grok the impact quickly.

## Related issues

- #...
