### PR TITLE
Fix devtools-expo metro-config require path

### DIFF
--- a/packages/@livestore/devtools-expo/src/index.cts
+++ b/packages/@livestore/devtools-expo/src/index.cts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line unicorn/prefer-module, @typescript-eslint/no-require-imports
-module.exports = require('./metro-config.cts')
+// biome-ignore lint/correctness/useImportExtensions: TypeScript's rewriteRelativeImportExtensions doesn't rewrite require() calls, so we need to use the output extension directly
+module.exports = require('./metro-config.cjs')
 
 export type * from './metro-config.cts'


### PR DESCRIPTION
## Problem

When running `expo start` with `@livestore/devtools-expo`, the error occurred: `Cannot find module './metro-config.cts'`. The compiled package tries to require a non-existent file because TypeScript's `rewriteRelativeImportExtensions` only rewrites `import` statements, not CommonJS `require()` calls.

## Solution

Changed the require path in `packages/@livestore/devtools-expo/src/index.cts` to reference the actual compiled output file (`metro-config.cjs` instead of `metro-config.cts`). Added a biome-ignore comment to clarify why the linter exception is needed.

## Validation

- TypeScript build passes (`mono ts`)
- Linting passes (`mono lint`)
- Compiled output correctly references `./metro-config.cjs`
- Tested locally: Expo example now successfully loads the devtools package

🤖 Generated with [Claude Code](https://claude.com/claude-code)