### PR TITLE
refactor(docs): migrate code snippets to type-checked files

### DIFF
--- a/docs/src/content/_assets/code/package.json
+++ b/docs/src/content/_assets/code/package.json
@@ -8,13 +8,18 @@
     "@effect-atom/atom": "0.3.0",
     "@effect-atom/atom-livestore": "0.3.0",
     "@effect-atom/atom-react": "0.3.0",
+    "@livestore/adapter-expo": "workspace:*",
     "@livestore/adapter-node": "workspace:*",
     "@livestore/adapter-web": "workspace:*",
+    "@livestore/devtools-expo": "workspace:*",
+    "@livestore/devtools-vite": "workspace:*",
     "@livestore/livestore": "workspace:*",
     "@livestore/react": "workspace:*",
     "@livestore/sync-cf": "workspace:*",
+    "@livestore/sync-electric": "workspace:*",
     "@types/node": "catalog:",
     "effect": "catalog:",
+    "expo": "54.0.12",
     "expo-status-bar": "3.0.8",
     "fractional-indexing": "3.2.0",
     "jose": "6.1.0",
@@ -23,6 +28,7 @@
     "react-error-boundary": "6.0.0",
     "react-native": "0.81.4",
     "solid-js": "1.9.9",
+    "vite": "catalog:",
     "vue-livestore": "0.2.3"
   }
 }

--- a/docs/src/content/_assets/code/package.json
+++ b/docs/src/content/_assets/code/package.json
@@ -12,7 +12,7 @@
     "@livestore/adapter-node": "workspace:*",
     "@livestore/adapter-web": "workspace:*",
     "@livestore/devtools-expo": "workspace:*",
-    "@livestore/devtools-vite": "workspace:*",
+    "@livestore/devtools-vite": "0.4.0-dev.18",
     "@livestore/livestore": "workspace:*",
     "@livestore/react": "workspace:*",
     "@livestore/sync-cf": "workspace:*",

--- a/docs/src/content/_assets/code/patterns/offline/tracking-connectivity.ts
+++ b/docs/src/content/_assets/code/patterns/offline/tracking-connectivity.ts
@@ -1,0 +1,18 @@
+import type { Store } from '@livestore/livestore'
+import { Effect, Stream } from 'effect'
+
+declare const store: Store
+
+// ---cut---
+
+const status = await store.networkStatus.pipe(Effect.runPromise)
+if (status.isConnected === false) {
+  console.warn('Sync backend offline since', new Date(status.timestampMs))
+}
+
+await store.networkStatus.changes.pipe(
+  Stream.tap((next) => Effect.sync(() => console.log('network status updated', next))),
+  Stream.runDrain,
+  Effect.scoped,
+  Effect.runPromise,
+)

--- a/docs/src/content/_assets/code/reference/devtools/metro-config.ts
+++ b/docs/src/content/_assets/code/reference/devtools/metro-config.ts
@@ -1,0 +1,10 @@
+// @noErrors
+// metro.config.js
+const { getDefaultConfig } = require('expo/metro-config')
+const { addLiveStoreDevtoolsMiddleware } = require('@livestore/devtools-expo')
+
+const config = getDefaultConfig(__dirname)
+
+addLiveStoreDevtoolsMiddleware(config, { schemaPath: './src/livestore/schema.ts' })
+
+module.exports = config

--- a/docs/src/content/_assets/code/reference/devtools/vite-config.ts
+++ b/docs/src/content/_assets/code/reference/devtools/vite-config.ts
@@ -1,0 +1,7 @@
+import { livestoreDevtoolsPlugin } from '@livestore/devtools-vite'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  // ...
+  plugins: [livestoreDevtoolsPlugin({ schemaPath: './src/livestore/schema.ts' })],
+})

--- a/docs/src/content/_assets/code/reference/events/event-type-namespaces.ts
+++ b/docs/src/content/_assets/code/reference/events/event-type-namespaces.ts
@@ -1,0 +1,27 @@
+import { EventSequenceNumber, type LiveStoreEvent } from '@livestore/livestore'
+
+// Input events (no sequence numbers) - used when committing
+const _input: LiveStoreEvent.Input.Decoded = {
+  name: 'todoCreated-v1',
+  args: { id: 'abc123', text: 'Buy milk' },
+}
+
+// Global events (sync backend format) - integer sequence numbers
+const _global: LiveStoreEvent.Global.Encoded = {
+  name: 'todoCreated-v1',
+  args: { id: 'abc123', text: 'Buy milk' },
+  seqNum: EventSequenceNumber.Global.make(5),
+  parentSeqNum: EventSequenceNumber.Global.make(4),
+  clientId: 'client-xyz',
+  sessionId: 'session-123',
+}
+
+// Client events (local format) - composite sequence numbers
+const _client: LiveStoreEvent.Client.Encoded = {
+  name: 'todoCreated-v1',
+  args: { id: 'abc123', text: 'Buy milk' },
+  seqNum: EventSequenceNumber.Client.Composite.make({ global: 5, client: 0, rebaseGeneration: 0 }),
+  parentSeqNum: EventSequenceNumber.Client.Composite.make({ global: 4, client: 0, rebaseGeneration: 0 }),
+  clientId: 'client-xyz',
+  sessionId: 'session-123',
+}

--- a/docs/src/content/_assets/code/reference/events/unknown-event-handling.ts
+++ b/docs/src/content/_assets/code/reference/events/unknown-event-handling.ts
@@ -1,0 +1,39 @@
+import { defineMaterializer, Events, makeSchema, Schema, State } from '@livestore/livestore'
+
+const tables = {
+  todos: State.SQLite.table({
+    name: 'todos',
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      text: State.SQLite.text(),
+    },
+  }),
+} as const
+
+const events = {
+  todoCreated: Events.synced({
+    name: 'v1.TodoCreated',
+    schema: Schema.Struct({ id: Schema.String, text: Schema.String }),
+  }),
+} as const
+
+const materializers = State.SQLite.materializers(events, {
+  [events.todoCreated.name]: defineMaterializer(events.todoCreated, ({ id, text }) =>
+    tables.todos.insert({ id, text }),
+  ),
+})
+
+const state = State.SQLite.makeState({ tables, materializers })
+
+// ---cut---
+
+const _schema = makeSchema({
+  events,
+  state,
+  unknownEventHandling: {
+    strategy: 'callback',
+    onUnknownEvent: (event, error) => {
+      console.warn('LiveStore saw an unknown event', { event, reason: error.reason })
+    },
+  },
+})

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/provider-logging.tsx
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/provider-logging.tsx
@@ -1,0 +1,27 @@
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { LiveStoreProvider } from '@livestore/react'
+import { Logger, LogLevel } from '@livestore/utils/effect'
+import type { FC, ReactNode } from 'react'
+import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
+
+import { schema } from './schema.ts'
+
+// ---cut---
+
+const adapter = makeInMemoryAdapter()
+
+const App: FC = () => <div>App</div>
+
+export const Root: FC<{ children: ReactNode }> = () => (
+  <LiveStoreProvider
+    schema={schema}
+    adapter={adapter}
+    batchUpdates={batchUpdates}
+    // Optional: swap the logger implementation
+    logger={Logger.prettyWithThread('app')}
+    // Optional: set minimum log level (use LogLevel.None to disable)
+    logLevel={LogLevel.Info}
+  >
+    <App />
+  </LiveStoreProvider>
+)

