### PR TITLE
chore: update Store class to refine internal event schema type

### DIFF
--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -113,7 +113,9 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   activeQueries: ReferenceCountedSet<LiveQuery<any>>
 
   // NOTE this is currently exposed for the Devtools databrowser to commit events
-  readonly __eventSchema
+  // Stripped by internal so this type is removed and does not cause errors for TypeScript coercion from `useStore().store as Store<typeof schema>`
+  /** @internal */
+  readonly __eventSchema: unknown
   readonly syncProcessor: ClientSessionSyncProcessor
 
   readonly boot: Effect.Effect<void, UnexpectedError, Scope.Scope>


### PR DESCRIPTION
- Modified the `__eventSchema` property in the Store class to be marked as internal and set its type to `unknown`, preventing TypeScript coercion issues.
- Enhanced code clarity by adding comments to explain the changes and their purpose.

## Problem

Prevent TypeScript from inferring this type as part of the declarations emit.

## Related issues

- #814 
