### PR TITLE
Fix GitHub language stats by excluding SQL benchmarks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark SQLite benchmark files as vendored to exclude from GitHub language stats
+# These are test fixtures with generated data, not actual source code
+packages/@livestore/wa-sqlite/demo/benchmarks/*.sql linguist-vendored


### PR DESCRIPTION
## Problem

GitHub's Linguist was incorrectly identifying ~119K lines of SQLite benchmark test data as PLpgSQL, causing it to dominate the repository language statistics at 68.7% instead of properly showing TypeScript as the primary language.

## Solution

Added a `.gitattributes` file to mark the SQL benchmark files in `packages/@livestore/wa-sqlite/demo/benchmarks/` as vendored. These files are generated test fixtures containing only INSERT statements and should not be included in language statistics.

## Validation

The `.gitattributes` configuration follows GitHub's Linguist conventions for excluding generated/vendored code from language statistics. The change has no impact on functionality or build output.