### PR TITLE
fix(react): correct error message in useStoreRegistry

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistryContext.tsx
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistryContext.tsx
@@ -17,7 +17,7 @@ export const useStoreRegistry = (override?: StoreRegistry) => {
 
   const storeRegistry = React.use(StoreRegistryContext)
 
-  if (!storeRegistry) throw new Error('useStoreRegistry() must be used within <MultiStoreProvider>')
+  if (!storeRegistry) throw new Error('useStoreRegistry() must be used within <StoreRegistryProvider>')
 
   return storeRegistry
 }


### PR DESCRIPTION
## Problem

The `useStoreRegistry` hook throws an error when used outside its provider context, but the error message references the wrong component name:

```typescript
throw new Error('useStoreRegistry() must be used within <MultiStoreProvider>')
```

However, the actual provider component is `<StoreRegistryProvider>`, not `<MultiStoreProvider>`.

## Solution

Updated the error message to reference the correct component name:

```typescript
throw new Error('useStoreRegistry() must be used within <StoreRegistryProvider>')
```

This improves developer experience by providing accurate guidance when debugging context-related issues.