### PR TITLE
refactor: rename `UnexpectedError` to `UnknownError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,26 @@
   const globalSeq: EventSequenceNumber.Global = 1
   ```
 
+- **Error class rename:** `UnexpectedError` has been renamed to `UnknownError` for better semantic clarity and consistency with Effect ecosystem naming conventions. The previous name conflicted with Effect's terminology where "unexpected errors" refer to defects, while this error type represents errors of unknown type from external libraries or infrastructure failures (See [PR #823](https://github.com/livestorejs/livestore/pull/823)).
+
+  Update all references:
+  - Class name: `UnexpectedError` → `UnknownError`
+  - Error tag: `'LiveStore.UnexpectedError'` → `'LiveStore.UnknownError'`
+  - Static methods: `mapToUnexpectedError*` → `mapToUnknownError*`
+  - Related type: `MergeResultUnexpectedError` → `MergeResultUnknownError`
+
+  ```typescript
+  // Before
+  import { UnexpectedError } from '@livestore/common'
+
+  effect.pipe(UnexpectedError.mapToUnexpectedError)
+
+  // After
+  import { UnknownError } from '@livestore/common'
+
+  effect.pipe(UnknownError.mapToUnknownError)
+  ```
+
 ### Changes
 
 #### Platform adapters
@@ -241,7 +261,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Query builder const assertions improve type inference, and `store.subscribe()` now accepts query builders (#371, thanks @rgbkrk).
 - **Store.subscribe async iteration:** The async iterator overload now exposes a first-class `AsyncIterable` so `for await` loops work without manual casts, and the new exported `Queryable` type documents the accepted inputs (livestorejs/livestore#736).
 - **Queryable type export:** `packages/@livestore/livestore` now re-exports `Queryable<TResult>` so shared utilities and framework adapters can describe the exact shapes accepted by `store.subscribe` and `subscribeStream` (livestorejs/livestore#736).
-- Store operations after shutdown are rejected with a descriptive `UnexpectedError`. Shutdown now returns an Effect (see breaking changes).
+- Store operations after shutdown are rejected with a descriptive `UnknownError`. Shutdown now returns an Effect (see breaking changes).
 - Exact optional property types are enabled, surfacing missing optional handling at compile time (#600).
 - Effect `Equal` and `Hash` implementations for `LiveQueryDef` and `SignalDef` improve comparisons.
 - Sync payload and store ID are exposed to `onPull`/`onPush` handlers (#451).

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -5,7 +5,7 @@ import {
   liveStoreStorageFormatVersion,
   makeClientSession,
   type SyncOptions,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import { type DevtoolsOptions, Eventlog, LeaderThreadCtx, makeLeaderThreadLayer } from '@livestore/common/leader-thread'
 import type { CfTypes } from '@livestore/common-cf'
@@ -45,7 +45,7 @@ export const makeAdapter =
       const makeSqliteDb = sqliteDbFactory({ sqlite3 })
 
       const syncInMemoryDb = yield* makeSqliteDb({ _tag: 'in-memory', storage, configureDb: () => {} }).pipe(
-        UnexpectedError.mapToUnexpectedError,
+        UnknownError.mapToUnknownError,
       )
 
       const schemaHashSuffix =
@@ -67,14 +67,14 @@ export const makeAdapter =
         storage,
         fileName: stateDbFileName,
         configureDb: () => {},
-      }).pipe(UnexpectedError.mapToUnexpectedError)
+      }).pipe(UnknownError.mapToUnknownError)
 
       const dbEventlog = yield* makeSqliteDb({
         _tag: 'storage',
         storage,
         fileName: eventlogDbFileName,
         configureDb: () => {},
-      }).pipe(UnexpectedError.mapToUnexpectedError)
+      }).pipe(UnknownError.mapToUnknownError)
 
       const shutdownChannel = yield* WebChannel.noopChannel<any, any>()
 
@@ -187,7 +187,7 @@ const resetDurableObjectPersistence = ({
         }
       }),
     catch: (cause) =>
