### PR TITLE
refactor(react): simplify StoreRegistry state management

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/useStore.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/useStore.ts
@@ -20,7 +20,7 @@ export const useStore = <TSchema extends LiveStoreSchema>(
     (onChange: () => void) => storeRegistry.subscribe(options.storeId, onChange),
     [storeRegistry, options.storeId],
   )
-  const getSnapshot = React.useCallback(() => storeRegistry.read(options), [storeRegistry, options])
+  const getSnapshot = React.useCallback(() => storeRegistry.getOrLoad(options), [storeRegistry, options])
 
   const storeOrPromise = React.useSyncExternalStore(subscribe, getSnapshot)
 


### PR DESCRIPTION
> [!NOTE]
> **PR Stack:**
> 1. #774
> 2. #784
> 3. #785 **← This PR**
> 
> Review #774 and #784 first

## Problem

The `StoreRegistry` implementation had several architectural issues:

1. **Duplicate logic**: The `read()` and `load()` methods contained nearly identical store loading logic, differing only in their return types
2. **Unclear state management**: Store state was tracked via separate nullable fields (`store`, `error`, `promise`) in `StoreEntry`, making state transitions implicit
3. **Mixed responsibilities**: GC scheduling logic was split between `StoreEntry` and `StoreRegistry`, obscuring ownership
4. **Inconsistent loading**: Store creation happened in `StoreRegistry` methods rather than being encapsulated in `StoreEntry`

## Solution

This refactoring improves the architecture through three key changes:

### 1. Explicit state machine in StoreEntry

Introduced a discriminated union `StoreEntryState` to make the store lifecycle explicit:
```typescript
type StoreEntryState<TSchema> =
  | { status: 'idle' }
  | { status: 'loading'; promise: Promise<Store<TSchema>> }
  | { status: 'success'; store: Store<TSchema> }
  | { status: 'error'; error: unknown }
```

This eliminates the ambiguity of multiple nullable fields and makes state transitions clear.

### 2. Consolidated loading in StoreEntry.getOrLoad()

Moved store creation logic into `StoreEntry` with a single `getOrLoad()` method that:
- Returns the store directly if already loaded (no Promise wrapper)
- Returns a stable Promise if loading is in progress
- Throws errors synchronously if a previous load failed
- Handles the complete load lifecycle internally

This eliminates the duplicate logic between `read()` and `load()` in `StoreRegistry`.

### 3. Centralized GC scheduling

Moved GC scheduling responsibility entirely to `StoreRegistry`:
- `StoreEntry` no longer knows about GC
- `StoreRegistry.getOrLoad()` schedules GC via `promise.finally()` if no subscribers remain
- Clear separation: `StoreEntry` manages store lifecycle, `StoreRegistry` manages cache eviction

## Testing

- Existing unit tests continue to pass (StoreRegistry behavior unchanged)
- Integration tests verify Suspense and error boundary integration still work

## Related

Part of #686 (multi-store support).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>