### PR TITLE
Overhaul Expo adapter reference documentation

### DIFF
--- a/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/adapter.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/adapter.ts
@@ -1,0 +1,7 @@
+/** biome-ignore-all lint/correctness/noUnusedVariables: docs snippet keeps inline adapter */
+// ---cut---
+import { makePersistedAdapter } from '@livestore/adapter-expo'
+
+const adapter = makePersistedAdapter({
+  storage: { subDirectory: 'my-app' },
+})

--- a/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/schema.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/schema.ts
@@ -1,0 +1,29 @@
+import { defineMaterializer, Events, makeSchema, Schema, State } from '@livestore/livestore'
+
+const tables = {
+  todos: State.SQLite.table({
+    name: 'todos',
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      text: State.SQLite.text(),
+      completed: State.SQLite.boolean({ default: false }),
+    },
+  }),
+} as const
+
+const events = {
+  todoCreated: Events.synced({
+    name: 'v1.TodoCreated',
+    schema: Schema.Struct({ id: Schema.String, text: Schema.String }),
+  }),
+} as const
+
+const materializers = State.SQLite.materializers(events, {
+  [events.todoCreated.name]: defineMaterializer(events.todoCreated, ({ id, text }) =>
+    tables.todos.insert({ id, text, completed: false }),
+  ),
+})
+
+const state = State.SQLite.makeState({ tables, materializers })
+
+export const schema = makeSchema({ events, state })

--- a/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/sync-backend.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/sync-backend.ts
@@ -1,0 +1,8 @@
+/** biome-ignore-all lint/correctness/noUnusedVariables: docs snippet keeps inline adapter */
+// ---cut---
+import { makePersistedAdapter } from '@livestore/adapter-expo'
+import { makeWsSync } from '@livestore/sync-cf/client'
+
+const adapter = makePersistedAdapter({
+  sync: { backend: makeWsSync({ url: 'wss://your-sync-backend.com' }) },
+})

--- a/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/usage.tsx
+++ b/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/usage.tsx
@@ -1,0 +1,22 @@
+import { makePersistedAdapter } from '@livestore/adapter-expo'
+import { LiveStoreProvider } from '@livestore/react'
+import { unstable_batchedUpdates as batchUpdates, SafeAreaView, Text } from 'react-native'
+
+import { schema } from './schema.ts'
+
+const adapter = makePersistedAdapter()
+
+export const App = () => (
+  <SafeAreaView style={{ flex: 1 }}>
+    <LiveStoreProvider
+      schema={schema}
+      adapter={adapter}
+      storeId="my-app"
+      batchUpdates={batchUpdates}
+      renderLoading={(status) => <Text>Loading ({status.stage})...</Text>}
+      renderError={(error) => <Text>Error: {String(error)}</Text>}
+    >
+      {/* Your app content */}
+    </LiveStoreProvider>
+  </SafeAreaView>
+)

--- a/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
+++ b/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
@@ -1,42 +1,173 @@
 ---
 title: Expo Adapter
+description: LiveStore adapter for React Native apps built with Expo
 sidebar:
   order: 2
 ---
 
+import AdapterSnippet from '../../../_assets/code/reference/platform-adapters/expo-adapter/adapter.ts?snippet'
+import UsageSnippet from '../../../_assets/code/reference/platform-adapters/expo-adapter/usage.tsx?snippet'
+import SyncBackendSnippet from '../../../_assets/code/reference/platform-adapters/expo-adapter/sync-backend.ts?snippet'
 import ResetPersistenceSnippet from '../../../_assets/code/reference/platform-adapters/expo-adapter/reset-persistence.ts?snippet'
 