-      new UnexpectedError({
+      new UnknownError({
         cause,
         note: `@livestore/adapter-cloudflare: Failed to reset persistence for store ${storeId}`,
       }),

--- a/packages/@livestore/adapter-expo/src/index.ts
+++ b/packages/@livestore/adapter-expo/src/index.ts
@@ -10,7 +10,7 @@ import {
   liveStoreStorageFormatVersion,
   makeClientSession,
   type SyncOptions,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import type { DevtoolsOptions, LeaderSqliteDb } from '@livestore/common/leader-thread'
 import { Eventlog, LeaderThreadCtx, makeLeaderThreadLayer } from '@livestore/common/leader-thread'
@@ -76,7 +76,7 @@ export const makePersistedAdapter =
   (adapterArgs) =>
     Effect.gen(function* () {
       if (IS_NEW_ARCH === false) {
-        return yield* UnexpectedError.make({
+        return yield* UnknownError.make({
           cause: new Error(
             'The LiveStore Expo adapter requires the new React Native architecture (aka Fabric). See https://docs.expo.dev/guides/new-architecture',
           ),
@@ -165,7 +165,7 @@ export const makePersistedAdapter =
       })
 
       return clientSession
-    }).pipe(UnexpectedError.mapToUnexpectedError, Effect.provide(FetchHttpClient.layer), Effect.tapCauseLogPretty)
+    }).pipe(UnknownError.mapToUnknownError, Effect.provide(FetchHttpClient.layer), Effect.tapCauseLogPretty)
 
 const makeLeaderThread = ({
   storeId,
@@ -323,7 +323,7 @@ const resetExpoPersistence = ({
       SQLite.deleteDatabaseSync(eventlogDatabaseName, directory)
     },
     catch: (cause) =>
-      new UnexpectedError({
+      new UnknownError({
         cause,
         note: `@livestore/adapter-expo: Failed to reset persistence for store ${storeId}`,
       }),
@@ -346,7 +346,7 @@ const makeDevtoolsOptions = ({
   dbEventlog: LeaderSqliteDb
   storeId: string
   clientId: string
-}): Effect.Effect<DevtoolsOptions, UnexpectedError, Scope.Scope> =>
+}): Effect.Effect<DevtoolsOptions, UnknownError, Scope.Scope> =>
   Effect.sync(() => {
     if (devtoolsEnabled === false) {
       return {

--- a/packages/@livestore/adapter-node/src/devtools/vite-dev-server.ts
+++ b/packages/@livestore/adapter-node/src/devtools/vite-dev-server.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import type { Devtools } from '@livestore/common'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { livestoreDevtoolsPlugin } from '@livestore/devtools-vite'
 import { isReadonlyArray } from '@livestore/utils'
 import { Effect } from '@livestore/utils/effect'
@@ -26,11 +26,11 @@ export type ViteDevtoolsOptions = {
 }
 
 // NOTE this is currently also used in @livestore/devtools-expo
-export const makeViteMiddleware = (options: ViteDevtoolsOptions): Effect.Effect<Vite.ViteDevServer, UnexpectedError> =>
+export const makeViteMiddleware = (options: ViteDevtoolsOptions): Effect.Effect<Vite.ViteDevServer, UnknownError> =>
   Effect.gen(function* () {
     const cwd = process.cwd()
 
-    const hmrPort = yield* getFreePort.pipe(UnexpectedError.mapToUnexpectedError)
+    const hmrPort = yield* getFreePort.pipe(UnknownError.mapToUnknownError)
 
     const defaultViteConfig = Vite.defineConfig({
       server: {
@@ -58,9 +58,7 @@ export const makeViteMiddleware = (options: ViteDevtoolsOptions): Effect.Effect<
 
     const viteConfig = options.viteConfig?.(defaultViteConfig) ?? defaultViteConfig
 
-    const viteServer = yield* Effect.promise(() => Vite.createServer(viteConfig)).pipe(
-      UnexpectedError.mapToUnexpectedError,
-    )
+    const viteServer = yield* Effect.promise(() => Vite.createServer(viteConfig)).pipe(UnknownError.mapToUnknownError)
 
     return viteServer
   }).pipe(Effect.withSpan('@livestore/adapter-node:devtools:makeViteServer'))

--- a/packages/@livestore/adapter-node/src/leader-thread-shared.ts
+++ b/packages/@livestore/adapter-node/src/leader-thread-shared.ts
@@ -7,7 +7,7 @@ if (process.execArgv.includes('--inspect')) {
 }
 
 import type { ClientSessionLeaderThreadProxy, MakeSqliteDb, SqliteDb, SyncOptions } from '@livestore/common'
-import { Devtools, liveStoreStorageFormatVersion, migrateDb, UnexpectedError } from '@livestore/common'
+import { Devtools, liveStoreStorageFormatVersion, migrateDb, UnknownError } from '@livestore/common'
 import type { DevtoolsOptions, LeaderSqliteDb, LeaderThreadCtx } from '@livestore/common/leader-thread'
 import { configureConnection, makeLeaderThreadLayer } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
@@ -30,7 +30,7 @@ export type TestingOverrides = {
       dbEventlog: SqliteDb
       dbState: SqliteDb
     },
-    UnexpectedError
+    UnknownError
   >
 }
 
@@ -59,8 +59,8 @@ export const makeLeaderThread = ({
   syncPayloadSchema,
   testing,
 }: MakeLeaderThreadArgs): Effect.Effect<
-  Layer.Layer<LeaderThreadCtx, UnexpectedError, Scope.Scope | HttpClient.HttpClient | FileSystem.FileSystem>,
-  UnexpectedError,
+  Layer.Layer<LeaderThreadCtx, UnknownError, Scope.Scope | HttpClient.HttpClient | FileSystem.FileSystem>,
+  UnknownError,
   Scope.Scope
 > =>
   Effect.gen(function* () {
@@ -120,7 +120,7 @@ export const makeLeaderThread = ({
     })
   }).pipe(
     Effect.tapCauseLogPretty,
-    UnexpectedError.mapToUnexpectedError,
+    UnknownError.mapToUnknownError,
     Effect.withSpan('@livestore/adapter-node:makeLeaderThread', {
       attributes: { storeId, clientId, storage, devtools, syncOptions },
     }),
@@ -140,7 +140,7 @@ const makeDevtoolsOptions = ({
   storeId: string
   clientId: string
   devtools: WorkerSchema.LeaderWorkerInnerInitialMessage['devtools']
-}): Effect.Effect<DevtoolsOptions, UnexpectedError, Scope.Scope> =>
+}): Effect.Effect<DevtoolsOptions, UnknownError, Scope.Scope> =>
   Effect.gen(function* () {
     if (devtools.enabled === false) {
       return {

--- a/packages/@livestore/adapter-node/src/make-leader-worker.ts
+++ b/packages/@livestore/adapter-node/src/make-leader-worker.ts
@@ -8,7 +8,7 @@ if (process.execArgv.includes('--inspect')) {
 }
 
 import type { SyncOptions } from '@livestore/common'
-import { LogConfig, UnexpectedError } from '@livestore/common'
+import { LogConfig, UnknownError } from '@livestore/common'
 import { Eventlog, LeaderThreadCtx } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { LiveStoreEvent } from '@livestore/common/schema'
@@ -88,27 +88,24 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
       }).pipe(Stream.unwrapScoped),
     Export: () =>
       Effect.andThen(LeaderThreadCtx, (_) => _.dbState.export()).pipe(
-        UnexpectedError.mapToUnexpectedError,
+        UnknownError.mapToUnknownError,
         Effect.withSpan('@livestore/adapter-node:worker:Export'),
       ),
     ExportEventlog: () =>
       Effect.andThen(LeaderThreadCtx, (_) => _.dbEventlog.export()).pipe(
-        UnexpectedError.mapToUnexpectedError,
+        UnknownError.mapToUnknownError,
         Effect.withSpan('@livestore/adapter-node:worker:ExportEventlog'),
       ),
     GetLeaderHead: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
-      }).pipe(UnexpectedError.mapToUnexpectedError, Effect.withSpan('@livestore/adapter-node:worker:GetLeaderHead')),
+      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetLeaderHead')),
     GetLeaderSyncState: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return yield* workerCtx.syncProcessor.syncState
-      }).pipe(
-        UnexpectedError.mapToUnexpectedError,
-        Effect.withSpan('@livestore/adapter-node:worker:GetLeaderSyncState'),
-      ),
+      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetLeaderSyncState')),
     SyncStateStream: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
@@ -118,7 +115,7 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return yield* workerCtx.networkStatus
-      }).pipe(UnexpectedError.mapToUnexpectedError, Effect.withSpan('@livestore/adapter-node:worker:GetNetworkStatus')),
+      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetNetworkStatus')),
     NetworkStatusStream: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
@@ -134,10 +131,7 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
         // return cachedSnapshot ?? workerCtx.db.export()
         const snapshot = workerCtx.dbState.export()
         return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
-      }).pipe(
-        UnexpectedError.mapToUnexpectedError,
-        Effect.withSpan('@livestore/adapter-node:worker:GetRecreateSnapshot'),
-      ),
+      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetRecreateSnapshot')),
     Shutdown: () =>
       // @effect-diagnostics-next-line unnecessaryEffectGen:off
       Effect.gen(function* () {
@@ -153,10 +147,10 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
         // Buy some time for Otel to flush
         // TODO find a cleaner way to do this
         // yield* Effect.sleep(1000)
-      }).pipe(UnexpectedError.mapToUnexpectedError, Effect.withSpan('@livestore/adapter-node:worker:Shutdown')),
+      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:Shutdown')),
     ExtraDevtoolsMessage: ({ message }) =>
       Effect.andThen(LeaderThreadCtx, (_) => _.extraIncomingMessagesQueue.offer(message)).pipe(
-        UnexpectedError.mapToUnexpectedError,
+        UnknownError.mapToUnknownError,
         Effect.withSpan('@livestore/adapter-node:worker:ExtraDevtoolsMessage'),
       ),
   }).pipe(

--- a/packages/@livestore/adapter-node/src/worker-schema.ts
+++ b/packages/@livestore/adapter-node/src/worker-schema.ts
@@ -5,7 +5,7 @@ import {
   MigrationsReport,
   SyncBackend,
   SyncState,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
 import { Schema, Transferable } from '@livestore/utils/effect'
@@ -61,7 +61,7 @@ export class LeaderWorkerOuterInitialMessage extends Schema.TaggedRequest<Leader
   {
     payload: { port: Transferable.MessagePort },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -88,7 +88,7 @@ export class LeaderWorkerInnerInitialMessage extends Schema.TaggedRequest<Leader
       ),
     },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -97,7 +97,7 @@ export class LeaderWorkerInnerBootStatusStream extends Schema.TaggedRequest<Lead
   {
     payload: {},
     success: BootStatus,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -108,7 +108,7 @@ export class LeaderWorkerInnerPullStream extends Schema.TaggedRequest<LeaderWork
   success: Schema.Struct({
     payload: SyncState.PayloadUpstream,
   }),
-  failure: UnexpectedError,
+  failure: UnknownError,
 }) {}
 
 export class LeaderWorkerInnerPushToLeader extends Schema.TaggedRequest<LeaderWorkerInnerPushToLeader>()(
@@ -118,14 +118,14 @@ export class LeaderWorkerInnerPushToLeader extends Schema.TaggedRequest<LeaderWo
       batch: Schema.Array(Schema.typeSchema(LiveStoreEvent.Client.Encoded)),
     },
     success: Schema.Void as Schema.Schema<void>,
-    failure: Schema.Union(UnexpectedError, LeaderAheadError),
+    failure: Schema.Union(UnknownError, LeaderAheadError),
   },
 ) {}
 
 export class LeaderWorkerInnerExport extends Schema.TaggedRequest<LeaderWorkerInnerExport>()('Export', {
   payload: {},
   success: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
-  failure: UnexpectedError,
+  failure: UnknownError,
 }) {}
 
 export class LeaderWorkerInnerGetRecreateSnapshot extends Schema.TaggedRequest<LeaderWorkerInnerGetRecreateSnapshot>()(
@@ -136,7 +136,7 @@ export class LeaderWorkerInnerGetRecreateSnapshot extends Schema.TaggedRequest<L
       snapshot: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
       migrationsReport: MigrationsReport,
     }),
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -145,7 +145,7 @@ export class LeaderWorkerInnerExportEventlog extends Schema.TaggedRequest<Leader
   {
     payload: {},
     success: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -154,7 +154,7 @@ export class LeaderWorkerInnerGetLeaderHead extends Schema.TaggedRequest<LeaderW
   {
     payload: {},
     success: Schema.typeSchema(EventSequenceNumber.Client.Composite),
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -163,7 +163,7 @@ export class LeaderWorkerInnerGetLeaderSyncState extends Schema.TaggedRequest<Le
   {
     payload: {},
     success: SyncState.SyncState,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -172,7 +172,7 @@ export class LeaderWorkerInnerSyncStateStream extends Schema.TaggedRequest<Leade
   {
     payload: {},
     success: SyncState.SyncState,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -181,7 +181,7 @@ export class LeaderWorkerInnerGetNetworkStatus extends Schema.TaggedRequest<Lead
   {
     payload: {},
     success: SyncBackend.NetworkStatus,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -190,14 +190,14 @@ export class LeaderWorkerInnerNetworkStatusStream extends Schema.TaggedRequest<L
   {
     payload: {},
     success: SyncBackend.NetworkStatus,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
 export class LeaderWorkerInnerShutdown extends Schema.TaggedRequest<LeaderWorkerInnerShutdown>()('Shutdown', {
   payload: {},
   success: Schema.Void,
-  failure: UnexpectedError,
+  failure: UnknownError,
 }) {}
 
 export class LeaderWorkerInnerExtraDevtoolsMessage extends Schema.TaggedRequest<LeaderWorkerInnerExtraDevtoolsMessage>()(
@@ -207,7 +207,7 @@ export class LeaderWorkerInnerExtraDevtoolsMessage extends Schema.TaggedRequest<
       message: Devtools.Leader.MessageToApp,
     },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -6,7 +6,7 @@ import {
   makeClientSession,
   migrateDb,
   type SyncOptions,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import type { DevtoolsOptions, LeaderSqliteDb } from '@livestore/common/leader-thread'
 import { configureConnection, Eventlog, LeaderThreadCtx, makeLeaderThreadLayer } from '@livestore/common/leader-thread'
@@ -96,7 +96,7 @@ export const makeInMemoryAdapter =
           }).pipe(
             Effect.provide(BrowserWorker.layer(() => sharedWebWorker)),
             Effect.tapCauseLogPretty,
-            UnexpectedError.mapToUnexpectedError,
+            UnknownError.mapToUnknownError,
             Effect.forkScoped,
           )
         : undefined
@@ -151,7 +151,7 @@ export const makeInMemoryAdapter =
       })
 
       return clientSession
-    }).pipe(UnexpectedError.mapToUnexpectedError, Effect.provide(FetchHttpClient.layer))
+    }).pipe(UnknownError.mapToUnknownError, Effect.provide(FetchHttpClient.layer))
 
 export interface MakeLeaderThreadArgs {
   schema: LiveStoreSchema
@@ -256,7 +256,7 @@ const makeLeaderThread = ({
 
 type SharedWorkerFiber = Fiber.Fiber<
   Worker.SerializedWorkerPool<typeof WebmeshWorker.Schema.Request.Type>,
-  UnexpectedError
+  UnknownError
 >
 
 const makeDevtoolsOptions = ({
@@ -273,7 +273,7 @@ const makeDevtoolsOptions = ({
   dbEventlog: LeaderSqliteDb
   storeId: string
   clientId: string
-}): Effect.Effect<DevtoolsOptions, UnexpectedError, Scope.Scope> =>
+}): Effect.Effect<DevtoolsOptions, UnknownError, Scope.Scope> =>
   Effect.gen(function* () {
     if (devtoolsEnabled === false || sharedWorkerFiber === undefined) {
       return { enabled: false }

--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
@@ -1,4 +1,4 @@
-import { liveStoreStorageFormatVersion, UnexpectedError } from '@livestore/common'
+import { liveStoreStorageFormatVersion, UnknownError } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { decodeSAHPoolFilename, HEADER_OFFSET_DATA, type WebDatabaseMetadataOpfs } from '@livestore/sqlite-wasm/browser'
 import { isDevEnv } from '@livestore/utils'
@@ -120,7 +120,7 @@ const opfsDeleteAbs = (absPath: string) =>
       }
     }
   }).pipe(
-    UnexpectedError.mapToUnexpectedError,
+    UnknownError.mapToUnknownError,
     Effect.withSpan('@livestore/adapter-web:worker:opfsDeleteFile', { attributes: { absFilePath: absPath } }),
   )
 

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -6,7 +6,7 @@ import {
   MigrationsReport,
   SyncBackend,
   SyncState,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
 import * as WebmeshWorker from '@livestore/devtools-web-common/worker'
@@ -49,7 +49,7 @@ export class LeaderWorkerOuterInitialMessage extends Schema.TaggedRequest<Leader
   {
     payload: { port: Transferable.MessagePort, storeId: Schema.String, clientId: Schema.String },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -68,7 +68,7 @@ export class LeaderWorkerInnerInitialMessage extends Schema.TaggedRequest<Leader
       syncPayloadEncoded: Schema.UndefinedOr(Schema.JsonValue),
     },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -77,7 +77,7 @@ export class LeaderWorkerInnerBootStatusStream extends Schema.TaggedRequest<Lead
   {
     payload: {},
     success: BootStatus,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -88,7 +88,7 @@ export class LeaderWorkerInnerPushToLeader extends Schema.TaggedRequest<LeaderWo
       batch: Schema.Array(Schema.typeSchema(LiveStoreEvent.Client.Encoded)),
     },
     success: Schema.Void as Schema.Schema<void>,
-    failure: Schema.Union(UnexpectedError, LeaderAheadError),
+    failure: Schema.Union(UnknownError, LeaderAheadError),
   },
 ) {}
 
@@ -99,13 +99,13 @@ export class LeaderWorkerInnerPullStream extends Schema.TaggedRequest<LeaderWork
   success: Schema.Struct({
     payload: SyncState.PayloadUpstream,
   }),
-  failure: UnexpectedError,
+  failure: UnknownError,
 }) {}
 
 export class LeaderWorkerInnerExport extends Schema.TaggedRequest<LeaderWorkerInnerExport>()('Export', {
   payload: {},
   success: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
-  failure: UnexpectedError,
+  failure: UnknownError,
 }) {}
 
 export class LeaderWorkerInnerExportEventlog extends Schema.TaggedRequest<LeaderWorkerInnerExportEventlog>()(
@@ -113,7 +113,7 @@ export class LeaderWorkerInnerExportEventlog extends Schema.TaggedRequest<Leader
   {
     payload: {},
     success: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -125,7 +125,7 @@ export class LeaderWorkerInnerGetRecreateSnapshot extends Schema.TaggedRequest<L
       snapshot: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
       migrationsReport: MigrationsReport,
     }),
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -134,7 +134,7 @@ export class LeaderWorkerInnerGetLeaderHead extends Schema.TaggedRequest<LeaderW
   {
     payload: {},
     success: Schema.typeSchema(EventSequenceNumber.Client.Composite),
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -143,7 +143,7 @@ export class LeaderWorkerInnerGetLeaderSyncState extends Schema.TaggedRequest<Le
   {
     payload: {},
     success: SyncState.SyncState,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -152,7 +152,7 @@ export class LeaderWorkerInnerSyncStateStream extends Schema.TaggedRequest<Leade
   {
     payload: {},
     success: SyncState.SyncState,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -161,7 +161,7 @@ export class LeaderWorkerInnerGetNetworkStatus extends Schema.TaggedRequest<Lead
   {
     payload: {},
     success: SyncBackend.NetworkStatus,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -170,14 +170,14 @@ export class LeaderWorkerInnerNetworkStatusStream extends Schema.TaggedRequest<L
   {
     payload: {},
     success: SyncBackend.NetworkStatus,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
 export class LeaderWorkerInnerShutdown extends Schema.TaggedRequest<LeaderWorkerInnerShutdown>()('Shutdown', {
   payload: {},
   success: Schema.Void,
-  failure: UnexpectedError,
+  failure: UnknownError,
 }) {}
 
 export class LeaderWorkerInnerExtraDevtoolsMessage extends Schema.TaggedRequest<LeaderWorkerInnerExtraDevtoolsMessage>()(
@@ -187,7 +187,7 @@ export class LeaderWorkerInnerExtraDevtoolsMessage extends Schema.TaggedRequest<
       message: Devtools.Leader.MessageToApp,
     },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 
@@ -226,7 +226,7 @@ export class SharedWorkerUpdateMessagePort extends Schema.TaggedRequest<SharedWo
       initial: LeaderWorkerInnerInitialMessage,
     },
     success: Schema.Void,
-    failure: UnexpectedError,
+    failure: UnknownError,
   },
 ) {}
 

--- a/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
+++ b/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
@@ -2,7 +2,7 @@ import type { Effect, Stream, Subscribable } from '@livestore/utils/effect'
 
 import type { MigrationsReport } from './defs.ts'
 import type * as Devtools from './devtools/mod.ts'
-import type { UnexpectedError } from './errors.ts'
+import type { UnknownError } from './errors.ts'
 import type * as EventSequenceNumber from './schema/EventSequenceNumber/mod.ts'
 import type { LiveStoreEvent } from './schema/mod.ts'
 import type { LeaderAheadError, SyncBackend } from './sync/sync.ts'
@@ -12,9 +12,9 @@ export interface ClientSessionLeaderThreadProxy {
   events: {
     pull: (args: {
       cursor: EventSequenceNumber.Client.Composite
-    }) => Stream.Stream<{ payload: typeof PayloadUpstream.Type }, UnexpectedError>
+    }) => Stream.Stream<{ payload: typeof PayloadUpstream.Type }, UnknownError>
     /** It's important that a client session doesn't call `push` concurrently. */
-    push(batch: ReadonlyArray<LiveStoreEvent.Client.Encoded>): Effect.Effect<void, UnexpectedError | LeaderAheadError>
+    push(batch: ReadonlyArray<LiveStoreEvent.Client.Encoded>): Effect.Effect<void, UnknownError | LeaderAheadError>
   }
   /** The initial state after the leader thread has booted */
   readonly initialState: {
@@ -23,11 +23,11 @@ export interface ClientSessionLeaderThreadProxy {
     /** The migrations report from the leader thread */
     readonly migrationsReport: MigrationsReport
   }
-  export: Effect.Effect<Uint8Array<ArrayBuffer>, UnexpectedError>
-  getEventlogData: Effect.Effect<Uint8Array<ArrayBuffer>, UnexpectedError>
-  syncState: Subscribable.Subscribable<SyncState, UnexpectedError>
+  export: Effect.Effect<Uint8Array<ArrayBuffer>, UnknownError>
+  getEventlogData: Effect.Effect<Uint8Array<ArrayBuffer>, UnknownError>
+  syncState: Subscribable.Subscribable<SyncState, UnknownError>
   /** For debugging purposes it can be useful to manually trigger devtools messages (e.g. to reset the database) */
-  sendDevtoolsMessage: (message: Devtools.Leader.MessageToApp) => Effect.Effect<void, UnexpectedError>
+  sendDevtoolsMessage: (message: Devtools.Leader.MessageToApp) => Effect.Effect<void, UnknownError>
   /**
    * Reactive stream describing the connectivity between the leader and its upstream sync backend.
    * Includes raw connection state, last transition timestamp, and devtools overrides (latch state).

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -10,7 +10,7 @@ import {
 
 import type { ClientSessionLeaderThreadProxy } from './ClientSessionLeaderThreadProxy.ts'
 import type * as Devtools from './devtools/mod.ts'
-import type { IntentionalShutdownCause, MaterializeError, UnexpectedError } from './errors.ts'
+import type { IntentionalShutdownCause, MaterializeError, UnknownError } from './errors.ts'
 import type { LiveStoreSchema } from './schema/mod.ts'
 import type { SqliteDb } from './sqlite-types.ts'
 import type { IsOfflineError, SyncError } from './sync/index.ts'
@@ -34,7 +34,7 @@ export interface ClientSession {
   /** Status info whether current session is leader or not */
   lockStatus: SubscriptionRef.SubscriptionRef<LockStatus>
   shutdown: (
-    cause: Exit.Exit<IntentionalShutdownCause, UnexpectedError | SyncError | MaterializeError>,
+    cause: Exit.Exit<IntentionalShutdownCause, UnknownError | SyncError | MaterializeError>,
   ) => Effect.Effect<void>
   /** A proxy API to communicate with the leader thread */
   leaderThread: ClientSessionLeaderThreadProxy
@@ -119,9 +119,9 @@ export interface ClientSessionDevtoolsChannel
 
 export type ConnectDevtoolsToStore = (
   storeDevtoolsChannel: ClientSessionDevtoolsChannel,
-) => Effect.Effect<void, UnexpectedError, Scope.Scope>
+) => Effect.Effect<void, UnknownError, Scope.Scope>
 
-export type Adapter = (args: AdapterArgs) => Effect.Effect<ClientSession, UnexpectedError, Scope.Scope>
+export type Adapter = (args: AdapterArgs) => Effect.Effect<ClientSession, UnknownError, Scope.Scope>
 
 export interface AdapterArgs {
   schema: LiveStoreSchema
@@ -130,7 +130,7 @@ export interface AdapterArgs {
   debugInstanceId: string
   bootStatusQueue: Queue.Queue<BootStatus>
   shutdown: (
-    exit: Exit.Exit<IntentionalShutdownCause, UnexpectedError | SyncError | MaterializeError | IsOfflineError>,
+    exit: Exit.Exit<IntentionalShutdownCause, UnknownError | SyncError | MaterializeError | IsOfflineError>,
   ) => Effect.Effect<void>
   connectDevtoolsToStore: ConnectDevtoolsToStore
   /**

--- a/packages/@livestore/common/src/devtools/devtools-messages-leader.ts
+++ b/packages/@livestore/common/src/devtools/devtools-messages-leader.ts
@@ -83,7 +83,7 @@ export const LoadDatabaseFile = LeaderReqResMessage('LSD.Leader.LoadDatabaseFile
     cause: Schema.Union(
       Schema.TaggedStruct('unsupported-file', {}),
       Schema.TaggedStruct('unsupported-database', {}),
-      Schema.TaggedStruct('unexpected-error', { cause: Schema.Defect }),
+      Schema.TaggedStruct('unknown-error', { cause: Schema.Defect }),
     ),
   },
 })
@@ -133,7 +133,7 @@ export const ResetAllData = LeaderReqResMessage('LSD.Leader.ResetAllData', {
 //     liveStoreVersion,
 //   },
 //   success: DatabaseFileInfo,
-//   failure: UnexpectedError,
+//   failure: UnknownError,
 // }) {}
 
 // export class NetworkStatus_ extends Schema.TaggedRequest<NetworkStatus_>()('LSD.Leader.NetworkStatus', {
@@ -142,7 +142,7 @@ export const ResetAllData = LeaderReqResMessage('LSD.Leader.ResetAllData', {
 //     liveStoreVersion,
 //   },
 //   success: NetworkStatus,
-//   failure: UnexpectedError,
+//   failure: UnknownError,
 // }) {}
 
 // export const MessageToApp_ = Schema.Union(DatabaseFileInfo_, NetworkStatus_)

--- a/packages/@livestore/common/src/errors.ts
+++ b/packages/@livestore/common/src/errors.ts
@@ -2,30 +2,28 @@ import { Cause, Effect, Layer, Schema, Stream } from '@livestore/utils/effect'
 
 import * as LiveStoreEvent from './schema/LiveStoreEvent/mod.ts'
 
-export class UnexpectedError extends Schema.TaggedError<UnexpectedError>()('LiveStore.UnexpectedError', {
+export class UnknownError extends Schema.TaggedError<UnknownError>()('LiveStore.UnknownError', {
   cause: Schema.Defect,
   note: Schema.optional(Schema.String),
   payload: Schema.optional(Schema.Any),
 }) {
-  static mapToUnexpectedError = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  static mapToUnknownError = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     effect.pipe(
-      Effect.mapError((cause) => (Schema.is(UnexpectedError)(cause) ? cause : new UnexpectedError({ cause }))),
-      Effect.catchAllDefect((cause) => new UnexpectedError({ cause })),
+      Effect.mapError((cause) => (Schema.is(UnknownError)(cause) ? cause : new UnknownError({ cause }))),
+      Effect.catchAllDefect((cause) => new UnknownError({ cause })),
     )
 
-  static mapToUnexpectedErrorLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) =>
+  static mapToUnknownErrorLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) =>
     layer.pipe(
       Layer.catchAllCause((cause) =>
-        Cause.isFailType(cause) && Schema.is(UnexpectedError)(cause.error)
+        Cause.isFailType(cause) && Schema.is(UnknownError)(cause.error)
           ? Layer.fail(cause.error)
-          : Layer.fail(new UnexpectedError({ cause: cause })),
+          : Layer.fail(new UnknownError({ cause: cause })),
       ),
     )
 
-  static mapToUnexpectedErrorStream = <A, E, R>(stream: Stream.Stream<A, E, R>) =>
-    stream.pipe(
-      Stream.mapError((cause) => (Schema.is(UnexpectedError)(cause) ? cause : new UnexpectedError({ cause }))),
-    )
+  static mapToUnknownErrorStream = <A, E, R>(stream: Stream.Stream<A, E, R>) =>
+    stream.pipe(Stream.mapError((cause) => (Schema.is(UnknownError)(cause) ? cause : new UnknownError({ cause }))))
 }
 
 export class MaterializerHashMismatchError extends Schema.TaggedError<MaterializerHashMismatchError>()(

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -19,12 +19,7 @@ import {
   SubscriptionRef,
 } from '@livestore/utils/effect'
 import type * as otel from '@opentelemetry/api'
-import {
-  type IntentionalShutdownCause,
-  type MaterializeError,
-  type SqliteDb,
-  UnexpectedError,
-} from '../adapter-types.ts'
+import { type IntentionalShutdownCause, type MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
 import { makeMaterializerHash } from '../materializer-helper.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '../schema/mod.ts'
@@ -113,7 +108,7 @@ export const makeLeaderSyncProcessor = ({
       localPushProcessing?: Effect.Effect<void>
     }
   }
-}): Effect.Effect<LeaderSyncProcessor, UnexpectedError, Scope.Scope> =>
+}): Effect.Effect<LeaderSyncProcessor, UnknownError, Scope.Scope> =>
   Effect.gen(function* () {
     const syncBackendPushQueue = yield* BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>()
     const localPushBatchSize = params.localPushBatchSize ?? 1
@@ -205,7 +200,7 @@ export const makeLeaderSyncProcessor = ({
             sessionId,
             seqNum: syncState.localHead,
           },
-        }).pipe(UnexpectedError.mapToUnexpectedError)
+        }).pipe(UnknownError.mapToUnknownError)
 
         if (resolution._tag === 'unknown') {
           // Ignore partial pushes for unrecognised events – they are still
@@ -260,7 +255,7 @@ export const makeLeaderSyncProcessor = ({
 
       const maybeShutdownOnError = (
         cause: Cause.Cause<
-          | UnexpectedError
+          | UnknownError
           | IntentionalShutdownCause
           | IsOfflineError
           | InvalidPushError
@@ -279,7 +274,7 @@ export const makeLeaderSyncProcessor = ({
             return
           }
 
-          const errorToSend = Cause.isFailType(cause) ? cause.error : UnexpectedError.make({ cause })
+          const errorToSend = Cause.isFailType(cause) ? cause.error : UnknownError.make({ cause })
           yield* shutdownChannel.send(errorToSend).pipe(Effect.orDie)
 
           return yield* Effect.die(cause)
@@ -488,12 +483,12 @@ const backgroundApplyLocalPushes = ({
       })
 
       switch (mergeResult._tag) {
-        case 'unexpected-error': {
-          otelSpan?.addEvent(`push:unexpected-error`, {
+        case 'unknown-error': {
+          otelSpan?.addEvent(`push:unknown-error`, {
             batchSize: newEvents.length,
             newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
           })
-          return yield* new UnexpectedError({ cause: mergeResult.message })
+          return yield* new UnknownError({ cause: mergeResult.message })
         }
         case 'rebase': {
           return shouldNeverHappen('The leader thread should never have to rebase due to a local push')
@@ -643,7 +638,7 @@ const backgroundBackendPulling = ({
   isClientEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   restartBackendPushing: (
     filteredRebasedPending: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
-  ) => Effect.Effect<void, UnexpectedError, LeaderThreadCtx | HttpClient.HttpClient>
+  ) => Effect.Effect<void, UnknownError, LeaderThreadCtx | HttpClient.HttpClient>
   otelSpan: otel.Span | undefined
   syncStateSref: SubscriptionRef.SubscriptionRef<SyncState.SyncState | undefined>
   dbState: SqliteDb
@@ -690,12 +685,12 @@ const backgroundBackendPulling = ({
 
         if (mergeResult._tag === 'reject') {
           return shouldNeverHappen('The leader thread should never reject upstream advances')
-        } else if (mergeResult._tag === 'unexpected-error') {
-          otelSpan?.addEvent(`pull:unexpected-error`, {
+        } else if (mergeResult._tag === 'unknown-error') {
+          otelSpan?.addEvent(`pull:unknown-error`, {
             newEventsCount: newEvents.length,
             newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
           })
-          return yield* new UnexpectedError({ cause: mergeResult.message })
+          return yield* new UnknownError({ cause: mergeResult.message })
         }
 
         const newBackendHead = newEvents.at(-1)!.seqNum
@@ -754,7 +749,7 @@ const backgroundBackendPulling = ({
                 EventSequenceNumber.Client.isEqual(event.seqNum, confirmedEvent.seqNum),
               ),
             )
-            yield* Eventlog.updateSyncMetadata(confirmedNewEvents).pipe(UnexpectedError.mapToUnexpectedError)
+            yield* Eventlog.updateSyncMetadata(confirmedNewEvents).pipe(UnknownError.mapToUnknownError)
           }
         }
 
@@ -853,9 +848,9 @@ const backgroundBackendPushing = ({
       // - Resets automatically after successful push
       // TODO(metrics): expose counters/gauges for retry attempts and queue health via devtools/metrics
 
-      // Only retry for transient UnexpectedError cases
+      // Only retry for transient UnknownError cases
       const isRetryable = (err: InvalidPushError | IsOfflineError) =>
-        err._tag === 'InvalidPushError' && err.cause._tag === 'LiveStore.UnexpectedError'
+        err._tag === 'InvalidPushError' && err.cause._tag === 'LiveStore.UnknownError'
 
       // Input: InvalidPushError | IsOfflineError, Output: Duration
       const retrySchedule: Schedule.Schedule<Duration.DurationInput, InvalidPushError | IsOfflineError> =
@@ -908,13 +903,13 @@ interface PullQueueSet {
     cursor: EventSequenceNumber.Client.Composite,
   ) => Effect.Effect<
     Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>,
-    UnexpectedError,
+    UnknownError,
     Scope.Scope | LeaderThreadCtx
   >
   offer: (item: {
     payload: typeof SyncState.PayloadUpstream.Type
     leaderHead: EventSequenceNumber.Client.Composite
-  }) => Effect.Effect<void, UnexpectedError>
+  }) => Effect.Effect<void, UnknownError>
 }
 
 const makePullQueueSet = Effect.gen(function* () {

--- a/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
+++ b/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
@@ -1,7 +1,7 @@
 import { Effect, FiberMap, Option, Stream, SubscriptionRef } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 
-import { Devtools, IntentionalShutdownCause, liveStoreVersion, UnexpectedError } from '../index.ts'
+import { Devtools, IntentionalShutdownCause, liveStoreVersion, UnknownError } from '../index.ts'
 import { SystemTables } from '../schema/mod.ts'
 import type { DevtoolsOptions, PersistenceInfoPair } from './types.ts'
 import { LeaderThreadCtx } from './types.ts'
@@ -184,7 +184,7 @@ const listenToDevtools = ({
                       sendMessage(
                         Devtools.Leader.LoadDatabaseFile.Error.make({
                           ...reqPayload,
-                          cause: { _tag: 'unexpected-error' as const, cause },
+                          cause: { _tag: 'unknown-error' as const, cause },
                         }),
                       ),
                     ),
@@ -391,7 +391,7 @@ const listenToDevtools = ({
           }
         }).pipe(Effect.withSpan(`@livestore/common:leader-thread:onDevtoolsMessage:${decodedEvent._tag}`)),
       ),
-      UnexpectedError.mapToUnexpectedErrorStream,
+      UnknownError.mapToUnknownErrorStream,
       Stream.runDrain,
     )
   })

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -18,7 +18,7 @@ import {
   type MaterializerHashMismatchError,
   type SqliteDb,
   type SqliteError,
-  UnexpectedError,
+  UnknownError,
 } from '../adapter-types.ts'
 import type { MigrationsReport } from '../defs.ts'
 import type * as Devtools from '../devtools/mod.ts'
@@ -82,7 +82,7 @@ export const makeLeaderThreadLayer = ({
   shutdownChannel,
   params,
   testing,
-}: MakeLeaderThreadLayerParams): Layer.Layer<LeaderThreadCtx, UnexpectedError, Scope.Scope | HttpClient.HttpClient> =>
+}: MakeLeaderThreadLayerParams): Layer.Layer<LeaderThreadCtx, UnknownError, Scope.Scope | HttpClient.HttpClient> =>
   Effect.gen(function* () {
     const syncPayloadDecoded =
       syncPayloadEncoded === undefined ? undefined : yield* Schema.decodeUnknown(syncPayloadSchema)(syncPayloadEncoded)
@@ -220,7 +220,7 @@ export const makeLeaderThreadLayer = ({
   }).pipe(
     Effect.withSpan('@livestore/common:leader-thread:boot'),
     Effect.withSpanScoped('@livestore/common:leader-thread'),
-    UnexpectedError.mapToUnexpectedError,
+    UnknownError.mapToUnknownError,
     Effect.tapCauseLogPretty,
     Layer.unwrapScoped,
   )
@@ -352,7 +352,7 @@ const bootLeaderThread = ({
   devtoolsOptions: DevtoolsOptions
 }): Effect.Effect<
   LeaderThreadCtx['Type']['initialState'],
-  UnexpectedError | SqliteError | IsOfflineError | InvalidPullError | MaterializerHashMismatchError,
+  UnknownError | SqliteError | IsOfflineError | InvalidPullError | MaterializerHashMismatchError,
   LeaderThreadCtx | Scope.Scope | HttpClient.HttpClient
 > =>
   Effect.gen(function* () {

--- a/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
+++ b/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
@@ -7,12 +7,12 @@ import {
   InvalidPushError,
   IsOfflineError,
   MaterializeError,
-  UnexpectedError,
+  UnknownError,
 } from '../index.ts'
 
 export class All extends Schema.Union(
   IntentionalShutdownCause,
-  UnexpectedError,
+  UnknownError,
   IsOfflineError,
   InvalidPushError,
   InvalidPullError,

--- a/packages/@livestore/common/src/leader-thread/types.ts
+++ b/packages/@livestore/common/src/leader-thread/types.ts
@@ -22,7 +22,7 @@ import type {
   PersistenceInfo,
   SqliteDb,
   SyncBackend,
-  UnexpectedError,
+  UnknownError,
 } from '../index.ts'
 import type { EventSequenceNumber, LiveStoreEvent, LiveStoreSchema } from '../schema/mod.ts'
 import type * as SyncState from '../sync/syncstate.ts'
@@ -66,7 +66,7 @@ export type DevtoolsOptions =
           persistenceInfo: PersistenceInfoPair
           mode: 'proxy' | 'direct'
         },
-        UnexpectedError,
+        UnknownError,
         Scope.Scope | HttpClient.HttpClient | LeaderThreadCtx
       >
     }
@@ -138,11 +138,11 @@ export interface LeaderSyncProcessor {
   /** Used by client sessions to subscribe to upstream sync state changes */
   pull: (args: {
     cursor: EventSequenceNumber.Client.Composite
-  }) => Stream.Stream<{ payload: typeof SyncState.PayloadUpstream.Type }, UnexpectedError>
+  }) => Stream.Stream<{ payload: typeof SyncState.PayloadUpstream.Type }, UnknownError>
   /** The `pullQueue` API can be used instead of `pull` when more convenient */
   pullQueue: (args: {
     cursor: EventSequenceNumber.Client.Composite
-  }) => Effect.Effect<Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>, UnexpectedError, Scope.Scope>
+  }) => Effect.Effect<Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>, UnknownError, Scope.Scope>
 
   /** Used by client sessions to push events to the leader thread */
   push: (
@@ -163,11 +163,11 @@ export interface LeaderSyncProcessor {
     event: LiveStoreEvent.Input.Encoded
     clientId: string
     sessionId: string
-  }) => Effect.Effect<void, UnexpectedError>
+  }) => Effect.Effect<void, UnknownError>
 
   boot: Effect.Effect<
     { initialLeaderHead: EventSequenceNumber.Client.Composite },
