### PR TITLE
fix: Version change style + iOS Safari switch support

### DIFF
--- a/docs/src/components/SocialIcons.astro
+++ b/docs/src/components/SocialIcons.astro
@@ -1,7 +1,7 @@
 ---
 import SocialIcons_ from '@astrojs/starlight/components/SocialIcons.astro'
 import { liveStoreVersion } from '@livestore/common'
-import { IS_MAIN_BRANCH } from '../../data.js'
+import { IS_MAIN_BRANCH } from '../data/data.ts'
 
 const devUrl = 'https://dev.docs.livestore.dev'
 const latestUrl = 'https://docs.livestore.dev'
@@ -29,7 +29,9 @@ const links = Object.entries({
 			<option value={latestUrl} selected={IS_MAIN_BRANCH}
 				>Version: {IS_MAIN_BRANCH ? liveStoreVersion : 'latest'}</option
 			>
-			<option value={devUrl} selected={!IS_MAIN_BRANCH}>Version: {IS_MAIN_BRANCH ? 'dev' : liveStoreVersion}</option>
+			<option value={devUrl} selected={!IS_MAIN_BRANCH}
+				>Version: {IS_MAIN_BRANCH ? 'dev' : liveStoreVersion}</option
+			>
 		</select>
 	</div>
 </div>
@@ -88,42 +90,71 @@ const links = Object.entries({
 	.version-select-wrapper select {
 		appearance: none;
 		background-color: transparent;
-		background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+		background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'12\' height=\'12\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'white\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-linejoin=\'round\'%3E%3Cpolyline points=\'6 9 12 15 18 9\'%3E%3C/polyline%3E%3C/svg%3E');
 		background-repeat: no-repeat;
 		background-position: right 0.5rem center;
-		color: white;
+
 		border: none;
 		font-size: 0.875rem;
 		padding: 0 1.5rem 0 0.5rem;
 		cursor: pointer;
 	}
 
-	/* Remove focus outline */
+	/* Style select options for light mode */
+	.version-select-wrapper select option {
+		background-color: var(--color-gray-200);
+		color: var(--sl-color-text);
+	}
+
+	/* Style select options for dark mode */
+	:root[data-theme='dark'] {
+		.version-select-wrapper select option {
+			background-color: var(--color-gray-800);
+			color: var(--sl-color-white);
+		}
+	}
+
+	/* fixes dropdown icon in light mode */
+	:root[data-theme='light'] {
+		.version-select-wrapper select {
+			background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'12\' height=\'12\' viewBox=\'0 0 24 24\' fill=\'none\' stroke=\'black\' stroke-width=\'2\' stroke-linecap=\'round\' stroke-linejoin=\'round\'%3E%3Cpolyline points=\'6 9 12 15 18 9\'%3E%3C/polyline%3E%3C/svg%3E');
+		}
+	}
+
+	.version-select-wrapper select:focus + .version-select-wrapper,
+	.version-select-wrapper:has(select:focus) {
+		border: 1px solid var(--custom-outline-color);
+	}
+
+	/* Alternative approach for browsers that don't support :has() */
 	.version-select-wrapper select:focus {
 		outline: none;
+	}
+
+	.version-select-wrapper:focus-within {
+		border: 1px solid var(--custom-outline-color);
 	}
 </style>
 
 <script>
 	// Handle version switching while preserving the current path
 	document.addEventListener('DOMContentLoaded', () => {
-		const versionSelect = document.getElementById('version-select') as HTMLSelectElement
+		const versionSelect = document.getElementById('version-select')
+		if (!(versionSelect instanceof HTMLSelectElement)) return
 
-		if (versionSelect) {
-			versionSelect.addEventListener('change', () => {
-				const targetUrl = versionSelect.value
-				if (targetUrl === undefined || targetUrl === null) return
+		versionSelect.addEventListener('change', () => {
+			const targetUrl = versionSelect.value;
+			if (targetUrl === undefined || targetUrl === null) return;
 
-				// Get current path and search params
-				const currentPath = window.location.pathname
-				const currentSearch = window.location.search
+			// Get current path and search params
+			const currentPath = window.location.pathname;
+			const currentSearch = window.location.search;
 
-				// Construct new URL with the same path
-				const newUrl = new URL(currentPath + currentSearch, targetUrl)
+			// Construct new URL with the same path
+			const newUrl = new URL(currentPath + currentSearch, targetUrl);
 
-				// Navigate to the new URL
-				window.location.href = newUrl.toString()
-			})
-		}
-	})
+			// Navigate to the new URL
+			window.location.href = newUrl.toString();
+		});
+	});
 </script>


### PR DESCRIPTION
_Notice, this PR targets `main`_

## Problem

Can't switch the docs page to the dev branch on a mobile device, and the switch styles are incorrect for light and dark modes.

## Solution

I brought in the SocialIcons code from `dev` branch and put it here.

## Validation

I wasn't able to run the docs site due to an issue with workspace package linking
```
> astro check && astro build

10:55:40 AM [vite] (ssr) Error when evaluating SSR module /Users/cole/phosphor/livestore/docs/astro.config.mjs: Failed to resolve entry for package "@livestore/common". The package may have incorrect main/module/exports specified in its package.json.
```

### Demo (optional)

Share logs, screenshots, CLI output, or quick diagrams (Mermaid/ASCII) that illustrate the change when it helps reviewers grok the impact quickly.

## Related issues

- #...
