### PR TITLE
refactor(react): rename gcTime to unusedCacheTime in multi-store API

### DIFF
--- a/docs/src/content/_assets/code/data-modeling/todo-workspaces/multi-store/user.store.ts
+++ b/docs/src/content/_assets/code/data-modeling/todo-workspaces/multi-store/user.store.ts
@@ -17,5 +17,5 @@ export const userStoreOptions = (username: string) =>
     storeId: `user-${username}`,
     schema,
     adapter,
-    gcTime: Number.POSITIVE_INFINITY, // Keep user store in memory indefinitely
+    unusedCacheTime: Number.POSITIVE_INFINITY, // Keep user store in memory indefinitely
   })

--- a/docs/src/content/_assets/code/data-modeling/todo-workspaces/multi-store/workspace.store.ts
+++ b/docs/src/content/_assets/code/data-modeling/todo-workspaces/multi-store/workspace.store.ts
@@ -17,5 +17,5 @@ export const workspaceStoreOptions = (workspaceId: string) =>
     storeId: `workspace-${workspaceId}`,
     schema,
     adapter,
-    gcTime: 60_000, // Keep in memory for 60 seconds after last use
+    unusedCacheTime: 60_000, // Keep in memory for 60 seconds after last use
   })

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/multi-store/App.tsx
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/multi-store/App.tsx
@@ -3,16 +3,7 @@ import { type ReactNode, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 
 export function App({ children }: { children: ReactNode }) {
-  const [storeRegistry] = useState(
-    () =>
-      new StoreRegistry({
-        defaultOptions: {
-          // These options apply to all stores unless overridden
-          batchUpdates,
-          // gcTime: 60_000, // Optional: default garbage collection time
-        },
-      }),
-  )
+  const [storeRegistry] = useState(() => new StoreRegistry({ defaultOptions: { batchUpdates } }))
 
   return <StoreRegistryProvider storeRegistry={storeRegistry}>{children}</StoreRegistryProvider>
 }

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/multi-store/store.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/multi-store/store.ts
@@ -9,6 +9,4 @@ export const issueStoreOptions = (issueId: string) =>
     storeId: `issue-${issueId}`,
     schema,
     adapter: makeInMemoryAdapter(),
-    // Optional: Configure garbage collection time
-    gcTime: 30_000, // 30 seconds
   })

--- a/docs/src/content/docs/reference/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/reference/framework-integrations/react-integration.mdx
@@ -97,7 +97,7 @@ The multi-store API introduces four main primitives:
 - **useStore()** - Suspense-enabled hook for accessing individual store instances
 - **storeOptions()** - Type-safe way to define reusable store configurations
 
-Stores are cached by their `storeId` and automatically disposed after being inactive for a configurable duration.
+Stores are cached by their `storeId` and automatically disposed after being unused for a configurable duration (`unusedCacheTime`)
 
 ### Setting Up
 
@@ -151,7 +151,7 @@ Options:
 - `storeId` - Unique identifier for this store instance (required)
 - `schema` - The LiveStore schema (required)
 - `adapter` - The platform adapter (required)
-- `gcTime` - Time in milliseconds to keep inactive stores in memory (default: 60_000 in browser, infinity in non-browser)
+- `unusedCacheTime` - Time in milliseconds to keep unused stores in memory (default: 60_000 in browser, infinity in non-browser)
 - `boot` - Function called when the store is first loaded
 - `batchUpdates` - Function for batching React updates
 - And other `CreateStoreOptions`

--- a/examples/web-email-client/src/stores/mailbox/index.ts
+++ b/examples/web-email-client/src/stores/mailbox/index.ts
@@ -29,7 +29,7 @@ export const mailboxStoreOptions = storeOptions({
   storeId: mailboxStoreId,
   schema,
   adapter,
-  gcTime: Number.POSITIVE_INFINITY, // Disable garbage collection
+  unusedCacheTime: Number.POSITIVE_INFINITY, // Disable automatic disposal
 })
 
 export const useMailboxStore = () => useStore(mailboxStoreOptions)

