### PR TITLE
Fix DOMException crash on Expo/Hermes

### DIFF
--- a/packages/@livestore/utils/src/mod.ts
+++ b/packages/@livestore/utils/src/mod.ts
@@ -1,7 +1,6 @@
 export { default as prettyBytes } from 'pretty-bytes'
 export * as base64 from './base64.ts'
 export * from './binary.ts'
-export * from './browser/mod.ts'
 export * from './Deferred.ts'
 export * from './env.ts'
 export * from './fast-deep-equal.ts'


### PR DESCRIPTION
## Summary

- Remove browser-only re-export from `@livestore/utils` universal entry point

The universal `@livestore/utils` entry was re-exporting browser-only code (`WebError`, `Opfs`, `WebLock`, etc.) which references `DOMException` at module scope. Hermes lacks `DOMException`, causing a `ReferenceError` on bundle load before LiveStore even initializes.

Browser-specific code is now only accessible via the explicit `@livestore/utils/effect/browser` entry point (which all existing code already uses).

## Test plan

- [x] TypeScript build passes
- [x] Lint passes
- [ ] Verify Expo app loads without crash on iOS simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)