### PR TITLE
Add external link icons to docs

### DIFF
--- a/docs/.astro/content.d.ts
+++ b/docs/.astro/content.d.ts
@@ -1,7 +1,7 @@
 declare module 'astro:content' {
 	interface Render {
 		'.mdx': Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
+			Content: import('astro').MDXContent;
 			headings: import('astro').MarkdownHeading[];
 			remarkPluginFrontmatter: Record<string, any>;
 			components: import('astro').MDXInstance<{}>['components'];

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -18,6 +18,7 @@ import starlightLinksValidator from 'starlight-links-validator'
 import starlightSidebarTopics from 'starlight-sidebar-topics'
 import starlightTypeDoc from 'starlight-typedoc'
 import { getBranchName } from './src/data/data.ts'
+import { rehypeExternalLinks } from './src/plugins/rehype/externalLinks.js'
 import { remarkGithubIssueLinks } from './src/plugins/remark/githubIssueLinks.js'
 import { createCopyPageClipboardFallbackIntegration } from './src/plugins/starlight/contextual-menu-fallback/plugin.ts'
 import starlightMarkdown from './src/plugins/starlight/markdown/index.js'
@@ -378,6 +379,9 @@ export default defineConfig({
       // MDX: \{#custom-id\}
       remarkCustomHeaderId,
     ],
-    rehypePlugins: [[rehypeMermaid, { strategy: 'img-svg', dark: true }]],
+    rehypePlugins: [
+      [rehypeMermaid, { strategy: 'img-svg', dark: true }],
+      [rehypeExternalLinks, { internalDomains: ['livestore.dev', 'localhost'] }],
+    ],
   },
 })