--- a/examples/web-multi-store/src/components/WorkspaceView.tsx
+++ b/examples/web-multi-store/src/components/WorkspaceView.tsx
@@ -33,7 +33,7 @@ export function WorkspaceView() {
   const preloadIssue = (issueId: string) =>
     storeRegistry.preload({
       ...issueStoreOptions(issueId),
-      gcTime: 10_000,
+      unusedCacheTime: 10_000,
     })
 
   return (

--- a/examples/web-multi-store/src/stores/issue/index.ts
+++ b/examples/web-multi-store/src/stores/issue/index.ts
@@ -24,7 +24,7 @@ export const issueStoreOptions = (issueId: string) =>
     storeId: `issue-${issueId}`,
     schema,
     adapter,
-    gcTime: 20_000,
+    unusedCacheTime: 20_000,
     boot: (store) => {
       // In a real-world app, you would handle seeding in the server by subscribing to the workspaceEvents.issueCreated event
       if (store.query(issueTables.issue.count()) === 0) {

--- a/examples/web-multi-store/src/stores/workspace/index.ts
+++ b/examples/web-multi-store/src/stores/workspace/index.ts
@@ -14,7 +14,7 @@ export const workspaceStoreOptions = storeOptions({
   storeId: 'workspace-root',
   schema,
   adapter,
-  gcTime: Number.POSITIVE_INFINITY, // Disable garbage collection
+  unusedCacheTime: Number.POSITIVE_INFINITY, // Disable disposal
   boot: (store) => {
     if (store.query(workspaceTables.workspaces.count()) === 0) {
       store.commit(workspaceEvents.workspaceCreated({ id: 'root', name: 'My Workspace', createdAt: new Date() }))

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.test.ts
@@ -2,7 +2,7 @@ import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { StoreInternalsSymbol } from '@livestore/livestore'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { schema } from '../../__tests__/fixture.tsx'
-import { DEFAULT_GC_TIME, StoreRegistry } from './StoreRegistry.ts'
+import { DEFAULT_UNUSED_CACHE_TIME, StoreRegistry } from './StoreRegistry.ts'
 import { storeOptions } from './storeOptions.ts'
 import type { CachedStoreOptions } from './types.ts'
 
@@ -74,21 +74,21 @@ describe('StoreRegistry', () => {
     expect(() => registry.getOrLoad(badOptions)).toThrow()
   })
 
-  it('disposes store after gc timeout expires', async () => {
+  it('disposes store after unusedCacheTime expires', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 25
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 25
+    const options = testStoreOptions({ unusedCacheTime })
 
     const store = await registry.getOrLoad(options)
 
     // Store should be cached
     expect(registry.getOrLoad(options)).toBe(store)
 
-    // Advance time to trigger GC
-    await vi.advanceTimersByTimeAsync(gcTime)
+    // Advance time to trigger disposal
+    await vi.advanceTimersByTimeAsync(unusedCacheTime)
 
-    // After GC, store should be disposed
+    // After disposal, store should be removed
     // The store is removed from cache, so next getOrLoad creates a new one
     const nextStore = await registry.getOrLoad(options)
 
@@ -96,25 +96,25 @@ describe('StoreRegistry', () => {
     expect(nextStore).not.toBe(store)
     expect(nextStore[StoreInternalsSymbol].clientSession.debugInstanceId).toBeDefined()
 
-    // Clean up the second store (first one was cleaned up by GC)
+    // Clean up the second store (first one was disposed)
     await nextStore.shutdownPromise()
   })
 
-  it('keeps the longest gcTime seen for a store when options vary across calls', async () => {
+  it('keeps the longest unusedCacheTime seen for a store when options vary across calls', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
 
-    const options = testStoreOptions({ gcTime: 10 })
+    const options = testStoreOptions({ unusedCacheTime: 10 })
     const unsubscribe = registry.subscribe(options.storeId, () => {})
 
     const store = await registry.getOrLoad(options)
 
-    // Call with longer gcTime
-    await registry.getOrLoad(testStoreOptions({ gcTime: 100 }))
+    // Call with longer unusedCacheTime
+    await registry.getOrLoad(testStoreOptions({ unusedCacheTime: 100 }))
 
     unsubscribe()
 
-    // After 99ms, store should still be alive (100ms gcTime used)
+    // After 99ms, store should still be alive (100ms unusedCacheTime used)
     await vi.advanceTimersByTimeAsync(99)
 
     // Store should still be cached
@@ -127,7 +127,7 @@ describe('StoreRegistry', () => {
     const nextStore = await registry.getOrLoad(options)
     expect(nextStore).not.toBe(store)
 
-    // Clean up the second store (first one was cleaned up by GC)
+    // Clean up the second store (first one was disposed)
     await nextStore.shutdownPromise()
   })
 
@@ -147,10 +147,10 @@ describe('StoreRegistry', () => {
     expect(() => registry.getOrLoad(badOptions)).toThrow()
   })
 
-  it('does not garbage collect when gcTime is Infinity', async () => {
+  it('does not dispose when unusedCacheTime is Infinity', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const options = testStoreOptions({ gcTime: Number.POSITIVE_INFINITY })
+    const options = testStoreOptions({ unusedCacheTime: Number.POSITIVE_INFINITY })
 
     const store = await registry.getOrLoad(options)
 
@@ -160,7 +160,7 @@ describe('StoreRegistry', () => {
     // Advance time by a very long duration
     await vi.advanceTimersByTimeAsync(1000000)
 
-    // Store should still be cached (not garbage collected)
+    // Store should still be cached (not disposed)
     expect(registry.getOrLoad(options)).toBe(store)
 
     // Clean up manually
@@ -230,8 +230,8 @@ describe('StoreRegistry', () => {
   it('handles rapid subscribe/unsubscribe cycles without errors', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 50
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 50
+    const options = testStoreOptions({ unusedCacheTime })
 
     const store = await registry.getOrLoad(options)
 
@@ -241,8 +241,8 @@ describe('StoreRegistry', () => {
       unsubscribe()
     }
 
-    // Advance time to check if GC is scheduled correctly
-    await vi.advanceTimersByTimeAsync(gcTime)
+    // Advance time to check if disposal is scheduled correctly
+    await vi.advanceTimersByTimeAsync(unusedCacheTime)
 
     // Store should be disposed after the last unsubscribe
     const nextStore = await registry.getOrLoad(options)
@@ -309,21 +309,21 @@ describe('StoreRegistry', () => {
     await store.shutdownPromise()
   })
 
-  it('cancels GC when a new subscription is added', async () => {
+  it('cancels disposal when a new subscription is added', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 50
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 50
+    const options = testStoreOptions({ unusedCacheTime })
 
     const store = await registry.getOrLoad(options)
 
-    // Advance time almost to GC threshold
-    await vi.advanceTimersByTimeAsync(gcTime - 5)
+    // Advance time almost to disposal threshold
+    await vi.advanceTimersByTimeAsync(unusedCacheTime - 5)
 
-    // Add a new subscription before GC triggers
+    // Add a new subscription before disposal triggers
     const unsubscribe = registry.subscribe(options.storeId, () => {})
 
-    // Complete the original GC time
+    // Complete the original unusedCacheTime
     await vi.advanceTimersByTimeAsync(5)
 
     // Store should not have been disposed because we added a subscription
@@ -331,7 +331,7 @@ describe('StoreRegistry', () => {
 
     // Clean up
     unsubscribe()
-    await vi.advanceTimersByTimeAsync(gcTime)
+    await vi.advanceTimersByTimeAsync(unusedCacheTime)
 
     // Now it should be disposed
     const nextStore = await registry.getOrLoad(options)
@@ -340,11 +340,11 @@ describe('StoreRegistry', () => {
     await nextStore.shutdownPromise()
   })
 
-  it('schedules GC if store becomes inactive during loading', async () => {
+  it('schedules disposal if store becomes unused during loading', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 50
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 50
+    const options = testStoreOptions({ unusedCacheTime })
 
     // Start loading without any subscription
     const storePromise = registry.getOrLoad(options)
@@ -352,8 +352,8 @@ describe('StoreRegistry', () => {
     // Wait for store to load (no subscribers registered)
     const store = await storePromise
 
-    // Since there were no subscribers when loading completed, GC should be scheduled
-    await vi.advanceTimersByTimeAsync(gcTime)
+    // Since there were no subscribers when loading completed, disposal should be scheduled
+    await vi.advanceTimersByTimeAsync(unusedCacheTime)
 
     // Store should be disposed
     const nextStore = await registry.getOrLoad(options)
@@ -362,11 +362,11 @@ describe('StoreRegistry', () => {
     await nextStore.shutdownPromise()
   })
 
-  it('aborts loading when GC fires while store is still loading', async () => {
+  it('aborts loading when disposal fires while store is still loading', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 10
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 10
+    const options = testStoreOptions({ unusedCacheTime })
 
     // Subscribe briefly to trigger getOrLoad and then unsubscribe
     const unsubscribe = registry.subscribe(options.storeId, () => {})
@@ -376,14 +376,14 @@ describe('StoreRegistry', () => {
 
     // Attach a catch handler to prevent unhandled rejection when the load is aborted
     const abortedPromise = (loadPromise as Promise<unknown>).catch(() => {
-      // Expected: load was aborted by GC
+      // Expected: load was aborted by disposal
     })
 
-    // Unsubscribe immediately, which schedules GC
+    // Unsubscribe immediately, which schedules disposal
     unsubscribe()
 
-    // Advance time to trigger GC while still loading
-    await vi.advanceTimersByTimeAsync(gcTime)
+    // Advance time to trigger disposal while still loading
+    await vi.advanceTimersByTimeAsync(unusedCacheTime)
 
     // Wait for the abort to complete
     await abortedPromise
@@ -402,24 +402,24 @@ describe('StoreRegistry', () => {
     await store.shutdownPromise()
   })
 
-  it('does not abort loading when new subscription arrives before GC fires', async () => {
+  it('does not abort loading when new subscription arrives before disposal fires', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 50
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 50
+    const options = testStoreOptions({ unusedCacheTime })
 
-    // Start loading and immediately unsubscribe to schedule GC
+    // Start loading and immediately unsubscribe to schedule disposal
     const unsub1 = registry.subscribe(options.storeId, () => {})
     const loadPromise = registry.getOrLoad(options)
     unsub1()
 
-    // Advance time partially (before GC fires)
-    await vi.advanceTimersByTimeAsync(gcTime - 10)
+    // Advance time partially (before disposal fires)
+    await vi.advanceTimersByTimeAsync(unusedCacheTime - 10)
 
-    // Add a new subscription - this should cancel the pending GC
+    // Add a new subscription - this should cancel the pending disposal
     const unsub2 = registry.subscribe(options.storeId, () => {})
 
-    // Advance past the original GC time
+    // Advance past the original unusedCacheTime
     await vi.advanceTimersByTimeAsync(20)
 
     // The load should complete normally (not be aborted)
@@ -437,8 +437,8 @@ describe('StoreRegistry', () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
 
-    const options1 = testStoreOptions({ storeId: 'store-1', gcTime: 50 })
-    const options2 = testStoreOptions({ storeId: 'store-2', gcTime: 100 })
+    const options1 = testStoreOptions({ storeId: 'store-1', unusedCacheTime: 50 })
+    const options2 = testStoreOptions({ storeId: 'store-2', unusedCacheTime: 100 })
 
     const store1 = await registry.getOrLoad(options1)
     const store2 = await registry.getOrLoad(options2)
@@ -458,7 +458,7 @@ describe('StoreRegistry', () => {
     expect(newStore1).not.toBe(store1)
     expect(registry.getOrLoad(options2)).toBe(store2)
 
-    // Subscribe to prevent GC of newStore1
+    // Subscribe to prevent disposal of newStore1
     const unsub1 = registry.subscribe(options1.storeId, () => {})
 
     // Advance remaining time to dispose store2
@@ -468,7 +468,7 @@ describe('StoreRegistry', () => {
     const newStore2 = await registry.getOrLoad(options2)
     expect(newStore2).not.toBe(store2)
 
-    // Subscribe to prevent GC of newStore2
+    // Subscribe to prevent disposal of newStore2
     const unsub2 = registry.subscribe(options2.storeId, () => {})
 
     // Clean up
@@ -483,7 +483,7 @@ describe('StoreRegistry', () => {
 
     const registry = new StoreRegistry({
       defaultOptions: {
-        gcTime: DEFAULT_GC_TIME * 2,
+        unusedCacheTime: DEFAULT_UNUSED_CACHE_TIME * 2,
       },
     })
 
@@ -495,10 +495,10 @@ describe('StoreRegistry', () => {
     expect(store).toBeDefined()
     expect(store[StoreInternalsSymbol].clientSession.debugInstanceId).toBeDefined()
 
-    // Verify configured default gcTime is applied by checking GC doesn't happen at library's default gc time
-    await vi.advanceTimersByTimeAsync(DEFAULT_GC_TIME)
+    // Verify configured default unusedCacheTime is applied by checking disposal doesn't happen at library's default time
+    await vi.advanceTimersByTimeAsync(DEFAULT_UNUSED_CACHE_TIME)
 
-    // Store should still be cached after default gc time
+    // Store should still be cached after default unusedCacheTime
     expect(registry.getOrLoad(options)).toBe(store)
 
     await store.shutdownPromise()
@@ -509,12 +509,12 @@ describe('StoreRegistry', () => {
 
     const registry = new StoreRegistry({
       defaultOptions: {
-        gcTime: 1000, // Default is long
+        unusedCacheTime: 1000, // Default is long
       },
     })
 
     const options = testStoreOptions({
-      gcTime: 10, // Override with shorter time
+      unusedCacheTime: 10, // Override with shorter time
     })
 
     const store = await registry.getOrLoad(options)
@@ -532,8 +532,8 @@ describe('StoreRegistry', () => {
   it('prevents subscriptions to stores that are shutting down', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 10
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 10
+    const options = testStoreOptions({ unusedCacheTime })
 
     // Load the store and wait for it to be ready
     const originalStore = await registry.getOrLoad(options)
@@ -552,11 +552,11 @@ describe('StoreRegistry', () => {
       })
     }
 
-    // Use vi.advanceTimersToNextTimer to advance ONLY to the GC timer firing,
+    // Use vi.advanceTimersToNextTimer to advance ONLY to the disposal timer firing,
     // then immediately (before microtasks resolve) try to get the store
     vi.advanceTimersToNextTimer()
 
-    // The GC callback has now executed synchronously, which means:
+    // The disposal callback has now executed synchronously, which means:
     // 1. Subscriber check passed (no subscribers)
     // 2. shutdown() was called (but it's async, hasn't resolved yet)
     // 3. Cache entry SHOULD have been removed
@@ -598,11 +598,11 @@ describe('StoreRegistry', () => {
     await store.shutdownPromise()
   })
 
-  it('schedules GC after preload if no subscribers are added', async () => {
+  it('schedules disposal after preload if no subscribers are added', async () => {
     vi.useFakeTimers()
     const registry = new StoreRegistry()
-    const gcTime = 50
-    const options = testStoreOptions({ gcTime })
+    const unusedCacheTime = 50
+    const options = testStoreOptions({ unusedCacheTime })
 
     // Preload without subscribing
     await registry.preload(options)
@@ -611,8 +611,8 @@ describe('StoreRegistry', () => {
     const store = registry.getOrLoad(options)
     expect(store).not.toBeInstanceOf(Promise)
 
-    // Advance time to trigger GC
-    await vi.advanceTimersByTimeAsync(gcTime)
+    // Advance time to trigger disposal
+    await vi.advanceTimersByTimeAsync(unusedCacheTime)
 
     // Store should be disposed since no subscribers were added
     const nextStore = await registry.getOrLoad(options)

--- a/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/StoreRegistry.ts
@@ -10,14 +10,14 @@ type StoreEntryState<TSchema extends LiveStoreSchema> =
   | { status: 'shutting_down'; shutdownPromise: Promise<void> }
 
 /**
- * Default garbage collection time for inactive stores.
+ * Default time to keep unused stores in cache.
  *
  * - Browser: 60 seconds (60,000ms)
- * - SSR: Infinity (disables GC to avoid disposing stores before server render completes)
+ * - SSR: Infinity (disables disposal to avoid disposing stores before server render completes)
  *
  * @internal Exported primarily for testing purposes.
  */
-export const DEFAULT_GC_TIME = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : 60_000
+export const DEFAULT_UNUSED_CACHE_TIME = typeof window === 'undefined' ? Number.POSITIVE_INFINITY : 60_000
 
 /**
  * @typeParam TSchema - The schema for this entry's store.
@@ -29,8 +29,8 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
 
   #state: StoreEntryState<TSchema> = { status: 'idle' }
 
-  #gcTime?: number
-  #gcTimeout?: ReturnType<typeof setTimeout> | null
+  #unusedCacheTime?: number
+  #disposalTimeout?: ReturnType<typeof setTimeout> | null
 
   /**
    * Set of subscriber callbacks to notify on state changes.
@@ -42,15 +42,15 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
     this.#cache = cache
   }
 
-  #scheduleGC = (): void => {
-    this.#cancelGC()
+  #scheduleDisposal = (): void => {
+    this.#cancelDisposal()
 
-    const effectiveGcTime = this.#gcTime === undefined ? DEFAULT_GC_TIME : this.#gcTime
+    const effectiveTime = this.#unusedCacheTime === undefined ? DEFAULT_UNUSED_CACHE_TIME : this.#unusedCacheTime
 
-    if (effectiveGcTime === Number.POSITIVE_INFINITY) return // Infinity disables GC
+    if (effectiveTime === Number.POSITIVE_INFINITY) return // Infinity disables disposal
 
-    this.#gcTimeout = setTimeout(() => {
-      this.#gcTimeout = null
+    this.#disposalTimeout = setTimeout(() => {
+      this.#disposalTimeout = null
 
       // Re-check to avoid racing with a new subscription
       if (this.#subscribers.size > 0) return
@@ -67,13 +67,13 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
       })
 
       this.#setShuttingDown(shutdownPromise)
-    }, effectiveGcTime)
+    }, effectiveTime)
   }
 
-  #cancelGC = (): void => {
-    if (!this.#gcTimeout) return
-    clearTimeout(this.#gcTimeout)
-    this.#gcTimeout = null
+  #cancelDisposal = (): void => {
+    if (!this.#disposalTimeout) return
+    clearTimeout(this.#disposalTimeout)
+    this.#disposalTimeout = null
   }
 
   /**
@@ -140,12 +140,12 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
    * @returns Unsubscribe function
    */
   subscribe = (listener: () => void): Unsubscribe => {
-    this.#cancelGC()
+    this.#cancelDisposal()
     this.#subscribers.add(listener)
     return () => {
       this.#subscribers.delete(listener)
-      // If no more subscribers remain, schedule GC
-      if (this.#subscribers.size === 0) this.#scheduleGC()
+      // If no more subscribers remain, schedule disposal
+      if (this.#subscribers.size === 0) this.#scheduleDisposal()
     }
   }
 
@@ -160,10 +160,11 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
    * - Returns the store directly if already loaded (synchronous)
    * - Returns a Promise if loading is in progress or needs to be initiated
    * - Transitions through loading → success/error states
-   * - Schedules GC when loading completes without active subscribers
+   * - Schedules disposal when loading completes without active subscribers
    */
   getOrLoad = (options: CachedStoreOptions<TSchema>): Store<TSchema> | Promise<Store<TSchema>> => {
-    if (options.gcTime !== undefined) this.#gcTime = Math.max(this.#gcTime ?? 0, options.gcTime)
+    if (options.unusedCacheTime !== undefined)
+      this.#unusedCacheTime = Math.max(this.#unusedCacheTime ?? 0, options.unusedCacheTime)
 
     if (this.#state.status === 'success') return this.#state.store
     if (this.#state.status === 'loading') return this.#state.promise
@@ -186,8 +187,8 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
         throw error
       })
       .finally(() => {
-        // The store entry may have become inactive (no subscribers) while loading the store
-        if (this.#subscribers.size === 0) this.#scheduleGC()
+        // The store entry may have become unused (no subscribers) while loading the store
+        if (this.#subscribers.size === 0) this.#scheduleDisposal()
       })
 
     this.#setLoading(promise, abortController)
@@ -209,7 +210,7 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
   #shutdown = async (): Promise<void> => {
     if (this.#state.status !== 'success') return
     await this.#state.store.shutdownPromise().catch((reason) => {
-      console.warn(`Store ${this.#storeId} failed to shutdown cleanly during GC:`, reason)
+      console.warn(`Store ${this.#storeId} failed to shutdown cleanly during disposal:`, reason)
     })
   }
 }
@@ -218,7 +219,7 @@ class StoreEntry<TSchema extends LiveStoreSchema = LiveStoreSchema> {
  * In-memory map of {@link StoreEntry} instances keyed by {@link StoreId}.
  *
  * @privateRemarks
- * The cache is intentionally small; eviction and GC timers are coordinated by the client.
+ * The cache is intentionally small; eviction and disposal timers are coordinated by the client.
  *
  * @internal
  */
@@ -257,22 +258,22 @@ type DefaultStoreOptions = Partial<
   >
 > & {
   /**
-   * The time in milliseconds that inactive stores remain in memory.
-   * When a store becomes inactive, it will be garbage collected
+   * The time in milliseconds that unused stores remain in memory.
+   * When a store becomes unused (no subscribers), it will be disposed
    * after this duration.
    *
-   * Stores transition to the inactive state as soon as they have no
+   * Stores transition to the unused state as soon as they have no
    * subscriptions registered, so when all components which use that
    * store have unmounted.
    *
    * @remarks
-   * - If set to `Infinity`, will disable garbage collection
+   * - If set to `Infinity`, will disable disposal
    * - The maximum allowed time is about {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value | 24 days}
    *
    * @defaultValue `60_000` (60 seconds) or `Infinity` during SSR to avoid
    * disposing stores before server render completes.
    */
-  gcTime?: number
+  unusedCacheTime?: number
 }
 
 type StoreRegistryConfig = {
@@ -280,7 +281,7 @@ type StoreRegistryConfig = {
 }
 
 /**
- * Store Registry coordinating cache, GC, and Suspense reads.
+ * Store Registry coordinating store loading, caching, and subscription
  *
  * @public
  */
@@ -328,7 +329,7 @@ export class StoreRegistry {
    *
    * @remarks
    * - We don't return the store or throw as this is a fire-and-forget operation.
-   * - If the entry remains unused after preload resolves/rejects, it is scheduled for GC.
+   * - If the entry remains unused after preload resolves/rejects, it is scheduled for disposal.
    */
   preload = async <TSchema extends LiveStoreSchema>(options: CachedStoreOptions<TSchema>): Promise<void> => {
     try {

--- a/packages/@livestore/react/src/experimental/multi-store/types.ts
+++ b/packages/@livestore/react/src/experimental/multi-store/types.ts
@@ -36,20 +36,20 @@ export type CachedStoreOptions<
     otelOptions?: Partial<OtelOptions>
     /**
      * The time in milliseconds that this store should remain
-     * in memory after becoming inactive. When this store becomes
-     * inactive, it will be garbage collected after this duration.
+     * in memory after becoming unused. When this store becomes
+     * unused (no subscribers), it will be disposed after this duration.
      *
-     * Stores transition to the inactive state as soon as they have no
+     * Stores transition to the unused state as soon as they have no
      * subscriptions registered, so when all components which use that
      * store have unmounted.
      *
      * @remarks
-     * - When different `gcTime` config are used for the same store, the longest one will be used.
-     * - If set to `Infinity`, will disable garbage collection
+     * - When different `unusedCacheTime` values are used for the same store, the longest one will be used.
+     * - If set to `Infinity`, will disable automatic disposal
      * - The maximum allowed time is about {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value | 24 days}
      *
      * @defaultValue `60_000` (60 seconds) or `Infinity` during SSR to avoid
      * disposing stores before server render completes.
      */
-    gcTime?: number
+    unusedCacheTime?: number
   }


### PR DESCRIPTION
## Summary

- Rename `gcTime` configuration option to `unusedCacheTime` for better clarity
- Update internal implementation (`DEFAULT_GC_TIME` → `DEFAULT_UNUSED_CACHE_TIME`, `#gcTime` → `#unusedCacheTime`)
- Update all documentation, examples, and tests

## Motivation

The name "gcTime" was confusing because:
- "gc" is a technical abbreviation that requires documentation lookup
- Users could confuse it with JavaScript's garbage collection
- The relationship to "unused/inactive stores" wasn't immediately clear

The new name "unusedCacheTime" communicates:
- **"unused"** - clearly describes the trigger condition (no active subscribers)
- **"cache"** - clarifies what's being timed (the cached store instance)
- **"Time"** - signals this is a duration/timing configuration

This follows similar discussions in [TanStack Query](https://github.com/TanStack/query/discussions/4252) where they also renamed `cacheTime` to `gcTime` to reduce confusion.

## Alternatives considered

| Name | Why not |
|------|---------|
| `ttl` / `unusedTtl` | TTL typically means absolute time-to-live from creation. Our behavior is idle-based (resets when subscribers attach), so TTL is semantically misleading. |
| `inactiveCacheTime` | "Inactive" is slightly more ambiguous — could mean the store itself is inactive vs. not being used by components. "Unused" more clearly describes the subscriber relationship. |
| `unusedTimeout` | Missing "cache" — unclear what's timing out. Could be confused with network timeouts. |

## Test plan

- [x] All existing StoreRegistry tests pass with updated naming
- [x] Lint passes