### PR TITLE
feat(react/multi-store): shutdown stores on cache eviction

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -168,12 +168,6 @@ class StoreCache {
     void entry.shutdown()
     this.#entries.delete(storeId)
   }
-
-  clear = (): void => {
-    for (const storeId of Array.from(this.#entries.keys())) {
-      this.remove(storeId)
-    }
-  }
 }
 
 const DEFAULT_GC_TIME = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : 60_000


### PR DESCRIPTION
## Problem

When cached stores are evicted from the `StoreRegistry` during garbage collection, they were removed from the cache without also shutting the store. This would lead to lingering store instances.

## Solution

Added automatic store shutdown during cache eviction:

- Introduced `StoreEntry#shutdown()` to handle graceful store cleanup and reset entry state
- Modified `StoreCache#remove()` to invoke shutdown before removing entries
- The shutdown occurs asynchronously (fire-and-forget) during GC to avoid blocking the removal process while ensuring resources are properly released

### Supporting Changes

- Made `StoreEntry.notify()` private since external notification on removal is no longer needed (shutdown handles the cleanup flow)
- Removed unused `StoreCache.clear()` method
- Inlined `StoreRegistry.ensureStoreEntry()` for simpler code flow
- Re-ordered methods for better logical grouping
- Updated TSDoc comments for clarity

## Validation

- Store lifecycle now properly cleans up when entries are garbage collected after subscriber count drops to zero

## Context

Related to #686 - this is part of the larger multi-store support effort.