### PR TITLE
fix(docs): add vue-livestore dependency to snippet workspace

### DIFF
--- a/docs/src/content/_assets/code/package.json
+++ b/docs/src/content/_assets/code/package.json
@@ -21,6 +21,7 @@
     "react-dom": "catalog:",
     "react-error-boundary": "6.0.0",
     "react-native": "0.81.4",
-    "solid-js": "1.9.9"
+    "solid-js": "1.9.9",
+    "vue-livestore": "0.2.3"
   }
 }

--- a/docs/src/content/_assets/code/reference/framework-integrations/vue/provider.vue
+++ b/docs/src/content/_assets/code/reference/framework-integrations/vue/provider.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-/// <reference path="./vue-livestore.d.ts" />
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 
 import { schema } from './schema.ts'

--- a/docs/src/content/_assets/code/reference/framework-integrations/vue/use-client-document.vue
+++ b/docs/src/content/_assets/code/reference/framework-integrations/vue/use-client-document.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-/// <reference path="./vue-livestore.d.ts" />
 import { useClientDocument } from 'vue-livestore'
 
 import { tables } from './schema.ts'

--- a/docs/src/content/_assets/code/reference/framework-integrations/vue/use-query.vue
+++ b/docs/src/content/_assets/code/reference/framework-integrations/vue/use-query.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-/// <reference path="./vue-livestore.d.ts" />
 import { queryDb } from '@livestore/livestore'
 import { useQuery } from 'vue-livestore'
 

--- a/docs/src/content/_assets/code/reference/framework-integrations/vue/use-store.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/vue/use-store.ts
@@ -1,4 +1,3 @@
-/// <reference path="./vue-livestore.d.ts" />
 import { useStore } from 'vue-livestore'
 
 import { events } from './schema.ts'

