### PR TITLE
docs(react): add minimal Multi-Store API example

### DIFF
--- a/docs/src/content/_assets/code/reference/framework-integrations/react/multi-store/minimal.tsx
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/multi-store/minimal.tsx
@@ -1,0 +1,28 @@
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { queryDb } from '@livestore/livestore'
+import { StoreRegistry, StoreRegistryProvider, storeOptions, useStore } from '@livestore/react/experimental'
+import { useState } from 'react'
+import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
+import { schema, tables } from './schema.ts'
+
+const issueStoreOptions = (issueId: string) =>
+  storeOptions({
+    storeId: `issue-${issueId}`,
+    schema,
+    adapter: makeInMemoryAdapter(),
+  })
+
+export function App() {
+  const [registry] = useState(() => new StoreRegistry({ defaultOptions: { batchUpdates } }))
+  return (
+    <StoreRegistryProvider storeRegistry={registry}>
+      <IssueView />
+    </StoreRegistryProvider>
+  )
+}
+
+function IssueView() {
+  const store = useStore(issueStoreOptions('abc123'))
+  const [issue] = store.useQuery(queryDb(tables.issue.select()))
+  return <div>{issue?.title}</div>
+}

--- a/docs/src/content/docs/reference/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/reference/framework-integrations/react-integration.mdx
@@ -16,6 +16,7 @@ import MultiStoreRegistrySnippet from '../../../_assets/code/reference/framework
 import MultiStoreUseStoreSnippet from '../../../_assets/code/reference/framework-integrations/react/multi-store/IssueView.tsx?snippet'
 import MultiStorePreloadSnippet from '../../../_assets/code/reference/framework-integrations/react/multi-store/PreloadedIssue.tsx?snippet'
 import MultiStoreInstanceSnippet from '../../../_assets/code/reference/framework-integrations/react/multi-store/IssueList.tsx?snippet'
+import MultiStoreMinimalSnippet from '../../../_assets/code/reference/framework-integrations/react/multi-store/minimal.tsx?snippet'
 import { getBranchName } from "../../../../data/data.ts";
 
 While LiveStore is framework agnostic, the `@livestore/react` package provides a first-class integration with React.
@@ -82,6 +83,8 @@ The multi-store API enables managing multiple stores within a single React appli
 
 - **Partial data synchronization** - Load only the data you need, when you need it
 - **Multi-tenant applications** - Separate stores for each workspace, organization, or project (like Slack workspaces, Notion pages, or Linear teams)
+
+<MultiStoreMinimalSnippet />
 
 :::caution[Experimental API]
 The Multi-Store API is still early in its development.


### PR DESCRIPTION
## Summary
- Add a minimal Multi-Store API example snippet above the "Core Concepts" section in the React integration docs
- Gives readers an at-a-glance view of the complete flow before diving into detailed explanations

## Test plan
- [x] Snippet compiles successfully (`mono docs snippets build`)
- [x] Linting passes (`mono lint`)