### PR TITLE
fix(react): store preloading

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -206,6 +206,7 @@ export class StoreRegistry {
   load = async <TSchema extends LiveStoreSchema>(options: CachedStoreOptions<TSchema>): Promise<Store<TSchema>> => {
     const optionsWithDefaults = this.#applyDefaultOptions(options)
     const entry = this.ensureStoreEntry<TSchema>(optionsWithDefaults.storeId)
+    this.#cancelGC(optionsWithDefaults.storeId)
 
     // If already loaded, return it
     if (entry.store) return entry.store
@@ -257,6 +258,7 @@ export class StoreRegistry {
   ): Store<TSchema> | Promise<Store<TSchema>> => {
     const optionsWithDefaults = this.#applyDefaultOptions(options)
     const entry = this.ensureStoreEntry<TSchema>(optionsWithDefaults.storeId)
+    this.#cancelGC(optionsWithDefaults.storeId)
 
     // If already loaded, return it directly (not wrapped in Promise)
     if (entry.store) return entry.store

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -34,11 +34,6 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
   #subscribers = new Set<() => void>()
 
   /**
-   * Monotonic counter that increments on every notify.
-   */
-  version = 0
-
-  /**
    * The number of active subscribers for this entry.
    */
   get subscriberCount() {
@@ -59,13 +54,12 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
   }
 
   /**
-   * Notifies all subscribers and increments the version counter.
+   * Notifies all subscribers of state changes.
    *
    * @remarks
    * This should be called after any meaningful state change.
    */
   notify = (): void => {
-    this.version++
     for (const sub of this.#subscribers) {
       try {
         sub()
@@ -220,7 +214,7 @@ export class StoreRegistry {
     if (entry.promise) return entry.promise
 
     // If a previous error exists, throw it
-    if (entry.error !== undefined) throw entry.error
+    if (entry.error) throw entry.error
 
     // Load store if none is in flight
     entry.promise = createStorePromise(optionsWithDefaults)
@@ -267,11 +261,11 @@ export class StoreRegistry {
     // If already loaded, return it directly (not wrapped in Promise)
     if (entry.store) return entry.store
 
-    // If a previous error exists, throw it
-    if (entry.error !== undefined) throw entry.error
-
     // If a load is already in flight, return the existing promise
     if (entry.promise) return entry.promise
+
+    // If a previous error exists, throw it
+    if (entry.error) throw entry.error
 
     // Load store if none is in flight
     entry.promise = createStorePromise(optionsWithDefaults)
@@ -319,15 +313,8 @@ export class StoreRegistry {
     return () => {
       unsubscribe()
       // If no more subscribers remain, schedule GC
-      if (entry.subscriberCount === 0) {
-        this.#scheduleGC(storeId)
-      }
+      if (entry.subscriberCount === 0) this.#scheduleGC(storeId)
     }
-  }
-
-  getVersion = <TSchema extends LiveStoreSchema>(storeId: StoreId): number => {
-    const entry = this.ensureStoreEntry<TSchema>(storeId)
-    return entry.version
   }
 
   #applyDefaultOptions = <TSchema extends LiveStoreSchema>(

--- a/packages/@livestore/react/src/experimental/multi-store/useStore.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/useStore.ts
@@ -16,23 +16,14 @@ export const useStore = <TSchema extends LiveStoreSchema>(
 ): Store<TSchema> & ReactApi => {
   const storeRegistry = useStoreRegistry()
 
-  storeRegistry.ensureStoreEntry(options.storeId)
-
   const subscribe = React.useCallback(
     (onChange: () => void) => storeRegistry.subscribe(options.storeId, onChange),
     [storeRegistry, options.storeId],
   )
-  const getSnapshot = React.useCallback(
-    () => storeRegistry.getVersion(options.storeId),
-    [storeRegistry, options.storeId],
-  )
+  const getSnapshot = React.useCallback(() => storeRegistry.read(options), [storeRegistry, options])
 
-  React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const storeOrPromise = React.useSyncExternalStore(subscribe, getSnapshot)
 
-  const storeOrPromise = storeRegistry.read(options)
-
-  // If read() returns a Promise, use React.use() to suspend
-  // If it returns a Store directly, use it immediately
   const loadedStore = storeOrPromise instanceof Promise ? React.use(storeOrPromise) : storeOrPromise
 
   return withReactApi(loadedStore)


### PR DESCRIPTION
> [!NOTE]
> **PR Stack:**
> 1. #774
> 2. #784 **← This PR**
> 3. #785
> 
> Review #774 first

## Problem

Two issues prevented proper store preloading in the multi-store React integration:

1. **GC race condition**: When a store was preloaded via `load()` or `read()`, pending GC timeouts weren't canceled, causing stores to be prematurely garbage collected while components were waiting for them to load.

2. **Preloading suspension broken**: The `useStore` hook tracked a monotonic version counter instead of the actual store state, preventing React's Suspense mechanism from properly handling store loading promises.

## Solution

### Cancel GC on preload access

Added `this.#cancelGC()` calls at the start of both `load()` and `read()` methods in `StoreRegistry`. This ensures that any pending GC timeout is cleared when a store is accessed, preventing premature cleanup.

```typescript
load = async <TSchema extends LiveStoreSchema>(options: CachedStoreOptions<TSchema>): Promise<Store<TSchema>> => {
  const optionsWithDefaults = this.#applyDefaultOptions(options)
  const entry = this.ensureStoreEntry<TSchema>(optionsWithDefaults.storeId)
  this.#cancelGC(optionsWithDefaults.storeId)  // ← Cancel any pending GC
  // ... rest of method
}
```

### Simplify useStore suspension

Removed the version-based tracking mechanism and changed `useStore` to use the store read result directly as the `useSyncExternalStore` snapshot. This allows React's Suspense to properly catch the loading promise and suspend the component.

**Before:**
```typescript
const getSnapshot = () => storeRegistry.getVersion(options.storeId)
useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
const storeOrPromise = storeRegistry.read(options)
```

**After:**
```typescript
const getSnapshot = () => storeRegistry.read(options)
const storeOrPromise = useSyncExternalStore(subscribe, getSnapshot)
```

### Example update

Updated the `web-multi-store` example to differ the loading of child issues so that preloading can properly be demonstrated.