### PR TITLE
feat(ci): add run ID affinity to Namespace runners for faster workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,15 @@ env:
 
 jobs:
   lint:
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     env:
       LIVESTORE_BRANCH_PROTECTION_REQUIRED: "true"
     defaults:
@@ -35,7 +43,15 @@ jobs:
       - run: mono lint
 
   test-unit:
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     env:
       LIVESTORE_BRANCH_PROTECTION_REQUIRED: "true"
     defaults:
@@ -48,7 +64,15 @@ jobs:
       - run: mono test unit
 
   test-integration-node-sync:
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     env:
       LIVESTORE_BRANCH_PROTECTION_REQUIRED: "true"
     defaults:
@@ -116,7 +140,15 @@ jobs:
             cf-do-rpc-d1,
             cf-do-rpc-do,
           ]
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     env:
       LIVESTORE_BRANCH_PROTECTION_REQUIRED: "true"
     defaults:
@@ -147,7 +179,15 @@ jobs:
     strategy:
       matrix:
         suite: [misc, todomvc, devtools]
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     env:
       LIVESTORE_BRANCH_PROTECTION_REQUIRED: "true"
     defaults:
@@ -246,7 +286,15 @@ jobs:
 
   publish-snapshot-version:
     if: github.event.pull_request.head.repo.fork != true
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     needs:
       [
         test-unit,
@@ -269,7 +317,15 @@ jobs:
       - run: mono release snapshot --git-sha=${{ github.sha }}
 
   build-and-deploy-examples-src:
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     defaults:
       run:
         shell: devenv shell bash -- -e {0}
@@ -289,7 +345,15 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   build-deploy-docs:
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     defaults:
       run:
         shell: devenv shell bash -- -e {0}
@@ -322,7 +386,15 @@ jobs:
     strategy:
       matrix:
         app: [web-todomvc, web-linearlite, expo-linearlite]
-    runs-on: namespace-profile-linux-x86-64
+    runs-on:
+      - namespace-profile-linux-x86-64
+      # By default, any runner with matching labels can pick up any waiting job, even from different
+      # workflow runs. This causes jobs from newer runs to "jump the queue" ahead of older runs when
+      # hitting concurrency limits, resulting in longer workflow run times. Adding the run ID as a
+      # label creates runner affinity: runners spawned for this workflow run can only execute jobs
+      # from this same run, ensuring older workflow runs finish before newer ones consume runner
+      # capacity.
+      - namespace-features:github.run-id=${{ github.run_id }}
     env:
       APP_PATH: examples/${{ matrix.app }}
       SNAPSHOT_VERSION: "0.0.0-snapshot-${{ github.sha }}"


### PR DESCRIPTION
## Summary

- Add `namespace-features:github.run-id` label to all Namespace runner jobs to create workflow run affinity
- This ensures runners spawned for a workflow run can only execute jobs from that same run
- Fixes job scheduling issue where newer workflow runs would "jump the queue" ahead of older runs when hitting concurrency limits, causing longer workflow run times

## Problem

By default, any Namespace runner with matching labels can pick up any waiting job, even from different workflow runs. When hitting concurrency limits, this causes jobs from newer runs to be scheduled before jobs from older, incomplete workflow runs. The result is that older workflows take significantly longer to complete.

## Solution

Adding `namespace-features:github.run-id=${{ github.run_id }}` as a runner label creates affinity between runners and their workflow run. Since Namespace spawns runners in the order it learns about jobs, older workflow runs will have their runners assigned first and complete before newer runs consume runner capacity.

## Test plan

- [x] Verify CI workflow syntax is valid
- [ ] Monitor workflow execution times after merging to confirm improved scheduling behavior