### PR TITLE
Quote SQLite identifiers to allow reserved column names

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -7,6 +7,8 @@ import type { State } from '../../../mod.ts'
 import type { QueryBuilderAst } from './api.ts'
 
 // Helper functions for SQL generation
+const quoteIdentifier = (identifier: string): string => `"${identifier.replace(/"/g, '""')}"`
+
 const formatWhereClause = (
   whereConditions: ReadonlyArray<QueryBuilderAst.Where>,
   tableDef: State.SQLite.TableDefBase,
@@ -16,13 +18,15 @@ const formatWhereClause = (
 
   const whereClause = whereConditions
     .map(({ col, op, value }) => {
+      const quotedCol = quoteIdentifier(col)
+
       // Handle NULL values
       if (value === null) {
         if (op !== '=' && op !== '!=') {
           throw new Error(`Unsupported operator for NULL value: ${op}`)
         }
         const opStmt = op === '=' ? 'IS' : 'IS NOT'
-        return `${col} ${opStmt} NULL`
+        return `${quotedCol} ${opStmt} NULL`
       }
 
       // Get column definition and encode value
@@ -48,11 +52,11 @@ const formatWhereClause = (
         const encodedValues = value.map((v) => Schema.encodeSync(colDef.schema)(v)) as SqlValue[]
         bindValues.push(...encodedValues)
         const placeholders = encodedValues.map(() => '?').join(', ')
-        return `${col} ${op} (${placeholders})`
+        return `${quotedCol} ${op} (${placeholders})`
       } else {
         const encodedValue = Schema.encodeSync(colDef.schema)(value)
         bindValues.push(encodedValue as SqlValue)
-        return `${col} ${op} ?`
+        return `${quotedCol} ${op} ?`
       }
     })
     .join(' AND ')
@@ -62,7 +66,7 @@ const formatWhereClause = (
 
 const formatReturningClause = (returning?: string[]): string => {
   if (!returning || returning.length === 0) return ''
-  return ` RETURNING ${returning.join(', ')}`
+  return ` RETURNING ${returning.map(quoteIdentifier).join(', ')}`
 }
 
 export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: SqlValue[]; usedTables: Set<string> } => {
@@ -72,6 +76,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
   // INSERT query
   if (ast._tag === 'InsertQuery') {
     const columns = Object.keys(ast.values)
+    const quotedColumns = columns.map(quoteIdentifier)
     const placeholders = columns.map(() => '?').join(', ')
     const encodedValues = Schema.encodeSync(ast.tableDef.insertSchema)(ast.values)
 
@@ -91,7 +96,8 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
         // For REPLACE, the conflict target is implied and no further clause is needed
       } else {
         // Build the ON CONFLICT clause for IGNORE or UPDATE
-        conflictClause = ` ON CONFLICT (${ast.onConflict.targets.join(', ')}) `
+        const conflictTargets = ast.onConflict.targets.map(quoteIdentifier).join(', ')
+        conflictClause = ` ON CONFLICT (${conflictTargets}) `
         if (ast.onConflict.action._tag === 'ignore') {
           conflictClause += 'DO NOTHING'
         } else {
@@ -105,8 +111,9 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
           const updates = updateCols
             .map((col) => {
               const value = updateValues[col]
+              const quotedCol = quoteIdentifier(col)
               // If the value is undefined, use excluded.col
-              return value === undefined ? `${col} = excluded.${col}` : `${col} = ?`
+              return value === undefined ? `${quotedCol} = excluded.${quotedCol}` : `${quotedCol} = ?`
             })
             .join(', ')
 
@@ -129,7 +136,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
     }
 
     // Construct the main query part
-    let query = `${insertVerb} INTO '${ast.tableDef.sqliteDef.name}' (${columns.join(', ')}) VALUES (${placeholders})`
+    let query = `${insertVerb} INTO '${ast.tableDef.sqliteDef.name}' (${quotedColumns.join(', ')}) VALUES (${placeholders})`
 
     // Append the conflict clause if it was generated (i.e., not for REPLACE)
     query += conflictClause
@@ -157,7 +164,9 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
       bindValues.push(encodedValues[col] as SqlValue)
     })
 
-    let query = `UPDATE '${ast.tableDef.sqliteDef.name}' SET ${setColumns.map((col) => `${col} = ?`).join(', ')}`
+    let query = `UPDATE '${ast.tableDef.sqliteDef.name}' SET ${setColumns
+      .map((col) => `${quoteIdentifier(col)} = ?`)
+      .join(', ')}`
 
     const whereClause = formatWhereClause(ast.where, ast.tableDef, bindValues)
     if (whereClause) query += ` ${whereClause}`
@@ -201,21 +210,21 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
     const encodedId = ast.id === SessionIdSymbol ? ast.id : Schema.encodeSync(idColDef.schema)(ast.id)
 
     return {
-      query: `SELECT * FROM '${ast.tableDef.sqliteDef.name}' WHERE id = ?`,
+      query: `SELECT * FROM '${ast.tableDef.sqliteDef.name}' WHERE ${quoteIdentifier('id')} = ?`,
       bindValues: [encodedId as SqlValue],
       usedTables,
     }
   }
 
   // SELECT query
-  const columnsStmt = ast.select.columns.length === 0 ? '*' : ast.select.columns.join(', ')
+  const columnsStmt = ast.select.columns.length === 0 ? '*' : ast.select.columns.map(quoteIdentifier).join(', ')
   const selectStmt = `SELECT ${columnsStmt}`
   const fromStmt = `FROM '${ast.tableDef.sqliteDef.name}'`
   const whereStmt = formatWhereClause(ast.where, ast.tableDef, bindValues)
 
   const orderByStmt =
     ast.orderBy.length > 0
-      ? `ORDER BY ${ast.orderBy.map(({ col, direction }) => `${col} ${direction}`).join(', ')}`
+      ? `ORDER BY ${ast.orderBy.map(({ col, direction }) => `${quoteIdentifier(col)} ${direction}`).join(', ')}`
       : ''
 
   const limitStmt = ast.limit._tag === 'Some' ? `LIMIT ?` : ''

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
@@ -73,7 +73,15 @@ const issue = State.SQLite.table({
   ],
 })
 