-    UnexpectedError,
+    UnknownError,
     LeaderThreadCtx | Scope.Scope | HttpClient.HttpClient
   >
   syncState: Subscribable.Subscribable<SyncState.SyncState>

--- a/packages/@livestore/common/src/make-client-session.ts
+++ b/packages/@livestore/common/src/make-client-session.ts
@@ -8,7 +8,7 @@ import type {
   ClientSessionLeaderThreadProxy,
   LockStatus,
   SqliteDb,
-  UnexpectedError,
+  UnknownError,
 } from './adapter-types.ts'
 import * as Devtools from './devtools/mod.ts'
 import { liveStoreVersion } from './version.ts'
@@ -44,7 +44,7 @@ export const makeClientSession = <R>({
   connectWebmeshNode: (args: {
     webmeshNode: Webmesh.MeshNode
     sessionInfo: Devtools.SessionInfo.SessionInfo
-  }) => Effect.Effect<void, UnexpectedError, Scope.Scope | R>
+  }) => Effect.Effect<void, UnknownError, Scope.Scope | R>
   webmeshMode: 'direct' | 'proxy'
   registerBeforeUnload: (onBeforeUnload: () => void) => () => void
   /** Browser origin of the client session; used for origin-scoped DevTools mesh channels */

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -1,7 +1,7 @@
 import { memoizeByRef } from '@livestore/utils'
 import { Chunk, Effect, Option, Schema, Stream } from '@livestore/utils/effect'
 
