### PR TITLE
feat(examples/web-multi-store): defer loading of sub-issues

### DIFF
--- a/examples/web-multi-store/src/components/IssueView.tsx
+++ b/examples/web-multi-store/src/components/IssueView.tsx
@@ -1,5 +1,8 @@
 import { queryDb } from '@livestore/livestore'
 import { useStore } from '@livestore/react/experimental'
+import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
 import { issueStoreOptions } from '@/stores/issue'
 import { issueEvents, issueTables } from '../stores/issue/schema.ts'
 
@@ -33,13 +36,17 @@ export function IssueView({ issueId }: { issueId: string }) {
       </p>
 
       {issue.childIssueIds.length > 0 && (
-        <ul>
-          {issue.childIssueIds.map((id) => (
-            <li key={id}>
-              <IssueView issueId={id} />
-            </li>
-          ))}
-        </ul>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <Suspense fallback={<div className="loading">Loading sub-issues...</div>}>
+            <ul>
+              {issue.childIssueIds.map((id) => (
+                <li key={id}>
+                  <IssueView issueId={id} />
+                </li>
+              ))}
+            </ul>
+          </Suspense>
+        </ErrorBoundary>
       )}
     </div>
   )


### PR DESCRIPTION
## Problem

The web-multi-store example loads all sub-issues synchronously when rendering parent issues, which blocks the parent rendering and prevents proper demonstration of the store preloading feature. This makes it harder for developers to understand how preloading works in practice.

## Solution

Wrap the sub-issues rendering in `Suspense` and `ErrorBoundary` components to defer their loading. This allows:
- Parent issues to render immediately without waiting for child data
- Proper demonstration of LiveStore's preloading capabilities
- Better user experience with loading states for hierarchical data

The change adds:
- `Suspense` wrapper with a "Loading sub-issues..." fallback
- `ErrorBoundary` to gracefully handle any errors in child issue loading

## Validation

Manual testing in the web-multi-store example:
- Parent issues now render immediately
- Sub-issues show loading state before appearing
- Preloading behavior is clearly visible

## Related issues

This improves the example demonstrating the multi-store API introduced in #764.