-const db = { todos, todosWithIntId, comments, issue, UiState, UiStateWithDefaultId }
+const selections = State.SQLite.table({
+  name: 'selections',
+  columns: {
+    id: State.SQLite.integer({ primaryKey: true }),
+    group: State.SQLite.text({}),
+  },
+})
+
+const db = { todos, todosWithIntId, comments, issue, selections, UiState, UiStateWithDefaultId }
 
 const dump = (qb: QueryBuilder<any, any, any>) => ({
   bindValues: qb.asSql().bindValues,
@@ -95,7 +103,7 @@ describe('query builder', () => {
       expect(dump(db.todos.select('id'))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT id FROM 'todos'",
+          "query": "SELECT "id" FROM 'todos'",
           "schema": "ReadonlyArray<({ readonly id: string } <-> string)>",
         }
       `)
@@ -103,7 +111,7 @@ describe('query builder', () => {
       expect(dump(db.todos.select('id', 'text'))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT id, text FROM 'todos'",
+          "query": "SELECT "id", "text" FROM 'todos'",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -115,7 +123,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT id, text FROM 'todos' LIMIT ?",
+          "query": "SELECT "id", "text" FROM 'todos' LIMIT ?",
           "schema": "(ReadonlyArray<{ readonly id: string; readonly text: string } | undefined> <-> { readonly id: string; readonly text: string } | undefined)",
         }
       `)
@@ -125,7 +133,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT id, text FROM 'todos' LIMIT ?",
+          "query": "SELECT "id", "text" FROM 'todos' LIMIT ?",
           "schema": "(ReadonlyArray<{ readonly id: string; readonly text: string }> <-> { readonly id: string; readonly text: string })",
         }
       `)
@@ -137,7 +145,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT id, text FROM 'todos' LIMIT ?",
+          "query": "SELECT "id", "text" FROM 'todos' LIMIT ?",
           "schema": "(ReadonlyArray<{ readonly id: string; readonly text: string }> | readonly [undefined] <-> { readonly id: string; readonly text: string } | undefined)",
         }
       `)
@@ -149,7 +157,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed = ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -158,7 +166,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed != ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" != ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -167,51 +175,51 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed = ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
       expect(dump(db.todos.select('id', 'text').where({ completed: undefined }))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT id, text FROM 'todos'",
+          "query": "SELECT "id", "text" FROM 'todos'",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
       expect(
         dump(db.todos.select('id', 'text').where({ deletedAt: { op: '<=', value: new Date('2024-01-01') } })),
       ).toMatchInlineSnapshot(`
-          {
-            "bindValues": [
-              "2024-01-01T00:00:00.000Z",
-            ],
-            "query": "SELECT id, text FROM 'todos' WHERE deletedAt <= ?",
-            "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
-          }
-        `)
+        {
+          "bindValues": [
+            "2024-01-01T00:00:00.000Z",
+          ],
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "deletedAt" <= ?",
+          "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
+        }
+      `)
       expect(
         dump(db.todos.select('id', 'text').where({ status: { op: 'IN', value: ['active'] } })),
       ).toMatchInlineSnapshot(`
-          {
-            "bindValues": [
-              "active",
-            ],
-            "query": "SELECT id, text FROM 'todos' WHERE status IN (?)",
-            "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
-          }
-        `)
+        {
+          "bindValues": [
+            "active",
+          ],
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "status" IN (?)",
+          "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
+        }
+      `)
       expect(
         dump(db.todos.select('id', 'text').where({ status: { op: 'NOT IN', value: ['active', 'completed'] } })),
       ).toMatchInlineSnapshot(`
-          {
-            "bindValues": [
-              "active",
-              "completed",
-            ],
-            "query": "SELECT id, text FROM 'todos' WHERE status NOT IN (?, ?)",
-            "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
-          }
-        `)
+        {
+          "bindValues": [
+            "active",
+            "completed",
+          ],
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "status" NOT IN (?, ?)",
+          "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
+        }
+      `)
 
       expect(
         dump(
@@ -222,15 +230,15 @@ describe('query builder', () => {
             .where({ deletedAt: undefined }),
         ),
       ).toMatchInlineSnapshot(`
-          {
-            "bindValues": [
-              0,
-              "active",
-            ],
-            "query": "SELECT id, text FROM 'todos' WHERE completed = ? AND status IN (?)",
-            "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
-          }
-        `)
+        {
+          "bindValues": [
+            0,
+            "active",
+          ],
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ? AND "status" IN (?)",
+          "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
+        }
+      `)
     })
 
     it('should handle OFFSET and LIMIT clauses', () => {
@@ -241,7 +249,7 @@ describe('query builder', () => {
             10,
             10,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed = ? OFFSET ? LIMIT ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ? OFFSET ? LIMIT ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -256,7 +264,7 @@ describe('query builder', () => {
             5,
             10,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed = ? OFFSET ? LIMIT ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ? OFFSET ? LIMIT ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -268,7 +276,7 @@ describe('query builder', () => {
             1,
             5,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed = ? OFFSET ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ? OFFSET ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -280,7 +288,7 @@ describe('query builder', () => {
             1,
             10,
           ],
-          "query": "SELECT id, text FROM 'todos' WHERE completed = ? LIMIT ?",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "completed" = ? LIMIT ?",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -299,7 +307,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT COUNT(*) as count FROM 'todos' WHERE completed = ?",
+          "query": "SELECT COUNT(*) as count FROM 'todos' WHERE "completed" = ?",
           "schema": "(ReadonlyArray<({ readonly count: number } <-> number)> <-> number)",
         }
       `)
@@ -308,7 +316,7 @@ describe('query builder', () => {
           "bindValues": [
             1,
           ],
-          "query": "SELECT COUNT(*) as count FROM 'todos' WHERE completed = ?",
+          "query": "SELECT COUNT(*) as count FROM 'todos' WHERE "completed" = ?",
           "schema": "(ReadonlyArray<({ readonly count: number } <-> number)> <-> number)",
         }
       `)
@@ -318,14 +326,14 @@ describe('query builder', () => {
       expect(dump(db.todos.select('id', 'text').where('deletedAt', '=', null))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT id, text FROM 'todos' WHERE deletedAt IS NULL",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "deletedAt" IS NULL",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
       expect(dump(db.todos.select('id', 'text').where('deletedAt', '!=', null))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT id, text FROM 'todos' WHERE deletedAt IS NOT NULL",
+          "query": "SELECT "id", "text" FROM 'todos' WHERE "deletedAt" IS NOT NULL",
           "schema": "ReadonlyArray<{ readonly id: string; readonly text: string }>",
         }
       `)
@@ -335,7 +343,7 @@ describe('query builder', () => {
       expect(dump(db.todos.orderBy('completed', 'desc'))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT * FROM 'todos' ORDER BY completed desc",
+          "query": "SELECT * FROM 'todos' ORDER BY "completed" desc",
           "schema": "ReadonlyArray<todos>",
         }
       `)
@@ -343,7 +351,7 @@ describe('query builder', () => {
       expect(dump(db.todos.orderBy([{ col: 'completed', direction: 'desc' }]))).toMatchInlineSnapshot(`
         {
           "bindValues": [],
-          "query": "SELECT * FROM 'todos' ORDER BY completed desc",
+          "query": "SELECT * FROM 'todos' ORDER BY "completed" desc",
           "schema": "ReadonlyArray<todos>",
         }
       `)
@@ -402,7 +410,7 @@ describe('query builder', () => {
             "Buy milk",
             "active",
           ],
-          "query": "INSERT INTO 'todos' (id, text, status) VALUES (?, ?, ?)",
+          "query": "INSERT INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?)",
           "schema": "number",
         }
       `)
@@ -416,7 +424,7 @@ describe('query builder', () => {
             "Buy milk",
             "active",
           ],
-          "query": "INSERT INTO 'todos' (id, text, status) VALUES (?, ?, ?)",
+          "query": "INSERT INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?)",
           "schema": "number",
         }
       `)
@@ -447,7 +455,7 @@ describe('query builder', () => {
             "a2",
             "John Doe",
           ],
-          "query": "INSERT INTO 'issue' (id, title, priority, created, modified, kanbanorder, creator) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          "query": "INSERT INTO 'issue' ("id", "title", "priority", "created", "modified", "kanbanorder", "creator") VALUES (?, ?, ?, ?, ?, ?, ?)",
           "schema": "number",
         }
       `)
@@ -460,7 +468,7 @@ describe('query builder', () => {
             "completed",
             "123",
           ],
-          "query": "UPDATE 'todos' SET status = ? WHERE id = ?",
+          "query": "UPDATE 'todos' SET "status" = ? WHERE "id" = ?",
           "schema": "number",
         }
       `)
@@ -482,7 +490,7 @@ describe('query builder', () => {
             "some text",
             "123",
           ],
-          "query": "UPDATE 'todos' SET text = ? WHERE id = ?",
+          "query": "UPDATE 'todos' SET "text" = ? WHERE "id" = ?",
           "schema": "number",
         }
       `)
@@ -496,7 +504,7 @@ describe('query builder', () => {
             "John Doe",
             1,
           ],
-          "query": "UPDATE 'issue' SET priority = ?, creator = ? WHERE id = ?",
+          "query": "UPDATE 'issue' SET "priority" = ?, "creator" = ? WHERE "id" = ?",
           "schema": "number",
         }
       `)
@@ -508,7 +516,7 @@ describe('query builder', () => {
           "bindValues": [
             "completed",
           ],
-          "query": "DELETE FROM 'todos' WHERE status = ?",
+          "query": "DELETE FROM 'todos' WHERE "status" = ?",
           "schema": "number",
         }
       `)
@@ -524,7 +532,7 @@ describe('query builder', () => {
             "Buy milk",
             "active",
           ],
-          "query": "INSERT INTO 'todos' (id, text, status) VALUES (?, ?, ?) ON CONFLICT (id) DO NOTHING",
+          "query": "INSERT INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?) ON CONFLICT ("id") DO NOTHING",
           "schema": "number",
         }
       `)
@@ -544,7 +552,7 @@ describe('query builder', () => {
             "Buy soy milk",
             "active",
           ],
-          "query": "INSERT INTO 'todos' (id, text, status) VALUES (?, ?, ?) ON CONFLICT (id) DO UPDATE SET text = ?, status = ?",
+          "query": "INSERT INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?) ON CONFLICT ("id") DO UPDATE SET "text" = ?, "status" = ?",
           "schema": "number",
         }
       `)
@@ -558,7 +566,33 @@ describe('query builder', () => {
             "Buy milk",
             "active",
           ],
-          "query": "INSERT OR REPLACE INTO 'todos' (id, text, status) VALUES (?, ?, ?)",
+          "query": "INSERT OR REPLACE INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?)",
+          "schema": "number",
+        }
+      `)
+    })
+
+    it('should quote reserved column names', () => {
+      expect(
+        dump(db.selections.insert({ id: 1, group: 'alpha' }).onConflict('id', 'ignore')),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            1,
+            "alpha",
+          ],
+          "query": "INSERT INTO 'selections' (\"id\", \"group\") VALUES (?, ?) ON CONFLICT (\"id\") DO NOTHING",
+          "schema": "number",
+        }
+      `)
+
+      expect(dump(db.selections.update({ group: 'beta' }).where({ id: 1 }))).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "beta",
+            1,
+          ],
+          "query": "UPDATE 'selections' SET \"group\" = ? WHERE \"id\" = ?",
           "schema": "number",
         }
       `)
@@ -574,7 +608,7 @@ describe('query builder', () => {
             "Buy milk",
             "active",
           ],
-          "query": "INSERT INTO 'todos' (id, text, status) VALUES (?, ?, ?) ON CONFLICT (id, status) DO NOTHING",
+          "query": "INSERT INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?) ON CONFLICT ("id", "status") DO NOTHING",
           "schema": "number",
         }
       `)
@@ -584,36 +618,36 @@ describe('query builder', () => {
       expect(
         dump(db.todos.insert({ id: '123', text: 'Buy milk', status: 'active' }).returning('id')),
       ).toMatchInlineSnapshot(`
-          {
-            "bindValues": [
-              "123",
-              "Buy milk",
-              "active",
-            ],
-            "query": "INSERT INTO 'todos' (id, text, status) VALUES (?, ?, ?) RETURNING id",
-            "schema": "ReadonlyArray<{ readonly id: string }>",
-          }
-        `)
+        {
+          "bindValues": [
+            "123",
+            "Buy milk",
+            "active",
+          ],
+          "query": "INSERT INTO 'todos' ("id", "text", "status") VALUES (?, ?, ?) RETURNING "id"",
+          "schema": "ReadonlyArray<{ readonly id: string }>",
+        }
+      `)
 
       expect(
         dump(db.todos.update({ status: 'completed' }).where({ id: '123' }).returning('id')),
       ).toMatchInlineSnapshot(`
-          {
-            "bindValues": [
-              "completed",
-              "123",
-            ],
-            "query": "UPDATE 'todos' SET status = ? WHERE id = ? RETURNING id",
-            "schema": "ReadonlyArray<{ readonly id: string }>",
-          }
-        `)
+        {
+          "bindValues": [
+            "completed",
+            "123",
+          ],
+          "query": "UPDATE 'todos' SET "status" = ? WHERE "id" = ? RETURNING "id"",
+          "schema": "ReadonlyArray<{ readonly id: string }>",
+        }
+      `)
 
       expect(dump(db.todos.delete().where({ status: 'completed' }).returning('id'))).toMatchInlineSnapshot(`
         {
           "bindValues": [
             "completed",
           ],
-          "query": "DELETE FROM 'todos' WHERE status = ? RETURNING id",
+          "query": "DELETE FROM 'todos' WHERE "status" = ? RETURNING "id"",
           "schema": "ReadonlyArray<{ readonly id: string }>",
         }
       `)
@@ -625,7 +659,7 @@ describe('query builder', () => {
           "bindValues": [
             "completed",
           ],
-          "query": "DELETE FROM 'todos' WHERE status = ?",
+          "query": "DELETE FROM 'todos' WHERE "status" = ?",
           "schema": "number",
         }
       `)
@@ -636,7 +670,7 @@ describe('query builder', () => {
           "bindValues": [
             "completed",
           ],
-          "query": "DELETE FROM 'todos' WHERE status = ? AND deletedAt IS NULL",
+          "query": "DELETE FROM 'todos' WHERE "status" = ? AND "deletedAt" IS NULL",
           "schema": "number",
         }
       `)
@@ -649,7 +683,7 @@ describe('query builder', () => {
             "completed",
             "123",
           ],
-          "query": "UPDATE 'todos' SET status = ? WHERE id = ?",
+          "query": "UPDATE 'todos' SET "status" = ? WHERE "id" = ?",
           "schema": "number",
         }
       `)
@@ -663,7 +697,7 @@ describe('query builder', () => {
             "completed",
             "123",
           ],
-          "query": "UPDATE 'todos' SET status = ? WHERE id = ? AND deletedAt IS NULL",
+          "query": "UPDATE 'todos' SET "status" = ? WHERE "id" = ? AND "deletedAt" IS NULL",
           "schema": "number",
         }
       `)
@@ -776,7 +810,7 @@ describe('query builder', () => {
             "Lovelace",
             "ada@example.com",
           ],
-          "query": "INSERT INTO 'contacts' (id, contactFirstName, contactLastName, contactEmail) VALUES (?, ?, ?, ?)",
+          "query": "INSERT INTO 'contacts' ("id", "contactFirstName", "contactLastName", "contactEmail") VALUES (?, ?, ?, ?)",
           "usedTables": Set {
             "contacts",
           },

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
@@ -573,15 +573,13 @@ describe('query builder', () => {
     })
 
     it('should quote reserved column names', () => {
-      expect(
-        dump(db.selections.insert({ id: 1, group: 'alpha' }).onConflict('id', 'ignore')),
-      ).toMatchInlineSnapshot(`
+      expect(dump(db.selections.insert({ id: 1, group: 'alpha' }).onConflict('id', 'ignore'))).toMatchInlineSnapshot(`
         {
           "bindValues": [
             1,
             "alpha",
           ],
-          "query": "INSERT INTO 'selections' (\"id\", \"group\") VALUES (?, ?) ON CONFLICT (\"id\") DO NOTHING",
+          "query": "INSERT INTO 'selections' ("id", "group") VALUES (?, ?) ON CONFLICT ("id") DO NOTHING",
           "schema": "number",
         }
       `)
@@ -592,7 +590,7 @@ describe('query builder', () => {
             "beta",
             1,
           ],
-          "query": "UPDATE 'selections' SET \"group\" = ? WHERE \"id\" = ?",
+          "query": "UPDATE 'selections' SET "group" = ? WHERE "id" = ?",
           "schema": "number",
         }
       `)

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -75,7 +75,7 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -162,7 +162,7 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -221,14 +221,14 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
         {
           "_name": "LiveStore.subscribe",
           "attributes": {
-            "queryLabel": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+            "queryLabel": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
           },
           "children": [
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "subscribe-initial-run:undefined",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 0,
               },
               "children": [
@@ -236,17 +236,17 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 0,
                   },
                 },
               ],
             },
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "commit",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 1,
               },
               "children": [
@@ -254,7 +254,7 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 1,
                   },
                 },
@@ -295,7 +295,7 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -428,7 +428,7 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -487,14 +487,14 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
         {
           "_name": "LiveStore.subscribe",
           "attributes": {
-            "queryLabel": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+            "queryLabel": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
           },
           "children": [
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "subscribe-initial-run:undefined",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 0,
               },
               "children": [
@@ -502,17 +502,17 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 0,
                   },
                 },
               ],
             },
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "commit",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 1,
               },
               "children": [
@@ -520,7 +520,7 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 1,
                   },
                 },
@@ -561,7 +561,7 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -627,14 +627,14 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
         {
           "_name": "LiveStore.subscribe",
           "attributes": {
-            "queryLabel": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+            "queryLabel": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
           },
           "children": [
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "subscribe-initial-run:undefined",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 0,
               },
               "children": [
@@ -642,17 +642,17 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 0,
                   },
                 },
               ],
             },
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "commit",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 1,
               },
               "children": [
@@ -660,7 +660,7 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 1,
                   },
                 },
@@ -671,14 +671,14 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
         {
           "_name": "LiveStore.subscribe",
           "attributes": {
-            "queryLabel": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+            "queryLabel": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
           },
           "children": [
             {
-              "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
               "attributes": {
                 "livestore.debugRefreshReason": "commit",
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 1,
               },
               "children": [
@@ -686,7 +686,7 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
                   "_name": "sql-in-memory-select",
                   "attributes": {
                     "sql.cached": false,
-                    "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                     "sql.rowsCount": 1,
                   },
                 },
@@ -727,7 +727,7 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -761,7 +761,7 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -884,7 +884,7 @@ exports[`otel > otel 4`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -1185,7 +1185,7 @@ exports[`otel > with thunks 8`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],
@@ -1242,9 +1242,9 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       "_name": "LiveStore:queries",
       "children": [
         {
-          "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+          "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
           "attributes": {
-            "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+            "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
             "sql.rowsCount": 0,
           },
           "children": [
@@ -1255,16 +1255,16 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
               "_name": "sql-in-memory-select",
               "attributes": {
                 "sql.cached": false,
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 0,
               },
             },
           ],
         },
         {
-          "_name": "db:SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+          "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
           "attributes": {
-            "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+            "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
             "sql.rowsCount": 1,
           },
           "children": [
@@ -1275,7 +1275,7 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
               "_name": "sql-in-memory-select",
               "attributes": {
                 "sql.cached": false,
-                "sql.query": "SELECT * FROM 'todos' WHERE completed = ? LIMIT ?",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
                 "sql.rowsCount": 1,
               },
             },
@@ -1314,7 +1314,7 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
               {
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
-                  "sql.query": "INSERT INTO 'todos' (id, text, completed) VALUES (?, ?, ?)",
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
             ],

--- a/packages/@livestore/react/src/__snapshots__/useQuery.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useQuery.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`useQuery (strictMode={ strictMode: false }) > filtered dependency query
       },
       "previousResult": {
         "_tag": "Some",
-        "value": "{"query":"SELECT * FROM 'todos' WHERE id = ?","bindValues":["t1"],"queriedTables":{}}",
+        "value": "{"query":"SELECT * FROM 'todos' WHERE \\"id\\" = ?","bindValues":["t1"],"queriedTables":{}}",
       },
       "recomputations": 1,
       "sub": [
@@ -158,7 +158,7 @@ exports[`useQuery (strictMode={ strictMode: false }) > filtered dependency query
       "id": "node-9",
       "invocations": 1,
       "isDestroyed": false,
-      "label": "subscribe:SELECT * FROM 'todos' WHERE id = ?",
+      "label": "subscribe:SELECT * FROM 'todos' WHERE "id" = ?",
       "sub": [
         "node-7",
       ],
@@ -268,7 +268,7 @@ exports[`useQuery (strictMode={ strictMode: false }) > filtered dependency query
       },
       "previousResult": {
         "_tag": "Some",
-        "value": "{"query":"SELECT * FROM 'todos' WHERE id = ?","bindValues":["t1"],"queriedTables":{}}",
+        "value": "{"query":"SELECT * FROM 'todos' WHERE \\"id\\" = ?","bindValues":["t1"],"queriedTables":{}}",
       },
       "recomputations": 1,
       "sub": [
@@ -325,7 +325,7 @@ exports[`useQuery (strictMode={ strictMode: false }) > filtered dependency query
       "id": "node-9",
       "invocations": 2,
       "isDestroyed": false,
-      "label": "subscribe:SELECT * FROM 'todos' WHERE id = ?",
+      "label": "subscribe:SELECT * FROM 'todos' WHERE "id" = ?",
       "sub": [
         "node-7",
       ],
@@ -435,7 +435,7 @@ exports[`useQuery (strictMode={ strictMode: false }) > filtered dependency query
       },
       "previousResult": {
         "_tag": "Some",
-        "value": "{"query":"SELECT * FROM 'todos' WHERE id = ?","bindValues":["t2"],"queriedTables":{}}",
+        "value": "{"query":"SELECT * FROM 'todos' WHERE \\"id\\" = ?","bindValues":["t2"],"queriedTables":{}}",
       },
       "recomputations": 2,
       "sub": [
@@ -492,7 +492,7 @@ exports[`useQuery (strictMode={ strictMode: false }) > filtered dependency query
       "id": "node-9",
       "invocations": 3,
       "isDestroyed": false,
-      "label": "subscribe:SELECT * FROM 'todos' WHERE id = ?",
+      "label": "subscribe:SELECT * FROM 'todos' WHERE "id" = ?",
       "sub": [
         "node-7",
       ],
@@ -1242,7 +1242,7 @@ exports[`useQuery (strictMode={ strictMode: true }) > filtered dependency query 
       },
       "previousResult": {
         "_tag": "Some",
-        "value": "{"query":"SELECT * FROM 'todos' WHERE id = ?","bindValues":["t1"],"queriedTables":{}}",
+        "value": "{"query":"SELECT * FROM 'todos' WHERE \\"id\\" = ?","bindValues":["t1"],"queriedTables":{}}",
       },
       "recomputations": 1,
       "sub": [
@@ -1299,7 +1299,7 @@ exports[`useQuery (strictMode={ strictMode: true }) > filtered dependency query 
       "id": "node-9",
       "invocations": 1,
       "isDestroyed": false,
-      "label": "subscribe:SELECT * FROM 'todos' WHERE id = ?",
+      "label": "subscribe:SELECT * FROM 'todos' WHERE "id" = ?",
       "sub": [
         "node-7",
       ],
@@ -1409,7 +1409,7 @@ exports[`useQuery (strictMode={ strictMode: true }) > filtered dependency query 
       },
       "previousResult": {
         "_tag": "Some",
-        "value": "{"query":"SELECT * FROM 'todos' WHERE id = ?","bindValues":["t1"],"queriedTables":{}}",
+        "value": "{"query":"SELECT * FROM 'todos' WHERE \\"id\\" = ?","bindValues":["t1"],"queriedTables":{}}",
       },
       "recomputations": 1,
       "sub": [
@@ -1466,7 +1466,7 @@ exports[`useQuery (strictMode={ strictMode: true }) > filtered dependency query 
       "id": "node-9",
       "invocations": 2,
       "isDestroyed": false,
-      "label": "subscribe:SELECT * FROM 'todos' WHERE id = ?",
+      "label": "subscribe:SELECT * FROM 'todos' WHERE "id" = ?",
       "sub": [
         "node-7",
       ],
@@ -1576,7 +1576,7 @@ exports[`useQuery (strictMode={ strictMode: true }) > filtered dependency query 
       },
       "previousResult": {
         "_tag": "Some",
-        "value": "{"query":"SELECT * FROM 'todos' WHERE id = ?","bindValues":["t2"],"queriedTables":{}}",
+        "value": "{"query":"SELECT * FROM 'todos' WHERE \\"id\\" = ?","bindValues":["t2"],"queriedTables":{}}",
       },
       "recomputations": 2,
       "sub": [
@@ -1633,7 +1633,7 @@ exports[`useQuery (strictMode={ strictMode: true }) > filtered dependency query 
       "id": "node-9",
       "invocations": 3,
       "isDestroyed": false,
-      "label": "subscribe:SELECT * FROM 'todos' WHERE id = ?",
+      "label": "subscribe:SELECT * FROM 'todos' WHERE "id" = ?",
       "sub": [
         "node-7",
       ],


### PR DESCRIPTION
## Problem
SQLite insert/update statements failed when schemas used reserved column names because query generation emitted unquoted identifiers.

## Solution
Quote SQLite identifiers throughout the query builder and add a regression test covering reserved column names.

## Validation
- pnpm vitest run packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts -u


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c28c7071c83299010d4550d46335a)