-import { type SqliteDb, UnexpectedError } from './adapter-types.ts'
+import { type SqliteDb, UnknownError } from './adapter-types.ts'
 import type { MaterializeEvent } from './leader-thread/mod.ts'
 import type { EventDef, LiveStoreSchema } from './schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from './schema/mod.ts'
@@ -52,7 +52,7 @@ export const rematerializeFromEventlog = ({
         const resolution = yield* resolveEventDef(schema, {
           operation: '@livestore/common:rematerializeFromEventlog:processEvent',
           event: eventEncoded,
-        }).pipe(UnexpectedError.mapToUnexpectedError)
+        }).pipe(UnknownError.mapToUnknownError)
 
         if (resolution._tag === 'unknown') {
           // Old snapshots can contain newer events. Skip until the runtime has
@@ -71,7 +71,7 @@ export const rematerializeFromEventlog = ({
         // Checking whether the schema has changed in an incompatible way
         yield* Schema.decodeUnknown(eventDef.schema)(args).pipe(
           Effect.mapError((cause) =>
-            UnexpectedError.make({
+            UnknownError.make({
               cause,
               note: `\
 There was an error during rematerializing from the eventlog while decoding

--- a/packages/@livestore/common/src/schema-management/migrations.ts
+++ b/packages/@livestore/common/src/schema-management/migrations.ts
@@ -34,7 +34,7 @@ import { Effect } from '@livestore/utils/effect'
 
 import type { SqliteDb } from '../adapter-types.ts'
 import type { MigrationsReport, MigrationsReportEntry } from '../defs.ts'
-import type { UnexpectedError } from '../errors.ts'
+import type { UnknownError } from '../errors.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { makeColumnSpec } from '../schema/state/sqlite/column-spec.ts'
 import { SqliteAst } from '../schema/state/sqlite/db-schema/mod.ts'
@@ -87,7 +87,7 @@ export const migrateDb = ({
   db: SqliteDb
   schema: LiveStoreSchema
   onProgress?: (opts: { done: number; total: number }) => Effect.Effect<void>
-}): Effect.Effect<MigrationsReport, UnexpectedError> =>
+}): Effect.Effect<MigrationsReport, UnknownError> =>
   Effect.gen(function* () {
     for (const tableDef of stateSystemTables) {
       yield* migrateTable({

--- a/packages/@livestore/common/src/schema-management/validate-schema.ts
+++ b/packages/@livestore/common/src/schema-management/validate-schema.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from '@livestore/utils/effect'
 
-import { UnexpectedError } from '../adapter-types.ts'
+import { UnknownError } from '../adapter-types.ts'
 import type { EventDef } from '../schema/EventDef/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import type { EventDefInfo, SchemaManager } from './common.ts'
@@ -15,7 +15,7 @@ export const validateSchema = (schema: LiveStoreSchema, schemaManager: SchemaMan
     )
 
     if (missingEventDefs.length > 0) {
-      return yield* new UnexpectedError({
+      return yield* new UnknownError({
         cause: `Missing mutation definitions: ${missingEventDefs.map((info) => info.eventName).join(', ')}`,
       })
     }

--- a/packages/@livestore/common/src/sqlite-types.ts
+++ b/packages/@livestore/common/src/sqlite-types.ts
@@ -1,5 +1,5 @@
 import { type Effect, Schema } from '@livestore/utils/effect'
-import type { SqliteError, UnexpectedError } from './errors.ts'
+import type { SqliteError, UnknownError } from './errors.ts'
 import type { EventSequenceNumber } from './schema/mod.ts'
 import type { QueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import type { PreparedBindValues } from './util.ts'
@@ -46,7 +46,7 @@ export type MakeSqliteDb<
   TMetadata extends TMetadata_ & { _tag: TInput['_tag'] } = TMetadata_ & { _tag: TInput['_tag'] },
 >(
   input: TInput,
-) => Effect.Effect<SqliteDb<TReq, Extract<TMetadata, { _tag: TInput['_tag'] }>>, SqliteError | UnexpectedError, R>
+) => Effect.Effect<SqliteDb<TReq, Extract<TMetadata, { _tag: TInput['_tag'] }>>, SqliteError | UnknownError, R>
 
 export interface PreparedStatement {
   execute(bindValues: PreparedBindValues | undefined, options?: { onRowsChanged?: (rowsChanged: number) => void }): void

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -15,7 +15,7 @@ import {
 } from '@livestore/utils/effect'
 import type * as otel from '@opentelemetry/api'
 
-import { type ClientSession, UnexpectedError } from '../adapter-types.ts'
+import { type ClientSession, UnknownError } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
@@ -146,8 +146,8 @@ export const makeClientSessionSyncProcessor = ({
       ...(TRACE_VERBOSE && { mergeResult: JSON.stringify(mergeResult) }),
     })
 
-    if (mergeResult._tag === 'unexpected-error') {
-      return shouldNeverHappen('Unexpected error in client-session-sync-processor', mergeResult.message)
+    if (mergeResult._tag === 'unknown-error') {
+      return shouldNeverHappen('Unknown error in client-session-sync-processor', mergeResult.message)
     }
 
     if (mergeResult._tag !== 'advance') {
@@ -236,8 +236,8 @@ export const makeClientSessionSyncProcessor = ({
             isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
           })
 
-          if (mergeResult._tag === 'unexpected-error') {
-            return yield* new UnexpectedError({ cause: mergeResult.message })
+          if (mergeResult._tag === 'unknown-error') {
+            return yield* new UnknownError({ cause: mergeResult.message })
           } else if (mergeResult._tag === 'reject') {
             return shouldNeverHappen('Unexpected reject in client-session-sync-processor', mergeResult)
           }
@@ -375,7 +375,7 @@ export interface ClientSessionSyncProcessor {
   push: (
     batch: ReadonlyArray<LiveStoreEvent.Input.Decoded>,
   ) => Effect.Effect<{ writeTables: Set<string> }, MaterializeError>
-  boot: Effect.Effect<void, UnexpectedError, Scope.Scope>
+  boot: Effect.Effect<void, UnknownError, Scope.Scope>
   /**
    * Only used for debugging / observability.
    */

--- a/packages/@livestore/common/src/sync/errors.ts
+++ b/packages/@livestore/common/src/sync/errors.ts
@@ -1,5 +1,5 @@
 import { Schema } from '@livestore/utils/effect'
-import { UnexpectedError } from '../errors.ts'
+import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber } from '../schema/mod.ts'
 
 export class IsOfflineError extends Schema.TaggedError<IsOfflineError>()('IsOfflineError', {
@@ -20,7 +20,7 @@ export class ServerAheadError extends Schema.TaggedError<ServerAheadError>()('Se
 }) {}
 
 export class InvalidPushError extends Schema.TaggedError<InvalidPushError>()('InvalidPushError', {
-  cause: Schema.Union(UnexpectedError, ServerAheadError, BackendIdMismatchError),
+  cause: Schema.Union(UnknownError, ServerAheadError, BackendIdMismatchError),
 }) {}
 
 export class InvalidPullError extends Schema.TaggedError<InvalidPullError>()('InvalidPullError', {

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -1,6 +1,6 @@
 import type { Schema, Scope } from '@livestore/utils/effect'
 import { Effect, Mailbox, Option, Queue, Stream, SubscriptionRef } from '@livestore/utils/effect'
-import { UnexpectedError } from '../errors.ts'
+import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
 import { InvalidPushError } from './errors.ts'
 import * as SyncBackend from './sync-backend.ts'
@@ -10,7 +10,7 @@ export interface MockSyncBackend {
   pushedEvents: Stream.Stream<LiveStoreEvent.Global.Encoded>
   connect: Effect.Effect<void>
   disconnect: Effect.Effect<void>
-  makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnexpectedError, Scope.Scope>
+  makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
   advance: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
   /** Fail the next N push calls with an InvalidPushError (or custom error) */
   failNextPushes: (
@@ -29,7 +29,7 @@ export interface MockSyncBackendOptions {
 
 export const makeMockSyncBackend = (
   options?: MockSyncBackendOptions,
-): Effect.Effect<MockSyncBackend, UnexpectedError, Scope.Scope> =>
+): Effect.Effect<MockSyncBackend, UnknownError, Scope.Scope> =>
   Effect.gen(function* () {
     const syncEventSequenceNumberRef = { current: EventSequenceNumber.Client.ROOT.global }
     const syncPullQueue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
@@ -115,7 +115,7 @@ export const makeMockSyncBackend = (
                 return yield* maybeFail(batch)
               }
               return yield* new InvalidPushError({
-                cause: new UnexpectedError({ cause: new Error('MockSyncBackend: simulated push failure') }),
+                cause: new UnknownError({ cause: new Error('MockSyncBackend: simulated push failure') }),
               })
             }
 

--- a/packages/@livestore/common/src/sync/sync-backend-kv.ts
+++ b/packages/@livestore/common/src/sync/sync-backend-kv.ts
@@ -1,11 +1,11 @@
 import { Effect, KeyValueStore, Option } from '@livestore/utils/effect'
-import { UnexpectedError } from '../errors.ts'
+import { UnknownError } from '../errors.ts'
 
 export const makeBackendIdHelper = Effect.gen(function* () {
   const kv = yield* KeyValueStore.KeyValueStore
 
   const backendIdKey = `backendId`
-  const backendIdRef = { current: yield* kv.get(backendIdKey).pipe(UnexpectedError.mapToUnexpectedError) }
+  const backendIdRef = { current: yield* kv.get(backendIdKey).pipe(UnknownError.mapToUnknownError) }
 
   const setBackendId = (backendId: string) =>
     Effect.gen(function* () {
@@ -13,7 +13,7 @@ export const makeBackendIdHelper = Effect.gen(function* () {
         backendIdRef.current = Option.some(backendId)
         yield* kv.set(backendIdKey, backendId)
       }
-    }).pipe(UnexpectedError.mapToUnexpectedError)
+    }).pipe(UnknownError.mapToUnknownError)
 
   return {
     lazySet: setBackendId,

--- a/packages/@livestore/common/src/sync/sync-backend.ts
+++ b/packages/@livestore/common/src/sync/sync-backend.ts
@@ -9,7 +9,7 @@ import {
   type Stream,
   type SubscriptionRef,
 } from '@livestore/utils/effect'
-import type { UnexpectedError } from '../adapter-types.ts'
+import type { UnknownError } from '../adapter-types.ts'
 import type * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { EventSequenceNumber } from '../schema/mod.ts'
 import type { InvalidPullError, InvalidPushError, IsOfflineError } from './errors.ts'
@@ -30,7 +30,7 @@ export type SyncBackendConstructor<TSyncMetadata = Schema.JsonValue, TPayload = 
   args: MakeBackendArgs<TPayload>,
 ) => Effect.Effect<
   SyncBackend<TSyncMetadata>,
-  UnexpectedError,
+  UnknownError,
   Scope.Scope | HttpClient.HttpClient | KeyValueStore.KeyValueStore
 >
 
@@ -45,7 +45,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
   /**
    * Can be implemented to prepare a connection to the sync backend to speed up the first pull/push.
    */
-  connect: Effect.Effect<void, IsOfflineError | UnexpectedError, Scope.Scope>
+  connect: Effect.Effect<void, IsOfflineError | UnknownError, Scope.Scope>
   pull: (
     cursor: Option.Option<{
       eventSequenceNumber: EventSequenceNumber.Global.Type
@@ -70,7 +70,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
      * */
     batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
   ) => Effect.Effect<void, IsOfflineError | InvalidPushError>
-  ping: Effect.Effect<void, IsOfflineError | UnexpectedError | Cause.TimeoutException>
+  ping: Effect.Effect<void, IsOfflineError | UnknownError | Cause.TimeoutException>
   // TODO also expose latency information additionally to whether the backend is connected
   isConnected: SubscriptionRef.SubscriptionRef<boolean>
   /**

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -134,7 +134,7 @@ describe('syncstate', () => {
           localHead: e1_0.seqNum,
         })
         const result = merge({ syncState, payload: { _tag: 'upstream-advance', newEvents: [e1_1, e1_0] } })
-        expect(result).toMatchObject({ _tag: 'unexpected-error' })
+        expect(result).toMatchObject({ _tag: 'unknown-error' })
       })
 
       it('should throw error if newEvents are not sorted in ascending order by event number (global)', () => {
@@ -144,7 +144,7 @@ describe('syncstate', () => {
           localHead: e1_0.seqNum,
         })
         const result = merge({ syncState, payload: { _tag: 'upstream-advance', newEvents: [e2_0, e1_0] } })
-        expect(result).toMatchObject({ _tag: 'unexpected-error' })
+        expect(result).toMatchObject({ _tag: 'unknown-error' })
       })
 
       it('should throw error if incoming event is < expected upstream head', () => {
@@ -154,7 +154,7 @@ describe('syncstate', () => {
           localHead: e2_0.seqNum,
         })
         const result = merge({ syncState, payload: { _tag: 'upstream-advance', newEvents: [e1_0] } })
-        expect(result).toMatchObject({ _tag: 'unexpected-error' })
+        expect(result).toMatchObject({ _tag: 'unknown-error' })
       })
 
       it('should throw error if incoming event is = expected upstream head', () => {
@@ -164,7 +164,7 @@ describe('syncstate', () => {
           localHead: e2_0.seqNum,
         })
         const result = merge({ syncState, payload: { _tag: 'upstream-advance', newEvents: [e2_0] } })
-        expect(result).toMatchObject({ _tag: 'unexpected-error' })
+        expect(result).toMatchObject({ _tag: 'unknown-error' })
       })
 
       it('should confirm pending event when receiving matching event', () => {
@@ -318,7 +318,7 @@ describe('syncstate', () => {
           localHead: e2_0.seqNum,
         })
         const result = merge({ syncState, payload: { _tag: 'upstream-advance', newEvents: [e1_0] } })
-        expect(result).toMatchObject({ _tag: 'unexpected-error' })
+        expect(result).toMatchObject({ _tag: 'unknown-error' })
       })
     })
 

--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -159,8 +159,8 @@ export class MergeResultReject extends Schema.Class<MergeResultReject>('MergeRes
   }
 }
 
-export class MergeResultUnexpectedError extends Schema.Class<MergeResultUnexpectedError>('MergeResultUnexpectedError')({
-  _tag: Schema.Literal('unexpected-error'),
+export class MergeResultUnknownError extends Schema.Class<MergeResultUnknownError>('MergeResultUnknownError')({
+  _tag: Schema.Literal('unknown-error'),
   message: Schema.String,
 }) {}
 
@@ -168,7 +168,7 @@ export class MergeResult extends Schema.Union(
   MergeResultAdvance,
   MergeResultRebase,
   MergeResultReject,
-  MergeResultUnexpectedError,
+  MergeResultUnknownError,
 ) {}
 
 export const payloadFromMergeResult = (
@@ -187,13 +187,13 @@ export const payloadFromMergeResult = (
     Match.exhaustive,
   )
 
-const unexpectedError = (message: string): MergeResultUnexpectedError => {
+const unknownError = (message: string): MergeResultUnknownError => {
   if (LS_DEV) {
     // biome-ignore lint/suspicious/noDebugger: debug
     debugger
   }
 
-  return MergeResultUnexpectedError.make({ _tag: 'unexpected-error', message })
+  return MergeResultUnknownError.make({ _tag: 'unknown-error', message })
 }
 
 // TODO Idea: call merge recursively through hierarchy levels
@@ -272,7 +272,7 @@ export const merge = ({
       // Validate that newEvents are sorted in ascending order by eventNum
       for (let i = 1; i < payload.newEvents.length; i++) {
         if (EventSequenceNumber.Client.isGreaterThan(payload.newEvents[i - 1]!.seqNum, payload.newEvents[i]!.seqNum)) {
-          return unexpectedError(
+          return unknownError(
             `Events must be sorted in ascending order by event number. Received: [${payload.newEvents.map((e) => EventSequenceNumber.Client.toString(e.seqNum)).join(', ')}]`,
           )
         }
@@ -283,7 +283,7 @@ export const merge = ({
         EventSequenceNumber.Client.isGreaterThan(syncState.upstreamHead, payload.newEvents[0]!.seqNum) ||
         EventSequenceNumber.Client.isEqual(syncState.upstreamHead, payload.newEvents[0]!.seqNum)
       ) {
-        return unexpectedError(
+        return unknownError(
           `Incoming events must be greater than upstream head. Expected greater than: ${EventSequenceNumber.Client.toString(syncState.upstreamHead)}. Received: [${payload.newEvents.map((e) => EventSequenceNumber.Client.toString(e.seqNum)).join(', ')}]`,
         )
       }
@@ -516,7 +516,7 @@ const validatePayload = (payload: typeof Payload.Type) => {
     if (
       EventSequenceNumber.Client.isGreaterThanOrEqual(payload.newEvents[i - 1]!.seqNum, payload.newEvents[i]!.seqNum)
     ) {
-      return unexpectedError(
+      return unknownError(
         `Events must be ordered in monotonically ascending order by eventNum. Received: [${payload.newEvents.map((e) => EventSequenceNumber.Client.toString(e.seqNum)).join(', ')}]`,
       )
     }
@@ -565,7 +565,7 @@ const validateSyncState = (syncState: SyncState) => {
 }
 
 const validateMergeResult = (mergeResult: typeof MergeResult.Type) => {
-  if (mergeResult._tag === 'unexpected-error' || mergeResult._tag === 'reject') return mergeResult
+  if (mergeResult._tag === 'unknown-error' || mergeResult._tag === 'reject') return mergeResult
 
   validateSyncState(mergeResult.newSyncState)
 

--- a/packages/@livestore/devtools-web-common/src/web-channel/index.ts
+++ b/packages/@livestore/devtools-web-common/src/web-channel/index.ts
@@ -1,4 +1,4 @@
-import { Devtools, UnexpectedError } from '@livestore/common'
+import { Devtools, UnknownError } from '@livestore/common'
 import { LS_DEV } from '@livestore/utils'
 import type { Scope, Worker } from '@livestore/utils/effect'
 import { Deferred, Effect, Schema, Stream, WebChannel } from '@livestore/utils/effect'
@@ -15,7 +15,7 @@ declare global {
 
 export const makeSessionInfoBroadcastChannel: Effect.Effect<
   WebChannel.WebChannel<Devtools.SessionInfo.Message, Devtools.SessionInfo.Message>,
-  UnexpectedError,
+  UnknownError,
   Scope.Scope
 > = WebChannel.broadcastChannel({
   channelName: 'session-info',
@@ -103,4 +103,4 @@ export const connectViaWorker = ({
     if (LS_DEV) {
       yield* Effect.logDebug(`@livestore/devtools-web-common: initiated connection: ${node.nodeName} → ${target}`)
     }
-  }).pipe(UnexpectedError.mapToUnexpectedError)
+  }).pipe(UnknownError.mapToUnknownError)

--- a/packages/@livestore/livestore/src/effect/LiveStore.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.ts
@@ -1,4 +1,4 @@
-import type { UnexpectedError } from '@livestore/common'
+import type { UnknownError } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { omitUndefineds } from '@livestore/utils'
 import type { Cause, OtelTracer, Scope } from '@livestore/utils/effect'
@@ -20,7 +20,7 @@ export const makeLiveStoreContext = <TSchema extends LiveStoreSchema, TContext =
   syncPayloadSchema,
 }: LiveStoreContextProps<TSchema, TContext>): Effect.Effect<
   LiveStoreContextRunning['Type'],
-  UnexpectedError | Cause.TimeoutException,
+  UnknownError | Cause.TimeoutException,
   DeferredStoreContext | Scope.Scope | OtelTracer.OtelTracer
 > =>
   pipe(
@@ -51,7 +51,7 @@ export const makeLiveStoreContext = <TSchema extends LiveStoreSchema, TContext =
 
 export const LiveStoreContextLayer = <TSchema extends LiveStoreSchema, TContext = {}>(
   props: LiveStoreContextProps<TSchema, TContext>,
-): Layer.Layer<LiveStoreContextRunning, UnexpectedError | Cause.TimeoutException, OtelTracer.OtelTracer> =>
+): Layer.Layer<LiveStoreContextRunning, UnknownError | Cause.TimeoutException, OtelTracer.OtelTracer> =>
   Layer.scoped(LiveStoreContextRunning, makeLiveStoreContext(props)).pipe(
     Layer.withSpan('LiveStore'),
     Layer.provide(LiveStoreContextDeferred),
@@ -59,5 +59,5 @@ export const LiveStoreContextLayer = <TSchema extends LiveStoreSchema, TContext 
 
 export const LiveStoreContextDeferred = Layer.effect(
   DeferredStoreContext,
-  Deferred.make<LiveStoreContextRunning['Type'], UnexpectedError>(),
+  Deferred.make<LiveStoreContextRunning['Type'], UnknownError>(),
 )

--- a/packages/@livestore/livestore/src/live-queries/db-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.ts
@@ -7,7 +7,7 @@ import {
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
   SessionIdSymbol,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import { deepEqual, omitUndefineds, shouldNeverHappen } from '@livestore/utils'
 import { Equal, Hash, Predicate, Schema, TreeFormatter } from '@livestore/utils/effect'
@@ -254,7 +254,7 @@ export class LiveStoreDbQuery<TResultSchema, TResult = TResultSchema> extends Li
               : undefined,
         }
       } catch (cause) {
-        throw new UnexpectedError({ cause, note: `Error building query for ${qb.toString()}`, payload: { qb } })
+        throw new UnknownError({ cause, note: `Error building query for ${qb.toString()}`, payload: { qb } })
       }
     }
 

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -12,7 +12,7 @@ import {
   type MigrationsReport,
   provideOtel,
   type SyncError,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { isDevEnv, LS_DEV, omitUndefineds } from '@livestore/utils'
@@ -60,7 +60,7 @@ export class LiveStoreContextRunning extends Context.Tag('@livestore/livestore/e
 
 export class DeferredStoreContext extends Context.Tag('@livestore/livestore/effect/DeferredStoreContext')<
   DeferredStoreContext,
-  Deferred.Deferred<LiveStoreContextRunning['Type'], UnexpectedError>
+  Deferred.Deferred<LiveStoreContextRunning['Type'], UnknownError>
 >() {}
 
 export type LiveStoreContextProps<
@@ -230,7 +230,7 @@ export const createStore = <
   syncPayloadSchema,
 }: CreateStoreOptions<TSchema, TContext, TSyncPayloadSchema>): Effect.Effect<
   Store<TSchema, TContext>,
-  UnexpectedError,
+  UnknownError,
   Scope.Scope | OtelTracer.OtelTracer
 > =>
   Effect.gen(function* () {
@@ -271,7 +271,7 @@ export const createStore = <
       const shutdown = (
         exit: Exit.Exit<
           IntentionalShutdownCause,
-          UnexpectedError | MaterializeError | SyncError | InvalidPullError | IsOfflineError
+          UnknownError | MaterializeError | SyncError | InvalidPullError | IsOfflineError
         >,
       ) =>
         Effect.gen(function* () {
@@ -301,7 +301,7 @@ export const createStore = <
       const syncPayloadEncoded =
         syncPayload === undefined
           ? undefined
-          : yield* Schema.encode(resolvedSyncPayloadSchema)(syncPayload).pipe(UnexpectedError.mapToUnexpectedError)
+          : yield* Schema.encode(resolvedSyncPayloadSchema)(syncPayload).pipe(UnknownError.mapToUnknownError)
 
       const clientSession: ClientSession = yield* adapter({
         schema,
@@ -354,7 +354,7 @@ export const createStore = <
         yield* Effect.tryAll(() =>
           boot(store, { migrationsReport: clientSession.leaderThread.initialState.migrationsReport, parentSpan: span }),
         ).pipe(
-          UnexpectedError.mapToUnexpectedError,
+          UnknownError.mapToUnknownError,
           Effect.provide(Layer.succeed(LiveStoreContextRunning, { stage: 'running', store: store as any as Store })),
           Effect.withSpan('createStore:boot'),
         )
@@ -384,7 +384,7 @@ const validateStoreId = (storeId: string) =>
     const validChars = /^[a-zA-Z0-9_-]+$/
 
     if (!validChars.test(storeId)) {
-      return yield* UnexpectedError.make({
+      return yield* UnknownError.make({
         cause: `Invalid storeId: ${storeId}. Only alphanumeric characters, underscores, and hyphens are allowed.`,
         payload: { storeId },
       })

--- a/packages/@livestore/livestore/src/store/devtools.ts
+++ b/packages/@livestore/livestore/src/store/devtools.ts
@@ -1,5 +1,5 @@
 import type { DebugInfo, SyncState } from '@livestore/common'
-import { Devtools, liveStoreVersion, UnexpectedError } from '@livestore/common'
+import { Devtools, liveStoreVersion, UnknownError } from '@livestore/common'
 import { throttle } from '@livestore/utils'
 import type { WebChannel } from '@livestore/utils/effect'
 import { Effect, Stream } from '@livestore/utils/effect'
@@ -332,4 +332,4 @@ export const connectDevtoolsToStore = ({
       Stream.runDrain,
       Effect.withSpan('LSD.devtools.onMessage'),
     )
-  }).pipe(UnexpectedError.mapToUnexpectedError, Effect.withSpan('LSD.devtools.connectStoreToDevtools'))
+  }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('LSD.devtools.connectStoreToDevtools'))

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -10,7 +10,7 @@ import {
   type QueryBuilder,
   type StoreInterrupted,
   type SyncError,
-  type UnexpectedError,
+  type UnknownError,
 } from '@livestore/common'
 import type { EventSequenceNumber, LiveStoreEvent, LiveStoreSchema } from '@livestore/common/schema'
 import type { Effect, Runtime, Schema, Scope } from '@livestore/utils/effect'
@@ -34,7 +34,7 @@ export type LiveStoreContext =
   | LiveStoreContextRunning
   | {
       stage: 'error'
-      error: UnexpectedError | unknown
+      error: UnknownError | unknown
     }
   | {
       stage: 'shutdown'
@@ -43,11 +43,11 @@ export type LiveStoreContext =
 
 export type ShutdownDeferred = Deferred.Deferred<
   IntentionalShutdownCause,
-  UnexpectedError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | IsOfflineError
+  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | IsOfflineError
 >
 export const makeShutdownDeferred: Effect.Effect<ShutdownDeferred> = Deferred.make<
   IntentionalShutdownCause,
-  UnexpectedError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | IsOfflineError
+  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | IsOfflineError
 >()
 
 export type LiveStoreContextRunning = {
@@ -146,7 +146,7 @@ export type StoreInternals = {
    * once per Store instance. Scoped; installs finalizers to end spans and
    * detach reactive refs.
    */
-  readonly boot: Effect.Effect<void, UnexpectedError, Scope.Scope>
+  readonly boot: Effect.Effect<void, UnknownError, Scope.Scope>
 
   /**
    * Tracks whether the Store has been shut down. When true, mutating APIs

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -15,7 +15,7 @@ import {
   prepareBindValues,
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { LiveStoreEvent, resolveEventDef, SystemTables } from '@livestore/common/schema'
@@ -235,7 +235,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
                   })
                 } catch (cause) {
                   // TOOD refactor with `SqliteError`
-                  throw UnexpectedError.make({
+                  throw UnknownError.make({
                     cause,
                     note: `Error executing materializer for event "${eventEncoded.name}".\nStatement: ${statementSql}\nBind values: ${JSON.stringify(bindValues)}`,
                   })
@@ -403,7 +403,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
   private checkShutdown = (operation: string): void => {
     if (this[StoreInternalsSymbol].isShutdown) {
-      throw new UnexpectedError({
+      throw new UnknownError({
         cause: `Store has been shut down (while performing "${operation}").`,
         note: `You cannot perform this operation after the store has been shut down.`,
       })
@@ -773,7 +773,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
             return runMaterializeEvents()
           }
         },
-        catch: (cause) => UnexpectedError.make({ cause }),
+        catch: (cause) => UnknownError.make({ cause }),
       })
 
       // Materialize events to state
@@ -878,7 +878,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    *
    * This is called automatically when the store was created using the React or Effect API.
    */
-  shutdownPromise = async (cause?: UnexpectedError) => {
+  shutdownPromise = async (cause?: UnknownError) => {
     this.checkShutdown('shutdownPromise')
 
     this[StoreInternalsSymbol].isShutdown = true
@@ -890,7 +890,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    *
    * This is called automatically when the store was created using the React or Effect API.
    */
-  shutdown = (cause?: Cause.Cause<UnexpectedError | MaterializeError>): Effect.Effect<void> => {
+  shutdown = (cause?: Cause.Cause<UnknownError | MaterializeError>): Effect.Effect<void> => {
     this[StoreInternalsSymbol].isShutdown = true
     return this[StoreInternalsSymbol].clientSession.shutdown(
       cause ? Exit.failCause(cause) : Exit.succeed(IntentionalShutdownCause.make({ reason: 'manual' })),

--- a/packages/@livestore/react/src/LiveStoreProvider.test.tsx
+++ b/packages/@livestore/react/src/LiveStoreProvider.test.tsx
@@ -115,7 +115,7 @@ describe.each([true, false])('LiveStoreProvider (strictMode: %s)', (strictMode) 
 
     expect(appRenderCount).toBe(0)
 
-    await ReactTesting.waitFor(() => ReactTesting.screen.getByText((_) => _.startsWith('LiveStore.UnexpectedError')))
+    await ReactTesting.waitFor(() => ReactTesting.screen.getByText((_) => _.startsWith('LiveStore.UnknownError')))
   })
 
   it('unmounts when store is shutdown', async () => {

--- a/packages/@livestore/react/src/LiveStoreProvider.tsx
+++ b/packages/@livestore/react/src/LiveStoreProvider.tsx
@@ -1,5 +1,5 @@
 import type { Adapter, BootStatus, IntentionalShutdownCause, MigrationsReport, SyncError } from '@livestore/common'
-import { LogConfig, provideOtel, UnexpectedError } from '@livestore/common'
+import { LogConfig, provideOtel, UnknownError } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import type {
   CreateStoreOptions,
@@ -37,7 +37,7 @@ export interface LiveStoreProviderProps<TSyncPayloadSchema extends Schema.Schema
   ) => void | Promise<void> | Effect.Effect<void, unknown, OtelTracer.OtelTracer>
   otelOptions?: Partial<OtelOptions>
   renderLoading?: (status: BootStatus) => React.ReactNode
-  renderError?: (error: UnexpectedError | unknown) => React.ReactNode
+  renderError?: (error: UnknownError | unknown) => React.ReactNode
   renderShutdown?: (cause: IntentionalShutdownCause | StoreInterrupted | SyncError) => React.ReactNode
   adapter: Adapter
   /**
@@ -74,8 +74,8 @@ export interface LiveStoreProviderProps<TSyncPayloadSchema extends Schema.Schema
   }
 }
 
-const defaultRenderError = (error: UnexpectedError | unknown) =>
-  IS_REACT_NATIVE ? null : Schema.is(UnexpectedError)(error) ? error.toString() : errorToString(error)
+const defaultRenderError = (error: UnknownError | unknown) =>
+  IS_REACT_NATIVE ? null : Schema.is(UnknownError)(error) ? error.toString() : errorToString(error)
 
 const defaultRenderShutdown = (cause: IntentionalShutdownCause | StoreInterrupted | SyncError) => {
   const reason =

--- a/packages/@livestore/react/src/__tests__/fixture.tsx
+++ b/packages/@livestore/react/src/__tests__/fixture.tsx
@@ -1,5 +1,5 @@
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
-import { provideOtel, type UnexpectedError } from '@livestore/common'
+import { provideOtel, type UnknownError } from '@livestore/common'
 import { Events, makeSchema, State } from '@livestore/common/schema'
 import type { LiveStoreSchema, SqliteDsl, Store } from '@livestore/livestore'
 import { createStore } from '@livestore/livestore'
@@ -107,7 +107,7 @@ export const makeTodoMvcReact: (opts?: MakeTodoMvcReactOptions) => Effect.Effect
     store: Store<LiveStoreSchema<SqliteDsl.DbSchema, State.SQLite.EventDefRecord>, {}> & LiveStoreReact.ReactApi
     renderCount: { readonly val: number; inc: () => void }
   },
-  UnexpectedError,
+  UnknownError,
   Scope.Scope
 > = (opts: MakeTodoMvcReactOptions = {}) =>
   Effect.gen(function* () {

--- a/packages/@livestore/sqlite-wasm/src/cf/mod.ts
+++ b/packages/@livestore/sqlite-wasm/src/cf/mod.ts
@@ -1,6 +1,6 @@
 // import path from 'node:path'
 
-import { type MakeSqliteDb, type PersistenceInfo, type SqliteDb, UnexpectedError } from '@livestore/common'
+import { type MakeSqliteDb, type PersistenceInfo, type SqliteDb, UnknownError } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
 import { Effect } from '@livestore/utils/effect'
 import type * as WaSqlite from '@livestore/wa-sqlite'
@@ -140,4 +140,4 @@ const makeCloudflareFsDb = ({
     const dbPointer = sqlite3.open_v2Sync(fileName, undefined, vfsName)
 
     return { dbPointer, vfs: {} as UNUSED<'only needed in web adapter currently and should longer-term be removed'> }
-  }).pipe(UnexpectedError.mapToUnexpectedError)
+  }).pipe(UnknownError.mapToUnknownError)

--- a/packages/@livestore/sqlite-wasm/src/node/mod.ts
+++ b/packages/@livestore/sqlite-wasm/src/node/mod.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { type MakeSqliteDb, type PersistenceInfo, type SqliteDb, UnexpectedError } from '@livestore/common'
+import { type MakeSqliteDb, type PersistenceInfo, type SqliteDb, UnknownError } from '@livestore/common'
 import { Effect, FileSystem } from '@livestore/utils/effect'
 import type * as WaSqlite from '@livestore/wa-sqlite'
 import type { MemoryVFS } from '@livestore/wa-sqlite/src/examples/MemoryVFS.js'
@@ -129,4 +129,4 @@ const makeNodeFsDb = ({
     const dbPointer = sqlite3.open_v2Sync(fileName, undefined, vfsName)
 
     return { dbPointer, vfs: {} as UNUSED<'only needed in web adapter currently and should longer-term be removed'> }
-  }).pipe(UnexpectedError.mapToUnexpectedError)
+  }).pipe(UnknownError.mapToUnknownError)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
@@ -1,4 +1,4 @@
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { EventSequenceNumber, State } from '@livestore/common/schema'
 import type { CfTypes } from '@livestore/common-cf'
 import { shouldNeverHappen } from '@livestore/utils'
@@ -43,7 +43,7 @@ export class DoCtx extends Effect.Service<DoCtx>()('DoCtx', {
         if (opt?._tag === 'd1') {
           const db = (doSelf.env as any)[opt.binding]
           if (!db) {
-            return yield* UnexpectedError.make({ cause: new Error(`D1 binding '${opt.binding}' not found on env`) })
+            return yield* UnknownError.make({ cause: new Error(`D1 binding '${opt.binding}' not found on env`) })
           }
           return { _tag: 'd1' as const, db }
         } else if (opt?._tag === 'do-sqlite' || opt === undefined) {
@@ -122,7 +122,7 @@ export class DoCtx extends Effect.Service<DoCtx>()('DoCtx', {
 
       return storageCache
     },
-    UnexpectedError.mapToUnexpectedError,
+    UnknownError.mapToUnknownError,
     Effect.withSpan('@livestore/sync-cf:durable-object:makeDoCtx'),
   ),
 }) {}

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, SyncBackend, UnexpectedError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, SyncBackend, UnknownError } from '@livestore/common'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { Chunk, Effect, Option, Schema, Stream } from '@livestore/utils/effect'
 import { MAX_PULL_EVENTS_PER_MESSAGE, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
@@ -24,9 +24,7 @@ export const makeEndingPullStream = (
     const { doOptions, backendId, storeId, storage } = yield* DoCtx
 
     if (doOptions?.onPull) {
-      yield* Effect.tryAll(() => doOptions!.onPull!(req, { storeId, payload })).pipe(
-        UnexpectedError.mapToUnexpectedError,
-      )
+      yield* Effect.tryAll(() => doOptions!.onPull!(req, { storeId, payload })).pipe(UnknownError.mapToUnknownError)
     }
 
     if (req.cursor._tag === 'Some' && req.cursor.value.backendId !== backendId) {
@@ -64,7 +62,7 @@ export const makeEndingPullStream = (
       Stream.tap(
         Effect.fn(function* (res) {
           if (doOptions?.onPullRes) {
-            yield* Effect.tryAll(() => doOptions.onPullRes!(res)).pipe(UnexpectedError.mapToUnexpectedError)
+            yield* Effect.tryAll(() => doOptions.onPullRes!(res)).pipe(UnknownError.mapToUnknownError)
           }
         }),
       ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -3,7 +3,7 @@ import {
   InvalidPushError,
   ServerAheadError,
   SyncBackend,
-  UnexpectedError,
+  UnknownError,
 } from '@livestore/common'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { type CfTypes, emitStreamResponse } from '@livestore/common-cf'
@@ -41,7 +41,7 @@ export const makePush =
 
       if (options?.onPush) {
         yield* Effect.tryAll(() => options.onPush!(pushRequest, { storeId, payload })).pipe(
-          UnexpectedError.mapToUnexpectedError,
+          UnknownError.mapToUnknownError,
         )
       }
 
@@ -127,7 +127,7 @@ export const makePush =
           for (const { response, encoded } of responses) {
             // Only calling once for now.
             if (options?.onPullRes) {
-              yield* Effect.tryAll(() => options.onPullRes!(response)).pipe(UnexpectedError.mapToUnexpectedError)
+              yield* Effect.tryAll(() => options.onPullRes!(response)).pipe(UnknownError.mapToUnknownError)
             }
 
             // NOTE we're also sending the pullRes chunk to the pushing ws client as confirmation
@@ -181,7 +181,7 @@ export const makePush =
       Effect.tap(
         Effect.fn(function* (message) {
           if (options?.onPushRes) {
-            yield* Effect.tryAll(() => options.onPushRes!(message)).pipe(UnexpectedError.mapToUnexpectedError)
+            yield* Effect.tryAll(() => options.onPushRes!(message)).pipe(UnknownError.mapToUnknownError)
           }
         }),
       ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/sync-storage.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/sync-storage.ts
@@ -1,4 +1,4 @@
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import type { LiveStoreEvent } from '@livestore/common/schema'
 import type { CfTypes } from '@livestore/common-cf'
 import { Chunk, Effect, Option, Schema, Stream } from '@livestore/utils/effect'
@@ -13,16 +13,16 @@ export type SyncStorage = {
       total: number
       stream: Stream.Stream<
         { eventEncoded: LiveStoreEvent.Global.Encoded; metadata: Option.Option<SyncMetadata> },
-        UnexpectedError
+        UnknownError
       >
     },
-    UnexpectedError
+    UnknownError
   >
   appendEvents: (
     batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
     createdAt: string,
-  ) => Effect.Effect<void, UnexpectedError>
-  resetStore: Effect.Effect<void, UnexpectedError>
+  ) => Effect.Effect<void, UnknownError>
+  resetStore: Effect.Effect<void, UnknownError>
 }
 
 export const makeStorage = (
@@ -35,7 +35,7 @@ export const makeStorage = (
   const execDb = <T>(cb: (db: CfTypes.D1Database) => Promise<CfTypes.D1Result<T>>) =>
     Effect.tryPromise({
       try: () => cb(engine._tag === 'd1' ? engine.db : (undefined as never)),
-      catch: (error) => new UnexpectedError({ cause: error, payload: { dbName } }),
+      catch: (error) => new UnknownError({ cause: error, payload: { dbName } }),
     }).pipe(
       Effect.map((_) => _.results),
       Effect.withSpan('@livestore/sync-cf:durable-object:execDb'),
@@ -77,10 +77,10 @@ export const makeStorage = (
       total: number
       stream: Stream.Stream<
         { eventEncoded: LiveStoreEvent.Global.Encoded; metadata: Option.Option<SyncMetadata> },
-        UnexpectedError
+        UnknownError
       >
     },
-    UnexpectedError
+    UnknownError
   > =>
     Effect.gen(function* () {
       const countStatement =
@@ -102,7 +102,7 @@ export const makeStorage = (
 
       const fetchPage = (
         state: State,
-      ): Effect.Effect<Option.Option<readonly [Chunk.Chunk<EmittedEvent>, State]>, UnexpectedError> =>
+      ): Effect.Effect<Option.Option<readonly [Chunk.Chunk<EmittedEvent>, State]>, UnknownError> =>
         Effect.gen(function* () {
           const statement =
             state.cursor === undefined
@@ -147,7 +147,7 @@ export const makeStorage = (
 
       return { total, stream }
     }).pipe(
-      UnexpectedError.mapToUnexpectedError,
+      UnknownError.mapToUnknownError,
       Effect.withSpan('@livestore/sync-cf:durable-object:getEvents', {
         attributes: { dbName, cursor, engine: engine._tag },
       }),
@@ -188,14 +188,14 @@ export const makeStorage = (
         )
       }
     }).pipe(
-      UnexpectedError.mapToUnexpectedError,
+      UnknownError.mapToUnknownError,
       Effect.withSpan('@livestore/sync-cf:durable-object:appendEvents', {
         attributes: { dbName, batchLength: batch.length, engine: engine._tag },
       }),
     )
 
   const resetStore = Effect.promise(() => ctx.storage.deleteAll()).pipe(
-    UnexpectedError.mapToUnexpectedError,
+    UnknownError.mapToUnknownError,
     Effect.withSpan('@livestore/sync-cf:durable-object:resetStore'),
   )
 
@@ -207,10 +207,10 @@ export const makeStorage = (
       total: number
       stream: Stream.Stream<
         { eventEncoded: LiveStoreEvent.Global.Encoded; metadata: Option.Option<SyncMetadata> },
-        UnexpectedError
+        UnknownError
       >
     },
-    UnexpectedError
+    UnknownError
   > =>
     Effect.gen(function* () {
       const selectCountSql =
@@ -228,7 +228,7 @@ export const makeStorage = (
           }
           return computed
         },
-        catch: (error) => new UnexpectedError({ cause: error, payload: { dbName, stage: 'count' } }),
+        catch: (error) => new UnknownError({ cause: error, payload: { dbName, stage: 'count' } }),
       })
 
       type State = { cursor: number | undefined }
@@ -239,7 +239,7 @@ export const makeStorage = (
 
       const fetchPage = (
         state: State,
-      ): Effect.Effect<Option.Option<readonly [Chunk.Chunk<EmittedEvent>, State]>, UnexpectedError> =>
+      ): Effect.Effect<Option.Option<readonly [Chunk.Chunk<EmittedEvent>, State]>, UnknownError> =>
         Effect.try({
           try: () => {
             const sql =
@@ -270,14 +270,14 @@ export const makeStorage = (
 
             return Option.some([eventsChunk, nextState] as const)
           },
-          catch: (error) => new UnexpectedError({ cause: error, payload: { dbName, stage: 'select' } }),
+          catch: (error) => new UnknownError({ cause: error, payload: { dbName, stage: 'select' } }),
         })
 
       const stream = Stream.unfoldChunkEffect(initialState, fetchPage)
 
       return { total, stream }
     }).pipe(
-      UnexpectedError.mapToUnexpectedError,
+      UnknownError.mapToUnknownError,
       Effect.withSpan('@livestore/sync-cf:durable-object:getEvents', {
         attributes: { dbName, cursor, engine: engine._tag },
       }),
@@ -305,12 +305,12 @@ export const makeStorage = (
           ctx.storage.sql.exec(sql, ...params)
         }
       },
-      catch: (error) => new UnexpectedError({ cause: error, payload: { dbName, stage: 'insert' } }),
+      catch: (error) => new UnknownError({ cause: error, payload: { dbName, stage: 'insert' } }),
     }).pipe(
       Effect.withSpan('@livestore/sync-cf:durable-object:appendEvents', {
         attributes: { dbName, batchLength: batch.length, engine: engine._tag },
       }),
-      UnexpectedError.mapToUnexpectedError,
+      UnknownError.mapToUnknownError,
     )
 
   if (engine._tag === 'd1') {

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -1,5 +1,5 @@
 import { env as importedEnv } from 'cloudflare:workers'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import type { HelperTypes } from '@livestore/common-cf'
 import { Effect, Schema } from '@livestore/utils/effect'
 import type { CfTypes, SearchParams } from '../common/mod.ts'
@@ -151,7 +151,7 @@ export const makeWorker = <
  * }
  * ```
  *
- * @throws {UnexpectedError} If the payload is invalid
+ * @throws {UnknownError} If the payload is invalid
  */
 export const handleSyncRequest = <
   TEnv extends Env = Env,
@@ -192,7 +192,7 @@ export const handleSyncRequest = <
 
         const result = yield* Effect.promise(async () =>
           validatePayload(decodedEither.right as TSyncPayload, { storeId }),
-        ).pipe(UnexpectedError.mapToUnexpectedError, Effect.either)
+        ).pipe(UnknownError.mapToUnknownError, Effect.either)
 
         if (result._tag === 'Left') {
           console.error('Invalid payload (validation failed)', result.left)
@@ -200,7 +200,7 @@ export const handleSyncRequest = <
         }
       } else {
         const result = yield* Effect.promise(async () => validatePayload(payload as TSyncPayload, { storeId })).pipe(
-          UnexpectedError.mapToUnexpectedError,
+          UnknownError.mapToUnknownError,
           Effect.either,
         )
 

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, SyncBackend, UnexpectedError } from '@livestore/common'
+import { InvalidPullError, InvalidPushError, SyncBackend, UnknownError } from '@livestore/common'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { type CfTypes, layerProtocolDurableObject } from '@livestore/common-cf'
 import { omit, shouldNeverHappen } from '@livestore/utils'
@@ -114,7 +114,7 @@ export const makeDoRpcSync =
                 backendId,
               }),
             }),
-            Effect.mapError((cause) => new InvalidPushError({ cause: new UnexpectedError({ cause }) })),
+            Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
           )
 
           for (const chunk of Chunk.toReadonlyArray(batchChunks)) {
@@ -123,9 +123,7 @@ export const makeDoRpcSync =
           }
         }).pipe(
           Effect.mapError((cause) =>
-            cause._tag === 'InvalidPushError'
-              ? cause
-              : InvalidPushError.make({ cause: new UnexpectedError({ cause }) }),
+            cause._tag === 'InvalidPushError' ? cause : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
           ),
           Effect.withSpan('rpc-sync-client:push'),
         )
