### PR TITLE
fix: prevent crash when import.meta.env is undefined in SSR detection

### DIFF
--- a/packages/@livestore/adapter-web/src/web-worker/client-session/sqlite-loader.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/sqlite-loader.ts
@@ -8,7 +8,7 @@ import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
  * The Cloudflare / Workerd runtime has stricter rules: async fetches during module
  * evaluation are blocked, so we defer loading until the worker asks for it.
  */
-const isServerRuntime = String(import.meta.env.SSR) === 'true'
+const isServerRuntime = String(import.meta.env?.SSR) === 'true' || typeof window === 'undefined'
 
 let sqlite3Promise: ReturnType<typeof loadSqlite3Wasm> | undefined
 


### PR DESCRIPTION
Fixes `react-router dev` server crash by safely accessing `import.meta.env.SSR` with optional chaining. Falls back to `typeof window === 'undefined'` when `import.meta.env` is not available (e.g. when running `react-router dev`).

Resolves: `Cannot read properties of undefined (reading 'SSR')`

<!-- Use a title that captures the problem and the approach, e.g. "Fix backlog replay flake by stabilizing event helper" -->

## Problem

Running `react-router dev` and then visiting the dev server URL results in an error.

## Solution

Uses optional chaining to avoid triggering an uncaught exception and falls back to a simple `typeof window` check to approximate the same heuristic.

## Validation

I would like to validate the fix, but I’m not sure how to do so.  That said, this particular change is trivial. But for future contributions, it would be great to have a setup that would allow me to test changes. Maybe via a new `examples/web-todomvc-react-router-ssr` example? or `examples/web-todomvc-react-router-framework-mode`?

## Related issues

- Fixes #791
