### PR TITLE
docs: fixes the worker initialization in the Node adapter

### DIFF
--- a/docs/src/content/docs/reference/platform-adapters/node-adapter.md
+++ b/docs/src/content/docs/reference/platform-adapters/node-adapter.md
@@ -35,11 +35,7 @@ const adapter = makeWorkerAdapter({
 
 // livestore.worker.ts
 import { makeWorker } from '@livestore/adapter-node/worker'
+import { schema } from './schema/index.js'
 
-const adapter = makeAdapter({
-	storage: { type: 'fs' },
-	// or in-memory:
-	// storage: { type: 'in-memory' },
-	sync: { backend: makeCfSync({ url: 'ws://localhost:8787' }) },
-})
+makeWorker({ schema })
 ```


### PR DESCRIPTION
## Problem

It fixes a misconfiguration of the worker when using the Node adapter.

## Solution

n/a

## Validation

n/a

### Demo (optional)

n/a

## Related issues

n/a