@@ -133,7 +131,7 @@ export const makeDoRpcSync =
       const ping: SyncBackend.SyncBackend<{ createdAt: string }>['ping'] = rpcClient.SyncDoRpc.Ping({
         storeId,
         payload,
-      }).pipe(UnexpectedError.mapToUnexpectedError, Effect.withSpan('rpc-sync-client:ping'))
+      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('rpc-sync-client:ping'))
 
       return SyncBackend.of({
         connect,

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, IsOfflineError, SyncBackend, UnexpectedError } from '@livestore/common'
+import { InvalidPullError, InvalidPushError, IsOfflineError, SyncBackend, UnknownError } from '@livestore/common'
 import type { LiveStoreEvent } from '@livestore/common/schema'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { omit } from '@livestore/utils'
@@ -73,7 +73,7 @@ export const makeWsSync =
         storeId,
         payload,
         transport: 'ws',
-      }).pipe(UnexpectedError.mapToUnexpectedError)
+      }).pipe(UnknownError.mapToUnknownError)
 
       const urlParams = UrlParams.fromInput(urlParamsData)
       const wsUrl = `${options.url}?${UrlParams.toString(urlParams)}`
@@ -119,7 +119,7 @@ export const makeWsSync =
       }).pipe(
         Effect.timeout(pingTimeout),
         Effect.catchTag('TimeoutException', () => SubscriptionRef.set(isConnected, false)),
-        UnexpectedError.mapToUnexpectedError,
+        UnknownError.mapToUnknownError,
         Effect.withSpan('ping'),
       )
 