--- a/docs/src/content/_assets/code/reference/mcp/module-contract.ts
+++ b/docs/src/content/_assets/code/reference/mcp/module-contract.ts
@@ -1,0 +1,7 @@
+import { makeWsSync } from '@livestore/sync-cf/client'
+
+export { schema } from './schema.ts'
+
+export const syncBackend = makeWsSync({ url: process.env.LIVESTORE_SYNC_URL ?? 'ws://localhost:8787' })
+
+export const syncPayload = { authToken: process.env.LIVESTORE_SYNC_AUTH_TOKEN ?? 'insecure-token-change-me' }

--- a/docs/src/content/_assets/code/reference/mcp/schema.ts
+++ b/docs/src/content/_assets/code/reference/mcp/schema.ts
@@ -1,0 +1,32 @@
+import { Events, makeSchema, Schema, State } from '@livestore/livestore'
+
+const events = {
+  entityCreated: Events.synced({
+    name: 'v1.EntityCreated',
+    schema: Schema.Struct({
+      id: Schema.String,
+      title: Schema.String,
+      createdAt: Schema.DateFromString,
+    }),
+  }),
+}
+
+const tables = {
+  entities: State.SQLite.table({
+    name: 'entities',
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      title: State.SQLite.text({ default: '' }),
+      createdAt: State.SQLite.text({ default: '' }),
+    },
+  }),
+}
+
+const materializers = State.SQLite.materializers(events, {
+  'v1.EntityCreated': ({ id, title, createdAt }) =>
+    tables.entities.insert({ id, title, createdAt: createdAt.toISOString() }),
+})
+
+const state = State.SQLite.makeState({ tables, materializers })
+
+export const schema = makeSchema({ events, state })

--- a/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/reset-persistence.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/reset-persistence.ts
@@ -1,0 +1,8 @@
+import { makePersistedAdapter } from '@livestore/adapter-expo'
+
+const resetPersistence = process.env.EXPO_PUBLIC_LIVESTORE_RESET === 'true'
+
+const _adapter = makePersistedAdapter({
+  storage: { subDirectory: 'dev' },
+  resetPersistence,
+})

--- a/docs/src/content/_assets/code/reference/platform-adapters/node-adapter/worker-logging.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/node-adapter/worker-logging.ts
@@ -1,0 +1,12 @@
+import { makeWorker } from '@livestore/adapter-node/worker'
+import { Logger, LogLevel } from '@livestore/utils/effect'
+
+import { schema } from './schema.ts'
+
+makeWorker({
+  schema,
+  // readable console output by thread name
+  logger: Logger.prettyWithThread('livestore-node-leader-thread'),
+  // choose verbosity: None | Error | Warning | Info | Debug
+  logLevel: LogLevel.Info,
+})

--- a/docs/src/content/_assets/code/reference/solid-integration/store-logging.ts
+++ b/docs/src/content/_assets/code/reference/solid-integration/store-logging.ts
@@ -1,0 +1,24 @@
+import { makePersistedAdapter } from '@livestore/adapter-web'
+import LiveStoreSharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
+import { getStore } from '@livestore/solid'
+import { Logger, LogLevel } from '@livestore/utils/effect'
+
+import LiveStoreWorker from './livestore/livestore.worker.ts?worker'
+import { schema } from './livestore/schema.ts'
+
+// ---cut---
+
+const adapter = makePersistedAdapter({
+  storage: { type: 'opfs' },
+  worker: LiveStoreWorker,
+  sharedWorker: LiveStoreSharedWorker,
+})
+
+const _store = await getStore({
+  schema,
+  adapter,
+  storeId: 'default',
+  // Optional: swap logger and minimum log level
+  logger: Logger.prettyWithThread('window'),
+  logLevel: LogLevel.Info, // use LogLevel.None to disable logs
+})

--- a/docs/src/content/_assets/code/reference/syncing/sync-provider/electricsql/api-proxy.ts
+++ b/docs/src/content/_assets/code/reference/syncing/sync-provider/electricsql/api-proxy.ts
@@ -1,0 +1,51 @@
+import { Schema } from '@livestore/livestore'
+import { ApiSchema, makeElectricUrl } from '@livestore/sync-electric'
+
+const electricHost = 'http://localhost:30000' // Your Electric server
+
+/** Placeholder for your database factory function */
+declare const makeDb: (storeId: string) => {
+  migrate: () => Promise<void>
+  disconnect: () => Promise<void>
+  createEvents: (batch: (typeof ApiSchema.PushPayload.Type)['batch']) => Promise<void>
+}
+
+// ---cut---
+
+// GET /api/electric - Pull events (proxied through Electric)
+export async function GET(request: Request) {
+  const searchParams = new URL(request.url).searchParams
+  const { url, storeId, needsInit } = makeElectricUrl({
+    electricHost,
+    searchParams,
+    apiSecret: 'your-electric-secret',
+  })
+
+  // Add your authentication logic here
+  // if (!isAuthenticated(request)) {
+  //   return new Response('Unauthorized', { status: 401 })
+  // }
+
+  // Initialize database tables if needed
+  if (needsInit) {
+    const db = makeDb(storeId)
+    await db.migrate()
+    await db.disconnect()
+  }
+
+  // Proxy pull request to Electric server for reading
+  return fetch(url)
+}
+
+// POST /api/electric - Push events (direct database write)
+export async function POST(request: Request) {
+  const payload = await request.json()
+  const parsed = Schema.decodeUnknownSync(ApiSchema.PushPayload)(payload)
+
+  // Write events directly to Postgres table (bypasses Electric)
+  const db = makeDb(parsed.storeId)
+  await db.createEvents(parsed.batch)
+  await db.disconnect()
+
+  return Response.json({ success: true })
+}

--- a/docs/src/content/_assets/code/reference/syncing/sync-provider/electricsql/client-setup.ts
+++ b/docs/src/content/_assets/code/reference/syncing/sync-provider/electricsql/client-setup.ts
@@ -1,0 +1,6 @@
+import { makeSyncBackend } from '@livestore/sync-electric'
+
+const _backend = makeSyncBackend({
+  endpoint: '/api/electric', // Your API proxy endpoint
+  ping: { enabled: true },
+})

--- a/docs/src/content/docs/evaluation/design-decisions.md
+++ b/docs/src/content/docs/evaluation/design-decisions.md
@@ -25,6 +25,7 @@ sidebar:
 - The current implementation of LiveStore assumes that the data is small enough to fit in memory. However, SQLite is very efficient so this should work for many use cases and apps.
 - LiveStore implements a Signals-based reactivity system based on the ideas of Adapton for incremental computation
 - The goal is to keep LiveStore syncing provider agnostic so you can use the right syncing provider for your use case.
+- LiveStore intentionally stays focused on core data management and syncing, leaving concerns like authentication, file uploads, and business logic to application code. This minimalist approach keeps the library maintainable by limiting surface area, flexible as a composable Unix-like building block, and unopinionated enough to adapt to diverse usage scenarios.
 
 ## Implementation decisions
 

--- a/docs/src/content/docs/patterns/app-evolution.mdx
+++ b/docs/src/content/docs/patterns/app-evolution.mdx
@@ -3,6 +3,8 @@ title: App Evolution
 description: How to evolve your app and roll out new app versions
 ---
 
+import UnknownEventHandlingSnippet from '../../_assets/code/reference/events/unknown-event-handling.ts?snippet'
+
 When building an app with LiveStore, you'll need to keep some things in mind when evolving your app.
 
 ## Schema changes
@@ -29,18 +31,6 @@ App instances running version 4 might commit events that are not yet supported b
 
 LiveStore exposes a dedicated `unknownEventHandling` configuration on `makeSchema` so you can codify the desired behaviour instead of sprinkling ad-hoc checks across your app. The default is `'warn'`, which logs every unknown event and keeps processing.
 
