### PR TITLE
Store Uint8Array columns as blobs in SQLite

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
@@ -299,7 +299,7 @@ describe('getColumnDefForSchema', () => {
   describe('binary data', () => {
     it('should handle Uint8Array as blob column', () => {
       const columnDef = State.SQLite.getColumnDefForSchema(Schema.Uint8Array)
-      expect(columnDef.columnType).toBe('text') // Stored as JSON
+      expect(columnDef.columnType).toBe('blob')
     })
   })
 

--- a/packages/@livestore/common/src/schema/state/sqlite/column-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-def.ts
@@ -165,6 +165,12 @@ const getColumnForSchema = (schema: Schema.Schema.AnyNoContext, nullable = false
   // Get the encoded AST - what actually gets stored in SQLite
   const encodedAst = Schema.encodedSchema(coreSchema).ast
 
+  const identifier = SchemaAST.getIdentifierAnnotation(coreAst).pipe(Option.getOrElse(() => ''))
+
+  if (identifier === 'Uint8Array' || identifier === 'Uint8ArrayFromSelf') {
+    return SqliteDsl.blob({ schema: coreSchema, nullable })
+  }
+
   // Check if the encoded type matches SQLite native types
   if (SchemaAST.isStringKeyword(encodedAst)) {
     return SqliteDsl.text({ schema: coreSchema, nullable })


### PR DESCRIPTION
## Problem
`Schema.Uint8Array` columns were mapped to SQLite `TEXT`, which fails when inserting binary values because SQLite rejects blobs into text columns.

## Solution
Detect `Uint8Array`/`Uint8ArrayFromSelf` schemas when deriving SQLite column definitions and map them to `BLOB` columns by default. Updated the corresponding test to reflect the blob storage expectation.

## Validation
- `pnpm vitest packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts`
- Linting not run (`mono` command unavailable in this environment)

## Related issues
- #470

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b6256c0088329bb4fdaf374f054f1)