@@ -169,7 +169,7 @@ export const makeWsSync =
                 maxBytes: MAX_WS_MESSAGE_BYTES,
                 encode: encodePayload,
               }),
-              Effect.mapError((cause) => new InvalidPushError({ cause: new UnexpectedError({ cause }) })),
+              Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
             )
 
             for (const sub of chunksChunk) {
@@ -182,7 +182,7 @@ export const makeWsSync =
                 Effect.mapError((cause) =>
                   cause._tag === 'InvalidPushError'
                     ? cause
-                    : new InvalidPushError({ cause: new UnexpectedError({ cause }) }),
+                    : new InvalidPushError({ cause: new UnknownError({ cause }) }),
                 ),
               )
             }

--- a/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, UnexpectedError } from '@livestore/common'
+import { InvalidPullError, InvalidPushError, UnknownError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 import * as SyncMessage from './sync-message-types.ts'
 
@@ -35,6 +35,6 @@ export class SyncHttpRpc extends RpcGroup.make(
       payload: Schema.optional(Schema.JsonValue),
     }),
     success: SyncMessage.Pong,
-    error: UnexpectedError,
+    error: UnknownError,
   }),
 ) {}

--- a/packages/@livestore/sync-electric/src/index.ts
+++ b/packages/@livestore/sync-electric/src/index.ts
@@ -1,10 +1,4 @@
-import {
-  InvalidPullError,
-  InvalidPushError,
-  type IsOfflineError,
-  SyncBackend,
-  UnexpectedError,
-} from '@livestore/common'
+import { InvalidPullError, InvalidPushError, type IsOfflineError, SyncBackend, UnknownError } from '@livestore/common'
 import { LiveStoreEvent } from '@livestore/common/schema'
 import { notYetImplemented } from '@livestore/utils'
 import {
@@ -274,7 +268,7 @@ export const makeSyncBackend =
 
         yield* SubscriptionRef.set(isConnected, true)
       }).pipe(
-        UnexpectedError.mapToUnexpectedError,
+        UnknownError.mapToUnknownError,
         Effect.timeout(pingTimeout),
         Effect.catchTag('TimeoutException', () => SubscriptionRef.set(isConnected, false)),
         Effect.withSpan('electric-provider:ping'),
@@ -291,7 +285,7 @@ export const makeSyncBackend =
       // otherwise we send a HEAD request to speed up the connection process
       const connect: SyncBackend.SyncBackend<SyncMetadata>['connect'] = pullEndpointHasSameOrigin
         ? Effect.void
-        : ping.pipe(UnexpectedError.mapToUnexpectedError)
+        : ping.pipe(UnknownError.mapToUnknownError)
 
       return SyncBackend.of({
         connect,
@@ -338,11 +332,11 @@ export const makeSyncBackend =
               Effect.andThen(httpClient.pipe(HttpClient.filterStatusOk).execute),
               Effect.andThen(HttpClientResponse.schemaBodyJson(Schema.Struct({ success: Schema.Boolean }))),
               Effect.scoped,
-              Effect.mapError((cause) => InvalidPushError.make({ cause: UnexpectedError.make({ cause }) })),
+              Effect.mapError((cause) => InvalidPushError.make({ cause: UnknownError.make({ cause }) })),
             )
 
             if (!resp.success) {
-              return yield* InvalidPushError.make({ cause: new UnexpectedError({ cause: new Error('Push failed') }) })
+              return yield* InvalidPushError.make({ cause: new UnknownError({ cause: new Error('Push failed') }) })
             }
           }).pipe(Effect.withSpan('electric-provider:push')),
         ping,