-```ts
-const schema = makeSchema({
-  events,
-  state,
-  unknownEventHandling: {
-    strategy: 'callback',
-    onUnknownEvent: (event, error) => {
-      // Optional observer hook (only used for the `callback` strategy)
-      console.warn('Unknown event seen in production', { event, reason: error.reason })
-    },
-  },
-})
-```
+<UnknownEventHandlingSnippet />
 
 Set the strategy to `'ignore'` to silently skip forward-only events, `'fail'` to stop immediately (useful during development), or `'callback'` to forward them to custom telemetry while continuing to replay the log.

--- a/docs/src/content/docs/patterns/offline.mdx
+++ b/docs/src/content/docs/patterns/offline.mdx
@@ -2,6 +2,8 @@
 title: Offline Support
 ---
 
+import TrackingConnectivitySnippet from '../../_assets/code/patterns/offline/tracking-connectivity.ts?snippet'
+
 - LiveStore supports offline data management out of the box. In order to make your app work fully offline, you might need to also consider the following:
   - Design your app in a way to treat the network as an optional feature (e.g. when relying on other APIs / external data)
   - Use service workers to cache assets locally (e.g. images, videos, etc.)
@@ -10,20 +12,6 @@ title: Offline Support
 
 Use `store.networkStatus` to react to connectivity transitions. The subscribable emits every time the sync backend connection flips or the devtools latch simulates an offline state.
 
-```ts
-import { Effect, Stream } from 'effect'
-
-const status = await store.networkStatus.pipe(Effect.runPromise)
-if (status.isConnected === false) {
-  console.warn('Sync backend offline since', new Date(status.timestampMs))
-}
-
-await store.networkStatus.changes.pipe(
-  Stream.tap((next) => console.log('network status updated', next)),
-  Stream.runDrain,
-  Effect.scoped,
-  Effect.runPromise,
-)
-```
+<TrackingConnectivitySnippet />
 
 When devtools close the sync latch to simulate an offline client, `status.devtools.latchClosed` is `true`, allowing you to differentiate between real and simulated outages. Remember to dispose of long-lived subscriptions using the Effect scope you already manage for your runtime.

--- a/docs/src/content/docs/reference/devtools.mdx
+++ b/docs/src/content/docs/reference/devtools.mdx
@@ -4,6 +4,9 @@ sidebar:
   order: 10
 ---
 
+import ViteConfigSnippet from '../../_assets/code/reference/devtools/vite-config.ts?snippet'
+import MetroConfigSnippet from '../../_assets/code/reference/devtools/metro-config.ts?snippet'
+
 NOTE: Once LiveStore is open source, the devtools will be a [sponsor-only benefit](/misc/sponsoring).
 
 ## Features
