### PR TITLE
Add package manager detection to CLI create flow

### DIFF
--- a/packages/@livestore/cli/package.json
+++ b/packages/@livestore/cli/package.json
@@ -19,7 +19,7 @@
     "@livestore/utils": "workspace:*"
   },
   "devDependencies": {
-    "@effect/vitest": "^0.26.0",
+    "@livestore/utils-dev": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/@livestore/cli/package.json
+++ b/packages/@livestore/cli/package.json
@@ -19,6 +19,7 @@
     "@livestore/utils": "workspace:*"
   },
   "devDependencies": {
+    "@effect/vitest": "^0.26.0",
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -12,6 +12,8 @@ import {
 } from '@livestore/utils/effect'
 import { Cli } from '@livestore/utils/node'
 
+import { detectPackageManager, pmCommands } from '../package-manager.ts'
+
 // Schema for GitHub API response
 const GitHubContentSchema = Schema.Struct({
   name: Schema.String,
@@ -21,6 +23,14 @@ const GitHubContentSchema = Schema.Struct({
 })
 
 const GitHubContentsResponseSchema = Schema.Array(GitHubContentSchema)
+
+/** Schema for parsing package.json scripts (dev or start) */
+const PackageJsonScriptsSchema = Schema.Struct({
+  scripts: Schema.Union(
+    Schema.Struct({ dev: Schema.String }),
+    Schema.Struct({ start: Schema.String }),
+  ),
+})
 
 // Error types
 export class ExampleNotFoundError extends Schema.TaggedError<ExampleNotFoundError>()('ExampleNotFoundError', {
@@ -251,13 +261,43 @@ export const createCommand = Cli.Command.make(
     // Download and extract the example
     yield* downloadExample(selectedExample, branch, destinationPath)
 
-    // Success message
+    // Detect available run script (dev or start) from the created project's package.json.
+    // Some examples use "dev" (web projects), others use "start" (Expo projects),
+    // and some have no run script at all (e.g., node-effect-cli).
+    const fs = yield* FileSystem.FileSystem
+    const packageJsonPath = nodePath.join(destinationPath, 'package.json')
+    const packageJsonContent = yield* fs.readFileString(packageJsonPath)
+    const runScript = yield* Schema.decodeUnknown(Schema.parseJson(PackageJsonScriptsSchema))(packageJsonContent).pipe(
+      Effect.map((pkg) => ('dev' in pkg.scripts ? ('dev' as const) : ('start' as const))),
+      Effect.orElseSucceed(() => undefined),
+    )
+
+    // Detect which package manager was used to invoke the CLI (via npm_config_user_agent).
+    // This ensures the "next steps" instructions match how the user ran the create command.
+    const pmResult = detectPackageManager()
+
     yield* Console.log('\n🎉 Project created successfully!')
     yield* Console.log(`📁 Location: ${destinationPath}`)
     yield* Console.log('\n📋 Next steps:')
     yield* Console.log(`   cd ${nodePath.basename(destinationPath)}`)
-    yield* Console.log('   pnpm install    # Install dependencies')
-    yield* Console.log('   pnpm dev        # Start development server')
+
+    // Yarn is not recommended for LiveStore projects. When detected, show a warning
+    // and suggest using bun instead for the next steps.
+    if (pmResult._tag === 'unsupported') {
+      yield* Console.log('   bun install    # Install dependencies (yarn is not recommended)')
+      if (runScript !== undefined) {
+        yield* Console.log(`   bun ${runScript}        # Start development server`)
+      }
+      yield* Console.log('\n⚠️  Yarn is not recommended for LiveStore projects.')
+      yield* Console.log('   We recommend using bun, pnpm, or npm instead.')
+      yield* Console.log('   The commands above use bun by default.')
+    } else {
+      const pm = pmResult.pm
+      yield* Console.log(`   ${pmCommands.install[pm]}    # Install dependencies`)
+      if (runScript !== undefined) {
+        yield* Console.log(`   ${pmCommands.run[pm](runScript)}        # Start development server`)
+      }
+    }
     yield* Console.log('\n💡 Tip: Run `git init` if you want to initialize version control')
   }),
 )

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -26,10 +26,7 @@ const GitHubContentsResponseSchema = Schema.Array(GitHubContentSchema)
 
 /** Schema for parsing package.json scripts (dev or start) */
 const PackageJsonScriptsSchema = Schema.Struct({
-  scripts: Schema.Union(
-    Schema.Struct({ dev: Schema.String }),
-    Schema.Struct({ start: Schema.String }),
-  ),
+  scripts: Schema.Union(Schema.Struct({ dev: Schema.String }), Schema.Struct({ start: Schema.String })),
 })
 
 // Error types

--- a/packages/@livestore/cli/src/package-manager.test.ts
+++ b/packages/@livestore/cli/src/package-manager.test.ts
@@ -1,0 +1,66 @@
+import * as Vitest from '@effect/vitest'
+
+import { detectPackageManager, pmCommands } from './package-manager.ts'
+
+Vitest.describe('detectPackageManager', () => {
+  Vitest.it('detects npm from user agent', () => {
+    const result = detectPackageManager('npm/10.2.4 node/v20.11.0 darwin arm64 workspaces/false')
+    Vitest.expect(result).toEqual({ _tag: 'supported', pm: 'npm' })
+  })
+
+  Vitest.it('detects pnpm from user agent', () => {
+    const result = detectPackageManager('pnpm/9.0.6 npm/? node/v22.0.0 darwin arm64')
+    Vitest.expect(result).toEqual({ _tag: 'supported', pm: 'pnpm' })
+  })
+
+  Vitest.it('detects yarn as unsupported', () => {
+    const result = detectPackageManager('yarn/1.22.19 npm/? node/v20.11.0 darwin arm64')
+    Vitest.expect(result).toEqual({ _tag: 'unsupported', pm: 'yarn' })
+  })
+
+  Vitest.it('detects bun from user agent', () => {
+    const result = detectPackageManager('bun/1.1.7')
+    Vitest.expect(result).toEqual({ _tag: 'supported', pm: 'bun' })
+  })
+
+  Vitest.it('falls back to bun for empty user agent', () => {
+    const result = detectPackageManager('')
+    Vitest.expect(result).toEqual({ _tag: 'supported', pm: 'bun' })
+  })
+
+  Vitest.it('uses process.env.npm_config_user_agent when no argument provided', () => {
+    const originalEnv = process.env.npm_config_user_agent
+    try {
+      process.env.npm_config_user_agent = 'pnpm/9.0.6'
+      const result = detectPackageManager()
+      Vitest.expect(result).toEqual({ _tag: 'supported', pm: 'pnpm' })
+    } finally {
+      process.env.npm_config_user_agent = originalEnv
+    }
+  })
+
+  Vitest.it('falls back to bun for unknown user agent', () => {
+    const result = detectPackageManager('some-unknown-tool/1.0.0')
+    Vitest.expect(result).toEqual({ _tag: 'supported', pm: 'bun' })
+  })
+})
+
+Vitest.describe('pmCommands', () => {
+  Vitest.it('provides correct install commands for each package manager', () => {
+    Vitest.expect(pmCommands.install.npm).toBe('npm install')
+    Vitest.expect(pmCommands.install.pnpm).toBe('pnpm install')
+    Vitest.expect(pmCommands.install.bun).toBe('bun install')
+  })
+
+  Vitest.it('provides correct run commands for dev script', () => {
+    Vitest.expect(pmCommands.run.npm('dev')).toBe('npm run dev')
+    Vitest.expect(pmCommands.run.pnpm('dev')).toBe('pnpm dev')
+    Vitest.expect(pmCommands.run.bun('dev')).toBe('bun dev')
+  })
+
+  Vitest.it('provides correct run commands for start script', () => {
+    Vitest.expect(pmCommands.run.npm('start')).toBe('npm run start')
+    Vitest.expect(pmCommands.run.pnpm('start')).toBe('pnpm start')
+    Vitest.expect(pmCommands.run.bun('start')).toBe('bun start')
+  })
+})

--- a/packages/@livestore/cli/src/package-manager.test.ts
+++ b/packages/@livestore/cli/src/package-manager.test.ts
@@ -1,4 +1,4 @@
-import * as Vitest from '@effect/vitest'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
 
 import { detectPackageManager, pmCommands } from './package-manager.ts'
 

--- a/packages/@livestore/cli/src/package-manager.ts
+++ b/packages/@livestore/cli/src/package-manager.ts
@@ -1,0 +1,44 @@
+/**
+ * Supported package managers for LiveStore projects.
+ * Yarn is explicitly not supported due to compatibility issues.
+ */
+export type PackageManager = 'npm' | 'pnpm' | 'bun'
+
+/**
+ * Result of package manager detection.
+ * Returns 'unsupported' for yarn to allow the CLI to show a warning message.
+ */
+export type DetectPackageManagerResult =
+  | { _tag: 'supported'; pm: PackageManager }
+  | { _tag: 'unsupported'; pm: 'yarn' }
+
+/**
+ * Detects the package manager used to invoke the CLI based on the `npm_config_user_agent`
+ * environment variable. This env var is set by npm, pnpm, yarn, and bun when running scripts.
+ *
+ * - Returns 'unsupported' for yarn so the CLI can show a recommendation to use bun instead
+ * - Falls back to 'bun' when detection fails (e.g., when run directly without a package manager)
+ */
+export const detectPackageManager = (userAgent = process.env.npm_config_user_agent ?? ''): DetectPackageManagerResult => {
+  if (userAgent.startsWith('bun/')) return { _tag: 'supported', pm: 'bun' }
+  if (userAgent.startsWith('pnpm/')) return { _tag: 'supported', pm: 'pnpm' }
+  if (userAgent.startsWith('npm/')) return { _tag: 'supported', pm: 'npm' }
+  if (userAgent.startsWith('yarn/')) return { _tag: 'unsupported', pm: 'yarn' }
+
+  // Default to bun when the package manager can't be detected
+  return { _tag: 'supported', pm: 'bun' }
+}
+
+/** Package manager command templates */
+export const pmCommands = {
+  install: {
+    npm: 'npm install',
+    pnpm: 'pnpm install',
+    bun: 'bun install',
+  },
+  run: {
+    npm: (script: string) => `npm run ${script}`,
+    pnpm: (script: string) => `pnpm ${script}`,
+    bun: (script: string) => `bun ${script}`,
+  },
+} as const

--- a/packages/@livestore/cli/src/package-manager.ts
+++ b/packages/@livestore/cli/src/package-manager.ts
@@ -8,9 +8,7 @@ export type PackageManager = 'npm' | 'pnpm' | 'bun'
  * Result of package manager detection.
  * Returns 'unsupported' for yarn to allow the CLI to show a warning message.
  */
-export type DetectPackageManagerResult =
-  | { _tag: 'supported'; pm: PackageManager }
-  | { _tag: 'unsupported'; pm: 'yarn' }
+export type DetectPackageManagerResult = { _tag: 'supported'; pm: PackageManager } | { _tag: 'unsupported'; pm: 'yarn' }
 
 /**
  * Detects the package manager used to invoke the CLI based on the `npm_config_user_agent`
@@ -19,7 +17,9 @@ export type DetectPackageManagerResult =
  * - Returns 'unsupported' for yarn so the CLI can show a recommendation to use bun instead
  * - Falls back to 'bun' when detection fails (e.g., when run directly without a package manager)
  */
-export const detectPackageManager = (userAgent = process.env.npm_config_user_agent ?? ''): DetectPackageManagerResult => {
+export const detectPackageManager = (
+  userAgent = process.env.npm_config_user_agent ?? '',
+): DetectPackageManagerResult => {
   if (userAgent.startsWith('bun/')) return { _tag: 'supported', pm: 'bun' }
   if (userAgent.startsWith('pnpm/')) return { _tag: 'supported', pm: 'pnpm' }
   if (userAgent.startsWith('npm/')) return { _tag: 'supported', pm: 'npm' }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,9 +1842,9 @@ importers:
         specifier: workspace:*
         version: link:../utils
     devDependencies:
-      '@effect/vitest':
-        specifier: ^0.26.0
-        version: 0.26.0(effect@3.18.0)(vitest@3.2.4)
+      '@livestore/utils-dev':
+        specifier: workspace:*
+        version: link:../utils-dev
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1842,6 +1842,9 @@ importers:
         specifier: workspace:*
         version: link:../utils
     devDependencies:
+      '@effect/vitest':
+        specifier: ^0.26.0
+        version: 0.26.0(effect@3.18.0)(vitest@3.2.4)
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.1


### PR DESCRIPTION
## Problem

The LiveStore CLI's create project flow always suggested pnpm commands regardless of which package manager the user actually invoked. Additionally, it didn't detect whether the created project had a dev or start script, so it couldn't provide the correct next steps.

## Solution

Added package manager detection via the `npm_config_user_agent` environment variable, which is set by npm, pnpm, yarn, and bun when running scripts. The CLI now:

- Detects and suggests commands for npm, pnpm, and bun
- Treats yarn as unsupported with a recommendation to use bun instead
- Detects whether the created project has dev or start scripts
- Shows next steps that match the detected package manager and available scripts

## Validation

Added comprehensive tests for package manager detection covering npm, pnpm, bun, yarn, and fallback cases.