### PR TITLE
feat(react/multi-store): support call-site `gcTime` override

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -45,13 +45,11 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
 
       // Re-check to avoid racing with a new subscription
       if (this.#subscribers.size > 0) return
+
       void this.#shutdown().finally(() => {
         // Double-check again just in case shutdown was slow
         if (this.#subscribers.size === 0) this.#cache.delete(this.#storeId)
       })
-
-      void this.#shutdown()
-      this.#cache.delete(this.#storeId)
     }, effectiveGcTime)
   }
 


### PR DESCRIPTION
## Problem

The multi-store cache currently uses a single global garbage collection (GC) timeout configured at registry creation time. This prevents callers from specifying different retention policies for individual stores based on their usage patterns. For example, a user profile store might need long retention while temporary search results could be collected more aggressively.

## Solution

This PR enables per-call `gcTime` override by:

1. **Moving GC ownership into `StoreEntry`** – Each entry now manages its own `gcTime` value and timeout, allowing fine-grained control per store instance
2. **Accepting `gcTime` in options** – Callers can pass `{ gcTime: number }` when loading a store; the entry adopts the maximum of all supplied values (preserving the longest requested lifetime)
3. **Scheduling GC when subscriber count reaches zero** – When the last subscriber unsubscribes or loading completes with no active subscribers, the entry schedules collection based on its `gcTime`

### Key changes

- `StoreEntry` constructor now requires `(storeId, cache)` to enable self-cleanup
- `StoreEntry#getOrLoad` accepts `gcTime` in options and updates the entry's GC window
- `StoreEntry#subscribe` cancels any pending GC on subscribe and schedules it on final unsubscribe
- `StoreEntry#shutdown` is now private (`#shutdown`) since GC is managed internally
- Removed `StoreRegistry#scheduleGC`, `#cancelGC`, and `#gcTimeouts` map (logic now lives in each entry)
- `StoreCache#remove` renamed to `#delete` for clarity and to match `Map` semantics

## Testing

- Manual verification: loading stores with different `gcTime` values respects the maximum and cleans up correctly when subscribers drop to zero