### PR TITLE
Quote and auto-increment for SQLite schema

### DIFF
--- a/packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts
+++ b/packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { Effect, Option, Schema } from '@livestore/utils/effect'
+
+import { migrateTable } from '../migrations.ts'
+import type { PreparedBindValues } from '../../util.ts'
+import type { PreparedStatement, SqliteDb } from '../../sqlite-types.ts'
+import { SqliteAst } from '../../schema/state/sqlite/db-schema/mod.ts'
+
+const makeStubDb = () => {
+  const executed: string[] = []
+
+  const db: SqliteDb = {
+    _tag: 'SqliteDb',
+    metadata: { dbPointer: 0, persistenceInfo: { fileName: ':memory:' } } as any,
+    debug: { head: 0 as any },
+    prepare: (queryStr: string): PreparedStatement => ({
+      sql: queryStr,
+      execute: (_bind: PreparedBindValues | undefined) => {
+        executed.push(queryStr)
+      },
+      select: <T>(_bind: PreparedBindValues | undefined) => [] as unknown as ReadonlyArray<T>,
+      finalize: () => {},
+    }),
+    execute: () => {},
+    select: () => [],
+    export: () => new Uint8Array(),
+    import: () => {},
+    close: () => {},
+    destroy: () => {},
+    session: () => ({ changeset: () => undefined, finish: () => {} }),
+    makeChangeset: () => ({ invert: () => ({ invert: () => ({} as any), apply: () => {} } as any), apply: () => {} }),
+  }
+
+  return { db, executed }
+}
+
+describe('migrateTable - quoting and autoincrement', () => {
+  it('creates valid CREATE TABLE with inline INTEGER PRIMARY KEY AUTOINCREMENT and double-quoted identifiers', () => {
+    const { db, executed } = makeStubDb()
+
+    const table = SqliteAst.table(
+      'todos',
+      [
+        SqliteAst.column({
+          name: 'id',
+          type: { _tag: 'integer' },
+          nullable: false,
+          primaryKey: true,
+          autoIncrement: true,
+          default: Option.none(),
+          schema: Schema.Number,
+        }),
+        SqliteAst.column({
+          name: 'text',
+          type: { _tag: 'text' },
+          nullable: false,
+          primaryKey: false,
+          autoIncrement: false,
+          default: Option.some(''),
+          schema: Schema.String,
+        }),
+        SqliteAst.column({
+          name: 'completed',
+          type: { _tag: 'integer' },
+          nullable: false,
+          primaryKey: false,
+          autoIncrement: false,
+          default: Option.some(0),
+          schema: Schema.Number,
+        }),
+      ],
+      [],
+    )
+
+    migrateTable({ db, tableAst: table, behaviour: 'create-if-not-exists', skipMetaTable: true }).pipe(Effect.runSync)
+
+    const createStmt = executed.find((s) => /create table if not exists/i.test(s))
+    expect(createStmt).toBeDefined()
+
+    // Identifiers must be double-quoted, not single-quoted
+    expect(createStmt!).toContain('create table if not exists "todos"')
+    expect(createStmt!).toContain('"id" integer primary key autoincrement')
+    expect(createStmt!).toContain(" default ''")
+    expect(createStmt!).not.toContain("PRIMARY KEY ('id')")
+    expect(createStmt!).not.toMatch(/'todos'|\'id\'|\'text\'/)
+  })
+})

--- a/packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts
+++ b/packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it } from 'vitest'
 import { Effect, Option, Schema } from '@livestore/utils/effect'
-
-import { migrateTable } from '../migrations.ts'
-import type { PreparedBindValues } from '../../util.ts'
-import type { PreparedStatement, SqliteDb } from '../../sqlite-types.ts'
+import { describe, expect, it } from 'vitest'
 import { SqliteAst } from '../../schema/state/sqlite/db-schema/mod.ts'