-## Notes on Android
+The Expo adapter enables LiveStore in React Native applications built with [Expo](https://expo.dev). It uses native SQLite via `expo-sqlite` for high-performance local persistence on iOS and Android devices.
 
-- By default, Android requires `https` (including WebSocket connections) when communicating with a sync backend.
+## Key Features
 
-To allow for `http` / `ws`, you can run `expo install expo-build-properties` and add the following to your `app.json` (see [here](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid) for more information):
+- **Native SQLite storage** — Uses `expo-sqlite` for fast, reliable persistence directly on the device
+- **Offline-first** — Full functionality without network connectivity; syncs when connected
+- **Real-time sync** — Optional sync backend integration for multi-device data synchronization
+- **Integrated devtools** — Debug and inspect your store via the [LiveStore Devtools](/reference/devtools)
+- **Automatic client identification** — Uses platform-specific device IDs for client tracking
+
+## Requirements
+
+- [Expo New Architecture](https://docs.expo.dev/guides/new-architecture/) (Fabric) must be enabled
+- `expo-sqlite` ^16.0.0
+- `expo-application` ^7.0.0
+
+:::note
+Expo Web is not currently supported. See [#130](https://github.com/livestorejs/livestore/issues/130) for progress.
+:::
+
+## Installation
+
+```bash
+npm install @livestore/adapter-expo @livestore/livestore @livestore/react expo-sqlite
+```
+
+For a complete setup including sync and devtools, see the [Expo getting started guide](/getting-started/expo).
+
+## Basic Usage
+
+Create an adapter and wrap your app with the `LiveStoreProvider`:
+
+<UsageSnippet />
+
+The adapter requires minimal configuration. For more details on the provider props, see the [React integration guide](/reference/framework-integrations/react-integration).
+
+## Configuration Options
+
+<AdapterSnippet />
+
+### Available Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `storage.subDirectory` | `string` | Subdirectory within the default SQLite location for organizing databases |
+| `sync` | `SyncOptions` | Sync backend configuration (see [Syncing](/reference/syncing)) |
+| `clientId` | `string` | Custom client identifier (defaults to device ID) |
+| `sessionId` | `string` | Session identifier (defaults to `'static'`) |
+| `resetPersistence` | `boolean` | Clear local databases on startup (development only) |
+
+## Adding a Sync Backend
+
+Connect to a sync backend for multi-device synchronization:
+
+<SyncBackendSnippet />
+
+See the [Syncing documentation](/reference/syncing) for available sync providers and configuration options.
+
+## Platform Notes
+
+### Android
+
+Android requires HTTPS for network connections by default. During development with a local sync backend using `http://` or `ws://`, add `expo-build-properties` to allow cleartext traffic:
+
+```bash
+npx expo install expo-build-properties
+```
+
+Then configure `app.json`:
 
 ```json
 {
   "expo": {
     "plugins": [
-      "expo-build-properties",
-      {
-        "android": {
-          "usesCleartextTraffic": true
-        },
-        "ios": {}
-      }
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
+      ]
     ]
   }
 }
 ```
 
+See [Expo build properties documentation](https://docs.expo.dev/versions/latest/sdk/build-properties/#pluginconfigtypeandroid) for more details.
 
-## Resetting local persistence
+### iOS
 
-When iterating locally you can ask the Expo adapter to drop the on-device state and eventlog databases before booting:
+No special configuration required. The adapter automatically retrieves the iOS vendor ID for client identification.
+
+## Devtools
+
+LiveStore provides integrated devtools for debugging your store. In development, press `shift + m` in the Expo CLI terminal, then select "LiveStore Devtools" to open the browser-based inspector.
+
+See the [Devtools reference](/reference/devtools) for full documentation.
+
+## Storage & Persistence
+
+### Database Location
+
+Databases are stored in the device's SQLite directory. The exact path depends on your setup:
+
+**Expo Go:**
+```bash
+open $(find $(xcrun simctl get_app_container booted host.exp.Exponent data) -path "*/Documents/ExponentExperienceData/*livestore*" -print -quit)/SQLite
+```
+
+**Development builds:**
+```bash
+open $(xcrun simctl get_app_container booted [APP_BUNDLE_ID] data)/Documents/SQLite
+```
+
+Replace `[APP_BUNDLE_ID]` with your app's bundle identifier (e.g., `dev.livestore.myapp`).
+
+### Resetting Local Persistence
+
+During development, you can clear local databases on startup:
 
 <ResetPersistenceSnippet />
 
 :::caution
-Resetting persistence deletes all local LiveStore data for the configured store. This only clears data on the device and does not touch any connected sync backend. Make sure this flag is disabled in production builds.
+This deletes all local LiveStore data for the configured store. It only clears on-device data and does not affect any connected sync backend. Ensure this flag is disabled in production builds.
 :::
 
+## Architecture
 
+The Expo adapter runs LiveStore directly in the main JavaScript thread, using native SQLite bindings provided by `expo-sqlite`. This differs from the [web adapter](/reference/platform-adapters/web-adapter), which uses web workers and WASM-based SQLite.
+
+```
+┌─────────────────────────────────────────┐
+│           React Native App              │
+│  ┌───────────────────────────────────┐  │
+│  │         LiveStore Client          │  │
+│  │  ┌─────────────┐ ┌─────────────┐  │  │
+│  │  │ State DB    │ │ Eventlog DB │  │  │
+│  │  │(expo-sqlite)│ │(expo-sqlite)│  │  │
+│  │  └─────────────┘ └─────────────┘  │  │
+│  └───────────────────────────────────┘  │
+│                    │                    │
+│                    ▼                    │
+│           ┌───────────────┐             │
+│           │ Sync Backend  │             │
+│           │  (optional)   │             │
+│           └───────────────┘             │
+└─────────────────────────────────────────┘
+```
+
+## Future Improvements
+
+We're exploring moving database operations to a background thread to further improve UI responsiveness during intensive writes. Follow [livestore/livestore](https://github.com/livestorejs/livestore) for updates.
+
+## See Also
+
+- [Expo Getting Started Guide](/getting-started/expo) — Complete setup tutorial
+- [Expo Adapter Examples](/examples/expo-adapter) — Example applications
+- [React Integration](/reference/framework-integrations/react-integration) — Provider and hooks documentation
+- [Syncing](/reference/syncing) — Multi-device synchronization
+- [Devtools](/reference/devtools) — Debugging and inspection tools

--- a/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
+++ b/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
@@ -14,11 +14,12 @@ The Expo adapter enables LiveStore in React Native applications built with [Expo
 
 ## Key Features
 
+- **Signals-based reactivity** — High-performance state management with fine-grained updates
+- **iOS and Android support** — Works seamlessly on both platforms with native performance
 - **Native SQLite storage** — Uses `expo-sqlite` for fast, reliable persistence directly on the device
 - **Offline-first** — Full functionality without network connectivity; syncs when connected
 - **Real-time sync** — Optional sync backend integration for multi-device data synchronization
 - **Integrated devtools** — Debug and inspect your store via the [LiveStore Devtools](/reference/devtools)
-- **Automatic client identification** — Uses platform-specific device IDs for client tracking
 
 ## Requirements
 
@@ -151,13 +152,13 @@ The Expo adapter runs LiveStore directly in the main JavaScript thread, using na
 │  │  │(expo-sqlite)│ │(expo-sqlite)│  │  │
 │  │  └─────────────┘ └─────────────┘  │  │
 │  └───────────────────────────────────┘  │
-│                    │                    │
-│                    ▼                    │
-│           ┌───────────────┐             │
-│           │ Sync Backend  │             │
-│           │  (optional)   │             │
-│           └───────────────┘             │
 └─────────────────────────────────────────┘
+                     │
+                     ▼ WebSocket
+            ┌───────────────┐
+            │ Sync Backend  │
+            │  (optional)   │
+            └───────────────┘
 ```
 
 ## Future Improvements

--- a/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
+++ b/docs/src/content/docs/reference/platform-adapters/expo-adapter.mdx
@@ -34,7 +34,7 @@ Expo Web is not currently supported. See [#130](https://github.com/livestorejs/l
 ## Installation
 
 ```bash
-npm install @livestore/adapter-expo @livestore/livestore @livestore/react expo-sqlite
+npm install @livestore/adapter-expo @livestore/livestore @livestore/react expo-sqlite expo-application
 ```
 
 For a complete setup including sync and devtools, see the [Expo getting started guide](/getting-started/expo).


### PR DESCRIPTION
## Problem

The Expo adapter reference page was minimal (43 lines) and didn't explain the adapter's core benefits or how to use it. Readers had to jump between getting-started and reference docs to understand what the adapter does.

## Solution

Restructured the documentation to lead with features and practical usage before diving into technical details. Added comprehensive sections covering adapter capabilities (native SQLite, offline-first, real-time sync), requirements, basic usage with code snippets, configuration options, platform-specific notes, storage locations, and architecture overview. Included links to related docs to guide readers without repetition.

## Validation

- Snippets build and type-check without errors
- Linting passes
- Documentation follows existing patterns from other adapters (web, node)
- All links to related pages verified

The page now provides a complete reference while deferring detailed setup instructions to the getting-started guide.