### PR TITLE
docs(sql): clarify upsert operations and onConflict API

### DIFF
--- a/docs/src/content/_assets/code/reference/state/sql-queries/query-builder.ts
+++ b/docs/src/content/_assets/code/reference/state/sql-queries/query-builder.ts
@@ -20,5 +20,6 @@ table.insert({ id: '123', name: 'Bob' })
 table.update({ name: 'Alice' }).where({ id: '123' })
 table.delete().where({ id: '123' })
 
+// Upserts (insert or update on conflict)
 table.insert({ id: '123', name: 'Charlie' }).onConflict('id', 'replace')
 table.insert({ id: '456', name: 'Diana' }).onConflict('id', 'update', { name: 'Diana Updated' })

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -347,22 +347,26 @@ export namespace QueryBuilder {
     >
 
     /**
-     * Example: If the row already exists, it will be ignored.
+     * Upsert: insert a row, or handle conflicts on existing rows.
+     * Equivalent to SQLite's `INSERT ... ON CONFLICT` clause.
+     *
+     * Actions:
+     * - `'ignore'`: Skip the insert if a row with the same key exists
+     * - `'replace'`: Delete the existing row and insert the new one
+     * - `'update'`: Update specific columns on the existing row
+     *
      * ```ts
+     * // Ignore: skip if row exists
      * db.todos.insert({ id: '123', text: 'Buy milk', status: 'active' }).onConflict('id', 'ignore')
-     * ```
      *
-     * Example: If the row already exists, it will be replaced.
-     * ```ts
+     * // Replace: delete existing row and insert new one
      * db.todos.insert({ id: '123', text: 'Buy milk', status: 'active' }).onConflict('id', 'replace')
-     * ```
      *
-     * Example: If the row already exists, it will be updated.
-     * ```ts
+     * // Update: merge specific columns into existing row
      * db.todos.insert({ id: '123', text: 'Buy milk', status: 'active' }).onConflict('id', 'update', { text: 'Buy soy milk' })
      * ```
      *
-     * NOTE This API doesn't yet support composite primary keys.
+     * NOTE: Composite primary keys are not yet supported.
      */
     readonly onConflict: {
       <TTarget extends SingleOrReadonlyArray<keyof TTableDef['sqliteDef']['columns']>>(


### PR DESCRIPTION
## Problem

The SQL queries documentation and the `onConflict` method's JSDoc were unclear about upserts—what they are, how they work, and what the three action types do.

## Solution

Added a code comment in the query builder snippet to label upsert examples, and improved the `onConflict` JSDoc to clearly explain that it implements SQLite's `INSERT ... ON CONFLICT` upsert pattern. Documented all three actions (`ignore`, `replace`, `update`) with concise descriptions and inline-commented examples.

## Validation

TypeScript and linting checks pass. Documentation examples are properly type-checked.