--- a/tests/integration/scripts/download-chrome-extension.ts
+++ b/tests/integration/scripts/download-chrome-extension.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { Effect, FileSystem, HttpClient, HttpClientResponse, Schema } from '@livestore/utils/effect'
 import { Cli } from '@livestore/utils/node'
 import { cmd } from '@livestore/utils-dev/node'
@@ -39,9 +39,7 @@ export const downloadChromeExtension = ({ version, targetDir }: { version?: stri
 
     const releaseResponse = yield* HttpClient.get(releaseUrl).pipe(
       Effect.andThen(HttpClientResponse.schemaBodyJson(ResponseSchema)),
-      Effect.mapError(
-        (cause) => new UnexpectedError({ cause, note: `Failed to fetch release info from ${releaseUrl}` }),
-      ),
+      Effect.mapError((cause) => new UnknownError({ cause, note: `Failed to fetch release info from ${releaseUrl}` })),
     )
 
     // Find the Chrome extension asset
@@ -51,7 +49,7 @@ export const downloadChromeExtension = ({ version, targetDir }: { version?: stri
 
     if (chromeExtensionAsset === undefined) {
       return yield* Effect.fail(
-        new UnexpectedError({
+        new UnknownError({
           cause: `Chrome extension asset not found in release ${releaseResponse.tag_name}`,
           note: 'Expected to find an asset with name containing "chrome-extension" and ending with ".zip"',
         }),
@@ -70,7 +68,7 @@ export const downloadChromeExtension = ({ version, targetDir }: { version?: stri
     const downloadResponse = yield* HttpClient.get(chromeExtensionAsset.browser_download_url).pipe(
       Effect.mapError(
         (cause) =>
-          new UnexpectedError({
+          new UnknownError({
             cause,
             note: `Failed to download extension from ${chromeExtensionAsset.browser_download_url}`,
           }),
@@ -81,7 +79,7 @@ export const downloadChromeExtension = ({ version, targetDir }: { version?: stri
     const zipData = yield* downloadResponse.arrayBuffer.pipe(
       Effect.mapError(
         (cause) =>
-          new UnexpectedError({
+          new UnknownError({
             cause,
             note: 'Failed to read extension data as ArrayBuffer',
           }),
@@ -109,7 +107,7 @@ const extractZipFile = (zipPath: string, targetDir: string) =>
 
     yield* cmd(['unzip', '-o', '-j', zipPath], { cwd: targetDir }).pipe(
       Effect.mapError(
-        (cause) => new UnexpectedError({ cause, note: `Failed to extract zip file from ${zipPath} to ${targetDir}` }),
+        (cause) => new UnknownError({ cause, note: `Failed to extract zip file from ${zipPath} to ${targetDir}` }),
       ),
     )
   })

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import type { CommandExecutor, Option, PlatformError } from '@livestore/utils/effect'
 import { Effect, FetchHttpClient, Layer, Logger, LogLevel, OtelTracer } from '@livestore/utils/effect'
 import { Cli, getFreePort, PlatformNode } from '@livestore/utils/node'
@@ -29,7 +29,7 @@ const viteDevServer = ({
   Effect.gen(function* () {
     const devPort = useWorkspacePort
       ? '4444'
-      : yield* getFreePort.pipe(Effect.map(String), UnexpectedError.mapToUnexpectedError)
+      : yield* getFreePort.pipe(Effect.map(String), UnknownError.mapToUnknownError)
 
     yield* cmd(`vite --config src/tests/playwright/fixtures/vite.config.ts dev --port ${devPort}`, {
       env: {
@@ -46,7 +46,7 @@ const viteDevServer = ({
 export const miscTest: Cli.Command.Command<
   'misc',
   CommandExecutor.CommandExecutor,
-  UnexpectedError | PlatformError.PlatformError | CmdError,
+  UnknownError | PlatformError.PlatformError | CmdError,
   {
     readonly mode: 'headless' | 'ui' | 'dev-server'
     readonly localDevtoolsPreview: boolean
@@ -87,7 +87,7 @@ export const miscTest: Cli.Command.Command<
 export const todomvcTest: Cli.Command.Command<
   'todomvc',
   CommandExecutor.CommandExecutor,
-  UnexpectedError | PlatformError.PlatformError | CmdError,
+  UnknownError | PlatformError.PlatformError | CmdError,
   {
     readonly mode: 'headless' | 'ui' | 'dev-server'
     readonly localDevtoolsPreview: boolean
@@ -127,7 +127,7 @@ export const todomvcTest: Cli.Command.Command<
 export const setupDevtools: Cli.Command.Command<
   'setup-devtools',
   CommandExecutor.CommandExecutor,
-  UnexpectedError | PlatformError.PlatformError,
+  UnknownError | PlatformError.PlatformError,
   {}
 > = Cli.Command.make(
   'setup-devtools',
@@ -140,13 +140,13 @@ export const setupDevtools: Cli.Command.Command<
     }).pipe(Effect.provide(Layer.mergeAll(FetchHttpClient.layer, PlatformNode.NodeContext.layer)))
 
     yield* Effect.logInfo(`Chrome extension downloaded to ${targetDir}`)
-  }, UnexpectedError.mapToUnexpectedError),
+  }, UnknownError.mapToUnknownError),
 )
 
 export const devtoolsTest: Cli.Command.Command<
   'devtools',
   CommandExecutor.CommandExecutor,
-  UnexpectedError | PlatformError.PlatformError | CmdError,
+  UnknownError | PlatformError.PlatformError | CmdError,
   {
     readonly mode: 'headless' | 'ui' | 'dev-server'
     readonly localDevtoolsPreview: boolean
@@ -198,7 +198,7 @@ export const commands = [miscTest, todomvcTest, devtoolsTest, setupDevtools] as 
 export const command: Cli.Command.Command<
   'integration-misc',
   CommandExecutor.CommandExecutor,
-  UnexpectedError | PlatformError.PlatformError | CmdError,
+  UnknownError | PlatformError.PlatformError | CmdError,
   {
     readonly subcommand: Option.Option<{ readonly headless: boolean } | {}>
   }

--- a/tests/integration/src/tests/node-misc/src/todomvc-node.test.ts
+++ b/tests/integration/src/tests/node-misc/src/todomvc-node.test.ts
@@ -68,13 +68,13 @@ Vitest.describe('todomvc-node', () => {
       expect(() =>
         store.commit(events.todoCreated({ id: nanoid(), title: 'Test' })),
       ).toThrowErrorMatchingInlineSnapshot(
-        `[LiveStore.UnexpectedError: { "cause": "Store has been shut down (while performing \\"commit\\").", "note": "You cannot perform this operation after the store has been shut down.", "payload": undefined }]`,
+        `[LiveStore.UnknownError: { "cause": "Store has been shut down (while performing \\"commit\\").", "note": "You cannot perform this operation after the store has been shut down.", "payload": undefined }]`,
       )
       expect(() => store.query(tables.todo)).toThrowErrorMatchingInlineSnapshot(
-        `[LiveStore.UnexpectedError: { "cause": "Store has been shut down (while performing \\"query\\").", "note": "You cannot perform this operation after the store has been shut down.", "payload": undefined }]`,
+        `[LiveStore.UnknownError: { "cause": "Store has been shut down (while performing \\"query\\").", "note": "You cannot perform this operation after the store has been shut down.", "payload": undefined }]`,
       )
       expect(() => store.subscribe(tables.todo, () => {})).toThrowErrorMatchingInlineSnapshot(
-        `[LiveStore.UnexpectedError: { "cause": "Store has been shut down (while performing \\"subscribe\\").", "note": "You cannot perform this operation after the store has been shut down.", "payload": undefined }]`,
+        `[LiveStore.UnknownError: { "cause": "Store has been shut down (while performing \\"subscribe\\").", "note": "You cannot perform this operation after the store has been shut down.", "payload": undefined }]`,
       )
     }).pipe(withTestCtx(test)),
   )

--- a/tests/integration/src/tests/playwright/misc-tests.play.ts
+++ b/tests/integration/src/tests/playwright/misc-tests.play.ts
@@ -1,4 +1,4 @@
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { Effect, Exit } from '@livestore/utils/effect'
 import { expect, test } from '@playwright/test'
 
@@ -43,7 +43,7 @@ test(
         schema: Bridge.ResultStoreBootError,
       })
 
-      expect(exit).toStrictEqual(Exit.fail(UnexpectedError.make({ cause: new Error('Boom!') })))
+      expect(exit).toStrictEqual(Exit.fail(UnknownError.make({ cause: new Error('Boom!') })))
     }),
   ),
 )

--- a/tests/integration/src/tests/playwright/shared-test.ts
+++ b/tests/integration/src/tests/playwright/shared-test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 
-import type { UnexpectedError } from '@livestore/common'
+import type { UnknownError } from '@livestore/common'
 import * as Playwright from '@livestore/effect-playwright'
 import { Deferred, Duration, Effect, Fiber, Layer, Logger, Schema } from '@livestore/utils/effect'
 import type * as PW from '@playwright/test'
@@ -46,10 +46,7 @@ export const runAndGetExit = <Tag extends string, A>({
 }: {
   importPath: string
   exportName: string
-  schema: Schema.TaggedStruct<
-    Tag,
-    { exit: Schema.Exit<Schema.Schema<A>, typeof UnexpectedError, typeof Schema.Defect> }
-  >
+  schema: Schema.TaggedStruct<Tag, { exit: Schema.Exit<Schema.Schema<A>, typeof UnknownError, typeof Schema.Defect> }>
 }) =>
   Effect.gen(function* () {
     const { browserContext } = yield* Playwright.BrowserContext

--- a/tests/integration/src/tests/playwright/unit-tests/bridge.ts
+++ b/tests/integration/src/tests/playwright/unit-tests/bridge.ts
@@ -1,4 +1,4 @@
-import { BootStatus, MigrationsReport, UnexpectedError } from '@livestore/common'
+import { BootStatus, MigrationsReport, UnknownError } from '@livestore/common'
 import { Schema } from '@livestore/utils/effect'
 
 export class ResultBootStatus extends Schema.TaggedStruct('Bridge.ResultBootStatus', {
@@ -7,7 +7,7 @@ export class ResultBootStatus extends Schema.TaggedStruct('Bridge.ResultBootStat
       bootStatusUpdates: Schema.Array(BootStatus),
       migrationsReport: MigrationsReport,
     }),
-    failure: UnexpectedError,
+    failure: UnknownError,
     defect: Schema.Defect,
   }),
 }) {}
@@ -15,7 +15,7 @@ export class ResultBootStatus extends Schema.TaggedStruct('Bridge.ResultBootStat
 export class ResultStoreBootError extends Schema.TaggedStruct('Bridge.ResultStoreBootError', {
   exit: Schema.Exit({
     success: Schema.Any,
-    failure: UnexpectedError,
+    failure: UnknownError,
     defect: Schema.Defect,
   }),
 }) {}
@@ -32,7 +32,7 @@ export class ResultMultipleMigrations extends Schema.TaggedStruct('Bridge.Result
         }),
       ),
     }),
-    failure: UnexpectedError,
+    failure: UnknownError,
     defect: Schema.Defect,
   }),
 }) {}

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -6,7 +6,7 @@ import {
   type ClientSessionLeaderThreadProxy,
   makeMockSyncBackend,
   SyncState,
-  type UnexpectedError,
+  type UnknownError,
 } from '@livestore/common'
 import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
@@ -229,7 +229,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       const error = yield* shutdownDeferred.pipe(Effect.flip)
 
-      expect(error._tag).toEqual('LiveStore.UnexpectedError')
+      expect(error._tag).toEqual('LiveStore.UnknownError')
       expect(error.cause).toEqual(
         'Incoming events must be greater than upstream head. Expected greater than: e1. Received: [e1]',
       )
@@ -592,7 +592,7 @@ class TestContext extends Context.Tag('TestContext')<
           }
         }
       }
-    }) => Effect.Effect<Store, UnexpectedError, Scope.Scope | OtelTracer.OtelTracer>
+    }) => Effect.Effect<Store, UnknownError, Scope.Scope | OtelTracer.OtelTracer>
     mockSyncBackend: MockSyncBackend
     shutdownDeferred: ShutdownDeferred
   }

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -8,7 +8,7 @@ import {
   ServerAheadError,
   type SyncBackend,
   type SyncState,
-  type UnexpectedError,
+  type UnknownError,
 } from '@livestore/common'
 import type { MakeLeaderThreadLayerParams } from '@livestore/common/leader-thread'
 import { LeaderThreadCtx, makeLeaderThreadLayer, ShutdownChannel as Shutdown } from '@livestore/common/leader-thread'
@@ -470,7 +470,7 @@ class TestContext extends Context.Tag('TestContext')<
     /** Equivalent to the ClientSessionSyncProcessor calling `.push` on the LeaderThreadCtx */
     pushEncoded: (
       ...events: ReadonlyArray<LiveStoreEvent.Global.Encoded>
-    ) => Effect.Effect<void, UnexpectedError | LeaderAheadError, Scope.Scope | LeaderThreadCtx>
+    ) => Effect.Effect<void, UnknownError | LeaderAheadError, Scope.Scope | LeaderThreadCtx>
   }
 >() {}
 

