### PR TITLE
Fix note formatting for versioning events and materializers

### DIFF
--- a/docs/src/content/docs/tutorial/3-read-and-write-todos-via-livestore.mdx
+++ b/docs/src/content/docs/tutorial/3-read-and-write-todos-via-livestore.mdx
@@ -118,7 +118,7 @@ Here's a quick summary of the code:
 
 The `tables`, `events` and `materializers` are packaged up into a `schema` object that's needed in the parts of your app where you interact with LiveStore.
 
-:::note[Versioning events and materializes]
+:::note[Versioning events and materializers]
 You may have noticed that event and materializer names are prefixed with `v1`. 
 
 It's good practice in LiveStore to version your events and materializers to ensure future compatibility between them as your app evolves.


### PR DESCRIPTION
<!-- Use a title that captures the problem and the approach, e.g. "Fix backlog replay flake by stabilizing event helper" -->

## Problem

Fixes typo in tutorial
