### PR TITLE
remove ADMIN_SECRET from cloudflare adapter

### DIFF
--- a/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/env.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/env.ts
@@ -5,5 +5,4 @@ export type Env = {
   CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
   DB: CfTypes.D1Database
-  ADMIN_SECRET: string
 }

--- a/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/reset.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/reset.ts
@@ -14,8 +14,7 @@ export const maybeResetStore = async ({
   ctx: CfTypes.DurableObjectState
 }) => {
   const url = new URL(request.url)
-  const shouldReset =
-    env.ADMIN_SECRET === url.searchParams.get('token') && url.pathname === '/internal/livestore-dev-reset'
+  const shouldReset = url.pathname === '/internal/livestore-dev-reset'
 
   const storeId = url.searchParams.get('storeId') ?? nanoid()
 

--- a/docs/src/content/_assets/code/reference/syncing/cloudflare/env.ts
+++ b/docs/src/content/_assets/code/reference/syncing/cloudflare/env.ts
@@ -1,6 +1,5 @@
 import type { CfTypes, SyncBackendRpcInterface } from '@livestore/sync-cf/cf-worker'
 
 export interface Env {
-  ADMIN_SECRET: string // Admin authentication
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
 }

--- a/docs/src/content/docs/reference/syncing/sync-provider/cloudflare.mdx
+++ b/docs/src/content/docs/reference/syncing/sync-provider/cloudflare.mdx
@@ -208,9 +208,6 @@ class_name = "SyncBackendDO"
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["SyncBackendDO"]
-
-[vars]
-ADMIN_SECRET = "your-admin-secret"
 ```
 
 To use D1 instead of DO SQLite, add a D1 binding and reference it from `makeDurableObject({ storage: { _tag: 'd1', binding: '...' } })`:
@@ -220,9 +217,6 @@ To use D1 instead of DO SQLite, add a D1 binding and reference it from `makeDura
 binding = "DB"
 database_name = "livestore-sync"
 database_id = "your-database-id"
-
-[vars]
-ADMIN_SECRET = "your-admin-secret"
 ```
 
 ### Environment Variables

--- a/examples/cf-chat/src/cf-worker/shared.ts
+++ b/examples/cf-chat/src/cf-worker/shared.ts
@@ -5,7 +5,6 @@ export type Env = {
   CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
   SYNC_BACKEND_URL: string
-  ADMIN_SECRET: string
 }
 
 export const storeIdFromRequest = (request: CfTypes.Request) => {

--- a/examples/cloudflare-todomvc/src/shared.ts
+++ b/examples/cloudflare-todomvc/src/shared.ts
@@ -4,7 +4,6 @@ import type { CfTypes, SyncBackendRpcInterface } from '@livestore/sync-cf/cf-wor
 export type Env = {
   CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
-  ADMIN_SECRET: string
 }
 
 export const storeIdFromRequest = (request: CfTypes.Request) => {

--- a/examples/cloudflare-todomvc/wrangler.toml
+++ b/examples/cloudflare-todomvc/wrangler.toml
@@ -67,8 +67,6 @@ tag = "v1"
 new_sqlite_classes = ["SyncBackendDO", "LiveStoreClientDO"]
 
 [vars]
-# should be set via CF dashboard (as secret)
-# ADMIN_SECRET = "..."
 SYNC_BACKEND_URL = "http://localhost:8787"
 
 

--- a/examples/expo-todomvc-sync-cf/wrangler.toml
+++ b/examples/expo-todomvc-sync-cf/wrangler.toml
@@ -63,7 +63,3 @@ new_sqlite_classes = ["SyncBackendDO"]
 binding = "DB"
 database_name = "livestore-sync-cf-demo"
 database_id = "1c9b5dae-f1fa-49d8-83fa-7bd5b39c4121"
-
-[vars]
-# should be set via CF dashboard (as secret)
-# ADMIN_SECRET = "..."

--- a/examples/web-linearlite/wrangler.toml
+++ b/examples/web-linearlite/wrangler.toml
@@ -47,7 +47,3 @@ class_name = "SyncBackendDO"
 [[env.dev.migrations]]
 tag = "v1"
 new_sqlite_classes = ["SyncBackendDO"]
-
-[vars]
-# should be set via CF dashboard (as secret)
-# ADMIN_SECRET = "..."

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -5,9 +5,7 @@ import { Effect, Schema, UrlParams } from '@livestore/utils/effect'
 import type { SearchParams } from '../common/mod.ts'
 import { SearchParamsSchema, SyncMessage } from '../common/mod.ts'
 
-export interface Env {
-  ADMIN_SECRET: string
-}
+export type Env = {}
 
 export type MakeDurableObjectClassOptions = {
   onPush?: (

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -34,7 +34,6 @@ type Env = {
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
   TEST_STORE_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>
   DB: CfTypes.D1Database
-  ADMIN_SECRET: string
 }
 
 export class SyncBackendDO extends makeDurableObject({}) {}

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -33,7 +33,6 @@ export interface Env {
   TEST_CLIENT_DO: CfTypes.DurableObjectNamespace
   /** Eventlog database */
   DB: CfTypes.D1Database
-  ADMIN_SECRET: string
 }
 
 export class SyncBackendDO extends makeDurableObject({

--- a/tests/sync-provider/src/providers/cloudflare/wrangler-d1.toml
+++ b/tests/sync-provider/src/providers/cloudflare/wrangler-d1.toml
@@ -10,9 +10,6 @@ binding = "DB"
 database_name = "hibernation-test-db"
 database_id = "hibernation-test-db"
 
-[vars]
-ADMIN_SECRET = "test-admin-secret-123"
-
 [[durable_objects.bindings]]
 name = "SYNC_BACKEND_DO"
 class_name = "SyncBackendDO"

--- a/tests/sync-provider/src/providers/cloudflare/wrangler-do-sqlite.toml
+++ b/tests/sync-provider/src/providers/cloudflare/wrangler-do-sqlite.toml
@@ -5,9 +5,6 @@ compatibility_flags = [
 ]
 main = "./test-worker.ts"
 
-[vars]
-ADMIN_SECRET = "test-admin-secret-123"
-
 [[durable_objects.bindings]]
 name = "SYNC_BACKEND_DO"
 class_name = "SyncBackendDO"
@@ -19,4 +16,3 @@ class_name = "TestClientDo"
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["SyncBackendDO", "TestClientDo"]
-


### PR DESCRIPTION
## Problem

`ADMIN_SECRET` is exposed to consumers of livestore via Typescript types. It's also an environment variable that is documented in the docs as required.

This created a bit of confusion for me as I wasn't sure if it was actually used. Following a chat in Discord, it sounds like it isn't so deleting here.

## Solution

This PR doesn't add or remove functionality. I guess when/if authentication is implementation by this library, the API could be revisited

## Validation

All runs as usual

### Demo (optional)

N/A