@@ -29,17 +32,7 @@ NOTE: Once LiveStore is open source, the devtools will be a [sponsor-only benefi
 
 Requires the `@livestore/devtools-vite` package to be installed and configured in your Vite config:
 
-```ts
-// vite.config.js
-import { livestoreDevtoolsPlugin } from '@livestore/devtools-vite'
-
-export default defineConfig({
-  // ...
-  plugins: [
-    livestoreDevtoolsPlugin({ schemaPath: './src/livestore/schema.ts' }),
-  ],
-})
-```
+<ViteConfigSnippet />
 
 The devtools can be opened in a separate tab (via e.g. `localhost:3000/_livestore/web). You should see the Devtools URL logged in the browser console when running the app.
 
@@ -61,17 +54,7 @@ To install the extension:
 
 Requires the `@livestore/devtools-expo` package to be installed and configured in your metro config:
 
-```ts
-// metro.config.js
-const { getDefaultConfig } = require('expo/metro-config')
-const { addLiveStoreDevtoolsMiddleware } = require('@livestore/devtools-expo')
-
-const config = getDefaultConfig(__dirname)
-
-addLiveStoreDevtoolsMiddleware(config, { schemaPath: './src/livestore/schema.ts' })
-
-module.exports = config
-```
+<MetroConfigSnippet />
 
 You can open the devtools by pressing `Shift+m` in the Expo CLI process and then selecting `@livestore/devtools-expo` which will open the devtools in a new tab.
   

--- a/docs/src/content/docs/reference/events.mdx
+++ b/docs/src/content/docs/reference/events.mdx
@@ -6,6 +6,8 @@ sidebar:
 
 import CommitEventSnippet from '../../_assets/code/reference/events/commit.ts?snippet'
 import EventSchemaSnippet from '../../_assets/code/reference/events/livestore-schema.ts?snippet'
+import UnknownEventHandlingSnippet from '../../_assets/code/reference/events/unknown-event-handling.ts?snippet'
+import EventTypeNamespacesSnippet from '../../_assets/code/reference/events/event-type-namespaces.ts?snippet'
 
 ## Event definitions
 
@@ -35,18 +37,7 @@ Events will be synced across clients and materialized into state (i.e. SQLite ta
 
 Older clients might receive events that were introduced in newer app versions. Configure the behaviour centrally via `unknownEventHandling` when constructing the schema:
 
-```ts
-const schema = makeSchema({
-  events,
-  state,
-  unknownEventHandling: {
-    strategy: 'callback',
-    onUnknownEvent: (event, error) => {
-      console.warn('LiveStore saw an unknown event', { event, reason: error.reason })
-    },
-  },
-})
-```
+<UnknownEventHandlingSnippet />
 
 Pick `'warn'` (default) to log every occurrence, `'ignore'` to silently drop new events until the client updates, `'fail'` to halt immediately, or `'callback'` to delegate to custom logging/telemetry while continuing to process the log.
 
@@ -134,35 +125,7 @@ LiveStore organizes event types into namespaces based on their usage context:
 | `LiveStoreEvent.Global` | Sync backend format | Integer (`seqNum: number`) |
 | `LiveStoreEvent.Client` | Client-side format with full metadata | Struct (`seqNum: { global, client, rebaseGeneration }`) |
 
-```typescript
-import { LiveStoreEvent, EventSequenceNumber } from '@livestore/livestore'
-
-// Input events (no sequence numbers) - used when committing
-const input: LiveStoreEvent.Input.Decoded = {
-  name: 'todoCreated-v1',
-  args: { id: 'abc123', text: 'Buy milk' }
-}
-
-// Global events (sync backend format) - integer sequence numbers
-const global: LiveStoreEvent.Global.Encoded = {
-  name: 'todoCreated-v1',
-  args: { id: 'abc123', text: 'Buy milk' },
-  seqNum: 5,  // EventSequenceNumber.Global
-  parentSeqNum: 4,
-  clientId: 'client-xyz',
-  sessionId: 'session-123'
-}
-
-// Client events (local format) - struct sequence numbers
-const client: LiveStoreEvent.Client.Encoded = {
-  name: 'todoCreated-v1',
-  args: { id: 'abc123', text: 'Buy milk' },
-  seqNum: { global: 5, client: 0, rebaseGeneration: 0 },
-  parentSeqNum: { global: 4, client: 0, rebaseGeneration: 0 },
-  clientId: 'client-xyz',
-  sessionId: 'session-123'
-}
-```
+<EventTypeNamespacesSnippet />
 
 ## Commiting events
 

--- a/docs/src/content/docs/reference/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/reference/framework-integrations/react-integration.mdx
@@ -7,6 +7,7 @@ description: How to integrate LiveStore with React.
 
 import ReactContextSnippet from '../../../_assets/code/reference/framework-integrations/react/context-provider.tsx?snippet'
 import ReactProviderSnippet from '../../../_assets/code/reference/framework-integrations/react/provider.tsx?snippet'
+import ReactProviderLoggingSnippet from '../../../_assets/code/reference/framework-integrations/react/provider-logging.tsx?snippet'
 import ReactUseClientDocumentSnippet from '../../../_assets/code/reference/framework-integrations/react/use-client-document.tsx?snippet'
 import ReactUseQuerySnippet from '../../../_assets/code/reference/framework-integrations/react/use-query.tsx?snippet'
 import ReactUseStoreSnippet from '../../../_assets/code/reference/framework-integrations/react/use-store.tsx?snippet'
@@ -39,21 +40,7 @@ In order to use LiveStore with React, you need to wrap your application in a `Li
 
 `LiveStoreProvider` accepts optional logging configuration:
 
-```tsx
-import { Logger, LogLevel } from '@livestore/utils/effect'
-
-<LiveStoreProvider
-  schema={schema}
-  adapter={adapter}
-  batchUpdates={batchUpdates}
-  // Optional: swap the logger implementation
-  logger={Logger.prettyWithThread('app')}
-  // Optional: set minimum log level (use LogLevel.None to disable)
-  logLevel={LogLevel.Info}
->
-  <App />
-</LiveStoreProvider>
-```
+<ReactProviderLoggingSnippet />
 
 For scenarios where you have an existing store instance, you can manually create a `LiveStoreContext.Provider`:
 

--- a/docs/src/content/docs/reference/framework-integrations/solid-integration.mdx
+++ b/docs/src/content/docs/reference/framework-integrations/solid-integration.mdx
@@ -7,6 +7,7 @@ description: How to integrate LiveStore with Solid.
 
 import SolidStoreSnippet from '../../../_assets/code/reference/solid-integration/livestore/store.ts?snippet'
 import SolidMainSectionSnippet from '../../../_assets/code/reference/solid-integration/MainSection.tsx?snippet'
+import SolidStoreLoggingSnippet from '../../../_assets/code/reference/solid-integration/store-logging.ts?snippet'
 
 ## Example
 
@@ -18,18 +19,6 @@ See [examples](/examples) for a complete example.
 
 ### Logging
 
-You can control logging for Solid’s runtime helpers via optional options passed to `getStore`:
+You can control logging for Solid's runtime helpers via optional options passed to `getStore`:
 
-```ts
-import { Logger, LogLevel } from '@livestore/utils/effect'
-import { getStore } from '@livestore/solid'
-
-const store = await getStore({
-  schema,
-  adapter,
-  storeId: 'default',
-  // Optional: swap logger and minimum log level
-  logger: Logger.prettyWithThread('window'),
-  logLevel: LogLevel.Info, // use LogLevel.None to disable logs
-})
-```
+<SolidStoreLoggingSnippet />

--- a/docs/src/content/docs/reference/mcp.mdx
+++ b/docs/src/content/docs/reference/mcp.mdx
@@ -3,6 +3,8 @@ title: MCP Integration
 description: Model Context Protocol integration for AI assistants like Claude.
 ---
 
+import McpModuleContractSnippet from '../../_assets/code/reference/mcp/module-contract.ts?snippet'
+
 LiveStore includes MCP (Model Context Protocol) integration that allows AI assistants like Claude to access LiveStore documentation, examples, and development tools.
 
 :::caution[Experimental]
@@ -43,12 +45,9 @@ Provides development tools and utilities for working with LiveStore projects.
     - Only one instance can be active at a time; connecting again shuts down and replaces the previous instance.
     - Reconnecting creates a fresh, in-memory client database. The visible state is populated by your backend's initial sync. Until sync completes, queries may return empty or partial results.
   - Module contract (generic example):
-    ```ts
-    import { makeWsSync } from '@livestore/sync-cf/client' // or another provider
-    export { schema } from './src/livestore/schema.ts'
-    export const syncBackend = makeWsSync({ url: process.env.LIVESTORE_SYNC_URL ?? 'ws://localhost:8787' })
-    export const syncPayload = { authToken: process.env.LIVESTORE_SYNC_AUTH_TOKEN ?? 'insecure-token-change-me' }
-    ```
+
+    <McpModuleContractSnippet />
+
   - Params example: `{ "storePath": "<path-to-your-mcp-module>.ts", "storeId": "<store-id>" }`
   - Returns example:
     `{ "storeId": "<store-id>", "clientId": "client-123", "sessionId": "session-abc", "schemaInfo": { "tableNames": ["..."], "eventNames": ["..."] } }`

--- a/docs/src/content/docs/reference/platform-adapters/electron-adapter.md
+++ b/docs/src/content/docs/reference/platform-adapters/electron-adapter.md
@@ -4,4 +4,16 @@ sidebar:
   order: 20
 ---
 
-LiveStore doesn't yet support Electron (see [this issue](https://github.com/livestorejs/livestore/issues/296) for more details).
+## Using LiveStore with Electron
+
+LiveStore can already be used in Electron through the [web adapter](/reference/platform-adapters/web-adapter), which works perfectly fine for most use cases. The web adapter leverages the browser APIs available in Electron's renderer process, providing full LiveStore functionality including reactive queries, offline-first operation, and sync capabilities.
+
+## Native Electron Adapter
+
+While the web adapter works well, there is room for further improvement through a dedicated native Electron adapter. A native adapter would leverage Electron's unique capabilities including:
+
+- **Transparent database file persistence** - Direct file system access instead of browser storage abstractions (IndexedDB/OPFS)
+- **Performance improvements** - Native SQLite bindings via Node.js integration
+- **Better integration with Electron's main process** - Coordination between main and renderer processes
+
+Development of the native Electron adapter is tracked in [this GitHub issue](https://github.com/livestorejs/livestore/issues/296). Contributors are welcome to help with the implementation, and sponsorship opportunities are available to accelerate development of this adapter.

--- a/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
+++ b/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
@@ -4,6 +4,8 @@ sidebar:
   order: 2
 ---
 
+import ResetPersistenceSnippet from '../../../_assets/code/reference/platform-adapters/expo-adapter/reset-persistence.ts?snippet'
+
 ## Notes on Android
 
 - By default, Android requires `https` (including WebSocket connections) when communicating with a sync backend.
@@ -31,16 +33,7 @@ To allow for `http` / `ws`, you can run `expo install expo-build-properties` and
 
 When iterating locally you can ask the Expo adapter to drop the on-device state and eventlog databases before booting:
 
-```ts
-import { makePersistedAdapter } from '@livestore/adapter-expo'
-
-const resetPersistence = process.env.EXPO_PUBLIC_LIVESTORE_RESET === 'true'
-
-const adapter = makePersistedAdapter({
-  storage: { subDirectory: 'dev' },
-  resetPersistence,
-})
-```
+<ResetPersistenceSnippet />
 
 :::caution
 Resetting persistence deletes all local LiveStore data for the configured store. This only clears data on the device and does not touch any connected sync backend. Make sure this flag is disabled in production builds.

--- a/docs/src/content/docs/reference/platform-adapters/node-adapter.mdx
+++ b/docs/src/content/docs/reference/platform-adapters/node-adapter.mdx
@@ -8,6 +8,7 @@ import NodeAdapterSnippet from '../../../_assets/code/reference/platform-adapter
 import NodeResetPersistenceSnippet from '../../../_assets/code/reference/platform-adapters/node-adapter/reset-persistence.ts?snippet'
 import NodeWorkerMainSnippet from '../../../_assets/code/reference/platform-adapters/node-adapter/worker-main.ts?snippet'
 import NodeWorkerWorkerSnippet from '../../../_assets/code/reference/platform-adapters/node-adapter/worker-worker.ts?snippet'
+import NodeWorkerLoggingSnippet from '../../../_assets/code/reference/platform-adapters/node-adapter/worker-logging.ts?snippet'
 
 Works with Node.js, Bun and Deno.
 
@@ -35,25 +36,14 @@ The worker adapter can be used for more advanced scenarios where it's preferable
 
 #### Logging
 
-You can control what the Node worker logs and how it’s formatted.
+You can control what the Node worker logs and how it's formatted.
 Pass two optional options to `makeWorker`:
 
 - `logger` — where/format of logs (e.g. pretty console output)
 - `logLevel` — how verbose logs are (`LogLevel.None` silences logs)
 
-```ts
-import { Logger, LogLevel } from '@livestore/utils/effect'
-import { makeWorker } from '@livestore/adapter-node'
-
-makeWorker({
-  schema,
-  // readable console output by thread name
-  logger: Logger.prettyWithThread('livestore-node-leader-thread'),
-  // choose verbosity: None | Error | Warning | Info | Debug
-  logLevel: LogLevel.Info,
-})
+<NodeWorkerLoggingSnippet />
 
 Tips:
 - Use `LogLevel.None` to keep test output quiet.
 - Keep the default (Debug) when diagnosing issues.
-```

--- a/docs/src/content/docs/reference/syncing/sync-provider/cloudflare.mdx
+++ b/docs/src/content/docs/reference/syncing/sync-provider/cloudflare.mdx
@@ -38,7 +38,54 @@ export const SNIPPETS = {
   multiTransport: MultiTransportSnippet,
 }
 
-The `@livestore/sync-cf` package provides a comprehensive LiveStore sync provider for Cloudflare Workers. It uses Durable Objects for connectivity and, by default, persists events in the Durable Object’s own SQLite. You can optionally use Cloudflare D1 instead. Multiple transports are supported to fit different deployment scenarios.
+The `@livestore/sync-cf` package provides a comprehensive LiveStore sync provider for Cloudflare Workers. It uses Durable Objects for connectivity and, by default, persists events in the Durable Object's own SQLite. You can optionally use Cloudflare D1 instead. Multiple transports are supported to fit different deployment scenarios.
+
+## Architecture
+
+<div class="d2-full-width">
+
+```d2
+...@../../../../base.d2
+
+direction: right
+
+Client: {
+  label: "LiveStore Client"
+  shape: rectangle
+}
+
+CF: {
+  label: "Cloudflare"
+  style.stroke-dash: 3
+
+  Worker: {
+    label: "Worker"
+    shape: rectangle
+  }
+
+  DO: {
+    label: "Durable Object\n(per storeId)"
+    shape: rectangle
+  }
+
+  Storage: {
+    label: "DO SQLite (default)\nor D1 (optional)"
+    shape: cylinder
+  }
+
+  Worker -> DO: "Route by\nstoreId"
+  DO -> Storage: "Read/Write"
+}
+
+Client -> CF.Worker: "WebSocket / HTTP\npush & pull"
+```
+
+</div>
+
+Key responsibilities:
+- **Worker**: Routes sync requests to Durable Objects by `storeId`, handles auth validation
+- **Durable Object**: Manages sync state, handles push/pull operations, maintains WebSocket connections
+- **Storage**: Persists events in DO SQLite (default) or D1 (optional)
 
 ## Installation
 

--- a/docs/src/content/docs/reference/syncing/sync-provider/electricsql.md
+++ b/docs/src/content/docs/reference/syncing/sync-provider/electricsql.md
@@ -4,6 +4,9 @@ sidebar:
   order: 11
 ---
 
+import ClientSetupSnippet from '../../../../_assets/code/reference/syncing/sync-provider/electricsql/client-setup.ts?snippet'
+import ApiProxySnippet from '../../../../_assets/code/reference/syncing/sync-provider/electricsql/api-proxy.ts?snippet'
+
 The `@livestore/sync-electric` package lets you sync LiveStore with ElectricSQL.
 
 - Package: `pnpm add @livestore/sync-electric`
@@ -48,14 +51,7 @@ The API proxy has dual responsibilities:
 
 Basic usage in your worker/server code:
 
-```ts
-import { makeSyncBackend } from '@livestore/sync-electric'
-
-const backend = makeSyncBackend({
-  endpoint: '/api/electric', // Your API proxy endpoint
-  ping: { enabled: true },
-})
-```
+<ClientSetupSnippet />
 
 ## API Proxy Implementation
 
@@ -63,50 +59,7 @@ ElectricSQL requires an API proxy on your server to handle authentication and da
 
 ### Minimal Implementation Example
 
-```ts
-import { Schema } from '@livestore/livestore'
-import { ApiSchema, makeElectricUrl } from '@livestore/sync-electric'
-
-const electricHost = 'http://localhost:30000' // Your Electric server
-
-// GET /api/electric - Pull events (proxied through Electric)
-export async function GET(request: Request) {
-  const searchParams = new URL(request.url).searchParams
-  const { url, storeId, needsInit } = makeElectricUrl({
-    electricHost,
-    searchParams,
-    apiSecret: 'your-electric-secret',
-  })
-  
-  // Add your authentication logic here
-  // if (!isAuthenticated(request)) {
-  //   return new Response('Unauthorized', { status: 401 })
-  // }
-  
-  // Initialize database tables if needed
-  if (needsInit) {
-    const db = makeDb(storeId)
-    await db.migrate()
-    await db.disconnect()
-  }
-  
-  // Proxy pull request to Electric server for reading
-  return fetch(url)
-}
-
-// POST /api/electric - Push events (direct database write)
-export async function POST(request: Request) {
-  const payload = await request.json()
-  const parsed = Schema.decodeUnknownSync(ApiSchema.PushPayload)(payload)
-  
-  // Write events directly to Postgres table (bypasses Electric)
-  const db = makeDb(parsed.storeId)
-  await db.createEvents(parsed.batch)
-  await db.disconnect()
-  
-  return Response.json({ success: true })
-}
-```
+<ApiProxySnippet />
 
 ### Important Considerations
 

--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -140,3 +140,8 @@
 svg[data-d2-version] {
   max-width: 500px;
 }
+
+/* Full-width D2 diagrams - use by wrapping in <div class="d2-full-width">...</div> */
+.d2-full-width svg[data-d2-version] {
+  max-width: 100%;
+}

--- a/examples/web-todomvc-sync-electric/package.json
+++ b/examples/web-todomvc-sync-electric/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@livestore/devtools-vite": "0.4.0-dev.18",
     "@playwright/test": "^1.56.0",
-    "@tanstack/react-router": "1.132.47",
+    "@tanstack/react-router": "^1.132.47",
     "@tanstack/router-devtools": "^1.133.1",
     "@tanstack/router-plugin": "^1.132.56",
     "@types/node": "^24.9.2",

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -70,10 +70,60 @@ if (isDevEnv()) {
   exposeDebugUtils()
 }
 
+/**
+ * Central interface to a LiveStore database providing reactive queries, event commits, and sync.
+ *
+ * A `Store` instance wraps a local SQLite database that is kept in sync with other clients via
+ * an event log. Instead of mutating state directly, you commit events that get materialized
+ * into database rows. Queries automatically re-run when their underlying tables change.
+ *
+ * ## Creating a Store
+ *
+ * Use `createStore` (Effect-based) or `createStorePromise` to obtain a Store instance.
+ * In React applications, use the `<LiveStoreProvider>` component which manages the Store lifecycle
+ * and exposes it via React context.
+ *
+ * ## Querying Data
+ *
+ * Use {@link Store.query} for one-shot reads or {@link Store.subscribe} for reactive subscriptions.
+ * Both accept query builders (e.g. `tables.todo.where({ complete: true })`) or custom `LiveQueryDef`s.
+ *
+ * ## Committing Events
+ *
+ * Use {@link Store.commit} to persist events. Events are immediately materialized locally and
+ * asynchronously synced to other clients. Multiple events can be committed atomically.
+ *
+ * ## Lifecycle
+ *
+ * The Store must be shut down when no longer needed via {@link Store.shutdown} or
+ * {@link Store.shutdownPromise}. Framework integrations (React, Effect) handle this automatically.
+ *
+ * @typeParam TSchema - The LiveStore schema defining tables and events
+ * @typeParam TContext - Optional user-defined context attached to the Store (e.g. for dependency injection)
+ *
+ * @example
+ * ```ts
+ * // Query data
+ * const todos = store.query(tables.todo.where({ complete: false }))
+ *
+ * // Subscribe to changes
+ * const unsubscribe = store.subscribe(tables.todo.all(), (todos) => {
+ *   console.log('Todos updated:', todos)
+ * })
+ *
+ * // Commit an event
+ * store.commit(events.todoCreated({ id: nanoid(), text: 'Buy milk' }))
+ * ```
+ */
 export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TContext = {}> extends Inspectable.Class {
+  /** Unique identifier for this Store instance, stable for its lifetime. */
   readonly storeId: string
-  schema: LiveStoreSchema
-  context: TContext
+
+  /** The LiveStore schema defining tables, events, and materializers. */
+  readonly schema: LiveStoreSchema
+
+  /** User-defined context attached to this Store (e.g. for dependency injection). */
+  readonly context: TContext
   /**
    * Reactive connectivity updates emitted by the backing sync backend.
    *
@@ -91,16 +141,14 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * )
    * ```
    */
-  readonly networkStatus: ClientSession['leaderThread']['networkStatus'];
-
-  /** Tracks whether the store has been shut down is kept in internals */
-
-  /** RC-based set to see which queries are currently subscribed to */
+  readonly networkStatus: ClientSession['leaderThread']['networkStatus']
 
   /**
-   * Store internals. Shouldn't be used directly in application code.
+   * Store internals. Not part of the public API — shapes and semantics may change without notice.
+   *
+   * @internal
    */
-  [StoreInternalsSymbol]: StoreInternals
+  readonly [StoreInternalsSymbol]: StoreInternals
 
   // #region constructor
   constructor({

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -145,8 +145,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
   /**
    * Store internals. Not part of the public API — shapes and semantics may change without notice.
-   *
-   * @internal
    */
   readonly [StoreInternalsSymbol]: StoreInternals
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,12 +302,21 @@ importers:
       '@effect-atom/atom-react':
         specifier: 0.3.0
         version: 0.3.0(@effect/experimental@0.56.0(@effect/platform@0.92.0(effect@3.18.0))(effect@3.18.0))(@effect/platform@0.92.0(effect@3.18.0))(@effect/rpc@0.71.0(@effect/platform@0.92.0(effect@3.18.0))(effect@3.18.0))(effect@3.18.0)(react@19.1.0)(scheduler@0.27.0)
+      '@livestore/adapter-expo':
+        specifier: workspace:*
+        version: link:../../../../../packages/@livestore/adapter-expo
       '@livestore/adapter-node':
         specifier: workspace:*
         version: link:../../../../../packages/@livestore/adapter-node
       '@livestore/adapter-web':
         specifier: workspace:*
         version: link:../../../../../packages/@livestore/adapter-web
+      '@livestore/devtools-expo':
+        specifier: workspace:*
+        version: link:../../../../../packages/@livestore/devtools-expo
+      '@livestore/devtools-vite':
+        specifier: 0.4.0-dev.18
+        version: 0.4.0-dev.18(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@livestore/livestore':
         specifier: workspace:*
         version: link:../../../../../packages/@livestore/livestore
@@ -317,12 +326,18 @@ importers:
       '@livestore/sync-cf':
         specifier: workspace:*
         version: link:../../../../../packages/@livestore/sync-cf
+      '@livestore/sync-electric':
+        specifier: workspace:*
+        version: link:../../../../../packages/@livestore/sync-electric
       '@types/node':
         specifier: 'catalog:'
         version: 24.9.2
       effect:
         specifier: 'catalog:'
         version: 3.18.0
+      expo:
+        specifier: 54.0.12
+        version: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.6)(react@19.1.0))(react@19.1.0)
       expo-status-bar:
         specifier: 3.0.8
         version: 3.0.8(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.6)(react@19.1.0))(react@19.1.0)
@@ -347,9 +362,12 @@ importers:
       solid-js:
         specifier: 1.9.9
         version: 1.9.9
+      vite:
+        specifier: 'catalog:'
+        version: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vue-livestore:
         specifier: 0.2.3
-        version: 0.2.3(typescript@5.9.3)(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 0.2.3(typescript@5.9.3)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
 
   examples/cf-chat:
     dependencies:
@@ -18224,12 +18242,6 @@ snapshots:
       '@livestore/utils': link:packages/@livestore/utils
       vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@livestore/devtools-vite@0.4.0-dev.18(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@livestore/adapter-web': link:packages/@livestore/adapter-web
-      '@livestore/utils': link:packages/@livestore/utils
-      vite: 7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-
   '@mapbox/node-pre-gyp@2.0.0':
     dependencies:
       consola: 3.4.2
@@ -31840,10 +31852,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-livestore@0.2.3(typescript@5.9.3)(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
+  vue-livestore@0.2.3(typescript@5.9.3)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@livestore/adapter-web': link:packages/@livestore/adapter-web
-      '@livestore/devtools-vite': 0.4.0-dev.18(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@livestore/devtools-vite': 0.4.0-dev.18(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@livestore/livestore': link:packages/@livestore/livestore
       '@livestore/peer-deps': link:packages/@livestore/peer-deps
       '@livestore/sync-cf': link:packages/@livestore/sync-cf

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: 0.1.4
       version: 0.1.4
     '@types/node':
-      specifier: 24.9.2
-      version: 24.9.2
+      specifier: 24.10.1
+      version: 24.10.1
     '@types/react':
       specifier: 19.1.13
       version: 19.1.13
@@ -58,8 +58,8 @@ catalogs:
       specifier: 5.9.2
       version: 5.9.2
     vite:
-      specifier: 7.1.7
-      version: 7.1.7
+      specifier: 7.2.4
+      version: 7.2.4
     vitest:
       specifier: 3.2.4
       version: 3.2.4
@@ -111,7 +111,7 @@ importers:
         version: 0.55.5
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       '@vitest/ui':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4)
@@ -129,10 +129,10 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       yaml:
         specifier: ^2.8.1
         version: 2.8.1
@@ -316,7 +316,7 @@ importers:
         version: link:../../../../../packages/@livestore/devtools-expo
       '@livestore/devtools-vite':
         specifier: 0.4.0-dev.18
-        version: 0.4.0-dev.18(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 0.4.0-dev.18(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@livestore/livestore':
         specifier: workspace:*
         version: link:../../../../../packages/@livestore/livestore
@@ -331,7 +331,7 @@ importers:
         version: link:../../../../../packages/@livestore/sync-electric
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       effect:
         specifier: 'catalog:'
         version: 3.18.0
@@ -364,10 +364,10 @@ importers:
         version: 1.9.9
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vue-livestore:
         specifier: 0.2.3
-        version: 0.2.3(typescript@5.9.3)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 0.2.3(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
 
   examples/cf-chat:
     dependencies:
@@ -1690,7 +1690,7 @@ importers:
         version: link:../common
       '@livestore/devtools-vite':
         specifier: 0.4.0-dev.18
-        version: 0.4.0-dev.18(vite@7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 0.4.0-dev.18(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@livestore/sqlite-wasm':
         specifier: workspace:*
         version: link:../sqlite-wasm
@@ -1705,7 +1705,7 @@ importers:
         version: 1.9.0
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^28.0.6
@@ -1777,7 +1777,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -1834,13 +1834,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       expo:
         specifier: ^54.0.12
         version: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.6)(react@19.1.0))(react@19.1.0)
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/@livestore/devtools-web-common:
     dependencies:
@@ -1865,7 +1865,7 @@ importers:
         version: 1.56.0
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
 
   packages/@livestore/graphql:
     dependencies:
@@ -1918,7 +1918,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -2030,7 +2030,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -2064,7 +2064,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -2092,13 +2092,13 @@ importers:
         version: 0.1.4
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       '@types/wicg-file-system-access':
         specifier: ^2023.10.6
         version: 2023.10.7
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       wrangler:
         specifier: 'catalog:'
         version: 4.42.2(@cloudflare/workers-types@4.20250923.0)
@@ -2216,7 +2216,7 @@ importers:
         version: 21.1.7
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       '@types/web':
         specifier: ^0.0.264
         version: 0.0.264
@@ -2228,7 +2228,7 @@ importers:
         version: 26.1.0
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/@livestore/utils-dev:
     dependencies:
@@ -2328,13 +2328,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       astro:
         specifier: ^5.13.4
-        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/@local/astro-twoslash-code:
     dependencies:
@@ -2346,7 +2346,7 @@ importers:
         version: link:../../@livestore/utils
       astro-expressive-code:
         specifier: 0.41.3
-        version: 0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
+        version: 0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
       expressive-code:
         specifier: 0.41.3
         version: 0.41.3
@@ -2365,25 +2365,25 @@ importers:
     devDependencies:
       '@astrojs/starlight':
         specifier: ^0.35.2
-        version: 0.35.2(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
+        version: 0.35.2(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       astro:
         specifier: ^5.13.4
-        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
+        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/@local/astro-twoslash-code/example:
     dependencies:
       '@astrojs/starlight':
         specifier: 0.35.2
-        version: 0.35.2(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
+        version: 0.35.2(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
       '@livestore/utils':
         specifier: workspace:*
         version: link:../../../@livestore/utils
@@ -2392,10 +2392,10 @@ importers:
         version: link:..
       astro:
         specifier: 5.13.4
-        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
+        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
       astro-expressive-code:
         specifier: 0.41.3
-        version: 0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
+        version: 0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
       expressive-code-twoslash:
         specifier: 0.5.3
         version: 0.5.3(@expressive-code/core@0.41.3)(expressive-code@0.41.3)(typescript@5.9.2)
@@ -2405,10 +2405,10 @@ importers:
         version: 1.56.0
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.1.13(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 4.1.13(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.13
@@ -2420,7 +2420,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
 
   scripts:
     devDependencies:
@@ -2450,7 +2450,7 @@ importers:
         version: 1.3.3
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
 
   tests/integration:
     dependencies:
@@ -2468,7 +2468,7 @@ importers:
         version: link:../../packages/@livestore/common
       '@livestore/devtools-vite':
         specifier: 0.4.0-dev.18
-        version: 0.4.0-dev.18(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 0.4.0-dev.18(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@livestore/effect-playwright':
         specifier: workspace:*
         version: link:../../packages/@livestore/effect-playwright
@@ -2517,10 +2517,10 @@ importers:
         version: 1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/router-plugin':
         specifier: ^1.132.56
-        version: 1.139.1(@tanstack/react-router@1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite-plugin-solid@2.11.10(solid-js@1.9.9)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 1.139.1(@tanstack/react-router@1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite-plugin-solid@2.11.10(solid-js@1.9.9)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       '@types/react':
         specifier: 'catalog:'
         version: 19.1.13
@@ -2538,10 +2538,10 @@ importers:
         version: 2.4.3
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       wrangler:
         specifier: 'catalog:'
         version: 4.42.2(@cloudflare/workers-types@4.20250923.0)
@@ -2605,7 +2605,7 @@ importers:
         version: 1.56.0
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       '@types/react':
         specifier: 'catalog:'
         version: 19.1.13
@@ -2614,7 +2614,7 @@ importers:
         version: 19.1.9(@types/react@19.1.13)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 5.0.3(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 5.0.3(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       react:
         specifier: 'catalog:'
         version: 19.1.0
@@ -2626,7 +2626,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 'catalog:'
-        version: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   tests/sync-provider:
     dependencies:
@@ -2672,10 +2672,10 @@ importers:
         version: link:../../packages/@livestore/utils-dev
       '@types/node':
         specifier: 'catalog:'
-        version: 24.9.2
+        version: 24.10.1
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   tests/wa-sqlite:
     devDependencies:
@@ -7721,9 +7721,6 @@ packages:
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
-
-  '@types/node@24.9.2':
-    resolution: {integrity: sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -15003,46 +15000,6 @@ packages:
       yaml:
         optional: true
 
-  vite@7.1.7:
-    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.2.4:
     resolution: {integrity: sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -15795,25 +15752,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.12(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))':
-    dependencies:
-      '@astrojs/markdown-remark': 6.3.9
-      '@mdx-js/mdx': 3.1.1
-      acorn: 8.15.0
-      astro: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
-      es-module-lexer: 1.7.0
-      estree-util-visit: 2.0.0
-      hast-util-to-html: 9.0.5
-      piccolore: 0.1.3
-      rehype-raw: 7.0.0
-      remark-gfm: 4.0.1
-      remark-smartypants: 3.0.2
-      source-map: 0.7.6
-      unist-util-visit: 5.0.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@astrojs/netlify@6.5.9(@types/node@24.10.1)(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)':
     dependencies:
       '@astrojs/internal-helpers': 0.7.2
@@ -15912,39 +15850,6 @@ snapshots:
       '@types/mdast': 4.0.4
       astro: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
       astro-expressive-code: 0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
-      bcp-47: 2.1.0
-      hast-util-from-html: 2.0.3
-      hast-util-select: 6.0.4
-      hast-util-to-string: 3.0.1
-      hastscript: 9.0.1
-      i18next: 23.16.8
-      js-yaml: 4.1.1
-      klona: 2.0.6
-      mdast-util-directive: 3.1.0
-      mdast-util-to-markdown: 2.1.2
-      mdast-util-to-string: 4.0.0
-      pagefind: 1.4.0
-      rehype: 13.0.2
-      rehype-format: 5.0.1
-      remark-directive: 3.0.1
-      ultrahtml: 1.6.0
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@astrojs/starlight@0.35.2(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))':
-    dependencies:
-      '@astrojs/markdown-remark': 6.3.9
-      '@astrojs/mdx': 4.3.12(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
-      '@astrojs/sitemap': 3.6.0
-      '@pagefind/default-ui': 1.4.0
-      '@types/hast': 3.0.4
-      '@types/js-yaml': 4.0.9
-      '@types/mdast': 4.0.4
-      astro: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
-      astro-expressive-code: 0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -16950,7 +16855,7 @@ snapshots:
   '@effect/vitest@0.26.0(effect@3.18.0)(vitest@3.2.4)':
     dependencies:
       effect: 3.18.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@effect/workflow@0.11.5(@effect/platform@0.92.0(effect@3.18.0))(@effect/rpc@0.71.0(@effect/platform@0.92.0(effect@3.18.0))(effect@3.18.0))(effect@3.18.0)':
     dependencies:
@@ -18223,18 +18128,6 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
-
-  '@livestore/devtools-vite@0.4.0-dev.18(vite@7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@livestore/adapter-web': link:packages/@livestore/adapter-web
-      '@livestore/utils': link:packages/@livestore/utils
-      vite: 7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-
-  '@livestore/devtools-vite@0.4.0-dev.18(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@livestore/adapter-web': link:packages/@livestore/adapter-web
-      '@livestore/utils': link:packages/@livestore/utils
-      vite: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@livestore/devtools-vite@0.4.0-dev.18(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
@@ -21129,13 +21022,6 @@ snapshots:
       tailwindcss: 4.1.13
       vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
-  '@tailwindcss/vite@4.1.13(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@tailwindcss/node': 4.1.13
-      '@tailwindcss/oxide': 4.1.13
-      tailwindcss: 4.1.13
-      vite: 7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-
   '@tailwindcss/vite@4.1.17(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.17
@@ -21366,29 +21252,6 @@ snapshots:
       '@tanstack/react-router': 1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vite-plugin-solid: 2.11.10(solid-js@1.9.9)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tanstack/router-plugin@1.139.1(@tanstack/react-router@1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite-plugin-solid@2.11.10(solid-js@1.9.9)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)))(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      '@tanstack/router-core': 1.139.1
-      '@tanstack/router-generator': 1.139.1
-      '@tanstack/router-utils': 1.139.0
-      '@tanstack/virtual-file-routes': 1.139.0
-      babel-dead-code-elimination: 1.0.10
-      chokidar: 3.6.0
-      unplugin: 2.3.11
-      zod: 3.25.76
-    optionalDependencies:
-      '@tanstack/react-router': 1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vite: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-      vite-plugin-solid: 2.11.10(solid-js@1.9.9)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -22116,10 +21979,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.9.2':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse5@6.0.3': {}
@@ -22338,7 +22197,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.0.3(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitejs/plugin-react@5.0.3(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -22346,7 +22205,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.35
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22389,14 +22248,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-
-  '@vitest/mocker@3.2.4(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -22986,11 +22837,6 @@ snapshots:
       astro: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
       rehype-expressive-code: 0.41.3
 
-  astro-expressive-code@0.41.3(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)):
-    dependencies:
-      astro: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
-      rehype-expressive-code: 0.41.3
-
   astro-og-canvas@0.7.0(astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)):
     dependencies:
       astro: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
@@ -23100,109 +22946,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1):
-    dependencies:
-      '@astrojs/compiler': 2.13.0
-      '@astrojs/internal-helpers': 0.7.2
-      '@astrojs/markdown-remark': 6.3.6
-      '@astrojs/telemetry': 3.3.0
-      '@capsizecss/unpack': 2.4.0
-      '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
-      acorn: 8.15.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      boxen: 8.0.1
-      ci-info: 4.3.1
-      clsx: 2.1.1
-      common-ancestor-path: 1.0.1
-      cookie: 1.0.2
-      cssesc: 3.0.0
-      debug: 4.4.3(supports-color@8.1.1)
-      deterministic-object-hash: 2.0.2
-      devalue: 5.5.0
-      diff: 5.2.0
-      dlv: 1.1.3
-      dset: 3.1.4
-      es-module-lexer: 1.7.0
-      esbuild: 0.25.12
-      estree-walker: 3.0.3
-      flattie: 1.1.1
-      fontace: 0.3.1
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.2.0
-      import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      mrmime: 2.0.1
-      neotraverse: 0.6.18
-      p-limit: 6.2.0
-      p-queue: 8.1.1
-      package-manager-detector: 1.5.0
-      picomatch: 4.0.3
-      prompts: 2.4.2
-      rehype: 13.0.2
-      semver: 7.7.3
-      shiki: 3.15.0
-      smol-toml: 1.5.2
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.2)
-      ultrahtml: 1.6.0
-      unifont: 0.5.2
-      unist-util-visit: 5.0.0
-      unstorage: 1.17.3(@netlify/blobs@10.4.1)
-      vfile: 6.0.3
-      vite: 6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
-      xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.2.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.0(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.2)(zod@3.25.76)
-    optionalDependencies:
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - db0
-      - encoding
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - lightningcss
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - yaml
-
-  astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1):
+  astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.2
@@ -23258,8 +23002,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.17.3(@netlify/blobs@10.4.1)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      vite: 6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -31474,41 +31218,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-plugin-solid@2.11.10(solid-js@1.9.9)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.10(@babel/core@7.28.5)(solid-js@1.9.9)
-      merge-anything: 5.1.7
-      solid-js: 1.9.9
-      solid-refresh: 0.6.3(solid-js@1.9.9)
-      vite: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-      vitefu: 1.1.1(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   vite-plugin-solid@2.11.10(solid-js@1.9.9)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@babel/core': 7.28.5
@@ -31561,57 +31270,6 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.9.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.20.6
-      yaml: 2.8.1
-
-  vite@7.1.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.20.6
-      yaml: 2.8.1
-
-  vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.9.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.20.6
-      yaml: 2.8.1
-
   vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
@@ -31629,35 +31287,9 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.9.2
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.1
-      tsx: 4.20.6
-      yaml: 2.8.1
-
   vitefu@1.1.1(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     optionalDependencies:
       vite: 6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-
-  vitefu@1.1.1(vite@6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 6.4.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-
-  vitefu@1.1.1(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
-    optionalDependencies:
-      vite: 7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-    optional: true
 
   vitefu@1.1.1(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     optionalDependencies:
@@ -31691,50 +31323,6 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.1
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
-      jsdom: 26.1.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.9.2)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
-      expect-type: 1.2.2
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 24.9.2
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:
@@ -31852,10 +31440,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-livestore@0.2.3(typescript@5.9.3)(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
+  vue-livestore@0.2.3(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       '@livestore/adapter-web': link:packages/@livestore/adapter-web
-      '@livestore/devtools-vite': 0.4.0-dev.18(vite@7.1.7(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@livestore/devtools-vite': 0.4.0-dev.18(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
       '@livestore/livestore': link:packages/@livestore/livestore
       '@livestore/peer-deps': link:packages/@livestore/peer-deps
       '@livestore/sync-cf': link:packages/@livestore/sync-cf

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1521,7 +1521,7 @@ importers:
         specifier: ^1.56.0
         version: 1.56.1
       '@tanstack/react-router':
-        specifier: ^1.132.47
+        specifier: 1.132.47
         version: 1.132.47(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/router-devtools':
         specifier: ^1.133.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,12 +12,12 @@ catalog:
   # Type packages
   "@types/react": 19.1.13
   "@types/react-dom": 19.1.9
-  "@types/node": 24.9.2
+  "@types/node": 24.10.1
   "@types/chrome": 0.1.4
 
   # Build tools
   typescript: 5.9.2
-  vite: 7.1.7
+  vite: 7.2.4
   vitest: 3.2.4
   "@vitest/ui": 3.2.4
   "@vitejs/plugin-react": 5.0.3


### PR DESCRIPTION
## Problem

Documentation code examples were embedded as inline code blocks in markdown files, making them difficult to maintain and unable to catch type errors or keep examples up-to-date with API changes.

## Solution

Extracted inline TypeScript code blocks from documentation into separate type-checked snippet files using the Twoslash and Expressive Code system. This allows all documentation examples to be:

- Automatically type-checked via TypeScript compiler
- Syntax-highlighted via Expressive Code
- Easily maintained as standalone files
- Converted from markdown to mdx where necessary to support JSX imports

Migrated 14 snippet files across patterns, reference documentation, and framework integrations. Updated documentation files to use snippet component imports instead of inline code blocks.

## Validation

- All snippets build successfully with `mono docs snippets build`
- Full documentation build passes with `mono docs build`
- All internal links are valid
- Linting passes with no new warnings or errors