### PR TITLE
Add ViteConf 2025 talk link to community docs

### DIFF
--- a/docs/src/content/docs/misc/community.mdx
+++ b/docs/src/content/docs/misc/community.mdx
@@ -32,6 +32,7 @@ You can join future office hour events [here](https://lu.ma/livestore).
 
 ## Conference talks & podcasts
 
+- [Native-Grade Web Apps with Local-First Data (ViteConf 2025)](https://www.youtube.com/watch?v=h5Bs0vEka5U)
 - [Sync different: Event sourcing in local-first apps](https://www.youtube.com/watch?v=nyPl84BopKc)
 - [From Prisma Founder to LiveStore: Building local-first apps with Johannes Schickling (Aaron Francis interview)](https://www.youtube.com/watch?v=aKTbGIrkrLE)
 


### PR DESCRIPTION
## Problem

The ViteConf 2025 talk "Native-Grade Web Apps with Local-First Data" was missing from the community documentation.

## Solution

Added the ViteConf 2025 talk link to the conference talks & podcasts section in the community page.

## Validation

Manual review of the community docs page to confirm the link is correctly displayed.