### PR TITLE
Support thunk defaults in SQLite columns for dynamic value generation

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
@@ -146,6 +146,22 @@ describe('makeColumnSpec', () => {
     expect(result).toContain('default RANDOM()')
   })
 
+  it('should omit default clause for thunk defaults', () => {
+    const table = SqliteAst.table(
+      'thunks',
+      [
+        createColumn('id', 'integer', { nullable: false, primaryKey: true }),
+        createColumn('token', 'text', { defaultValue: () => 'dynamic-token' }),
+      ],
+      [],
+    )
+
+    const result = makeColumnSpec(table)
+    expect(result).toMatchInlineSnapshot(`""id" integer primary key   , "token" text    "`)
+    expect(result).not.toContain('dynamic-token')
+    expect(result).not.toMatch(/token\" text\s+default/i)
+  })
+
   it('should handle null default values', () => {
     const table = SqliteAst.table(
       'nullable_defaults',

--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.ts
@@ -47,11 +47,16 @@ const toSqliteColumnSpec = (column: SqliteAst.Column, opts: { inlinePrimaryKey: 
   const defaultValueStr = (() => {
     if (column.default._tag === 'None') return ''
 
-    if (column.default.value === null) return 'default null'
-    if (SqliteDsl.isSqlDefaultValue(column.default.value)) return `default ${column.default.value.sql}`
+    const defaultValue = column.default.value
+    if (SqliteDsl.isDefaultThunk(defaultValue)) return ''
+
+    const resolvedDefault = SqliteDsl.resolveColumnDefault(defaultValue)
+
+    if (resolvedDefault === null) return 'default null'
+    if (SqliteDsl.isSqlDefaultValue(resolvedDefault)) return `default ${resolvedDefault.sql}`
 
     const encodeValue = Schema.encodeSync(column.schema)
-    const encodedDefaultValue = encodeValue(column.default.value)
+    const encodedDefaultValue = encodeValue(resolvedDefault)
 
     if (columnTypeStr === 'text') return `default '${encodedDefaultValue}'`
     return `default ${encodedDefaultValue}`

--- a/packages/@livestore/common/src/schema/state/sqlite/schema-helpers.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/schema-helpers.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import * as State from '../mod.ts'
+import { getDefaultValuesDecoded, getDefaultValuesEncoded } from './schema-helpers.ts'
+
+describe('schema-helpers', () => {
+  it('resolves thunk defaults when decoding values', () => {
+    let counter = 0
+    const table = State.SQLite.table({
+      name: 'sessions',
+      columns: {
+        id: State.SQLite.text({ primaryKey: true }),
+        token: State.SQLite.text({ default: () => `token-${++counter}` }),
+      },
+    })
+
+    expect(counter).toBe(0)
+
+    const firstDefaults = getDefaultValuesDecoded(table)
+    const secondDefaults = getDefaultValuesDecoded(table)
+
+    expect(firstDefaults.token).toBe('token-1')
+    expect(secondDefaults.token).toBe('token-2')
+  })
+
+  it('resolves thunk defaults when encoding values', () => {
+    let counter = 0
+    const table = State.SQLite.table({
+      name: 'sessions_encoded',
+      columns: {
+        id: State.SQLite.text({ primaryKey: true }),
+        token: State.SQLite.text({ default: () => `encoded-${++counter}` }),
+      },
+    })
+
+    expect(counter).toBe(0)
+
+    const firstDefaults = getDefaultValuesEncoded(table)
+    const secondDefaults = getDefaultValuesEncoded(table)
+
+    expect(firstDefaults.token).toBe('encoded-1')
+    expect(secondDefaults.token).toBe('encoded-2')
+  })
+})

--- a/packages/@livestore/common/src/schema/state/sqlite/schema-helpers.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/schema-helpers.ts
@@ -15,15 +15,19 @@ export const getDefaultValuesEncoded = <TTableDef extends TableDef>(
       if (key === 'id') return false
       return col!.default._tag === 'None' || SqliteDsl.isSqlDefaultValue(col!.default.value) === false
     }),
-    ReadonlyRecord.map((column, columnName) =>
-      fallbackValues?.[columnName] === undefined
-        ? column!.default._tag === 'None'
-          ? column!.nullable === true
-            ? null
-            : shouldNeverHappen(`Column ${columnName} has no default value and is not nullable`)
-          : Schema.encodeSync(column!.schema)(column!.default.value)
-        : fallbackValues[columnName],
-    ),
+    ReadonlyRecord.map((column, columnName) => {
+      if (fallbackValues?.[columnName] !== undefined) return fallbackValues[columnName]
+      if (column!.default._tag === 'None') {
+        return column!.nullable === true
+          ? null
+          : shouldNeverHappen(`Column ${columnName} has no default value and is not nullable`)
+      }
+
+      const defaultValue = column!.default.value
+      const resolvedDefault = SqliteDsl.resolveColumnDefault(defaultValue)
+
+      return Schema.encodeSync(column!.schema)(resolvedDefault)
+    }),
   )
 
 export const getDefaultValuesDecoded = <TTableDef extends TableDefBase>(
@@ -37,13 +41,17 @@ export const getDefaultValuesDecoded = <TTableDef extends TableDefBase>(
       if (key === 'id') return false
       return col!.default._tag === 'None' || SqliteDsl.isSqlDefaultValue(col!.default.value) === false
     }),
-    ReadonlyRecord.map((column, columnName) =>
-      fallbackValues?.[columnName] === undefined
-        ? column!.default._tag === 'None'
-          ? column!.nullable === true
-            ? null
-            : shouldNeverHappen(`Column ${columnName} has no default value and is not nullable`)
-          : Schema.validateSync(column!.schema)(column!.default.value)
-        : fallbackValues[columnName],
-    ),
+    ReadonlyRecord.map((column, columnName) => {
+      if (fallbackValues?.[columnName] !== undefined) return fallbackValues[columnName]
+      if (column!.default._tag === 'None') {
+        return column!.nullable === true
+          ? null
+          : shouldNeverHappen(`Column ${columnName} has no default value and is not nullable`)
+      }
+
+      const defaultValue = column!.default.value
+      const resolvedDefault = SqliteDsl.resolveColumnDefault(defaultValue)
+
+      return Schema.validateSync(column!.schema)(resolvedDefault)
+    }),
   )

--- a/packages/@livestore/common/src/sql-queries/sql-queries.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-queries.ts
@@ -247,7 +247,15 @@ export const createTable = ({
     .map(([columnName, _]) => columnName)
   const columnDefStrs = Object.entries(table.columns).map(([columnName, columnDef]) => {
     const nullModifier = columnDef.nullable === true ? '' : 'NOT NULL'
-    const defaultModifier = columnDef.default._tag === 'None' ? '' : `DEFAULT ${columnDef.default.value}`
+    const defaultModifier = (() => {
+      if (columnDef.default._tag === 'None') return ''
+      const defaultValue = columnDef.default.value
+      if (typeof defaultValue === 'function') return ''
+      if (defaultValue && typeof defaultValue === 'object' && 'sql' in defaultValue) {
+        return `DEFAULT ${defaultValue.sql}`
+      }
+      return `DEFAULT ${defaultValue}`
+    })()
     return sql`${columnName} ${columnDef.columnType} ${nullModifier} ${defaultModifier}`
   })
 


### PR DESCRIPTION
## Problem

SQLite column defaults were eagerly evaluated at table definition time, preventing dynamic defaults like ID generators. Users couldn't pass functions to the `default` parameter—every default value was computed once during schema construction rather than per-row.

## Solution

Added support for function-based defaults (thunks) in SQLite column definitions:

- Introduced `ColumnDefaultThunk<T>` type allowing `() => T` functions as defaults
- Thunks are not evaluated at table definition time (lazy evaluation)
- Added `isDefaultThunk` and `resolveColumnDefault` helpers to detect and call thunks
- Updated `getDefaultValuesEncoded`/`getDefaultValuesDecoded` to resolve thunks when fetching defaults
- Modified column spec generation to omit thunk defaults from SQL DDL (handled at runtime)

Trade-offs: Thunk defaults are evaluated in application code rather than database layer, so they won't appear in SQL schema inspections.

## Validation

Added tests verifying:
- Thunks are not eagerly evaluated during table definition
- Each call to get defaults invokes the thunk (counter increments)
- SQL column specs omit thunk defaults
- Both encoded and decoded helpers properly resolve thunks

## Related issues

- Fixes #799
