### PR TITLE
Document event format and client-side sequence numbers

### DIFF
--- a/docs/src/content/docs/reference/events.mdx
+++ b/docs/src/content/docs/reference/events.mdx
@@ -60,6 +60,70 @@ Pick `'warn'` (default) to log every occurrence, `'ignore'` to silently drop new
       - you can add new fields if they have default values or are optional
       - you can remove fields
 
+## Event format
+
+Each event has the following structure:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Event name matching the event definition |
+| `args` | Event arguments as defined by the event schema |
+| `seqNum` | Sequence number identifying this event |
+| `parentSeqNum` | Parent event's sequence number (for causal ordering) |
+| `clientId` | Identifier of the client that created the event |
+| `sessionId` | Identifier of the session |
+
+### Encoded vs decoded events
+
+Events exist in two formats:
+
+**Decoded** - Native TypeScript types used in application code:
+
+```json
+{
+  "name": "todoCreated-v1",
+  "args": { "id": "abc123", "text": "Buy milk", "createdAt": Date },
+  "seqNum": 5,
+  "parentSeqNum": 4,
+  "clientId": "client-xyz",
+  "sessionId": "session-123"
+}
+```
+
+**Encoded** - Serialized format for storage and sync:
+
+```json
+{
+  "name": "todoCreated-v1",
+  "args": { "id": "abc123", "text": "Buy milk", "createdAt": "2024-01-15T10:30:00.000Z" },
+  "seqNum": 5,
+  "parentSeqNum": 4,
+  "clientId": "client-xyz",
+  "sessionId": "session-123"
+}
+```
+
+The `args` field is encoded according to the event's schema (e.g., `Date` objects become ISO strings, binary data becomes base64). LiveStore handles encoding/decoding automatically.
+
+### Client-side sequence numbers
+
+On the client, sequence numbers are expanded to track additional information for local events:
+
+```json
+{
+  "seqNum": { "global": 5, "client": 1, "rebaseGeneration": 0 },
+  "parentSeqNum": { "global": 5, "client": 0, "rebaseGeneration": 0 }
+}
+```
+
+- **global**: Globally unique integer assigned by the sync backend
+- **client**: Client-local counter (0 for synced events, increments for client-only events)
+- **rebaseGeneration**: Increments when the client rebases unconfirmed events
+
+Events can be represented as strings like `e5` (global event 5), `e5.1` (client-local event), or `e5r1` (after a rebase).
+
+For the full type definitions, see [`LiveStoreEvent.ts`](https://github.com/livestorejs/livestore/tree/dev/packages/@livestore/common/src/schema/LiveStoreEvent.ts).
+
 ## Commiting events
 
 <CommitEventSnippet />


### PR DESCRIPTION
## Problem

The events reference documentation didn't explain the actual structure and format of events, making it unclear what fields events contain and how they differ between the sync backend format and the client-side format.

## Solution

Added a new "Event format" section that documents the six core event fields, explains the encoded vs decoded distinction with JSON examples, and separately documents how client-side sequence numbers expand the format with global/client/rebaseGeneration tracking for local events. This provides clarity on the two event representations while keeping the primary focus on the standard format.

## Validation

- Linting passes (biome, syncpack)
- Docs check passes (astro check)
- Markdown renders correctly with examples