+import type { PreparedStatement, SqliteDb } from '../../sqlite-types.ts'
+import type { PreparedBindValues } from '../../util.ts'
+import { migrateTable } from '../migrations.ts'
 
 const makeStubDb = () => {
   const executed: string[] = []
@@ -28,7 +27,7 @@ const makeStubDb = () => {
     close: () => {},
     destroy: () => {},
     session: () => ({ changeset: () => undefined, finish: () => {} }),
-    makeChangeset: () => ({ invert: () => ({ invert: () => ({} as any), apply: () => {} } as any), apply: () => {} }),
+    makeChangeset: () => ({ invert: () => ({ invert: () => ({}) as any, apply: () => {} }) as any, apply: () => {} }),
   }
 
   return { db, executed }
@@ -82,6 +81,6 @@ describe('migrateTable - quoting and autoincrement', () => {
     expect(createStmt!).toContain('"id" integer primary key autoincrement')
     expect(createStmt!).toContain(" default ''")
     expect(createStmt!).not.toContain("PRIMARY KEY ('id')")
-    expect(createStmt!).not.toMatch(/'todos'|\'id\'|\'text\'/)
+    expect(createStmt!).not.toMatch(/'todos'|'id'|'text'/)
   })
 })

--- a/packages/@livestore/common/src/schema-management/migrations.ts
+++ b/packages/@livestore/common/src/schema-management/migrations.ts
@@ -168,10 +168,10 @@ export const migrateTable = ({
 
     if (behaviour === 'drop-and-recreate') {
       // TODO need to possibly handle cascading deletes due to foreign keys
-      dbExecute(db, sql`drop table if exists '${tableName}'`)
-      dbExecute(db, sql`create table if not exists '${tableName}' (${columnSpec}) strict`)
+      dbExecute(db, sql`drop table if exists "${tableName}"`)
+      dbExecute(db, sql`create table if not exists "${tableName}" (${columnSpec}) strict`)
     } else if (behaviour === 'create-if-not-exists') {
-      dbExecute(db, sql`create table if not exists '${tableName}' (${columnSpec}) strict`)
+      dbExecute(db, sql`create table if not exists "${tableName}" (${columnSpec}) strict`)
     }
 
     for (const index of tableAst.indexes) {
@@ -201,5 +201,7 @@ export const migrateTable = ({
 
 const createIndexFromDefinition = (tableName: string, index: SqliteAst.Index) => {
   const uniqueStr = index.unique ? 'UNIQUE' : ''
-  return sql`create ${uniqueStr} index if not exists '${index.name}' on '${tableName}' (${index.columns.map((col) => `'${col}'`).join(', ')})`
+  return sql`create ${uniqueStr} index if not exists "${index.name}" on "${tableName}" (${index.columns
+    .map((col) => `"${col}"`)
+    .join(', ')})`
 }

--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
@@ -56,9 +56,9 @@ describe('makeColumnSpec', () => {
     )
 
     const result = makeColumnSpec(table)
-    expect(result).toMatchInlineSnapshot(`"'order' integer not null  , 'group' text   "`)
-    expect(result).toContain("'order'")
-    expect(result).toContain("'group'")
+    expect(result).toMatchInlineSnapshot(`""order" integer   not null , "group" text    "`)
+    expect(result).toContain('"order"')
+    expect(result).toContain('"group"')
   })
 
   it('should handle basic columns with primary keys', () => {
@@ -69,8 +69,7 @@ describe('makeColumnSpec', () => {
     )
 
     const result = makeColumnSpec(table)
-    expect(result).toMatchInlineSnapshot(`"'id' text not null  , 'name' text   , PRIMARY KEY ('id')"`)
-    expect(result).toContain("PRIMARY KEY ('id')")
+    expect(result).toMatchInlineSnapshot(`""id" text primary key   , "name" text    "`)
   })
 
   it('should handle multi-column primary keys', () => {
@@ -85,9 +84,9 @@ describe('makeColumnSpec', () => {
 
     const result = makeColumnSpec(table)
     expect(result).toMatchInlineSnapshot(
-      `"'tenant_id' text not null  , 'user_id' text not null  , PRIMARY KEY ('tenant_id', 'user_id')"`,
+      `""tenant_id" text   not null , "user_id" text   not null , PRIMARY KEY ("tenant_id", "user_id")"`,
     )
-    expect(result).toContain("PRIMARY KEY ('tenant_id', 'user_id')")
+    expect(result).toContain('PRIMARY KEY ("tenant_id", "user_id")')
   })
 
   it('should handle auto-increment columns', () => {
@@ -101,9 +100,9 @@ describe('makeColumnSpec', () => {
     )
 
     const result = makeColumnSpec(table)
-    expect(result).toMatchInlineSnapshot(`"'id' integer not null autoincrement , 'title' text   , PRIMARY KEY ('id')"`)
+    expect(result).toMatchInlineSnapshot(`""id" integer primary key autoincrement  , "title" text    "`)
     expect(result).toContain('autoincrement')
-    expect(result).toContain("PRIMARY KEY ('id')")
+    expect(result).not.toContain("PRIMARY KEY ('id')")
   })
 
   it('should handle columns with default values', () => {
@@ -121,7 +120,7 @@ describe('makeColumnSpec', () => {
 
     const result = makeColumnSpec(table)
     expect(result).toMatchInlineSnapshot(
-      `"'id' integer not null  , 'name' text not null  , 'price' real   default 0, 'active' integer   default true, 'description' text   default 'No description', PRIMARY KEY ('id')"`,
+      `""id" integer primary key   , "name" text   not null , "price" real    default 0, "active" integer    default true, "description" text    default 'No description'"`,
     )
     expect(result).toContain('default 0')
     expect(result).toContain('default true')
@@ -141,7 +140,7 @@ describe('makeColumnSpec', () => {
 
     const result = makeColumnSpec(table)
     expect(result).toMatchInlineSnapshot(
-      `"'id' integer not null  , 'created_at' text   default CURRENT_TIMESTAMP, 'random_value' real   default RANDOM(), PRIMARY KEY ('id')"`,
+      `""id" integer primary key   , "created_at" text    default CURRENT_TIMESTAMP, "random_value" real    default RANDOM()"`,
     )
     expect(result).toContain('default CURRENT_TIMESTAMP')
     expect(result).toContain('default RANDOM()')
@@ -159,7 +158,7 @@ describe('makeColumnSpec', () => {
 
     const result = makeColumnSpec(table)
     expect(result).toMatchInlineSnapshot(
-      `"'id' integer not null  , 'optional_text' text   default null, PRIMARY KEY ('id')"`,
+      `""id" integer primary key   , "optional_text" text    default null"`,
     )
     expect(result).toContain('default null')
   })
@@ -190,7 +189,7 @@ describe('makeColumnSpec', () => {
 
     const result = makeColumnSpec(table)
     expect(result).toMatchInlineSnapshot(
-      `"'id' integer not null autoincrement , 'name' text not null  default 'Unnamed', 'created_at' text not null  default CURRENT_TIMESTAMP, 'status' text   default 'pending', PRIMARY KEY ('id')"`,
+      `""id" integer primary key autoincrement  , "name" text   not null default 'Unnamed', "created_at" text   not null default CURRENT_TIMESTAMP, "status" text    default 'pending'"`,
     )
   })
 
@@ -213,7 +212,7 @@ describe('makeColumnSpec', () => {
     const result = makeColumnSpec(table)
     // The makeColumnSpec function only generates column specifications, not indexes
     expect(result).toMatchInlineSnapshot(
-      `"'id' integer not null autoincrement , 'email' text not null  , 'username' text not null  , 'created_at' text   default CURRENT_TIMESTAMP, PRIMARY KEY ('id')"`,
+      `""id" integer primary key autoincrement  , "email" text   not null , "username" text   not null , "created_at" text    default CURRENT_TIMESTAMP"`,
     )
     // Verify the table has the indexes (even though they're not in the column spec)
     expect(table.indexes).toHaveLength(3)

--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
@@ -157,9 +157,7 @@ describe('makeColumnSpec', () => {
     )
 
     const result = makeColumnSpec(table)
-    expect(result).toMatchInlineSnapshot(
-      `""id" integer primary key   , "optional_text" text    default null"`,
-    )
+    expect(result).toMatchInlineSnapshot(`""id" integer primary key   , "optional_text" text    default null"`)
     expect(result).toContain('default null')
   })
 

--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.ts
@@ -32,18 +32,14 @@ export const makeColumnSpec = (tableAst: SqliteAst.Table) => {
 }
 
 /** NOTE primary keys are applied on a table level not on a column level to account for multi-column primary keys */
-const toSqliteColumnSpec = (
-  column: SqliteAst.Column,
-  opts: { inlinePrimaryKey: boolean },
-) => {
+const toSqliteColumnSpec = (column: SqliteAst.Column, opts: { inlinePrimaryKey: boolean }) => {
   const columnTypeStr = column.type._tag
   // When PRIMARY KEY is declared inline, NOT NULL is implied and should not be emitted,
   // and AUTOINCREMENT must immediately follow PRIMARY KEY within the same constraint.
   const nullableStr = opts.inlinePrimaryKey ? '' : column.nullable === false ? 'not null' : ''
 
   // Only include AUTOINCREMENT when it's valid: single-column INTEGER PRIMARY KEY
-  const includeAutoIncrement =
-    opts.inlinePrimaryKey && column.type._tag === 'integer' && column.autoIncrement === true
+  const includeAutoIncrement = opts.inlinePrimaryKey && column.type._tag === 'integer' && column.autoIncrement === true
 
   const pkStr = opts.inlinePrimaryKey ? 'primary key' : ''
   const autoIncrementStr = includeAutoIncrement ? 'autoincrement' : ''

--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.ts
@@ -10,21 +10,44 @@ import { type SqliteAst, SqliteDsl } from './db-schema/mod.ts'
  * ```
  */
 export const makeColumnSpec = (tableAst: SqliteAst.Table) => {
-  const primaryKeys = tableAst.columns.filter((_) => _.primaryKey).map((_) => `'${_.name}'`)
-  const columnDefStrs = tableAst.columns.map(toSqliteColumnSpec)
+  const pkColumns = tableAst.columns.filter((_) => _.primaryKey)
+  const hasSinglePk = pkColumns.length === 1
+  const pkColumn = hasSinglePk ? pkColumns[0] : undefined
 
-  if (primaryKeys.length > 0) {
-    columnDefStrs.push(`PRIMARY KEY (${primaryKeys.join(', ')})`)
+  // Build column definitions, handling the special SQLite rule that AUTOINCREMENT
+  // is only valid on a single column declared as INTEGER PRIMARY KEY (column-level).
+  const columnDefStrs = tableAst.columns.map((column) =>
+    toSqliteColumnSpec(column, {
+      inlinePrimaryKey: hasSinglePk && column === pkColumn && column.primaryKey === true,
+    }),
+  )
+
+  // For composite primary keys, add a table-level PRIMARY KEY clause.
+  if (pkColumns.length > 1) {
+    const quotedPkCols = pkColumns.map((_) => `"${_.name}"`)
+    columnDefStrs.push(`PRIMARY KEY (${quotedPkCols.join(', ')})`)
   }
 
   return columnDefStrs.join(', ')
 }
 
 /** NOTE primary keys are applied on a table level not on a column level to account for multi-column primary keys */
-const toSqliteColumnSpec = (column: SqliteAst.Column) => {
+const toSqliteColumnSpec = (
+  column: SqliteAst.Column,
+  opts: { inlinePrimaryKey: boolean },
+) => {
   const columnTypeStr = column.type._tag
-  const nullableStr = column.nullable === false ? 'not null' : ''
-  const autoIncrementStr = column.autoIncrement ? 'autoincrement' : ''
+  // When PRIMARY KEY is declared inline, NOT NULL is implied and should not be emitted,
+  // and AUTOINCREMENT must immediately follow PRIMARY KEY within the same constraint.
+  const nullableStr = opts.inlinePrimaryKey ? '' : column.nullable === false ? 'not null' : ''
+
+  // Only include AUTOINCREMENT when it's valid: single-column INTEGER PRIMARY KEY
+  const includeAutoIncrement =
+    opts.inlinePrimaryKey && column.type._tag === 'integer' && column.autoIncrement === true
+
+  const pkStr = opts.inlinePrimaryKey ? 'primary key' : ''
+  const autoIncrementStr = includeAutoIncrement ? 'autoincrement' : ''
+
   const defaultValueStr = (() => {
     if (column.default._tag === 'None') return ''
 
@@ -38,5 +61,6 @@ const toSqliteColumnSpec = (column: SqliteAst.Column) => {
     return `default ${encodedDefaultValue}`
   })()
 
-  return `'${column.name}' ${columnTypeStr} ${nullableStr} ${autoIncrementStr} ${defaultValueStr}`
+  // Ensure order: PRIMARY KEY [AUTOINCREMENT] [NOT NULL] ...
+  return `"${column.name}" ${columnTypeStr} ${pkStr} ${autoIncrementStr} ${nullableStr} ${defaultValueStr}`
 }


### PR DESCRIPTION
## Problem

Previously, SQLite table and column identifiers were not consistently double-quoted, which could lead to issues with reserved keywords or case sensitivity. Additionally, the handling of `AUTOINCREMENT` for primary keys was not always correct, especially when defined inline with other constraints.

## Solution

This PR addresses these issues by:

1.  **Double-quoting all identifiers:** Table names, column names, and index names are now consistently enclosed in double quotes (`"`) when generating SQL statements. This ensures correct parsing by SQLite, especially for names that might conflict with SQL keywords or contain special characters.
2.  **Correctly handling `AUTOINCREMENT`:** The `AUTOINCREMENT` keyword is now only applied when it's syntactically valid according to SQLite's rules: it must be part of an `INTEGER PRIMARY KEY` declaration on a single column.
    *   When a single column is declared as `INTEGER PRIMARY KEY AUTOINCREMENT`, the `PRIMARY KEY` and `AUTOINCREMENT` are combined inline, and `NOT NULL` is implicitly handled.
    *   For composite primary keys or non-`INTEGER` primary keys, `AUTOINCREMENT` is not applied.
    *   A table-level `PRIMARY KEY` clause is generated for multi-column primary keys.

This change involves modifications to:
*   `migrations.ts`: Updated `dbExecute` calls to use double quotes for table and index names.
*   `column-spec.ts`: Refactored `makeColumnSpec` and `toSqliteColumnSpec` to correctly handle quoting and the logic for `AUTOINCREMENT` and inline primary keys.
*   Added a new test file `migrations-autoincrement-quoting.test.ts` to specifically verify `CREATE TABLE` statements generated with inline `AUTOINCREMENT` and double-quoted identifiers.
*   Updated existing tests in `column-spec.test.ts` to reflect the new quoting and primary key declaration styles.

## Validation

*   **New test:** `packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts` ensures that `CREATE TABLE` statements are correctly generated with double-quoted identifiers and inline `AUTOINCREMENT`.
*   **Updated tests:** Existing tests in `packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts` have been updated to pass with the new quoting and primary key declaration behavior.
*   **Manual checks:** Reviewed the diff to ensure all generated SQL statements for table creation, index creation, and column specifications now use double quotes.

### Demo

**Example `CREATE TABLE` statement generated after this change:**

```sql
create table if not exists "todos" ("id" integer primary key autoincrement, "text" text not null, "completed" integer not null default 0) strict
```

Note the double quotes around table and column names, and the inline `integer primary key autoincrement` for the `id` column.

## Related issues

- #None