--- a/docs/package.json
+++ b/docs/package.json
@@ -52,7 +52,8 @@
     "terrastruct-d2-bin": "0.7.1",
     "typedoc": "0.28.11",
     "typedoc-plugin-markdown": "4.8.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "unist-util-visit": "5.0.0"
   },
   "devDependencies": {
     "@playwright/test": "catalog:",

--- a/docs/src/plugins/rehype/externalLinks.js
+++ b/docs/src/plugins/rehype/externalLinks.js
@@ -1,0 +1,188 @@
+/**
+ * Rehype plugin that adds external link indicators to links pointing outside the docs.
+ *
+ * ## What it does
+ *
+ * 1. Detects external links (URLs starting with http:// or https:// that don't point to internal domains)
+ * 2. Adds an inline SVG icon after the link text to indicate it opens externally
+ * 3. Adds `target="_blank"` and `rel="noopener noreferrer"` for security
+ * 4. Adds CSS classes for styling
+ *
+ * ## Configuration
+ *
+ * @param {Object} options - Plugin options
+ * @param {string[]} [options.internalDomains] - Domains to treat as internal (no icon added).
+ *   Defaults to ['livestore.dev', 'localhost'].
+ * @param {boolean} [options.addTargetBlank] - Whether to add target="_blank" to external links.
+ *   Defaults to true.
+ * @param {boolean} [options.addIcon] - Whether to add the external link icon.
+ *   Defaults to true.
+ *
+ * ## Usage in astro.config.ts
+ *
+ * ```ts
+ * import { rehypeExternalLinks } from './src/plugins/rehype/externalLinks.js'
+ *
+ * export default defineConfig({
+ *   markdown: {
+ *     rehypePlugins: [
+ *       [rehypeExternalLinks, { internalDomains: ['livestore.dev', 'localhost'] }],
+ *     ],
+ *   },
+ * })
+ * ```
+ *
+ * ## Styling
+ *
+ * The plugin adds a `.external-link-icon` class to the SVG icon element.
+ * Add styles in your CSS:
+ *
+ * ```css
+ * .external-link-icon {
+ *   display: inline-block;
+ *   width: 0.75em;
+ *   height: 0.75em;
+ *   margin-left: 0.125em;
+ *   vertical-align: baseline;
+ * }
+ * ```
+ *
+ * @see https://unifiedjs.com/learn/guide/create-a-rehype-plugin/
+ */
+
+import { visit } from 'unist-util-visit'
+
+/** Default domains considered internal (links to these won't get icons) */
+const DEFAULT_INTERNAL_DOMAINS = ['livestore.dev', 'localhost']
+
+/**
+ * External link icon SVG as an HAST (Hypertext Abstract Syntax Tree) element.
+ * Uses currentColor for stroke so it inherits the link's text color.
+ *
+ * Icon source: Heroicons "arrow-top-right-on-square"
+ * @see https://heroicons.com/
+ */
+const externalLinkIconHast = {
+  type: 'element',
+  tagName: 'svg',
+  properties: {
+    className: ['external-link-icon'],
+    'aria-hidden': 'true',
+    xmlns: 'http://www.w3.org/2000/svg',
+    fill: 'none',
+    viewBox: '0 0 24 24',
+    'stroke-width': '2',
+    stroke: 'currentColor',
+  },
+  children: [
+    {
+      type: 'element',
+      tagName: 'path',
+      properties: {
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+        d: 'M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25',
+      },
+      children: [],
+    },
+  ],
+}
+
+/**
+ * Checks if a URL is external (not pointing to an internal domain).
+ *
+ * @param {string} href - The URL to check
+ * @param {string[]} internalDomains - List of internal domain patterns
+ * @returns {boolean} True if the link is external
+ */
+const isExternalLink = (href, internalDomains) => {
+  if (!href || typeof href !== 'string') return false
+
+  // Only process absolute URLs starting with http(s)
+  if (!href.startsWith('http://') && !href.startsWith('https://')) {
+    return false
+  }
+
+  try {
+    const url = new URL(href)
+    const hostname = url.hostname.toLowerCase()
+
+    // Check if the hostname matches any internal domain
+    // Supports both exact matches and subdomain matches
+    return !internalDomains.some((domain) => {
+      const normalizedDomain = domain.toLowerCase()
+      return hostname === normalizedDomain || hostname.endsWith(`.${normalizedDomain}`)
+    })
+  } catch {
+    // Invalid URL, treat as not external
+    return false
+  }
+}
+
+/**
+ * Creates a deep clone of an HAST node to avoid shared references.
+ *
+ * @param {Object} node - The HAST node to clone
+ * @returns {Object} A deep clone of the node
+ */
+const cloneHastNode = (node) => {
+  if (Array.isArray(node)) {
+    return node.map(cloneHastNode)
+  }
+  if (node && typeof node === 'object') {
+    const clone = {}
+    for (const key of Object.keys(node)) {
+      clone[key] = cloneHastNode(node[key])
+    }
+    return clone
+  }
+  return node
+}
+
+/**
+ * Rehype plugin that adds external link indicators.
+ *
+ * @param {Object} [options={}] - Plugin options
+ * @returns {(tree: Object) => void} The transformer function
+ */
+export const rehypeExternalLinks = (options = {}) => {
+  const { internalDomains = DEFAULT_INTERNAL_DOMAINS, addTargetBlank = true, addIcon = true } = options
+
+  return (tree) => {
+    visit(tree, 'element', (node) => {
+      // Only process anchor elements with href
+      if (node.tagName !== 'a') return
+      if (!node.properties?.href) return
+
+      const href = node.properties.href
+
+      // Check if this is an external link
+      if (!isExternalLink(href, internalDomains)) return
+
+      // Add target="_blank" for external links (security best practice)
+      if (addTargetBlank) {
+        node.properties.target = '_blank'
+        // noopener prevents the new page from accessing window.opener
+        // noreferrer additionally prevents the Referer header from being sent
+        node.properties.rel = 'noopener noreferrer'
+      }
+
+      // Add the external link icon as the last child
+      if (addIcon && Array.isArray(node.children)) {
+        // Clone the icon to avoid shared references between nodes
+        const iconNode = cloneHastNode(externalLinkIconHast)
+        node.children.push(iconNode)
+      }
+
+      // Add a class for additional CSS targeting if needed
+      if (!node.properties.className) {
+        node.properties.className = []
+      }
+      if (Array.isArray(node.properties.className)) {
+        node.properties.className.push('external-link')
+      }
+    })
+  }
+}
+
+export default rehypeExternalLinks

--- a/docs/src/tailwind.css
+++ b/docs/src/tailwind.css
@@ -145,3 +145,21 @@ svg[data-d2-version] {
 .d2-full-width svg[data-d2-version] {
   max-width: 100%;
 }
+
+/*
+ * External link icon styling
+ * Added by the rehypeExternalLinks plugin to indicate links leaving the docs.
+ * Icon uses currentColor to inherit the link's text color automatically.
+ */
+.external-link-icon {
+  display: inline-block;
+  width: 0.7em;
+  height: 0.7em;
+  margin-left: 0.2em;
+  /* Align with text baseline, slight adjustment for visual balance */
+  vertical-align: baseline;
+  position: relative;
+  top: -0.1em;
+  /* Prevent icon from being orphaned on line wrap */
+  flex-shrink: 0;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+      unist-util-visit:
+        specifier: 5.0.0
+        version: 5.0.0
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -2517,7 +2520,7 @@ importers:
     dependencies:
       '@kitschpatrol/tldraw-cli':
         specifier: 5.0.0
-        version: 5.0.0(typescript@5.9.2)
+        version: 5.0.0(typescript@5.9.3)
       '@livestore/utils':
         specifier: workspace:*
         version: link:../../@livestore/utils
@@ -2527,7 +2530,7 @@ importers:
         version: 24.10.1
       astro:
         specifier: ^5.13.4
-        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
+        version: 5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -4540,7 +4543,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@54.0.10':
     resolution: {integrity: sha512-iw9gAnN6+PKWWLIyYmiskY/wzZjuFMctunqGXuC8BGATWgtr/HpzjVqWbcL3KIX/GvEBCCh74Tkckrh+Ylxh5Q==}
@@ -5422,7 +5425,6 @@ packages:
   '@oclif/screen@3.0.8':
     resolution: {integrity: sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==}
     engines: {node: '>=12.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oozcitak/dom@1.15.10':
     resolution: {integrity: sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==}
@@ -8396,7 +8398,6 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -10837,11 +10838,9 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -11006,7 +11005,6 @@ packages:
 
   hast@1.0.0:
     resolution: {integrity: sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==}
-    deprecated: Renamed to rehype
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
@@ -11205,7 +11203,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -11678,7 +11675,6 @@ packages:
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
     engines: {node: '>= 0.6'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
@@ -11950,7 +11946,6 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -12693,7 +12688,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -14040,12 +14034,10 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@5.0.10:
@@ -14601,7 +14593,6 @@ packages:
 
   sudo-prompt@9.1.1:
     resolution: {integrity: sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -18655,12 +18646,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kitschpatrol/tldraw-cli@5.0.0(typescript@5.9.2)':
+  '@kitschpatrol/tldraw-cli@5.0.0(typescript@5.9.3)':
     dependencies:
       '@fontsource/inter': 5.2.8
       '@hono/node-server': 1.19.6(hono@4.10.6)
       hono: 4.10.6
-      puppeteer: 24.31.0(typescript@5.9.2)
+      puppeteer: 24.31.0(typescript@5.9.3)
       uint8array-extras: 1.5.0
       yargs: 18.0.0
     transitivePeerDependencies:
@@ -23519,6 +23510,108 @@ snapshots:
       - uploadthing
       - yaml
 
+  astro@5.13.4(@netlify/blobs@10.4.1)(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1):
+    dependencies:
+      '@astrojs/compiler': 2.13.0
+      '@astrojs/internal-helpers': 0.7.2
+      '@astrojs/markdown-remark': 6.3.6
+      '@astrojs/telemetry': 3.3.0
+      '@capsizecss/unpack': 2.4.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
+      acorn: 8.15.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      boxen: 8.0.1
+      ci-info: 4.3.1
+      clsx: 2.1.1
+      common-ancestor-path: 1.0.1
+      cookie: 1.0.2
+      cssesc: 3.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      deterministic-object-hash: 2.0.2
+      devalue: 5.5.0
+      diff: 5.2.0
+      dlv: 1.1.3
+      dset: 3.1.4
+      es-module-lexer: 1.7.0
+      esbuild: 0.25.12
+      estree-walker: 3.0.3
+      flattie: 1.1.1
+      fontace: 0.3.1
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      import-meta-resolve: 4.2.0
+      js-yaml: 4.1.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      mrmime: 2.0.1
+      neotraverse: 0.6.18
+      p-limit: 6.2.0
+      p-queue: 8.1.1
+      package-manager-detector: 1.5.0
+      picomatch: 4.0.3
+      prompts: 2.4.2
+      rehype: 13.0.2
+      semver: 7.7.3
+      shiki: 3.15.0
+      smol-toml: 1.5.2
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tsconfck: 3.1.6(typescript@5.9.3)
+      ultrahtml: 1.6.0
+      unifont: 0.5.2
+      unist-util-visit: 5.0.0
+      unstorage: 1.17.3(@netlify/blobs@10.4.1)
+      vfile: 6.0.3
+      vite: 6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 21.1.1
+      yocto-spinner: 0.2.3
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.0(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+    optionalDependencies:
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - encoding
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - lightningcss
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - yaml
+
   async-limiter@1.0.1: {}
 
   async-mutex@0.4.0:
@@ -24428,6 +24521,15 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.2
+
+  cosmiconfig@9.0.0(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   crc-32@1.2.2: {}
 
@@ -29507,11 +29609,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@24.31.0(typescript@5.9.2):
+  puppeteer@24.31.0(typescript@5.9.3):
     dependencies:
       '@puppeteer/browsers': 2.10.13
       chromium-bidi: 11.0.0(devtools-protocol@0.0.1521046)
-      cosmiconfig: 9.0.0(typescript@5.9.2)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       devtools-protocol: 0.0.1521046
       puppeteer-core: 24.31.0
       typed-query-selector: 2.12.0
@@ -32410,6 +32512,11 @@ snapshots:
   zod-to-ts@1.2.0(typescript@5.9.2)(zod@3.25.76):
     dependencies:
       typescript: 5.9.2
+      zod: 3.25.76
+
+  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      typescript: 5.9.3
       zod: 3.25.76
 
   zod@3.22.3: {}


### PR DESCRIPTION
## Problem

External links in the documentation don't clearly indicate that they point outside the site, making it less obvious to users that they're leaving the docs.

## Solution

Implemented a well-documented rehype plugin (`rehypeExternalLinks`) that automatically detects external links and adds an SVG icon from Heroicons that visually indicates they leave the site. The icon:
- Uses `currentColor` to inherit the link's text color in both light and dark modes
- Is sized appropriately relative to text (0.7em)
- Includes proper accessibility attributes (`aria-hidden`)
- Adds `target="_blank"` and `rel="noopener noreferrer"` for security

The plugin is configurable with a list of internal domains to exclude, and all links are processed automatically during the Astro build phase with no changes needed to existing markdown/MDX files.

## Validation

Built the docs successfully with the plugin and verified external links render with the icon intact in the generated HTML. TypeScript, linting, and all pre-commit checks pass.