--- a/docs/src/content/_assets/code/reference/framework-integrations/vue/vue-livestore.d.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/vue/vue-livestore.d.ts
@@ -1,6 +1,0 @@
-declare module 'vue-livestore' {
-  export const LiveStoreProvider: any
-  export const useStore: () => { store: any }
-  export const useQuery: (query: unknown) => any
-  export const useClientDocument: (doc: unknown) => Record<string, any>
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       solid-js:
         specifier: 1.9.9
         version: 1.9.9
+      vue-livestore:
+        specifier: 0.2.3
+        version: 0.2.3(typescript@5.9.3)(vite@7.1.9(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))
 
   examples/cf-chat:
     dependencies:
@@ -7744,20 +7747,34 @@ packages:
   '@vscode/l10n@0.0.18':
     resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
 
-  '@vue/compiler-core@3.5.21':
-    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
+  '@vue/compiler-core@3.5.22':
+    resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
 
-  '@vue/compiler-dom@3.5.21':
-    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
+  '@vue/compiler-dom@3.5.22':
+    resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
 
-  '@vue/compiler-sfc@3.5.21':
-    resolution: {integrity: sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==}
+  '@vue/compiler-sfc@3.5.22':
+    resolution: {integrity: sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==}
 
-  '@vue/compiler-ssr@3.5.21':
-    resolution: {integrity: sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==}
+  '@vue/compiler-ssr@3.5.22':
+    resolution: {integrity: sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==}
 
-  '@vue/shared@3.5.21':
-    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
+  '@vue/reactivity@3.5.22':
+    resolution: {integrity: sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==}
+
+  '@vue/runtime-core@3.5.22':
+    resolution: {integrity: sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==}
+
+  '@vue/runtime-dom@3.5.22':
+    resolution: {integrity: sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==}
+
+  '@vue/server-renderer@3.5.22':
+    resolution: {integrity: sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==}
+    peerDependencies:
+      vue: 3.5.22
+
+  '@vue/shared@3.5.22':
+    resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
 
   '@web/browser-logs@0.4.1':
     resolution: {integrity: sha512-ypmMG+72ERm+LvP+loj9A64MTXvWMXHUOu773cPO4L1SV/VWg6xA9Pv7vkvkXQX+ItJtCJt+KQ+U6ui2HhSFUw==}
@@ -14877,6 +14894,17 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-livestore@0.2.3:
+    resolution: {integrity: sha512-clmeEHa+IOmfalxulUHtbWF9/4puCRbY0kDscWnd65sZa3kcCXj96HKI7ATli2/lhr3adeqmp/9FlCneCLZ5gw==}
+
+  vue@3.5.22:
+    resolution: {integrity: sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -21925,37 +21953,59 @@ snapshots:
 
   '@vscode/l10n@0.0.18': {}
 
-  '@vue/compiler-core@3.5.21':
+  '@vue/compiler-core@3.5.22':
     dependencies:
       '@babel/parser': 7.28.4
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.21':
+  '@vue/compiler-dom@3.5.22':
     dependencies:
-      '@vue/compiler-core': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-core': 3.5.22
+      '@vue/shared': 3.5.22
 
-  '@vue/compiler-sfc@3.5.21':
+  '@vue/compiler-sfc@3.5.22':
     dependencies:
       '@babel/parser': 7.28.4
-      '@vue/compiler-core': 3.5.21
-      '@vue/compiler-dom': 3.5.21
-      '@vue/compiler-ssr': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-core': 3.5.22
+      '@vue/compiler-dom': 3.5.22
+      '@vue/compiler-ssr': 3.5.22
+      '@vue/shared': 3.5.22
       estree-walker: 2.0.2
       magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.21':
+  '@vue/compiler-ssr@3.5.22':
     dependencies:
-      '@vue/compiler-dom': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-dom': 3.5.22
+      '@vue/shared': 3.5.22
 
-  '@vue/shared@3.5.21': {}
+  '@vue/reactivity@3.5.22':
+    dependencies:
+      '@vue/shared': 3.5.22
+
+  '@vue/runtime-core@3.5.22':
+    dependencies:
+      '@vue/reactivity': 3.5.22
+      '@vue/shared': 3.5.22
+
+  '@vue/runtime-dom@3.5.22':
+    dependencies:
+      '@vue/reactivity': 3.5.22
+      '@vue/runtime-core': 3.5.22
+      '@vue/shared': 3.5.22
+      csstype: 3.1.3
+
+  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.22
+      '@vue/shared': 3.5.22
+      vue: 3.5.22(typescript@5.9.3)
+
+  '@vue/shared@3.5.22': {}
 
   '@web/browser-logs@0.4.1':
     dependencies:
@@ -24058,7 +24108,7 @@ snapshots:
   detective-vue2@2.2.0(typescript@5.9.3):
     dependencies:
       '@dependents/detective-less': 5.0.1
-      '@vue/compiler-sfc': 3.5.21
+      '@vue/compiler-sfc': 3.5.22
       detective-es6: 5.0.1
       detective-sass: 6.0.1
       detective-scss: 5.0.1
@@ -31181,6 +31231,29 @@ snapshots:
   vscode-uri@3.0.8: {}
 
   vscode-uri@3.1.0: {}
+
+  vue-livestore@0.2.3(typescript@5.9.3)(vite@7.1.9(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1)):
+    dependencies:
+      '@livestore/adapter-web': link:packages/@livestore/adapter-web
+      '@livestore/devtools-vite': 0.4.0-dev.16(vite@7.1.9(@types/node@24.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@livestore/livestore': link:packages/@livestore/livestore
+      '@livestore/peer-deps': link:packages/@livestore/peer-deps
+      '@livestore/sync-cf': link:packages/@livestore/sync-cf
+      '@livestore/wa-sqlite': link:packages/@livestore/wa-sqlite
+      vue: 3.5.22(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+      - vite
+
+  vue@3.5.22(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.22
+      '@vue/compiler-sfc': 3.5.22
+      '@vue/runtime-dom': 3.5.22
+      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@5.9.3))
+      '@vue/shared': 3.5.22
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
## Summary

This PR fixes the "Could not find vue-livestore" error during docs development by adding the actual `vue-livestore` package as a dependency in the snippet workspace.

## Problem

When running `pnpm astro dev` or `mono docs dev`, Vite failed with the error:
```
The following dependencies are imported but could not be resolved:
  vue-livestore (imported by .../vue/use-query.vue)
```

The Vue documentation snippets were importing from `vue-livestore`, but this was only handled via a local type declaration file (`vue-livestore.d.ts`) with placeholder types. While this worked for type-checking during snippet pre-rendering, it failed when Vite tried to resolve the actual module during dev server startup.

## Solution

- Add `vue-livestore@0.2.3` as a dependency to the snippet workspace (`docs/src/content/_assets/code/package.json`)
- Remove the local `vue-livestore.d.ts` type declaration file (no longer needed)
- Remove all `/// <reference path="./vue-livestore.d.ts" />` directives from Vue snippet files

This aligns the Vue snippets with how other framework snippets (React, Solid) are handled - by installing the actual integration package rather than using type stubs.

## Test plan

- [x] Verified `mono docs dev` starts successfully without module resolution errors
- [x] Confirmed Vue snippets can be properly pre-rendered by Twoslash
- [x] Verified no Vite optimization errors during dev server startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)