--- a/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
+++ b/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { SyncBackend, UnexpectedError } from '@livestore/common'
+import { SyncBackend, UnknownError } from '@livestore/common'
 import { MAX_DO_RPC_REQUEST_BYTES, MAX_PUSH_EVENTS_PER_REQUEST, splitChunkBySize } from '@livestore/sync-cf/common'
 import { omit } from '@livestore/utils'
 import {
@@ -47,7 +47,7 @@ const makeLayer = (config?: { wranglerConfigPath?: string; label: string }): Syn
         wranglerConfigPath: config?.wranglerConfigPath,
       }).pipe(Layer.provide(PlatformNode.NodeContext.layer)),
     ),
-    UnexpectedError.mapToUnexpectedErrorLayer,
+    UnknownError.mapToUnknownErrorLayer,
   )
 
 export const d1 = {

--- a/tests/sync-provider/src/providers/cloudflare-http-rpc.ts
+++ b/tests/sync-provider/src/providers/cloudflare-http-rpc.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { makeHttpSync } from '@livestore/sync-cf/client'
 import { Effect, Layer } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
@@ -36,7 +36,7 @@ const makeLayer = (config?: { wranglerConfigPath?: string; label: string }): Syn
         wranglerConfigPath: config?.wranglerConfigPath,
       }).pipe(Layer.provide(PlatformNode.NodeContext.layer)),
     ),
-    UnexpectedError.mapToUnexpectedErrorLayer,
+    UnknownError.mapToUnknownErrorLayer,
   )
 
 export const d1 = {

--- a/tests/sync-provider/src/providers/cloudflare-ws.ts
+++ b/tests/sync-provider/src/providers/cloudflare-ws.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { makeWsSync } from '@livestore/sync-cf/client'
 import { Effect, Layer } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
@@ -30,7 +30,7 @@ const makeLayer = (config?: { wranglerConfigPath?: string; label: string }): Syn
         wranglerConfigPath: config?.wranglerConfigPath,
       }).pipe(Layer.provide(PlatformNode.NodeContext.layer)),
     ),
-    UnexpectedError.mapToUnexpectedErrorLayer,
+    UnknownError.mapToUnknownErrorLayer,
   )
 
 export const d1 = {

--- a/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
+++ b/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, IsOfflineError, UnexpectedError } from '@livestore/common'
+import { InvalidPullError, InvalidPushError, IsOfflineError, UnknownError } from '@livestore/common'
 import { LiveStoreEvent } from '@livestore/common/schema'
 import { SyncMessage } from '@livestore/sync-cf/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
@@ -15,7 +15,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
   Rpc.make('Connect', {
     payload: Schema.Struct(commonFields),
     success: Schema.Void,
-    error: Schema.Union(IsOfflineError, UnexpectedError),
+    error: Schema.Union(IsOfflineError, UnknownError),
   }),
 
   // Mirror the pull method
@@ -47,7 +47,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
       ...commonFields,
     }),
     success: Schema.Void,
-    error: Schema.Union(IsOfflineError, UnexpectedError),
+    error: Schema.Union(IsOfflineError, UnknownError),
   }),
 
   // Mirror the isConnected subscription

--- a/tests/sync-provider/src/providers/electric.ts
+++ b/tests/sync-provider/src/providers/electric.ts
@@ -10,7 +10,7 @@
  */
 import http from 'node:http'
 import path from 'node:path'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import type { LiveStoreEvent } from '@livestore/livestore'
 import { nanoid, Schema } from '@livestore/livestore'
 import * as ElectricSync from '@livestore/sync-electric'
@@ -82,7 +82,7 @@ export const layer: SyncProviderLayer = Layer.scoped(
 ).pipe(
   Layer.provide(DockerComposeLive),
   Layer.provide(PlatformNode.NodeContext.layer),
-  UnexpectedError.mapToUnexpectedErrorLayer,
+  UnknownError.mapToUnknownErrorLayer,
 )
 
 const startElectricApi = Effect.gen(function* () {

--- a/tests/sync-provider/src/providers/mock.ts
+++ b/tests/sync-provider/src/providers/mock.ts
@@ -1,4 +1,4 @@
-import { type MockSyncBackend, makeMockSyncBackend, UnexpectedError } from '@livestore/common'
+import { type MockSyncBackend, makeMockSyncBackend, UnknownError } from '@livestore/common'
 import { Effect, Layer, Ref } from '@livestore/utils/effect'
 import { SyncProviderImpl, type SyncProviderLayer } from '../types.ts'
 
@@ -48,4 +48,4 @@ export const layer: SyncProviderLayer = Layer.scoped(
       providerSpecific: {},
     }
   }),
-).pipe(UnexpectedError.mapToUnexpectedErrorLayer)
+).pipe(UnknownError.mapToUnknownErrorLayer)

--- a/tests/sync-provider/src/providers/s2.ts
+++ b/tests/sync-provider/src/providers/s2.ts
@@ -1,5 +1,5 @@
 import http from 'node:http'
-import { UnexpectedError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import type { LiveStoreEvent } from '@livestore/livestore'
 import * as S2Sync from '@livestore/sync-s2'
 import { makeSyncBackend } from '@livestore/sync-s2'
@@ -108,7 +108,7 @@ export const layer: SyncProviderLayer = Layer.scoped(
       },
     }
   }),
-).pipe(UnexpectedError.mapToUnexpectedErrorLayer)
+).pipe(UnknownError.mapToUnknownErrorLayer)
 
 const startApiProxy = Effect.gen(function* () {
   const endpointPort = yield* getFreePort

--- a/tests/sync-provider/src/types.ts
+++ b/tests/sync-provider/src/types.ts
@@ -1,4 +1,4 @@
-import type { SyncBackend, UnexpectedError } from '@livestore/common'
+import type { SyncBackend, UnknownError } from '@livestore/common'
 import { Context, type Effect, type HttpClient, type Layer, type Schedule } from '@livestore/utils/effect'
 
 export interface SyncProviderOptions {
@@ -19,4 +19,4 @@ export class SyncProviderImpl extends Context.Tag('SyncProviderImpl')<
   }
 >() {}
 
-export type SyncProviderLayer = Layer.Layer<SyncProviderImpl, UnexpectedError, HttpClient.HttpClient>
+export type SyncProviderLayer = Layer.Layer<SyncProviderImpl, UnknownError, HttpClient.HttpClient>

--- a/wip/2025-cf.md
+++ b/wip/2025-cf.md
@@ -17,7 +17,7 @@
   - [ ] Get rid of (or minimize) adapter `polyfill.ts`
   - [ ] Ungraceful error handling when DO/client gets into an inconsistent state (e.g. for a unique constraint violation in the materializer)
       ```
-      [19:12:55.160 DoClient] LiveStore.UnexpectedError: { "cause": Error: This should never happen: During boot the backend head (9) should never be greater than the local head (8), "note": undefined, "payload": undefined } LiveStore.UnexpectedError: { "cause": Error: This should never happen: During boot the backend head (9) should never be greater than the local head (8), "note": undefined, "payload": undefined }
+      [19:12:55.160 DoClient] LiveStore.UnknownError: { "cause": Error: This should never happen: During boot the backend head (9) should never be greater than the local head (8), "note": undefined, "payload": undefined } LiveStore.UnknownError: { "cause": Error: This should never happen: During boot the backend head (9) should never be greater than the local head (8), "note": undefined, "payload": undefined }
       ```
   - [ ] Create CF worker only example (without DO)
   - [ ] Test with multiple stores in a single client DO

--- a/wip/upcoming-specs/store-commit-receipt.md
+++ b/wip/upcoming-specs/store-commit-receipt.md
@@ -33,7 +33,7 @@ interface SyncStage {
 - No new error types; re-use the existing tagged errors already exposed by the sync stack:
   - `InvalidPushError` (including nested `LeaderAheadError`, `ServerAheadError`, `BackendIdMismatchError`).
   - `IsOfflineError` when the push loop gives up permanently or the platform signals an unrecoverable offline condition.
-  - `UnexpectedError` for defects.
+  - `UnknownError` for defects.
 - `leaderSync.confirmation` unwraps `LeaderAheadError` via the existing mapping to `InvalidPushError`.
 - `backendSync.confirmation` resolves only after a successful `syncBackend.push` and otherwise stays pending while the backend is offline; permanent failures reject via the errors above.
 


### PR DESCRIPTION
## Summary

Renames `UnexpectedError` to `UnknownError` for better semantic clarity and consistency with Effect ecosystem naming conventions.

## Justification

The previous name `UnexpectedError` conflicted with Effect's terminology where ["unexpected errors" refer to defects](https://effect.website/docs/error-management/two-error-types/#unexpected-errors) (errors that escape the typed error channel), while this error type represents external libraries, infrastructure failures, or defects that have been caught and normalized. Here's why `UnknownError` is more appropriate:

### 1. Avoids Confusion with Effect Terminology

Effect uses ["unexpected error" to mean **defects**](https://effect.website/docs/error-management/two-error-types/#unexpected-errors) - errors that escape the typed error channel. The current name creates confusion because:

- Effect's `catchAllDefect` catches "unexpected errors" (defects)
- LiveStore's `UnexpectedError` wraps both typed errors AND defects
- This creates semantic overlap that muddies the distinction

Using `UnknownError` clearly distinguishes: "this is an error whose type we don't model in our domain" vs Effect's "this is an unexpected defect."

### 2. Alignment with Effect Ecosystem Evolution

The Effect ecosystem is moving toward `UnknownError` naming:
- **Effect 4.0 (effect-smol)**: Uses [`UnknownError`](https://github.com/Effect-TS/effect-smol/blob/e3ea0b51ca004084eac9072fbf8a026f7f875517/packages/effect/src/Cause.ts#L906) as a [typed catch-all error](https://github.com/Effect-TS/effect-smol/blob/main/.patterns/error-handling.md#error-transformation-utilities).
- **Effect AI**: [Already uses an `UnknownError`](https://raw.githubusercontent.com/Effect-TS/effect/refs/heads/main/packages/ai/ai/src/AiError.ts) with the same semantic.

### 3. Usage Patterns Support This Naming

Looking at how it's actually used:

```typescript
// These aren't "unexpected" - they're expected to possibly happen
// But their TYPE is unknown to our domain model
yield* fs.remove(directory).pipe(UnexpectedError.mapToUnexpectedError)
yield* getFreePort.pipe(UnexpectedError.mapToUnexpectedError)
yield* kv.get(backendIdKey).pipe(UnexpectedError.mapToUnexpectedError)

// This wraps defects (which ARE unexpected) but also typed errors (which aren't)
effect.pipe(
  Effect.mapError((cause) => new UnexpectedError({ cause })),
  Effect.catchAllDefect((cause) => new UnexpectedError({ cause }))
)
```

The helper methods normalize **any error type** into this wrapper - the commonality is that the error type is **unknown in our domain**, not that it's unexpected to occur.

## Changes

- **Class rename**: `UnexpectedError` → `UnknownError`
- **Error tag**: `'LiveStore.UnexpectedError'` → `'LiveStore.UnknownError'`
- **Static methods**: `mapToUnexpectedError*` → `mapToUnknownError*`
- **Related type**: `MergeResultUnexpectedError` → `MergeResultUnknownError`
- **Documentation**: Added breaking change entry to CHANGELOG.md

## Validation

- ✅ TypeScript compilation passes
- ✅ Linting passes
- ✅ All occurrences renamed (76 files, ~366 occurrences)
- ✅ Test assertions updated for new error tags
- ✅ CHANGELOG.md updated with breaking change documentation