### PR TITLE
Fix CI docs deploy to work with both PRs and pushes to dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main  # Only run on pushes to main
+      - dev   # Also run on pushes to dev to keep dev docs deploys consistent
   pull_request:
     branches: ['**']  # Run on PRs targeting any branch
 
@@ -277,8 +278,9 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup-env
       - run: mono docs build --api-docs
-      - run: mono docs deploy
-        if: github.event.pull_request.head.repo.fork != true
+      - name: Deploy docs (PRs from non-forks or any push)
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
+        run: mono docs deploy
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 


### PR DESCRIPTION
## Problem

The docs deploy step in the CI workflow had two issues that prevented it from working correctly:

1. **Missing dev branch trigger**: The workflow only triggered on pushes to `main`, not `dev`. This caused the dev branch docs to become out of sync when changes were pushed directly to dev without going through main.

2. **Incorrect conditional syntax**: The conditional checking for fork status used GitHub Actions expression syntax incorrectly. The condition `if: github.event.pull_request.head.repo.fork != true` would fail on push events (non-PR) because `github.event.pull_request` is null, causing the expression to error.

## Solution

- **Added `dev` branch to push triggers** to ensure docs stay in sync when pushing directly to dev
- **Fixed the conditional expression** to properly handle both PR and push events:
  - Uses `${{ }}` expression syntax
  - Checks `github.event_name != 'pull_request'` first to handle push events
  - Only checks fork status when the event is actually a pull request
- **Clarified the step name** to indicate it runs for "PRs from non-forks OR any push"

The new conditional `${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}` correctly handles:
- All push events (to main or dev)
- Pull requests from non-fork repositories
- Skips only pull requests from forks (which don't have access to secrets)

## Validation

- [x] Linting passes: `mono lint`
- [x] No circular dependencies detected
- [x] Workflow syntax is valid GitHub Actions expression syntax

## Related

Related to recent docs deploy work in 884c267b

🤖 Generated with [Claude Code](https://claude.com/claude-code)