### PR TITLE
fix(react): prevent subscriptions to stores being shutdown

### DIFF
--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -529,6 +529,55 @@ describe('StoreRegistry', () => {
     await nextStore.shutdownPromise()
   })
 
+  it('prevents subscriptions to stores that are shutting down', async () => {
+    vi.useFakeTimers()
+    const registry = new StoreRegistry()
+    const gcTime = 10
+    const options = testStoreOptions({ gcTime })
+
+    // Load the store and wait for it to be ready
+    const originalStore = await registry.getOrLoad(options)
+
+    // Verify store is cached
+    expect(registry.getOrLoad(options)).toBe(originalStore)
+
+    // Spy on shutdownPromise to detect when shutdown starts
+    let shutdownStarted = false
+    let shutdownCompleted = false
+    const originalShutdownPromise = originalStore.shutdownPromise.bind(originalStore)
+    originalStore.shutdownPromise = () => {
+      shutdownStarted = true
+      return originalShutdownPromise().finally(() => {
+        shutdownCompleted = true
+      })
+    }
+
+    // Use vi.advanceTimersToNextTimer to advance ONLY to the GC timer firing,
+    // then immediately (before microtasks resolve) try to get the store
+    vi.advanceTimersToNextTimer()
+
+    // The GC callback has now executed synchronously, which means:
+    // 1. Subscriber check passed (no subscribers)
+    // 2. shutdown() was called (but it's async, hasn't resolved yet)
+    // 3. Cache entry SHOULD have been removed
+
+    // Verify shutdown was initiated
+    expect(shutdownStarted).toBe(true)
+    // Shutdown is async, so it shouldn't have completed yet in the same tick
+    expect(shutdownCompleted).toBe(false)
+
+    const storeOrPromise = registry.getOrLoad(options)
+
+    if (!(storeOrPromise instanceof Promise)) {
+      expect.fail('getOrLoad returned dying store synchronously instead of starting fresh load')
+    }
+
+    const freshStore = await storeOrPromise
+    // A fresh load was triggered because cache was cleared
+    expect(freshStore).not.toBe(originalStore)
+    await freshStore.shutdownPromise()
+  })
+
   it('warms the cache so subsequent getOrLoad is synchronous after preload', async () => {
     const registry = new StoreRegistry()
     const options = testStoreOptions()

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -266,7 +266,7 @@ type DefaultStoreOptions = Partial<
    * store have unmounted.
    *
    * @remarks
-   * - If set to `infinity`, will disable garbage collection
+   * - If set to `Infinity`, will disable garbage collection
    * - The maximum allowed time is about {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value | 24 days}
    *
    * @defaultValue `60_000` (60 seconds) or `Infinity` during SSR to avoid

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -7,6 +7,7 @@ type StoreEntryState<TSchema extends LiveStoreSchema> =
   | { status: 'loading'; promise: Promise<Store<TSchema>>; abortController: AbortController }
   | { status: 'success'; store: Store<TSchema> }
   | { status: 'error'; error: unknown }
+  | { status: 'shutting_down'; shutdownPromise: Promise<void> }
 
 /**
  * Default garbage collection time for inactive stores.
@@ -57,10 +58,15 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
       // Abort any in-progress loading to release resources early
       this.#abortLoading()
 
-      void this.#shutdown().finally(() => {
-        // Double-check again just in case shutdown was slow
+      // Transition to shutting_down state BEFORE starting async shutdown.
+      // This prevents new subscribers from receiving a store that's about to be disposed.
+      const shutdownPromise = this.#shutdown().finally(() => {
+        // Reset to idle so fresh loads can proceed, then remove from cache if still inactive
+        this.#setIdle()
         if (this.#subscribers.size === 0) this.#cache.delete(this.#storeId)
       })
+
+      this.#setShuttingDown(shutdownPromise)
     }, effectiveGcTime)
   }
 
@@ -93,6 +99,22 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
   #setError = (error: unknown): void => {
     this.#state = { status: 'error', error }
     this.#notify()
+  }
+
+  /**
+   * Transitions to the shutting_down state.
+   */
+  #setShuttingDown = (shutdownPromise: Promise<void>): void => {
+    this.#state = { status: 'shutting_down', shutdownPromise }
+    this.#notify()
+  }
+
+  /**
+   * Transitions to the idle state.
+   */
+  #setIdle = (): void => {
+    this.#state = { status: 'idle' }
+    // No notify needed - getOrLoad will handle the fresh load
   }
 
   /**
@@ -146,6 +168,11 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
     if (this.#state.status === 'success') return this.#state.store
     if (this.#state.status === 'loading') return this.#state.promise
     if (this.#state.status === 'error') throw this.#state.error
+
+    // Wait for shutdown to complete, then recursively call to load a fresh store
+    if (this.#state.status === 'shutting_down') {
+      return this.#state.shutdownPromise.then(() => this.getOrLoad(options))
+    }
 
     const abortController = new AbortController()
 


### PR DESCRIPTION
Fixes #837

## Summary

- Fixes race condition where new subscriptions could attach to a store that was in the process of shutting down
- Adds `shutting_down` state to `StoreEntry` to block new subscribers during shutdown
- `getOrLoad()` now waits for shutdown to complete before loading a fresh store

## Test plan

- [x] Added regression test that reproduces the race condition
- [x] All existing `StoreRegistry` tests pass (23 tests)
- [x] All `useStore` integration tests pass (6 tests)
- [x] TypeScript and lint checks pass