### PR TITLE
fix(ci): `build-example-create` failing on PR refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
         #   `github.ref` provides the full ref (e.g., `refs/pull/123/merge`) that the API understands.
         #
         # See https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/
-        run: pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --branch ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}
+        run: pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --ref ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}
       - name: Increase pnpm fetch retries
         # Sometimes the snapshot version is not available immediately after publishing due to network propagation delays.
         # We increase the fetch retries to mitigate this issue.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,11 +343,14 @@ jobs:
             jq -r '.[0].dependencies | keys | join(" ")' \
           )" >> $GITHUB_ENV
       - name: Copy example app
-        # We use `github.ref_name` instead of `github.sha` because, when a workflow is triggered by a pull request,
-        # `github.sha` refers to a temporary commit SHA that can become inaccessible in some contexts.
+        # - We use `github.ref` instead of `github.sha` because, when a workflow is triggered by a pull request,
+        #   `github.sha` refers to a temporary commit SHA that can become inaccessible in some contexts.
+        # - We use `github.ref` instead of `github.ref_name` because GitHub's public API requires full refs.
+        #   `github.ref_name` produces shortened refs like `123/merge` for PRs, which the API doesn't recognize.
+        #   `github.ref` provides the full ref (e.g., `refs/pull/123/merge`) that the API understands.
+        #
         # See https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/
-        # Use the LiveStore CLI (snapshot version) to scaffold the example
-        run: pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --branch ${{ github.ref_name }} ${{ runner.temp }}/${{ env.APP_PATH }}
+        run: pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --branch ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}
       - name: Increase pnpm fetch retries
         # Sometimes the snapshot version is not available immediately after publishing due to network propagation delays.
         # We increase the fetch retries to mitigate this issue.

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -19,7 +19,7 @@ bunx @livestore/cli --help
 
 # Alternative options:
 npm install -g @livestore/cli        # Global install
-npm install -D @livestore/cli        # Project install  
+npm install -D @livestore/cli        # Project install
 npx @livestore/cli --help            # Use with npx
 ```
 

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -40,11 +40,11 @@ export class DirectoryExistsError extends Schema.TaggedError<DirectoryExistsErro
 }) {}
 
 // Fetch available examples from GitHub
-const fetchExamples = (branch: string) =>
+const fetchExamples = (ref: string) =>
   Effect.gen(function* () {
-    const url = `https://api.github.com/repos/livestorejs/livestore/contents/examples?ref=${branch}`
+    const url = `https://api.github.com/repos/livestorejs/livestore/contents/examples?ref=${ref}`
 
-    yield* Effect.log(`Fetching examples from branch: ${branch}`)
+    yield* Effect.log(`Fetching examples from ref: ${ref}`)
 
     const request = HttpClientRequest.get(url)
     const response = yield* HttpClient.execute(request).pipe(
@@ -100,13 +100,13 @@ const selectExample = (examples: string[]) =>
   })
 
 // Download and extract example using tiged approach
