### PR TITLE
feat(react): auto-abort store loading when no longer needed

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -362,6 +362,77 @@ describe('StoreRegistry', () => {
     await nextStore.shutdownPromise()
   })
 
+  it('aborts loading when GC fires while store is still loading', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 10
+    const options = testStoreOptions({ gcTime })
+
+    // Subscribe briefly to trigger getOrLoad and then unsubscribe
+    const unsubscribe = registry.subscribe(options.storeId, () => {})
+
+    // Start loading - this will be slow due to fake timers
+    const loadPromise = registry.getOrLoad(options)
+
+    // Attach a catch handler to prevent unhandled rejection when the load is aborted
+    const abortedPromise = (loadPromise as Promise<unknown>).catch(() => {
+      // Expected: load was aborted by GC
+    })
+
+    // Unsubscribe immediately, which schedules GC
+    unsubscribe()
+
+    // Advance time to trigger GC while still loading
+    await vi.advanceTimersByTimeAsync(gcTime)
+
+    // Wait for the abort to complete
+    await abortedPromise
+
+    // After abort, a new getOrLoad should start a fresh load
+    const freshLoadPromise = registry.getOrLoad(options)
+
+    // This should be a new promise (not the aborted one)
+    expect(freshLoadPromise).toBeInstanceOf(Promise)
+    expect(freshLoadPromise).not.toBe(loadPromise)
+
+    // Wait for fresh load to complete
+    const store = await freshLoadPromise
+    expect(store).toBeDefined()
+
+    await store.shutdownPromise()
+  })
+
+  it('does not abort loading when new subscription arrives before GC fires', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 50
+    const options = testStoreOptions({ gcTime })
+
+    // Start loading and immediately unsubscribe to schedule GC
+    const unsub1 = registry.subscribe(options.storeId, () => {})
+    const loadPromise = registry.getOrLoad(options)
+    unsub1()
+
+    // Advance time partially (before GC fires)
+    await vi.advanceTimersByTimeAsync(gcTime - 10)
+
+    // Add a new subscription - this should cancel the pending GC
+    const unsub2 = registry.subscribe(options.storeId, () => {})
+
+    // Advance past the original GC time
+    await vi.advanceTimersByTimeAsync(20)
+
+    // The load should complete normally (not be aborted)
+    const store = await loadPromise
+
+    // And should be the same instance when retrieved again
+    const cachedStore = registry.getOrLoad(options)
+    expect(cachedStore).toBe(store)
+
+    unsub2()
+    await store.shutdownPromise()
+  })
+
   it('manages multiple stores with different IDs independently', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -73,7 +73,7 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
   /**
    * Transitions to the loading state.
    */
-  #setPromise(promise: Promise<Store<TSchema>>, abortController: AbortController): void {
+  #setLoading(promise: Promise<Store<TSchema>>, abortController: AbortController): void {
     if (this.#state.status === 'success' || this.#state.status === 'loading') return
     this.#state = { status: 'loading', promise, abortController }
     this.#notify()
@@ -163,7 +163,7 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
         if (this.#subscribers.size === 0) this.#scheduleGC()
       })
 
-    this.#setPromise(promise, abortController)
+    this.#setLoading(promise, abortController)
 
     return promise
   }

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -4,7 +4,7 @@ import type { CachedStoreOptions, StoreId } from './types.ts'
 
 type StoreEntryState<TSchema extends LiveStoreSchema> =
   | { status: 'idle' }
-  | { status: 'loading'; promise: Promise<Store<TSchema>> }
+  | { status: 'loading'; promise: Promise<Store<TSchema>>; abortController: AbortController }
   | { status: 'success'; store: Store<TSchema> }
   | { status: 'error'; error: unknown }
 
@@ -54,6 +54,9 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
       // Re-check to avoid racing with a new subscription
       if (this.#subscribers.size > 0) return
 
+      // Abort any in-progress loading to release resources early
+      this.#abortLoading()
+
       void this.#shutdown().finally(() => {
         // Double-check again just in case shutdown was slow
         if (this.#subscribers.size === 0) this.#cache.delete(this.#storeId)
@@ -70,9 +73,9 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
   /**
    * Transitions to the loading state.
    */
-  #setPromise(promise: Promise<Store<TSchema>>): void {
+  #setPromise(promise: Promise<Store<TSchema>>, abortController: AbortController): void {
     if (this.#state.status === 'success' || this.#state.status === 'loading') return
-    this.#state = { status: 'loading', promise }
+    this.#state = { status: 'loading', promise, abortController }
     this.#notify()
   }
 
@@ -144,7 +147,9 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
     if (this.#state.status === 'loading') return this.#state.promise
     if (this.#state.status === 'error') throw this.#state.error
 
-    const promise = createStorePromise(options)
+    const abortController = new AbortController()
+
+    const promise = createStorePromise({ ...options, signal: abortController.signal })
       .then((store) => {
         this.#setStore(store)
         return store
@@ -158,9 +163,20 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
         if (this.#subscribers.size === 0) this.#scheduleGC()
       })
 
-    this.#setPromise(promise)
+    this.#setPromise(promise, abortController)
 
     return promise
+  }
+
+  /**
+   * Aborts an in-progress store load.
+   *
+   * This signals the createStorePromise to cancel, releasing resources like
+   * worker threads, SQLite connections, and network requests.
+   */
+  #abortLoading = (): void => {
+    if (this.#state.status !== 'loading') return
+    this.#state.abortController.abort()
   }
 
   #shutdown = async (): Promise<void> => {


### PR DESCRIPTION
Closes #836

## Problem

`StoreEntry` in the multi-store registry never creates or passes an `AbortSignal` to `createStorePromise()`, even though the function accepts one. This means store loading operations continue to completion even when they're no longer needed—wasting CPU, network bandwidth, SQLite connections, and worker threads on stores that will be immediately discarded.

## Solution

Each `StoreEntry` now owns an `AbortController` that is created when loading starts. When GC fires while a store is still loading (all subscribers have unmounted), the controller is aborted, releasing resources early via Effect's scope closure mechanism.

Changes:
- Added `abortController` to the `loading` state in `StoreEntryState`
- Pass abort signal to `createStorePromise()` in `getOrLoad()`
- Added `#abortLoading()` helper called by `#scheduleGC()` when status is `loading`
- Renamed `#setPromise` → `#setLoading` to align with state machine pattern

## Test plan

- [x] Added test: GC aborts loading when no subscribers remain
- [x] Added test: New subscription prevents abort during loading
- [x] All existing `StoreRegistry` and `useStore` tests pass