### PR TITLE
test(react/multi-store): write tests and fix suspend resume

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -1,0 +1,161 @@
+import type { LiveStoreSchema } from '@livestore/common/schema'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CachedStoreOptions } from './types.ts'
+
+vi.mock('@livestore/livestore', () => ({
+  createStorePromise: vi.fn(),
+}))
+
+import { createStorePromise, type Store } from '@livestore/livestore'
+import { StoreRegistry } from './StoreRegistry.ts'
+
+type TestSchema = LiveStoreSchema.Any
+
+const mockedCreateStorePromise = vi.mocked(createStorePromise)
+
+describe('StoreRegistry', () => {
+  beforeEach(() => {
+    mockedCreateStorePromise.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('returns a Promise when the store is loading', () => {
+    const registry = new StoreRegistry()
+    const { promise } = createDeferred<Store<TestSchema>>()
+    mockedCreateStorePromise.mockReturnValueOnce(promise)
+
+    const result = registry.getOrLoad(makeOptions())
+
+    expect(result).toBeInstanceOf(Promise)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns cached store synchronously after first load resolves', async () => {
+    const registry = new StoreRegistry()
+    const store = createTestStore()
+    mockedCreateStorePromise.mockResolvedValueOnce(store)
+
+    const initial = registry.getOrLoad(makeOptions())
+    expect(initial).toBeInstanceOf(Promise)
+
+    await expect(initial).resolves.toBe(store)
+
+    const cached = registry.getOrLoad(makeOptions())
+    expect(cached).toBe(store)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses the same promise for concurrent getOrLoad calls while loading', async () => {
+    const registry = new StoreRegistry()
+    const store = createTestStore()
+    const deferred = createDeferred<typeof store>()
+    mockedCreateStorePromise.mockReturnValueOnce(deferred.promise)
+
+    const options = makeOptions()
+    const first = registry.getOrLoad(options)
+    const second = registry.getOrLoad(options)
+
+    expect(first).toBe(second)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+
+    deferred.resolve(store)
+    await expect(first).resolves.toBe(store)
+  })
+
+  it('stores and rethrows the rejection on subsequent getOrLoad calls after a failure', async () => {
+    const registry = new StoreRegistry()
+    const error = new Error('load failed')
+    mockedCreateStorePromise.mockRejectedValueOnce(error)
+
+    await expect(registry.getOrLoad(makeOptions())).rejects.toBe(error)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+
+    expect(() => registry.getOrLoad(makeOptions())).toThrow(error)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+  })
+
+  it('disposes store after gc timeout expires', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 25
+    const options = makeOptions({ gcTime })
+    const store = createTestStore()
+    const shutdownSpy = store.shutdownPromise as unknown as ReturnType<typeof vi.fn>
+    mockedCreateStorePromise.mockResolvedValueOnce(store)
+
+    await registry.getOrLoad(options)
+    await vi.advanceTimersByTimeAsync(gcTime)
+    await Promise.resolve()
+
+    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+
+    const nextStore = createTestStore()
+    mockedCreateStorePromise.mockResolvedValueOnce(nextStore)
+    await registry.getOrLoad(options)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the longest gcTime seen for a store when options vary across calls', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const store = createTestStore()
+    const shutdownSpy = store.shutdownPromise as unknown as ReturnType<typeof vi.fn>
+    mockedCreateStorePromise.mockResolvedValue(store)
+
+    const options = makeOptions({ gcTime: 10 })
+    const unsubscribe = registry.subscribe(options.storeId, () => {})
+
+    await registry.getOrLoad(options)
+
+    await registry.getOrLoad(makeOptions({ gcTime: 100 }))
+
+    unsubscribe()
+
+    await vi.advanceTimersByTimeAsync(99)
+    expect(shutdownSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await Promise.resolve()
+    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('preload does not throw', async () => {
+    const registry = new StoreRegistry()
+    const error = new Error('preload failed')
+    mockedCreateStorePromise.mockRejectedValueOnce(error)
+
+    await expect(registry.preload(makeOptions())).resolves.toBeUndefined()
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+
+    expect(() => registry.getOrLoad(makeOptions())).toThrow(error)
+    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+  })
+})
+
+const baseSchema = {} as TestSchema
+const baseAdapter = {} as CachedStoreOptions<TestSchema>['adapter']
+
+const makeOptions = (overrides: Partial<CachedStoreOptions<TestSchema>> = {}): CachedStoreOptions<TestSchema> => ({
+  storeId: 'test-store',
+  schema: baseSchema,
+  adapter: baseAdapter,
+  gcTime: 50,
+  ...overrides,
+})
+
+const createTestStore = () =>
+  ({
+    shutdownPromise: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as Store<TestSchema>
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -2,7 +2,7 @@ import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { schema } from '../../__tests__/fixture.tsx'
 import { DEFAULT_GC_TIME, StoreRegistry } from './StoreRegistry.ts'
-import { storeOptions } from './storeOptions.js'
+import { storeOptions } from './storeOptions.ts'
 import type { CachedStoreOptions } from './types.ts'
 
 describe('StoreRegistry', () => {

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -5,15 +5,12 @@ import { DEFAULT_GC_TIME, StoreRegistry } from './StoreRegistry.ts'
 import { storeOptions } from './storeOptions.js'
 import type { CachedStoreOptions } from './types.ts'
 
-const testStoreOptions = (overrides: Partial<CachedStoreOptions<typeof schema>> = {}) =>
-  storeOptions({
-    storeId: 'test-store',
-    schema,
-    adapter: makeInMemoryAdapter(),
-    ...overrides,
+describe('StoreRegistry', () => {
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
   })
 
-describe('StoreRegistry', () => {
   it('returns a Promise when the store is loading', async () => {
     const registry = new StoreRegistry()
     const result = registry.getOrLoad(testStoreOptions())
@@ -503,3 +500,11 @@ describe('StoreRegistry', () => {
     await nextStore.shutdownPromise()
   })
 })
+
+const testStoreOptions = (overrides: Partial<CachedStoreOptions<typeof schema>> = {}) =>
+  storeOptions({
+    storeId: 'test-store',
+    schema,
+    adapter: makeInMemoryAdapter(),
+    ...overrides,
+  })

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -1,81 +1,77 @@
-import type { LiveStoreSchema } from '@livestore/common/schema'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { schema } from '../../__tests__/fixture.tsx'
+import { StoreRegistry } from './StoreRegistry.ts'
 import type { CachedStoreOptions } from './types.ts'
 
-vi.mock('@livestore/livestore', () => ({
-  createStorePromise: vi.fn(),
-}))
-
-import { createStorePromise, type Store } from '@livestore/livestore'
-import { StoreRegistry } from './StoreRegistry.ts'
-
-type TestSchema = LiveStoreSchema.Any
-
-const mockedCreateStorePromise = vi.mocked(createStorePromise)
+type TestSchema = typeof schema
 
 describe('StoreRegistry', () => {
-  beforeEach(() => {
-    mockedCreateStorePromise.mockReset()
-  })
-
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
   })
 
-  it('returns a Promise when the store is loading', () => {
+  it('returns a Promise when the store is loading', async () => {
     const registry = new StoreRegistry()
-    const { promise } = createDeferred<Store<TestSchema>>()
-    mockedCreateStorePromise.mockReturnValueOnce(promise)
-
     const result = registry.getOrLoad(makeOptions())
 
     expect(result).toBeInstanceOf(Promise)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+
+    // Clean up
+    const store = await result
+    await store.shutdownPromise()
   })
 
   it('returns cached store synchronously after first load resolves', async () => {
     const registry = new StoreRegistry()
-    const store = createTestStore()
-    mockedCreateStorePromise.mockResolvedValueOnce(store)
 
     const initial = registry.getOrLoad(makeOptions())
     expect(initial).toBeInstanceOf(Promise)
 
-    await expect(initial).resolves.toBe(store)
+    const store = await initial
 
     const cached = registry.getOrLoad(makeOptions())
     expect(cached).toBe(store)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+    expect(cached).not.toBeInstanceOf(Promise)
+
+    // Clean up
+    await store.shutdownPromise()
   })
 
   it('reuses the same promise for concurrent getOrLoad calls while loading', async () => {
     const registry = new StoreRegistry()
-    const store = createTestStore()
-    const deferred = createDeferred<typeof store>()
-    mockedCreateStorePromise.mockReturnValueOnce(deferred.promise)
-
     const options = makeOptions()
+
     const first = registry.getOrLoad(options)
     const second = registry.getOrLoad(options)
 
+    // Both should be the same promise
     expect(first).toBe(second)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+    expect(first).toBeInstanceOf(Promise)
 
-    deferred.resolve(store)
-    await expect(first).resolves.toBe(store)
+    const store = await first
+
+    // Both promises should resolve to the same store
+    expect(await second).toBe(store)
+
+    // Clean up
+    await store.shutdownPromise()
   })
 
   it('stores and rethrows the rejection on subsequent getOrLoad calls after a failure', async () => {
     const registry = new StoreRegistry()
-    const error = new Error('load failed')
-    mockedCreateStorePromise.mockRejectedValueOnce(error)
 
-    await expect(registry.getOrLoad(makeOptions())).rejects.toBe(error)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+    // Create an invalid adapter that will cause an error
+    const badOptions = makeOptions({
+      // @ts-expect-error - intentionally passing invalid adapter to trigger error
+      adapter: null,
+    })
 
-    expect(() => registry.getOrLoad(makeOptions())).toThrow(error)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+    await expect(registry.getOrLoad(badOptions)).rejects.toThrow()
+
+    // Subsequent call should throw the cached error synchronously
+    expect(() => registry.getOrLoad(badOptions)).toThrow()
   })
 
   it('disposes store after gc timeout expires', async () => {
@@ -83,79 +79,81 @@ describe('StoreRegistry', () => {
     const registry = new StoreRegistry()
     const gcTime = 25
     const options = makeOptions({ gcTime })
-    const store = createTestStore()
-    const shutdownSpy = store.shutdownPromise as unknown as ReturnType<typeof vi.fn>
-    mockedCreateStorePromise.mockResolvedValueOnce(store)
 
-    await registry.getOrLoad(options)
+    const store = await registry.getOrLoad(options)
+
+    // Store should be cached
+    expect(registry.getOrLoad(options)).toBe(store)
+
+    // Advance time to trigger GC
     await vi.advanceTimersByTimeAsync(gcTime)
     await Promise.resolve()
 
-    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+    // After GC, store should be disposed and queries should fail
+    // The store is removed from cache, so next getOrLoad creates a new one
+    const nextStore = await registry.getOrLoad(options)
 
-    const nextStore = createTestStore()
-    mockedCreateStorePromise.mockResolvedValueOnce(nextStore)
-    await registry.getOrLoad(options)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(2)
+    // Should be a different store instance
+    expect(nextStore).not.toBe(store)
+    expect(nextStore.clientSession.debugInstanceId).toBeDefined()
+
+    // Clean up the second store (first one was cleaned up by GC)
+    await nextStore.shutdownPromise()
   })
 
   it('keeps the longest gcTime seen for a store when options vary across calls', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const store = createTestStore()
-    const shutdownSpy = store.shutdownPromise as unknown as ReturnType<typeof vi.fn>
-    mockedCreateStorePromise.mockResolvedValue(store)
 
     const options = makeOptions({ gcTime: 10 })
     const unsubscribe = registry.subscribe(options.storeId, () => {})
 
-    await registry.getOrLoad(options)
+    const store = await registry.getOrLoad(options)
 
+    // Call with longer gcTime
     await registry.getOrLoad(makeOptions({ gcTime: 100 }))
 
     unsubscribe()
 
+    // After 99ms, store should still be alive (100ms gcTime used)
     await vi.advanceTimersByTimeAsync(99)
-    expect(shutdownSpy).not.toHaveBeenCalled()
 
+    // Store should still be cached
+    expect(registry.getOrLoad(options)).toBe(store)
+
+    // After the full 100ms, store should be disposed
     await vi.advanceTimersByTimeAsync(1)
     await Promise.resolve()
-    expect(shutdownSpy).toHaveBeenCalledTimes(1)
+
+    // Next getOrLoad should create a new store
+    const nextStore = await registry.getOrLoad(options)
+    expect(nextStore).not.toBe(store)
+
+    // Clean up the second store (first one was cleaned up by GC)
+    await nextStore.shutdownPromise()
   })
 
   it('preload does not throw', async () => {
     const registry = new StoreRegistry()
-    const error = new Error('preload failed')
-    mockedCreateStorePromise.mockRejectedValueOnce(error)
 
-    await expect(registry.preload(makeOptions())).resolves.toBeUndefined()
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+    // Create invalid options that would cause an error
+    const badOptions = makeOptions({
+      // @ts-expect-error - intentionally passing invalid adapter to trigger error
+      adapter: null,
+    })
 
-    expect(() => registry.getOrLoad(makeOptions())).toThrow(error)
-    expect(mockedCreateStorePromise).toHaveBeenCalledTimes(1)
+    // preload should not throw
+    await expect(registry.preload(badOptions)).resolves.toBeUndefined()
+
+    // But subsequent getOrLoad should throw the cached error
+    expect(() => registry.getOrLoad(badOptions)).toThrow()
   })
 })
-
-const baseSchema = {} as TestSchema
-const baseAdapter = {} as CachedStoreOptions<TestSchema>['adapter']
 
 const makeOptions = (overrides: Partial<CachedStoreOptions<TestSchema>> = {}): CachedStoreOptions<TestSchema> => ({
   storeId: 'test-store',
-  schema: baseSchema,
-  adapter: baseAdapter,
+  schema,
+  adapter: makeInMemoryAdapter(),
   gcTime: 50,
   ...overrides,
 })
-
-const createTestStore = () =>
-  ({
-    shutdownPromise: vi.fn().mockResolvedValue(undefined),
-  }) as unknown as Store<TestSchema>
-
-const createDeferred = <T>() => {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((res) => {
-    resolve = res
-  })
-  return { promise, resolve }
-}

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -1,7 +1,7 @@
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { schema } from '../../__tests__/fixture.tsx'
-import { StoreRegistry } from './StoreRegistry.ts'
+import { DEFAULT_GC_TIME, StoreRegistry } from './StoreRegistry.ts'
 import type { CachedStoreOptions } from './types.ts'
 
 type TestSchema = typeof schema
@@ -87,9 +87,8 @@ describe('StoreRegistry', () => {
 
     // Advance time to trigger GC
     await vi.advanceTimersByTimeAsync(gcTime)
-    await Promise.resolve()
 
-    // After GC, store should be disposed and queries should fail
+    // After GC, store should be disposed
     // The store is removed from cache, so next getOrLoad creates a new one
     const nextStore = await registry.getOrLoad(options)
 
@@ -123,7 +122,6 @@ describe('StoreRegistry', () => {
 
     // After the full 100ms, store should be disposed
     await vi.advanceTimersByTimeAsync(1)
-    await Promise.resolve()
 
     // Next getOrLoad should create a new store
     const nextStore = await registry.getOrLoad(options)
@@ -148,12 +146,370 @@ describe('StoreRegistry', () => {
     // But subsequent getOrLoad should throw the cached error
     expect(() => registry.getOrLoad(badOptions)).toThrow()
   })
+
+  it('does not garbage collect when gcTime is Infinity', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const options = makeOptions({ gcTime: Number.POSITIVE_INFINITY })
+
+    const store = await registry.getOrLoad(options)
+
+    // Store should be cached
+    expect(registry.getOrLoad(options)).toBe(store)
+
+    // Advance time by a very long duration
+    await vi.advanceTimersByTimeAsync(1000000)
+
+    // Store should still be cached (not garbage collected)
+    expect(registry.getOrLoad(options)).toBe(store)
+
+    // Clean up manually
+    await store.shutdownPromise()
+  })
+
+  it('throws the same error instance on multiple synchronous calls after failure', async () => {
+    const registry = new StoreRegistry()
+
+    const badOptions = makeOptions({
+      // @ts-expect-error - intentionally passing invalid adapter to trigger error
+      adapter: null,
+    })
+
+    // Wait for the first failure
+    await expect(registry.getOrLoad(badOptions)).rejects.toThrow()
+
+    // Capture the errors from subsequent synchronous calls
+    let error1: unknown
+    let error2: unknown
+
+    try {
+      registry.getOrLoad(badOptions)
+    } catch (err) {
+      error1 = err
+    }
+
+    try {
+      registry.getOrLoad(badOptions)
+    } catch (err) {
+      error2 = err
+    }
+
+    // Both should be the exact same error instance (cached)
+    expect(error1).toBeDefined()
+    expect(error1).toBe(error2)
+  })
+
+  it('notifies subscribers when store state changes', async () => {
+    const registry = new StoreRegistry()
+    const options = makeOptions()
+
+    let notificationCount = 0
+    const listener = () => {
+      notificationCount++
+    }
+
+    const unsubscribe = registry.subscribe(options.storeId, listener)
+
+    // Start loading the store
+    const storePromise = registry.getOrLoad(options)
+
+    // Listener should be called when store starts loading
+    expect(notificationCount).toBe(1)
+
+    const store = await storePromise
+
+    // Listener should be called when store loads successfully
+    expect(notificationCount).toBe(2)
+
+    unsubscribe()
+
+    // Clean up
+    await store.shutdownPromise()
+  })
+
+  it('handles rapid subscribe/unsubscribe cycles without errors', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 50
+    const options = makeOptions({ gcTime })
+
+    const store = await registry.getOrLoad(options)
+
+    // Rapidly subscribe and unsubscribe multiple times
+    for (let i = 0; i < 10; i++) {
+      const unsubscribe = registry.subscribe(options.storeId, () => {})
+      unsubscribe()
+    }
+
+    // Advance time to check if GC is scheduled correctly
+    await vi.advanceTimersByTimeAsync(gcTime)
+
+    // Store should be disposed after the last unsubscribe
+    const nextStore = await registry.getOrLoad(options)
+    expect(nextStore).not.toBe(store)
+
+    await nextStore.shutdownPromise()
+  })
+
+  it('swallows errors thrown by subscribers during notification', async () => {
+    const registry = new StoreRegistry()
+    const options = makeOptions()
+
+    let errorListenerCalled = false
+    let goodListenerCalled = false
+
+    const errorListener = () => {
+      errorListenerCalled = true
+      throw new Error('Listener error')
+    }
+
+    const goodListener = () => {
+      goodListenerCalled = true
+    }
+
+    registry.subscribe(options.storeId, errorListener)
+    registry.subscribe(options.storeId, goodListener)
+
+    // Should not throw despite errorListener throwing
+    const store = await registry.getOrLoad(options)
+
+    // Both listeners should have been called
+    expect(errorListenerCalled).toBe(true)
+    expect(goodListenerCalled).toBe(true)
+
+    await store.shutdownPromise()
+  })
+
+  it('supports concurrent load and subscribe operations', async () => {
+    const registry = new StoreRegistry()
+    const options = makeOptions()
+
+    let notificationCount = 0
+    const listener = () => {
+      notificationCount++
+    }
+
+    // Subscribe before loading starts
+    const unsubscribe = registry.subscribe(options.storeId, listener)
+
+    // Start loading
+    const storePromise = registry.getOrLoad(options)
+
+    // Listener should be notified when loading starts
+    expect(notificationCount).toBeGreaterThan(0)
+
+    const store = await storePromise
+
+    // Listener should be notified when loading completes
+    expect(notificationCount).toBe(2)
+
+    unsubscribe()
+
+    // Clean up
+    await store.shutdownPromise()
+  })
+
+  it('cancels GC when a new subscription is added', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 50
+    const options = makeOptions({ gcTime })
+
+    const store = await registry.getOrLoad(options)
+
+    // Advance time almost to GC threshold
+    await vi.advanceTimersByTimeAsync(gcTime - 5)
+
+    // Add a new subscription before GC triggers
+    const unsubscribe = registry.subscribe(options.storeId, () => {})
+
+    // Complete the original GC time
+    await vi.advanceTimersByTimeAsync(5)
+
+    // Store should not have been disposed because we added a subscription
+    expect(registry.getOrLoad(options)).toBe(store)
+
+    // Clean up
+    unsubscribe()
+    await vi.advanceTimersByTimeAsync(gcTime)
+
+    // Now it should be disposed
+    const nextStore = await registry.getOrLoad(options)
+    expect(nextStore).not.toBe(store)
+
+    await nextStore.shutdownPromise()
+  })
+
+  it('schedules GC if store becomes inactive during loading', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 50
+    const options = makeOptions({ gcTime })
+
+    // Start loading without any subscription
+    const storePromise = registry.getOrLoad(options)
+
+    // Wait for store to load (no subscribers registered)
+    const store = await storePromise
+
+    // Since there were no subscribers when loading completed, GC should be scheduled
+    await vi.advanceTimersByTimeAsync(gcTime)
+
+    // Store should be disposed
+    const nextStore = await registry.getOrLoad(options)
+    expect(nextStore).not.toBe(store)
+
+    await nextStore.shutdownPromise()
+  })
+
+  it('manages multiple stores with different IDs independently', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+
+    const options1 = makeOptions({ storeId: 'store-1', gcTime: 50 })
+    const options2 = makeOptions({ storeId: 'store-2', gcTime: 100 })
+
+    const store1 = await registry.getOrLoad(options1)
+    const store2 = await registry.getOrLoad(options2)
+
+    // Should be different store instances
+    expect(store1).not.toBe(store2)
+
+    // Both should be cached independently
+    expect(registry.getOrLoad(options1)).toBe(store1)
+    expect(registry.getOrLoad(options2)).toBe(store2)
+
+    // Advance time to dispose store1 only
+    await vi.advanceTimersByTimeAsync(50)
+
+    // store1 should be disposed, store2 should still be cached
+    const newStore1 = await registry.getOrLoad(options1)
+    expect(newStore1).not.toBe(store1)
+    expect(registry.getOrLoad(options2)).toBe(store2)
+
+    // Subscribe to prevent GC of newStore1
+    const unsub1 = registry.subscribe(options1.storeId, () => {})
+
+    // Advance remaining time to dispose store2
+    await vi.advanceTimersByTimeAsync(50)
+
+    // store2 should be disposed
+    const newStore2 = await registry.getOrLoad(options2)
+    expect(newStore2).not.toBe(store2)
+
+    // Subscribe to prevent GC of newStore2
+    const unsub2 = registry.subscribe(options2.storeId, () => {})
+
+    // Clean up
+    unsub1()
+    unsub2()
+    await newStore1.shutdownPromise()
+    await newStore2.shutdownPromise()
+  })
+
+  it('applies default options from constructor', async () => {
+    vi.useFakeTimers()
+
+    const registry = new StoreRegistry({
+      defaultOptions: {
+        gcTime: DEFAULT_GC_TIME * 2,
+      },
+    })
+
+    // Construct options without gcTime to use default
+    const options: CachedStoreOptions<TestSchema> = {
+      storeId: 'test-store',
+      schema,
+      adapter: makeInMemoryAdapter(),
+    }
+
+    const store = await registry.getOrLoad(options)
+
+    // Verify the store loads successfully
+    expect(store).toBeDefined()
+    expect(store.clientSession.debugInstanceId).toBeDefined()
+
+    // Verify configured default gcTime is applied by checking GC doesn't happen at library's default gc time
+    await vi.advanceTimersByTimeAsync(DEFAULT_GC_TIME)
+
+    // Store should still be cached after default gc time
+    expect(registry.getOrLoad(options)).toBe(store)
+
+    await store.shutdownPromise()
+  })
+
+  it('allows call-site options to override default options', async () => {
+    vi.useFakeTimers()
+
+    const registry = new StoreRegistry({
+      defaultOptions: {
+        gcTime: 1000, // Default is long
+      },
+    })
+
+    const options = makeOptions({
+      gcTime: 10, // Override with shorter time
+    })
+
+    const store = await registry.getOrLoad(options)
+
+    // Advance by the override time (10ms)
+    await vi.advanceTimersByTimeAsync(10)
+
+    // Should be disposed according to the override time, not default
+    const nextStore = await registry.getOrLoad(options)
+    expect(nextStore).not.toBe(store)
+
+    await nextStore.shutdownPromise()
+  })
+
+  it('warms the cache so subsequent getOrLoad is synchronous after preload', async () => {
+    const registry = new StoreRegistry()
+    const options = makeOptions()
+
+    // Preload the store
+    await registry.preload(options)
+
+    // Subsequent getOrLoad should return synchronously (not a Promise)
+    const store = registry.getOrLoad(options)
+    expect(store).not.toBeInstanceOf(Promise)
+
+    // TypeScript doesn't narrow the type, so we need to assert
+    if (store instanceof Promise) {
+      throw new Error('Expected store, got Promise')
+    }
+
+    // Clean up
+    await store.shutdownPromise()
+  })
+
+  it('schedules GC after preload if no subscribers are added', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 50
+    const options = makeOptions({ gcTime })
+
+    // Preload without subscribing
+    await registry.preload(options)
+
+    // Get the store
+    const store = registry.getOrLoad(options)
+    expect(store).not.toBeInstanceOf(Promise)
+
+    // Advance time to trigger GC
+    await vi.advanceTimersByTimeAsync(gcTime)
+
+    // Store should be disposed since no subscribers were added
+    const nextStore = await registry.getOrLoad(options)
+    expect(nextStore).not.toBe(store)
+
+    await nextStore.shutdownPromise()
+  })
 })
 
 const makeOptions = (overrides: Partial<CachedStoreOptions<TestSchema>> = {}): CachedStoreOptions<TestSchema> => ({
   storeId: 'test-store',
   schema,
   adapter: makeInMemoryAdapter(),
-  gcTime: 50,
   ...overrides,
 })

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -8,6 +8,14 @@ type StoreEntryState<TSchema extends LiveStoreSchema> =
   | { status: 'success'; store: Store<TSchema> }
   | { status: 'error'; error: unknown }
 
+/**
+ * Default garbage collection time for inactive stores.
+ *
+ * - Browser: 60 seconds (60,000ms)
+ * - SSR: Infinity (disables GC to avoid disposing stores before server render completes)
+ *
+ * @internal Exported primarily for testing purposes.
+ */
 export const DEFAULT_GC_TIME = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : 60_000
 
 /**

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -8,7 +8,7 @@ type StoreEntryState<TSchema extends LiveStoreSchema> =
   | { status: 'success'; store: Store<TSchema> }
   | { status: 'error'; error: unknown }
 
-const DEFAULT_GC_TIME = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : 60_000
+export const DEFAULT_GC_TIME = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : 60_000
 
 /**
  * @typeParam TSchema - The schema for this entry's store.

--- a/packages/@livestore/react/src/experimental/multi-store/useStore.test.tsx
+++ b/packages/@livestore/react/src/experimental/multi-store/useStore.test.tsx
@@ -1,0 +1,269 @@
+import { createStorePromise, type Store } from '@livestore/livestore'
+import { act, render, renderHook, waitFor } from '@testing-library/react'
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { withReactApi } from '../../useStore.ts'
+import { StoreRegistry } from './StoreRegistry.ts'
+import { StoreRegistryProvider } from './StoreRegistryContext.tsx'
+import type { CachedStoreOptions } from './types.ts'
+import { useStore } from './useStore.ts'
+
+vi.mock('../../useStore.ts', () => ({
+  withReactApi: vi.fn((store: Record<string, unknown>) => ({ ...store, decorated: true })),
+}))
+
+vi.mock('@livestore/livestore', () => ({
+  createStorePromise: vi.fn(),
+}))
+
+const mockedWithReactApi = vi.mocked(withReactApi)
+const mockedCreateStorePromise = vi.mocked(createStorePromise)
+
+describe('experimental useStore', () => {
+  beforeEach(() => {
+    mockedWithReactApi.mockClear()
+    mockedCreateStorePromise.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('suspends when the store is loading', async () => {
+    const store = createTestStore()
+    const deferred = createDeferred<typeof store>()
+    const registry = new StoreRegistry()
+    mockedCreateStorePromise.mockReturnValueOnce(deferred.promise as Promise<Store<any>>)
+    const options = makeOptions()
+
+    const view = render(
+      <StoreRegistryProvider storeRegistry={registry}>
+        <React.Suspense fallback={<div data-testid="fallback" />}>
+          <StoreConsumer options={options} />
+        </React.Suspense>
+      </StoreRegistryProvider>,
+    )
+
+    expect(view.getByTestId('fallback')).toBeDefined()
+    expect(mockedWithReactApi).not.toHaveBeenCalled()
+
+    await act(async () => {
+      deferred.resolve(store)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(mockedWithReactApi).toHaveBeenCalledWith(store))
+    expect(view.queryByTestId('fallback')).toBeNull()
+  })
+
+  it('does not re-suspend on subsequent renders when store is already loaded', async () => {
+    const store = createTestStore()
+    const deferred = createDeferred<typeof store>()
+    const registry = new StoreRegistry()
+    mockedCreateStorePromise.mockReturnValueOnce(deferred.promise as Promise<Store<any>>)
+    const options = makeOptions()
+
+    const Wrapper = ({ opts }: { opts: CachedStoreOptions }) => (
+      <StoreRegistryProvider storeRegistry={registry}>
+        <React.Suspense fallback={<div data-testid="fallback" />}>
+          <StoreConsumer options={opts} />
+        </React.Suspense>
+      </StoreRegistryProvider>
+    )
+
+    const view = render(<Wrapper opts={options} />)
+    expect(view.getByTestId('fallback')).toBeDefined()
+
+    await act(async () => {
+      deferred.resolve(store)
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(mockedWithReactApi).toHaveBeenCalledWith(store))
+    expect(view.queryByTestId('fallback')).toBeNull()
+    const callsAfterLoad = mockedWithReactApi.mock.calls.length
+
+    view.rerender(<Wrapper opts={{ ...options }} />)
+    expect(view.queryByTestId('fallback')).toBeNull()
+    expect(mockedWithReactApi.mock.calls.length).toBeGreaterThanOrEqual(callsAfterLoad)
+  })
+
+  it('subscribes to store registry on mount', () => {
+    const store = createTestStore()
+    const registry = createMockRegistry({
+      getOrLoad: vi.fn().mockReturnValue(store),
+    })
+    const options = makeOptions()
+
+    renderHook(() => useStore(options), {
+      wrapper: makeProvider(registry),
+    })
+
+    expect(registry.subscribe).toHaveBeenCalledWith(options.storeId, expect.any(Function))
+  })
+
+  it('unsubscribes from store registry on unmount', () => {
+    const store = createTestStore()
+    const registry = createMockRegistry({
+      getOrLoad: vi.fn().mockReturnValue(store),
+    })
+    const options = makeOptions()
+
+    const { unmount } = renderHook(() => useStore(options), {
+      wrapper: makeProvider(registry),
+    })
+
+    unmount()
+    expect(registry.unsubscribeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles rapid mount/unmount cycles', () => {
+    const store = createTestStore()
+    const registry = createMockRegistry({
+      getOrLoad: vi.fn().mockReturnValue(store),
+    })
+    const options = makeOptions()
+
+    const first = renderHook(() => useStore(options), {
+      wrapper: makeProvider(registry),
+    })
+    first.unmount()
+
+    const second = renderHook(() => useStore(options), {
+      wrapper: makeProvider(registry),
+    })
+    second.unmount()
+
+    expect(registry.subscribe).toHaveBeenCalledTimes(2)
+    expect(registry.unsubscribeSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws when store loading fails', () => {
+    const error = new Error('failed to load')
+    const registry = createMockRegistry({
+      getOrLoad: vi.fn(() => {
+        throw error
+      }),
+    })
+    const options = makeOptions()
+
+    expect(() =>
+      renderHook(() => useStore(options), {
+        wrapper: makeProvider(registry),
+      }),
+    ).toThrow(error)
+  })
+
+  it.each([
+    { label: 'non-strict mode', strict: false },
+    { label: 'strict mode', strict: true },
+  ])('works with both $label', async ({ strict }) => {
+    const store = createTestStore()
+    const registry = createMockRegistry({
+      getOrLoad: vi.fn().mockReturnValue(store),
+    })
+    const options = makeOptions()
+
+    const { result, unmount } = renderHook(() => useStore(options), {
+      wrapper: makeProvider(registry, { strict }),
+    })
+
+    await waitFor(() => expect(result.current).toMatchObject({ decorated: true }))
+    expect(registry.subscribe).toHaveBeenCalled()
+    unmount()
+    expect(registry.unsubscribeSpy).toHaveBeenCalled()
+  })
+
+  it('handles switching between different storeId values', () => {
+    const storeA = { id: 'a', shutdownPromise: vi.fn() } as unknown as Store<any>
+    const storeB = { id: 'b', shutdownPromise: vi.fn() } as unknown as Store<any>
+    const getOrLoadMock = vi.fn(
+      (opts: CachedStoreOptions) => (opts.storeId === 'a' ? storeA : storeB) as Store<any> | Promise<Store<any>>,
+    )
+    const registry = createMockRegistry({ getOrLoad: getOrLoadMock as StoreRegistry['getOrLoad'] })
+
+    const { rerender } = renderHook((opts) => useStore(opts), {
+      initialProps: makeOptions({ storeId: 'a' }),
+      wrapper: makeProvider(registry),
+    })
+
+    expect(registry.subscribe).toHaveBeenCalledWith('a', expect.any(Function))
+    expect(mockedWithReactApi).toHaveBeenLastCalledWith(storeA)
+
+    rerender(makeOptions({ storeId: 'b' }))
+    expect(registry.unsubscribeSpy).toHaveBeenCalledTimes(1)
+    expect(registry.subscribe).toHaveBeenLastCalledWith('b', expect.any(Function))
+    expect(mockedWithReactApi).toHaveBeenLastCalledWith(storeB)
+  })
+})
+
+type RegistryMock = StoreRegistry & {
+  getOrLoad: ReturnType<typeof vi.fn> & StoreRegistry['getOrLoad']
+  subscribe: ReturnType<typeof vi.fn> & StoreRegistry['subscribe']
+  unsubscribeSpy: ReturnType<typeof vi.fn>
+}
+
+const createMockRegistry = (overrides: Partial<{ getOrLoad: StoreRegistry['getOrLoad'] }> = {}) => {
+  const registry = new StoreRegistry() as RegistryMock
+  const listeners = new Set<() => void>()
+  const unsubscribeSpy = vi.fn()
+
+  const subscribe = vi.fn((_: string, listener: () => void) => {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+      unsubscribeSpy()
+    }
+  }) as RegistryMock['subscribe']
+
+  const getOrLoad = (overrides.getOrLoad ?? vi.fn()) as RegistryMock['getOrLoad']
+
+  Object.assign(registry, { getOrLoad, subscribe, unsubscribeSpy })
+
+  return registry
+}
+
+const StoreConsumer = ({ options }: { options: CachedStoreOptions }) => {
+  useStore(options)
+  return <div data-testid="ready" />
+}
+
+const makeProvider =
+  (
+    registry: ReturnType<typeof createMockRegistry>,
+    { suspense = false, strict = false }: { suspense?: boolean; strict?: boolean } = {},
+  ) =>
+  ({ children }: { children: React.ReactNode }) => {
+    let content = <StoreRegistryProvider storeRegistry={registry as never}>{children}</StoreRegistryProvider>
+
+    if (suspense) {
+      content = <React.Suspense fallback={null}>{content}</React.Suspense>
+    }
+
+    if (strict) {
+      content = <React.StrictMode>{content}</React.StrictMode>
+    }
+
+    return content
+  }
+
+const makeOptions = (overrides: Partial<CachedStoreOptions> = {}): CachedStoreOptions => ({
+  adapter: {} as CachedStoreOptions['adapter'],
+  schema: {} as CachedStoreOptions['schema'],
+  storeId: 'default-store',
+  ...overrides,
+})
+
+const createTestStore = () =>
+  ({
+    shutdownPromise: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as Store<any>
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}

--- a/packages/@livestore/react/src/experimental/multi-store/useStore.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/useStore.ts
@@ -20,11 +20,15 @@ export const useStore = <TSchema extends LiveStoreSchema>(
     (onChange: () => void) => storeRegistry.subscribe(options.storeId, onChange),
     [storeRegistry, options.storeId],
   )
-  const getSnapshot = React.useCallback(() => storeRegistry.getOrLoad(options), [storeRegistry, options])
+  const getSnapshot = React.useCallback(() => {
+    const storeOrPromise = storeRegistry.getOrLoad(options)
 
-  const storeOrPromise = React.useSyncExternalStore(subscribe, getSnapshot)
+    if (storeOrPromise instanceof Promise) throw storeOrPromise
 
-  const loadedStore = storeOrPromise instanceof Promise ? React.use(storeOrPromise) : storeOrPromise
+    return storeOrPromise
+  }, [storeRegistry, options])
+
+  const loadedStore = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 
   return withReactApi(loadedStore)
 }


### PR DESCRIPTION
## Summary

- Add comprehensive test coverage for `StoreRegistry` and experimental `useStore` hook
- Fix suspend/resume behavior by moving promise throw inside `useSyncExternalStore` callback

## Problem

The experimental multi-store `useStore` hook lacked test coverage for critical functionality:
- Store lifecycle management (load, cache, GC)
- Concurrent request handling during loading
- Error handling and failure recovery
- React integration (suspense, subscription, mount/unmount)

Additionally, the suspend mechanism wasn't correctly integrated with `useSyncExternalStore`, preventing proper resume after suspending on a loading store.

## Solution

**Test Coverage:**
- `StoreRegistry.test.ts`: Tests store caching, promise reuse, error propagation, GC timeout behavior, and `gcTime` tracking
- `useStore.test.tsx`: Tests React integration including suspense, subscription lifecycle, rapid mount/unmount, strict mode compatibility, and dynamic `storeId` switching

**Suspend Fix:**
The promise throw was moved inside the `getSnapshot` callback so that `useSyncExternalStore` properly handles the suspend-resume cycle.

## Test Plan

- [x] All new tests pass: `vitest run packages/@livestore/react/src/experimental/multi-store/*.test.{ts,tsx}`
- [x] Tests cover both strict and non-strict React modes
- [x] Tests verify proper cleanup and subscription management
- [x] Error cases are thoroughly tested (load failures, thrown errors)