### PR TITLE
Fix DOMException crash on Expo/Hermes

### DIFF
--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -43,9 +43,8 @@ import { loadSqlite3 } from './sqlite-loader.ts'
 
 if (isDevEnv()) {
   globalThis.__debugLiveStoreUtils = {
+    ...globalThis.__debugLiveStoreUtils,
     opfs: Opfs.debugUtils,
-    runSync: (effect: Effect.Effect<any, any, never>) => Effect.runSync(effect),
-    runFork: (effect: Effect.Effect<any, any, never>) => Effect.runFork(effect),
   }
 }
 

--- a/packages/@livestore/livestore/src/utils/dev.ts
+++ b/packages/@livestore/livestore/src/utils/dev.ts
@@ -1,10 +1,8 @@
 import type { SqliteDb } from '@livestore/common'
 import { prettyBytes } from '@livestore/utils'
 import { Effect } from '@livestore/utils/effect'
-import { Opfs } from '@livestore/utils/effect/browser'
 
 declare global {
-  // declaring a global *value* is the least fussy when augmenting inline
   var __debugLiveStoreUtils: any
 }
 
@@ -34,7 +32,6 @@ export const downloadURL = (data: string, fileName: string) => {
 
 export const exposeDebugUtils = () => {
   globalThis.__debugLiveStoreUtils = {
-    opfs: Opfs.debugUtils,
     downloadBlob,
     runSync: (effect: Effect.Effect<any, any, never>) => Effect.runSync(effect),
     runFork: (effect: Effect.Effect<any, any, never>) => Effect.runFork(effect),


### PR DESCRIPTION
## Summary

- Remove browser-only imports (`Opfs`) from `@livestore/livestore` core package
- Keep `exposeDebugUtils` but without browser-specific dependencies
- Extend debug utils with `opfs` in `@livestore/adapter-web` where browser APIs are expected

The `@livestore/livestore` package was importing browser-only code (`Opfs` from `@livestore/utils/effect/browser`) at module scope via `utils/dev.ts`. This pulled in `WebError.ts` which references `DOMException` - causing a crash on Hermes/React Native where `DOMException` does not exist.

**Import chain causing the crash:**
```
@livestore/react
  → @livestore/livestore/dist/store/store.js
  → ../utils/dev.js (was importing Opfs from @livestore/utils/effect/browser)
  → @livestore/utils/dist/browser/mod.js
  → @livestore/utils/dist/browser/WebError.js (DOMException at top-level)
```

**Fix:**
- `@livestore/livestore/utils/dev.ts` no longer imports from `@livestore/utils/effect/browser`
- `exposeDebugUtils()` is kept but without the `opfs` property
- `@livestore/adapter-web` extends `__debugLiveStoreUtils` with `opfs` for browser environments

## Test plan

- [x] TypeScript build passes
- [x] Lint passes
- [ ] Verify Expo app loads without crash on iOS simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)