-const downloadExample = (exampleName: string, branch: string, destinationPath: string) =>
+const downloadExample = (exampleName: string, ref: string, destinationPath: string) =>
   Effect.gen(function* () {
-    yield* Console.log(`📥 Downloading example "${exampleName}" from branch "${branch}"...`)
+    yield* Console.log(`📥 Downloading example "${exampleName}" from ref "${ref}"...`)
 
     const tempDir = yield* Effect.sync(() => os.tmpdir())
-    const tarballPath = nodePath.join(tempDir, `livestore-${branch}-${Date.now()}.tar.gz`)
-    const tarballUrl = `https://api.github.com/repos/livestorejs/livestore/tarball/${branch}`
+    const tarballPath = nodePath.join(tempDir, `livestore-${ref}-${Date.now()}.tar.gz`)
+    const tarballUrl = `https://api.github.com/repos/livestorejs/livestore/tarball/${ref}`
 
     // Download tarball directly
     const request = HttpClientRequest.get(tarballUrl)
@@ -199,9 +199,12 @@ export const createCommand = Cli.Command.make(
       Cli.Options.optional,
       Cli.Options.withDescription('Example name to create (bypasses interactive selection)'),
     ),
-    branch: Cli.Options.text('branch').pipe(
+    ref: Cli.Options.text('ref').pipe(
+      Cli.Options.withAlias('commit'),
+      Cli.Options.withAlias('branch'),
+      Cli.Options.withAlias('tag'),
       Cli.Options.withDefault('dev'),
-      Cli.Options.withDescription('Branch to fetch examples from'),
+      Cli.Options.withDescription('The name of the commit/branch/tag to fetch examples from'),
     ),
     path: Cli.Args.text({ name: 'path' }).pipe(
       Cli.Args.optional,
@@ -210,17 +213,17 @@ export const createCommand = Cli.Command.make(
   },
   Effect.fn(function* ({
     example,
-    branch,
+    ref,
     path,
   }: {
     example: Option.Option<string>
-    branch: string
+    ref: string
     path: Option.Option<string>
   }) {
     yield* Effect.log('🚀 Creating new LiveStore project...')
 
     // Fetch available examples
-    const examples = yield* fetchExamples(branch)
+    const examples = yield* fetchExamples(ref)
 
     if (examples.length === 0) {
       yield* Console.log('❌ No examples found in the repository')
@@ -249,7 +252,7 @@ export const createCommand = Cli.Command.make(
     const destinationPath = Option.isSome(path) ? nodePath.resolve(path.value) : nodePath.resolve(selectedExample)
 
     // Download and extract the example
-    yield* downloadExample(selectedExample, branch, destinationPath)
+    yield* downloadExample(selectedExample, ref, destinationPath)
 
     // Success message
     yield* Console.log('\n🎉 Project created successfully!')

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -204,7 +204,9 @@ export const createCommand = Cli.Command.make(
       Cli.Options.withAlias('branch'),
       Cli.Options.withAlias('tag'),
       Cli.Options.withDefault('dev'),
-      Cli.Options.withDescription('The name of the commit/branch/tag to fetch examples from'),
+      Cli.Options.withDescription(
+        'The name of the commit/branch/tag to fetch examples from. Pull requests refs must be fully-formed (e.g., `refs/pull/123/merge`).',
+      ),
     ),
     path: Cli.Args.text({ name: 'path' }).pipe(
       Cli.Args.optional,

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -1,5 +1,6 @@
 import * as os from 'node:os'
 import * as nodePath from 'node:path'
+import { sluggify } from '@livestore/utils'
 import {
   Command,
   Console,
@@ -105,7 +106,7 @@ const downloadExample = (exampleName: string, ref: string, destinationPath: stri
     yield* Console.log(`📥 Downloading example "${exampleName}" from ref "${ref}"...`)
 
     const tempDir = yield* Effect.sync(() => os.tmpdir())
-    const tarballPath = nodePath.join(tempDir, `livestore-${ref}-${Date.now()}.tar.gz`)
+    const tarballPath = nodePath.join(tempDir, `livestore-${sluggify(ref)}-${Date.now()}.tar.gz`)
     const tarballUrl = `https://api.github.com/repos/livestorejs/livestore/tarball/${ref}`
 
     // Download tarball directly


### PR DESCRIPTION
## Summary

- Use `github.ref` instead of `github.ref_name` in CI because GitHub's public API requires full refs (e.g., `refs/pull/123/merge` not `123/merge`)
- Rename CLI `--branch` option to `--ref` to align with GitHub API parameter naming, since the value can be a branch, tag, commit SHA, or full ref
- Add `--branch`, `--tag`, `--commit` as aliases
- Fix tarball path for refs containing slashes (e.g., `refs/pull/123/merge`) by using `sluggify` to sanitize the filename

## Test plan

- [x] Verify `build-example-create` job passes on this PR
- [x] Test CLI with `--ref` and `--branch` options
- [x] Test CLI with full PR ref format (`refs/pull/878/head`)

Fixes #871