### PR TITLE
Make markdown negotiation happen before cache

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -21,6 +21,7 @@ remote_images = ["https://gitbucket\\.schickling\\.dev/.*"]
 [build]
 command = "bunx astro build"
 publish = "docs/dist"
+edge_functions = "docs/netlify/edge-functions"
 
 # Edge Function configuration. The Edge runtime bundles the file(s) below and
 # attaches them at the CDN layer during the Netlify build phase.

--- a/docs/netlify/edge-functions/markdown-negotiation.ts
+++ b/docs/netlify/edge-functions/markdown-negotiation.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'netlify:edge'
+import type { Config, Context } from 'netlify:edge'
 
 import { appendVary, buildMarkdownUrl, isAssetPath, preferredMarkdown } from '../../src/server/markdown-negotiation.ts'
 
@@ -57,4 +57,9 @@ export default async function handler(request: Request, context: Context): Promi
     : new Response(markdownResponse.body, { status: markdownResponse.status, headers })
   appendVary(response, 'Accept')
   return response
+}
+
+export const config : Config = {
+  path: "/*",
+  cache: "manual"
 }


### PR DESCRIPTION
This improves the middleware for markdown negotiation by making sure it runs after the cache.