### PR TITLE
Add rich deployment metadata to Netlify docs deploys

### DIFF
--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -226,6 +226,26 @@ export const docsCommand = Cli.Command.make('docs').pipe(
             return undefined
           })()
           const shortSha = yield* cmdText('git rev-parse --short HEAD').pipe(Effect.map((s) => s.trim()))
+          const repo = process.env.GITHUB_REPOSITORY ?? 'livestorejs/livestore'
+          const fullSha =
+            process.env.GITHUB_SHA ?? (yield* cmdText('git rev-parse HEAD').pipe(Effect.map((s) => s.trim())))
+          const runId = process.env.GITHUB_RUN_ID
+          const commitUrl = `https://github.com/${repo}/commit/${fullSha}`
+          const prUrl = prNumber ? `https://github.com/${repo}/pull/${prNumber}` : undefined
+          const runUrl = runId ? `https://github.com/${repo}/actions/runs/${runId}` : undefined
+
+          const contextLabelFor = (isProd: boolean, a: string) => (isProd ? 'prod' : `alias:${a}`)
+          const buildMessage = (ctx: string) =>
+            [
+              'docs deploy',
+              `context: ${ctx}`,
+              `branch: ${branchName}`,
+              `commit: ${shortSha} ${commitUrl}`,
+              prNumber ? `pr: #${prNumber} ${prUrl}` : undefined,
+              runUrl ? `run: ${runUrl}` : undefined,
+            ]
+              .filter((p): p is string => typeof p === 'string')
+              .join(' | ')
 
           yield* Effect.log(`Deploying to "${site}" for draft URL`)
 
@@ -237,6 +257,7 @@ export const docsCommand = Cli.Command.make('docs').pipe(
             target: { _tag: 'draft' },
             cwd: docsPath,
             filter: deployFilter,
+            message: buildMessage('draft'),
           })
 
           const alias = (() => {
@@ -264,6 +285,7 @@ export const docsCommand = Cli.Command.make('docs').pipe(
             target: prod ? { _tag: 'prod' } : { _tag: 'alias', alias },
             cwd: docsPath,
             filter: deployFilter,
+            message: buildMessage(contextLabelFor(prod, alias)),
           })
 
           if (purgeCdn) {

--- a/scripts/src/shared/netlify.ts
+++ b/scripts/src/shared/netlify.ts
@@ -58,12 +58,14 @@ export const deployToNetlify = ({
   target,
   cwd,
   filter,
+  message,
 }: {
   site: string
   dir: string
   target: Target
   cwd: string
   filter?: string
+  message?: string
 }) =>
   Effect.gen(function* () {
     const netlifyStatus = yield* cmdText(['bunx', 'netlify-cli', 'status'], { cwd, stderr: 'pipe' })
@@ -87,6 +89,7 @@ export const deployToNetlify = ({
         `--dir=${dir}`,
         `--site=${site}`,
         filter ? `--filter=${filter}` : undefined,
+        message ? `--message=${message}` : undefined,
         // Either use `--prod` or `--alias`
         target._tag === 'prod' ? '--prod' : target._tag === 'alias' ? `--alias=${target.alias}` : undefined,
       ],


### PR DESCRIPTION
## Problem

Netlify deployments lacked context about their source, making it difficult to trace a deployment back to the specific commit, PR, or CI run that created it. When reviewing deployments in the Netlify dashboard, there was no easy way to understand what change triggered a deployment.

## Solution

Enhanced the docs deployment workflow with rich metadata in Netlify deploy messages that include:

1. **Repository metadata extraction**:
   - Extract `GITHUB_REPOSITORY`, `GITHUB_SHA`, and `GITHUB_RUN_ID` from environment
   - Generate full commit SHA with fallback to git command
   - Extract PR number from `GITHUB_REF` when in PR context

2. **URL generation**:
   - Build GitHub URLs for commits, PRs, and CI runs
   - Include these URLs directly in deployment messages

3. **Helper functions**:
   - `contextLabelFor`: Distinguishes prod vs alias deployments
   - `buildMessage`: Formats deployment context with all metadata

4. **Netlify CLI integration**:
   - Added `message` parameter to `deployToNetlify` function
   - Pass structured messages via `--message` flag to Netlify CLI
   - Apply to both draft and final deploys

### Example deploy message

```
docs deploy | context: alias:pr-773-abc1234 | branch: schickling/docs/add-deployment-metadata | commit: abc1234 https://github.com/livestorejs/livestore/commit/abc123... | pr: #773 https://github.com/livestorejs/livestore/pull/773 | run: https://github.com/livestorejs/livestore/actions/runs/123
```

This makes it trivial to trace each Netlify deployment back to its source commit, PR, and CI run directly from the Netlify dashboard.

## Files Changed

- `scripts/src/commands/docs.ts`: Added metadata extraction and buildMessage helper
- `scripts/src/shared/netlify.ts`: Added optional `message` parameter to deployToNetlify

## Validation

- [x] TypeScript compiles: `mono ts`
- [x] Linting passes: `mono lint`
- [x] No circular dependencies detected

## Related

Builds on the deployment enhancements from PR #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)