### PR TITLE
Add JSDoc documentation to core LiveStore APIs

### DIFF
--- a/packages/@livestore/adapter-cloudflare/src/create-store-do.ts
+++ b/packages/@livestore/adapter-cloudflare/src/create-store-do.ts
@@ -44,6 +44,46 @@ export type CreateStoreDoOptions<TSchema extends LiveStoreSchema, TEnv, TState> 
   resetPersistence?: boolean
 } & LogConfig.WithLoggerOptions
 
+/**
+ * Creates a LiveStore instance inside a Cloudflare Durable Object.
+ *
+ * This function bootstraps a full LiveStore client within a Durable Object, enabling
+ * persistent state management with automatic sync to a sync backend. Use this when you
+ * need server-side LiveStore instances that can communicate with other clients.
+ *
+ * Returns an Effect that resolves to a Store instance. For a Promise-based API,
+ * use `createStoreDoPromise` instead.
+ *
+ * @example
+ * ```ts
+ * import { createStoreDo } from '@livestore/adapter-cloudflare'
+ * import { schema } from './schema'
+ *
+ * export class MyDurableObject extends DurableObject {
+ *   store: Store | undefined
+ *
+ *   async fetch(request: Request) {
+ *     if (!this.store) {
+ *       this.store = await createStoreDo({
+ *         schema,
+ *         storeId: 'my-store',
+ *         clientId: this.ctx.id.toString(),
+ *         sessionId: 'do-session',
+ *         durableObject: {
+ *           ctx: this.ctx,
+ *           env: this.env,
+ *           bindingName: 'MY_DO',
+ *         },
+ *         syncBackendStub: this.env.SYNC_BACKEND_DO.get(syncBackendId),
+ *       }).pipe(Effect.runPromise)
+ *     }
+ *     // Use this.store...
+ *   }
+ * }
+ * ```
+ *
+ * @see https://livestore.dev/docs/reference/adapters/cloudflare for setup guide
+ */
 // TODO Also support in Cloudflare workers outside of a durable object context.
 export const createStoreDo = <
   TSchema extends LiveStoreSchema,
@@ -83,6 +123,31 @@ export const createStoreDo = <
     return yield* createStore({ schema, adapter, storeId }).pipe(Scope.extend(scope), provideOtel({}))
   })
 
+/**
+ * Promise-based wrapper around `createStoreDo` for simpler async/await usage.
+ *
+ * Equivalent to calling `createStoreDo(options).pipe(Effect.runPromise)` with
+ * logging configured automatically.
+ *
+ * @example
+ * ```ts
+ * import { createStoreDoPromise } from '@livestore/adapter-cloudflare'
+ *
+ * export class MyDurableObject extends DurableObject {
+ *   async fetch(request: Request) {
+ *     const store = await createStoreDoPromise({
+ *       schema,
+ *       storeId: 'my-store',
+ *       clientId: this.ctx.id.toString(),
+ *       sessionId: 'do-session',
+ *       durableObject: { ctx: this.ctx, env: this.env, bindingName: 'MY_DO' },
+ *       syncBackendStub: this.env.SYNC_BACKEND_DO.get(syncBackendId),
+ *     })
+ *     // Use store...
+ *   }
+ * }
+ * ```
+ */
 export const createStoreDoPromise = <
   TSchema extends LiveStoreSchema,
   TEnv,

--- a/packages/@livestore/adapter-expo/src/index.ts
+++ b/packages/@livestore/adapter-expo/src/index.ts
@@ -70,6 +70,40 @@ const IS_NEW_ARCH =
   // TurboModule proxy – indicates new arch TurboModules
   Boolean((globalThis as any).__turboModuleProxy)
 
+/**
+ * Creates a persisted LiveStore adapter for Expo/React Native applications.
+ *
+ * This adapter stores data in SQLite databases on the device filesystem, providing
+ * persistence across app restarts. It supports optional sync backends for multi-device
+ * synchronization.
+ *
+ * **Requirements:**
+ * - React Native New Architecture (Fabric) must be enabled
+ * - Expo SDK 51+ recommended
+ *
+ * @example
+ * ```ts
+ * import { makePersistedAdapter } from '@livestore/adapter-expo'
+ * import { makeWsSync } from '@livestore/sync-cf/client'
+ *
+ * const adapter = makePersistedAdapter({
+ *   sync: {
+ *     backend: makeWsSync({ url: 'wss://api.example.com/sync' }),
+ *   },
+ *   storage: {
+ *     subDirectory: 'my-app',
+ *   },
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Minimal setup without sync
+ * const adapter = makePersistedAdapter()
+ * ```
+ *
+ * @see https://livestore.dev/docs/reference/adapters/expo for detailed setup guide
+ */
 // TODO refactor with leader-thread code from `@livestore/common/leader-thread`
 export const makePersistedAdapter =
   (options: MakeDbOptions = {}): Adapter =>

--- a/packages/@livestore/adapter-node/src/client-session/adapter.ts
+++ b/packages/@livestore/adapter-node/src/client-session/adapter.ts
@@ -88,7 +88,43 @@ export interface NodeAdapterOptions {
   }
 }
 
-/** Runs everything in the same thread. Use `makeWorkerAdapter` for multi-threaded implementation. */
+/**
+ * Creates a single-threaded LiveStore adapter for Node.js applications.
+ *
+ * This adapter runs the leader thread (persistence and sync) in the same thread as
+ * your application. Suitable for CLI tools, scripts, and applications where simplicity
+ * is preferred over maximum performance.
+ *
+ * For production servers or performance-critical applications, consider `makeWorkerAdapter`
+ * which runs persistence/sync in a separate worker thread.
+ *
+ * @example
+ * ```ts
+ * import { makeAdapter } from '@livestore/adapter-node'
+ * import { makeWsSync } from '@livestore/sync-cf/client'
+ *
+ * const adapter = makeAdapter({
+ *   storage: { type: 'fs', baseDirectory: './data' },
+ *   sync: {
+ *     backend: makeWsSync({ url: 'wss://api.example.com/sync' }),
+ *   },
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With DevTools support
+ * const adapter = makeAdapter({
+ *   storage: { type: 'fs', baseDirectory: './data' },
+ *   devtools: {
+ *     schemaPath: new URL('./schema.ts', import.meta.url),
+ *     port: 4242,
+ *   },
+ * })
+ * ```
+ *
+ * @see https://livestore.dev/docs/reference/adapters/node for setup guide
+ */
 export const makeAdapter = ({
   sync,
   ...options
@@ -97,7 +133,36 @@ export const makeAdapter = ({
 }): Adapter => makeAdapterImpl({ ...options, leaderThread: { _tag: 'single-threaded', sync } })
 
 /**
- * Runs persistence and syncing in a worker thread.
+ * Creates a multi-threaded LiveStore adapter for Node.js applications.
+ *
+ * This adapter runs the leader thread (persistence, sync, and heavy SQLite operations)
+ * in a separate worker thread, keeping your main thread responsive. Recommended for
+ * production servers and performance-critical applications.
+ *
+ * You must create a worker file that calls `makeLeaderWorker()` and pass its URL
+ * to this function.
+ *
+ * @example
+ * ```ts
+ * // In your main file:
+ * import { makeWorkerAdapter } from '@livestore/adapter-node'
+ *
+ * const adapter = makeWorkerAdapter({
+ *   storage: { type: 'fs', baseDirectory: './data' },
+ *   workerUrl: new URL('./livestore.worker.ts', import.meta.url),
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // In livestore.worker.ts:
+ * import { makeLeaderWorker } from '@livestore/adapter-node/worker'
+ * import { schema } from './schema'
+ *
+ * makeLeaderWorker({ schema })
+ * ```
+ *
+ * @see https://livestore.dev/docs/reference/adapters/node for setup guide
  */
 export const makeWorkerAdapter = ({
   workerUrl,

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -54,14 +54,48 @@ export interface InMemoryAdapterOptions {
 }
 
 /**
- * Create a web-only in-memory LiveStore adapter.
+ * Creates a web-only in-memory LiveStore adapter.
  *
- * - Runs entirely in memory: fast, zero I/O, great for tests, sandboxes, or ephemeral sessions.
- * - Works across browser execution contexts: Window, WebWorker, SharedWorker, and ServiceWorker.
- * - DevTools: to inspect this adapter from the browser DevTools, provide a `sharedWorker` in `options.devtools`.
- *   (The shared worker is used to bridge the DevTools UI to the running session.)
- * - No persistence support: nothing is written to OPFS/IndexedDB/localStorage. `importSnapshot`
- *   can bootstrap initial state only; subsequent changes are not persisted anywhere.
+ * This adapter runs entirely in memory with no persistence. Ideal for:
+ * - Unit tests and integration tests
+ * - Sandboxes and demos
+ * - Ephemeral sessions where persistence isn't needed
+ *
+ * **Characteristics:**
+ * - Fast, zero I/O overhead
+ * - Works in all browser contexts: Window, WebWorker, SharedWorker, ServiceWorker
+ * - Supports optional sync backends for real-time collaboration
+ * - No data persists after page reload
+ *
+ * For persistent storage, use `makePersistedAdapter` instead.
+ *
+ * @example
+ * ```ts
+ * import { makeInMemoryAdapter } from '@livestore/adapter-web'
+ *
+ * const adapter = makeInMemoryAdapter()
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With sync backend for real-time collaboration
+ * import { makeInMemoryAdapter } from '@livestore/adapter-web'
+ * import { makeWsSync } from '@livestore/sync-cf/client'
+ *
+ * const adapter = makeInMemoryAdapter({
+ *   sync: {
+ *     backend: makeWsSync({ url: 'wss://api.example.com/sync' }),
+ *   },
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Pre-populate with existing data
+ * const adapter = makeInMemoryAdapter({
+ *   importSnapshot: existingDbSnapshot,
+ * })
+ * ```
  */
 export const makeInMemoryAdapter =
   (options: InMemoryAdapterOptions = {}): Adapter =>

--- a/packages/@livestore/livestore/src/live-queries/base-class.ts
+++ b/packages/@livestore/livestore/src/live-queries/base-class.ts
@@ -35,34 +35,87 @@ export type GetResult<TQuery extends LiveQueryDef.Any | LiveQuery.Any | SignalDe
 
 let queryIdCounter = 0
 
+/**
+ * A signal definition representing ephemeral, local-only reactive state.
+ *
+ * `SignalDef` is the type returned by {@link signal}. It's a blueprint for creating
+ * signal instances—the actual instance is created when you use the definition with
+ * a Store via `store.query()` or `store.setSignal()`.
+ *
+ * @typeParam T - The type of value the signal holds
+ */
 export interface SignalDef<T> extends LiveQueryDef<T, 'signal-def'> {
   _tag: 'signal-def'
+  /** The initial value used when the signal is first created */
   defaultValue: T
+  /** Unique identifier for caching and deduplication */
   hash: string
+  /** Human-readable label for debugging and devtools */
   label: string
+  /** Creates a reference-counted signal instance bound to a Store's reactivity graph */
   make: (ctx: ReactivityGraphContext) => RcRef<ISignal<T>>
   [Equal.symbol](that: SignalDef<T>): boolean
   [Hash.symbol](): number
 }
 
+/**
+ * Interface for a live signal instance.
+ *
+ * This represents an active signal bound to a Store's reactivity graph.
+ * Use `store.setSignal()` to update values and `store.query()` to read them.
+ *
+ * @typeParam T - The type of value the signal holds
+ */
 export interface ISignal<T> extends LiveQuery<T> {
   _tag: 'signal'
   reactivityGraph: ReactivityGraph
+  /** The underlying reactive reference in the graph */
   ref: RG.Ref<T, ReactivityGraphContext, RefreshReason>
+  /** Sets the signal's value (prefer using `store.setSignal()` instead) */
   set: (value: T) => void
+  /** Gets the signal's current value (prefer using `store.query()` instead) */
   get: () => T
+  /** Removes the signal from the reactivity graph */
   destroy: () => void
 }
 
 export const TypeId = Symbol.for('LiveQuery')
 export type TypeId = typeof TypeId
 
+/**
+ * A reference-counted wrapper around a LiveQuery or Signal instance.
+ *
+ * LiveStore uses reference counting to manage query lifecycle. When multiple
+ * components or subscriptions use the same query definition, they share a single
+ * instance. The instance is destroyed when the last reference is released.
+ *
+ * You typically don't interact with `RcRef` directly—it's used internally by
+ * hooks like `useQuery` and `useQueryRef`.
+ */
 export interface RcRef<T> {
+  /** Current reference count */
   rc: number
+  /** The wrapped query or signal instance */
   value: T
+  /** Decrements the reference count; destroys the instance when it reaches zero */
   deref: () => void
 }
 
+/**
+ * Dependency key used to identify queries on platforms where `fn.toString()` isn't reliable.
+ *
+ * On Expo/React Native, Hermes compiles functions to bytecode, so `fn.toString()` returns
+ * `[native code]`. To uniquely identify contextual queries, you must provide explicit `deps`.
+ *
+ * @example
+ * ```ts
+ * // On Expo, this would fail without deps:
+ * const filtered$ = queryDb(
+ *   (get) => tables.todos.where({ userId: get(userId$) }),
+ *   { deps: [userId] } // Required on Expo/React Native
+ * )
+ * ```
+ */
 export type DepKey = string | number | ReadonlyArray<string | number | undefined | null>
 
 export const depsToString = (deps: DepKey): string => {
@@ -72,12 +125,26 @@ export const depsToString = (deps: DepKey): string => {
   return deps.filter(isNotNil).join(',')
 }
 
+/**
+ * A query definition representing a blueprint for a reactive query.
+ *
+ * Query definitions are created by {@link queryDb}, {@link computed}, and {@link signal}.
+ * They're lightweight and can be defined at module scope. The actual query instance
+ * (which holds state) is created lazily when you use the definition with a Store.
+ *
+ * Multiple uses of the same definition share a single instance via reference counting.
+ *
+ * @typeParam TResult - The type of value the query returns
+ * @typeParam TTag - Internal discriminator tag ('def' for queries, 'signal-def' for signals)
+ */
 // TODO we should refactor/clean up how LiveQueryDef / SignalDef / LiveQuery / ISignal are defined (particularly on the type-level)
 export interface LiveQueryDef<TResult, TTag extends string = 'def'> {
   _tag: TTag
-  /** Creates a new LiveQuery instance bound to a specific store/reactivityGraph */
+  /** Creates a reference-counted query instance bound to a Store's reactivity graph */
   make: (ctx: ReactivityGraphContext, otelContext?: otel.Context) => RcRef<LiveQuery<TResult> | ISignal<TResult>>
+  /** Human-readable label for debugging and devtools */
   label: string
+  /** Unique identifier derived from the query string or explicit deps; used for caching */
   hash: string
   [Equal.symbol](that: LiveQueryDef<TResult, TTag>): boolean
   [Hash.symbol](): number
@@ -88,39 +155,51 @@ export namespace LiveQueryDef {
 }
 
 /**
- * A LiveQuery is stateful
+ * A live query instance bound to a specific Store.
+ *
+ * `LiveQuery` represents an active, stateful query in the reactivity graph. Unlike
+ * query definitions (`LiveQueryDef`), instances maintain state like execution counts,
+ * timing data, and active subscriptions.
+ *
+ * You typically don't work with `LiveQuery` directly—use `store.query()` for one-shot
+ * reads or `store.subscribe()` for reactive subscriptions. The instance is managed
+ * automatically via reference counting.
+ *
+ * @typeParam TResult - The type of value the query returns
  */
 export interface LiveQuery<TResult> {
+  /** Unique identifier for this query instance */
   id: number
+  /** Discriminator for the query type */
   _tag: 'computed' | 'db' | 'graphql' | 'signal'
   [TypeId]: TypeId
 
-  // reactivityGraph: ReactivityGraph
-
-  /** This should only be used on a type-level and doesn't hold any value during runtime */
+  /** Type-level only—extracts the result type from a LiveQuery */
   '__result!': TResult
 
-  /** A reactive thunk representing the query results */
+  /** The underlying reactive atom in the graph that holds the query result */
   results$: RG.Atom<TResult, ReactivityGraphContext, RefreshReason>
 
+  /** Human-readable label for debugging and devtools */
   label: string
 
+  /** Executes the query and returns the result */
   run: (args: { otelContext?: otel.Context; debugRefreshReason?: RefreshReason }) => TResult
 
+  /** Removes the query from the reactivity graph */
   destroy: () => void
+  /** Whether this query instance has been destroyed */
   isDestroyed: boolean
 
-  // subscribe(
-  //   onNewValue: (value: TResult) => void,
-  //   onUnsubsubscribe?: () => void,
-  //   options?: { label?: string; otelContext?: otel.Context },
-  // ): () => void
-
+  /** Stack traces of active subscriptions (for debugging) */
   activeSubscriptions: Set<StackInfo>
 
+  /** Number of times this query has been executed */
   runs: number
 
+  /** Execution times in milliseconds (for performance monitoring) */
   executionTimes: number[]
+  /** The definition that created this instance */
   def: LiveQueryDef<TResult> | SignalDef<TResult>
 }
 
@@ -176,6 +255,22 @@ export abstract class LiveStoreQueryBase<TResult> implements LiveQuery<TResult> 
   //   RG.throwContextNotSetError(this.reactivityGraph)
 }
 
+/**
+ * Function signature for the `get` parameter in `computed()` and `queryDb()` callbacks.
+ *
+ * Call `get()` with a query definition, signal, or live query instance to:
+ * 1. Read its current value
+ * 2. Establish a reactive dependency (the caller re-runs when the dependency changes)
+ *
+ * @example
+ * ```ts
+ * const filtered$ = computed((get) => {
+ *   const todos = get(todos$)        // Depends on todos$
+ *   const filter = get(filterText$)  // Depends on filterText$
+ *   return todos.filter((t) => t.text.includes(filter))
+ * })
+ * ```
+ */
 export type GetAtomResult = <T>(
   atom: RG.Atom<T, any, RefreshReason> | LiveQueryDef<T> | LiveQuery<T> | ISignal<T> | SignalDef<T>,
   otelContext?: otel.Context | undefined,

--- a/packages/@livestore/livestore/src/live-queries/computed.ts
+++ b/packages/@livestore/livestore/src/live-queries/computed.ts
@@ -8,6 +8,55 @@ import { isValidFunctionString } from '../utils/function-string.ts'
 import type { DepKey, GetAtomResult, LiveQueryDef, ReactivityGraph, ReactivityGraphContext } from './base-class.ts'
 import { depsToString, LiveStoreQueryBase, makeGetAtomResult, withRCMap } from './base-class.ts'
 
+/**
+ * Creates a derived query that computes a value from other queries or signals.
+ *
+ * Computed queries are memoized—they only re-evaluate when their dependencies change,
+ * and if the new result equals the previous result, downstream dependents won't re-run.
+ * Use them for expensive calculations, aggregations, or transformations.
+ *
+ * The `get` function inside `computed` establishes reactive dependencies automatically.
+ * When any dependency updates, the computed re-evaluates.
+ *
+ * @example
+ * ```ts
+ * // Derive a count from a database query
+ * const todos$ = queryDb(tables.todos.all())
+ * const todoCount$ = computed((get) => get(todos$).length, { label: 'todoCount' })
+ *
+ * // Use in a component
+ * const count = store.query(todoCount$) // 5
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Combine multiple queries into derived stats
+ * const stats$ = computed((get) => {
+ *   const todos = get(todos$)
+ *   const completed = todos.filter((t) => t.completed).length
+ *   return {
+ *     total: todos.length,
+ *     completed,
+ *     remaining: todos.length - completed,
+ *     percentComplete: todos.length > 0 ? (completed / todos.length) * 100 : 0,
+ *   }
+ * }, { label: 'todoStats' })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Chain computed queries
+ * const hasCompletedTodos$ = computed(
+ *   (get) => get(stats$).completed > 0,
+ *   { label: 'hasCompletedTodos' }
+ * )
+ * ```
+ *
+ * @param fn - Pure function that computes the result. Use `get()` to read dependencies.
+ * @param options.label - Human-readable label for debugging and devtools
+ * @param options.deps - Explicit dependency keys (required on Expo/React Native where `fn.toString()` returns `[native code]`)
+ * @returns A query definition usable with `store.query()`, `store.subscribe()`, and as a dependency in other queries
+ */
 export const computed = <TResult>(
   fn: (get: GetAtomResult) => TResult,
   options?: {
@@ -47,6 +96,13 @@ export const computed = <TResult>(
   return def
 }
 
+/**
+ * A live computed query instance bound to a specific Store.
+ *
+ * Computed query instances are created internally when you use a `LiveQueryDef` (from {@link computed})
+ * with the Store. You typically don't construct these directly—use `computed()` to create definitions
+ * and `store.query()` / `store.subscribe()` to interact with them.
+ */
 export class LiveStoreComputedQuery<TResult> extends LiveStoreQueryBase<TResult> {
   _tag = 'computed' as const
 

--- a/packages/@livestore/livestore/src/live-queries/signal.ts
+++ b/packages/@livestore/livestore/src/live-queries/signal.ts
@@ -6,6 +6,48 @@ import type { RefreshReason } from '../store/store-types.ts'
 import type { ISignal, ReactivityGraph, ReactivityGraphContext, SignalDef } from './base-class.ts'
 import { LiveStoreQueryBase, withRCMap } from './base-class.ts'
 
+/**
+ * Creates a reactive signal for ephemeral, local-only state that isn't persisted to the database.
+ *
+ * Signals are useful for UI state that needs to trigger query re-evaluation but shouldn't be
+ * synced across clients or stored permanently—such as search filters, selected items, or
+ * temporary form values.
+ *
+ * Unlike database-backed state (via events), signals:
+ * - Are not persisted or synced
+ * - Exist only for the lifetime of the Store
+ * - Can hold any value type (primitives, objects, functions)
+ *
+ * @example
+ * ```ts
+ * // Create a signal for search text
+ * const searchText$ = signal('', { label: 'searchText' })
+ *
+ * // Create a query that depends on the signal
+ * const filteredTodos$ = queryDb(
+ *   (get) => tables.todos.where({ text: { $like: `%${get(searchText$)}%` } }),
+ *   { deps: [searchText$] }
+ * )
+ *
+ * // Update the signal (triggers query re-evaluation)
+ * store.setSignal(searchText$, 'buy')
+ *
+ * // Read the current value
+ * const results = store.query(filteredTodos$)
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Counter with functional updates
+ * const count$ = signal(0, { label: 'count' })
+ *
+ * store.setSignal(count$, (prev) => prev + 1)
+ * ```
+ *
+ * @param defaultValue - Initial value of the signal
+ * @param options.label - Human-readable label for debugging and devtools
+ * @returns A signal definition that can be used with `store.query()`, `store.setSignal()`, and as a dependency in other queries
+ */
 export const signal = <T>(
   defaultValue: T,
   options?: {
@@ -39,6 +81,13 @@ export const signal = <T>(
   return def
 }
 
+/**
+ * A live signal instance bound to a specific Store.
+ *
+ * Signal instances are created internally when you use a `SignalDef` with the Store.
+ * You typically don't construct these directly—use {@link signal} to create definitions
+ * and `store.setSignal()` / `store.query()` to interact with them.
+ */
 export class Signal<T> extends LiveStoreQueryBase<T> implements ISignal<T> {
   _tag = 'signal' as const
   readonly ref: RG.Ref<T, ReactivityGraphContext, RefreshReason>

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -30,6 +30,14 @@ import type { ReferenceCountedSet } from '../utils/data-structures.ts'
 import type { StackInfo } from '../utils/stack-info.ts'
 import type { Store } from './store.ts'
 
+/**
+ * Union type representing the possible states of a LiveStore context.
+ *
+ * Used by framework integrations (React, Solid, etc.) to track Store lifecycle:
+ * - `running`: Store is active and ready for queries/commits
+ * - `error`: Store failed during boot or operation
+ * - `shutdown`: Store was intentionally shut down or interrupted
+ */
 export type LiveStoreContext =
   | LiveStoreContextRunning
   | {
@@ -50,6 +58,12 @@ export const makeShutdownDeferred: Effect.Effect<ShutdownDeferred> = Deferred.ma
   UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | IsOfflineError
 >()
 
+/**
+ * Context state when the Store is active and ready for use.
+ *
+ * This is the normal operating state where you can query data, commit events,
+ * and subscribe to changes.
+ */
 export type LiveStoreContextRunning = {
   stage: 'running'
   store: Store
@@ -176,6 +190,12 @@ export type StoreOptions<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, 
   __runningInDevtools: boolean
 }
 
+/**
+ * Tagged union describing why a reactive refresh occurred.
+ *
+ * Used internally for debugging and devtools to trace the cause of query re-evaluations.
+ * Each variant includes context about what triggered the refresh.
+ */
 export type RefreshReason =
   | DebugRefreshReasonBase
   | {
@@ -197,10 +217,19 @@ export type RefreshReason =
   | { _tag: 'subscribe.update'; label?: string }
   | { _tag: 'manual'; label?: string }
 
+/**
+ * Debug information captured for each query execution.
+ *
+ * Used by devtools and performance monitoring to track query behavior.
+ */
 export type QueryDebugInfo = {
+  /** Query type discriminator ('db', 'computed', etc.) */
   _tag: string
+  /** Human-readable query label */
   label: string
+  /** SQL query string or computed function representation */
   query: string
+  /** Execution time in milliseconds */
   durationMs: number
 }
 
@@ -241,14 +270,37 @@ export type StoreEventsOptions<TSchema extends LiveStoreSchema> = {
   excludeUnpushed?: boolean
 }
 
+/**
+ * Function returned by `store.subscribe()` to stop receiving updates.
+ *
+ * Call this to unsubscribe from a query and release the associated resources.
+ *
+ * @example
+ * ```ts
+ * const unsubscribe = store.subscribe(todos$, (todos) => console.log(todos))
+ * // Later...
+ * unsubscribe()
+ * ```
+ */
 export type Unsubscribe = () => void
 
+/**
+ * Options for `store.subscribe()`.
+ *
+ * @typeParam TResult - The result type of the subscribed query
+ */
 export type SubscribeOptions<TResult> = {
+  /** Callback invoked when the subscription is established (receives the live query instance) */
   onSubscribe?: (query$: LiveQuery<TResult>) => void
+  /** Callback invoked when the subscription is terminated */
   onUnsubsubscribe?: () => void
+  /** Label for debugging and devtools */
   label?: string
+  /** If true, skips invoking the callback for the initial value */
   skipInitialRun?: boolean
+  /** OpenTelemetry context for tracing */
   otelContext?: otel.Context
+  /** Stack trace info for debugging subscription origins */
   stackInfo?: StackInfo
 }
 
@@ -277,6 +329,21 @@ export namespace Queryable {
   export type Result<TQueryable extends Queryable<any>> = TQueryable extends Queryable<infer TResult> ? TResult : never
 }
 
+/**
+ * Type guard that checks if a value is a query or signal definition.
+ *
+ * Use this to distinguish between definitions (blueprints) and instances (live queries).
+ * Definitions are created by `queryDb()`, `computed()`, and `signal()`.
+ *
+ * @example
+ * ```ts
+ * const todos$ = queryDb(tables.todos.all())
+ *
+ * if (isLiveQueryDef(todos$)) {
+ *   console.log('This is a definition:', todos$.label)
+ * }
+ * ```
+ */
 export const isLiveQueryDef = (value: unknown): value is LiveQueryDef<any> | SignalDef<any> => {
   if (typeof value !== 'object' || value === null) {
     return false
@@ -305,7 +372,41 @@ export const isLiveQueryDef = (value: unknown): value is LiveQueryDef<any> | Sig
   return true
 }
 
+/**
+ * Type guard that checks if a value is a live query instance.
+ *
+ * Live query instances are stateful objects bound to a Store's reactivity graph.
+ * They're created internally when you use a definition with `store.query()` or `store.subscribe()`.
+ *
+ * @example
+ * ```ts
+ * const [, , , query$] = useClientDocument(tables.uiState)
+ *
+ * if (isLiveQueryInstance(query$)) {
+ *   console.log('Execution count:', query$.runs)
+ * }
+ * ```
+ */
 export const isLiveQueryInstance = (value: unknown): value is LiveQuery<any> => Predicate.hasProperty(value, TypeId)
 
+/**
+ * Type guard that checks if a value can be used with `store.query()` or `store.subscribe()`.
+ *
+ * Queryable values include:
+ * - Query definitions (`LiveQueryDef` from `queryDb()`, `computed()`)
+ * - Signal definitions (`SignalDef` from `signal()`)
+ * - Live query instances (`LiveQuery`)
+ * - Query builders (e.g., `tables.todos.where(...)`)
+ *
+ * @example
+ * ```ts
+ * const handleQuery = (input: unknown) => {
+ *   if (isQueryable(input)) {
+ *     return store.query(input)
+ *   }
+ *   throw new Error('Not a valid query')
+ * }
+ * ```
+ */
 export const isQueryable = (value: unknown): value is Queryable<unknown> =>
   isQueryBuilder(value) || isLiveQueryInstance(value) || isLiveQueryDef(value)

--- a/packages/@livestore/react/src/LiveStoreContext.ts
+++ b/packages/@livestore/react/src/LiveStoreContext.ts
@@ -4,11 +4,38 @@ import React from 'react'
 import type { useClientDocument } from './useClientDocument.ts'
 import type { useQuery } from './useQuery.ts'
 
+/**
+ * React-specific methods added to the Store when used via React hooks.
+ *
+ * These methods are attached by `withReactApi()` and `useStore()`, allowing you
+ * to call `store.useQuery()` and `store.useClientDocument()` directly on the
+ * Store instance.
+ */
 export type ReactApi = {
+  /** Hook version of query subscription—re-renders component when query result changes */
   useQuery: typeof useQuery
+  /** Hook for reading and writing client-document tables with React state semantics */
   useClientDocument: typeof useClientDocument
 }
 
+/**
+ * React context for accessing the LiveStore instance.
+ *
+ * This context is provided by `<LiveStoreProvider>` and consumed by hooks like
+ * `useStore()`, `useQuery()`, and `useClientDocument()`.
+ *
+ * The context value is `undefined` until the Store has finished booting,
+ * then transitions to `{ stage: 'running', store: ... }`.
+ *
+ * @example
+ * ```tsx
+ * // Typically you don't use this directly—use useStore() instead
+ * const context = React.useContext(LiveStoreContext)
+ * if (context?.stage === 'running') {
+ *   console.log('Store ready:', context.store.storeId)
+ * }
+ * ```
+ */
 export const LiveStoreContext = React.createContext<
   { stage: 'running'; store: LiveStoreContextRunning['store'] & ReactApi } | undefined
 >(undefined)

--- a/packages/@livestore/react/src/useClientDocument.ts
+++ b/packages/@livestore/react/src/useClientDocument.ts
@@ -9,6 +9,17 @@ import React from 'react'
 import { LiveStoreContext } from './LiveStoreContext.ts'
 import { useQueryRef } from './useQuery.ts'
 
+/**
+ * Return type of `useClientDocument` hook.
+ *
+ * A tuple providing React-style state access to a client-document table row:
+ * - `[0]` row: The current value (decoded according to the table schema)
+ * - `[1]` setRow: Setter function to update the document
+ * - `[2]` id: The document's ID (resolved from `SessionIdSymbol` if applicable)
+ * - `[3]` query$: The underlying `LiveQuery` for advanced use cases
+ *
+ * @typeParam TTableDef - The client-document table definition type
+ */
 export type UseClientDocumentResult<TTableDef extends State.SQLite.ClientDocumentTableDef.TraitAny> = [
   row: TTableDef['Value'],
   setRow: StateSetters<TTableDef>,
@@ -140,10 +151,34 @@ export const useClientDocument: {
   return [queryRef.valueRef.current, setState, idStr, queryRef.queryRcRef.value]
 }
 
+/**
+ * A function that dispatches an action. Mirrors React's `Dispatch` type.
+ * @typeParam A - The action type
+ */
 export type Dispatch<A> = (action: A) => void
+
+/**
+ * A state update that can be either a partial value or a function returning a partial value.
+ * Used when the client-document table has `partialSet: true`.
+ * @typeParam S - The state type
+ */
 export type SetStateActionPartial<S> = Partial<S> | ((previousValue: S) => Partial<S>)
+
+/**
+ * A state update that can be either a full value or a function returning a full value.
+ * Mirrors React's `SetStateAction` type.
+ * @typeParam S - The state type
+ */
 export type SetStateAction<S> = S | ((previousValue: S) => S)
 
+/**
+ * The setter function type for `useClientDocument`, determined by the table's `partialSet` option.
+ *
+ * - If `partialSet: false` (default), requires full state replacement
+ * - If `partialSet: true`, accepts partial updates merged with existing state
+ *
+ * @typeParam TTableDef - The client-document table definition type
+ */
 export type StateSetters<TTableDef extends State.SQLite.ClientDocumentTableDef.TraitAny> = Dispatch<
   TTableDef[State.SQLite.ClientDocumentTableDefSymbol]['options']['partialSet'] extends false
     ? SetStateAction<TTableDef['Value']>

--- a/packages/@livestore/react/src/useStore.ts
+++ b/packages/@livestore/react/src/useStore.ts
@@ -7,6 +7,19 @@ import { LiveStoreContext } from './LiveStoreContext.ts'
 import { useClientDocument } from './useClientDocument.ts'
 import { useQuery } from './useQuery.ts'
 
+/**
+ * Augments a Store instance with React-specific methods (`useQuery`, `useClientDocument`).
+ *
+ * This is called automatically by `useStore()` and `LiveStoreProvider`. You typically
+ * don't need to call it directly unless you're building custom integrations.
+ *
+ * @example
+ * ```ts
+ * // Usually not needed—useStore() does this automatically
+ * const store = withReactApi(myStore)
+ * const todos = store.useQuery(tables.todos.all())
+ * ```
+ */
 export const withReactApi = <TSchema extends LiveStoreSchema>(store: Store<TSchema>): Store<TSchema> & ReactApi => {
   // @ts-expect-error TODO properly implement this
 
@@ -17,6 +30,44 @@ export const withReactApi = <TSchema extends LiveStoreSchema>(store: Store<TSche
   return store as Store<TSchema> & ReactApi
 }
 
+/**
+ * Returns the current Store instance from React context, augmented with React-specific methods.
+ *
+ * Use this hook when you need direct access to the Store for operations like
+ * `store.commit()`, `store.subscribe()`, or accessing `store.sessionId`.
+ *
+ * For reactive queries, prefer `useQuery()` or `useClientDocument()` which handle
+ * subscriptions and re-renders automatically.
+ *
+ * @example
+ * ```ts
+ * const MyComponent = () => {
+ *   const { store } = useStore()
+ *
+ *   const handleClick = () => {
+ *     store.commit(events.todoCreated({ id: nanoid(), text: 'New todo' }))
+ *   }
+ *
+ *   return <button onClick={handleClick}>Add Todo</button>
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Access store metadata
+ * const { store } = useStore()
+ * console.log('Session ID:', store.sessionId)
+ * console.log('Client ID:', store.clientId)
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Use with an explicit store instance (bypasses context)
+ * const { store } = useStore({ store: myExternalStore })
+ * ```
+ *
+ * @throws Error if called outside of `<LiveStoreProvider>` or before the store is running
+ */
 export const useStore = (options?: { store?: Store }): { store: Store & ReactApi } => {
   if (options?.store !== undefined) {
     return { store: withReactApi(options.store) }

--- a/packages/@livestore/sync-electric/src/index.ts
+++ b/packages/@livestore/sync-electric/src/index.ts
@@ -150,6 +150,47 @@ export const SyncMetadata = Schema.Struct({
 
 export type SyncMetadata = typeof SyncMetadata.Type
 
+/**
+ * Creates a sync backend that uses ElectricSQL for real-time event synchronization.
+ *
+ * ElectricSQL enables real-time sync by streaming PostgreSQL changes to clients.
+ * This backend handles push (inserting events) and pull (streaming events via Electric's
+ * shape-based sync protocol).
+ *
+ * The endpoint should typically be part of your API layer to handle authentication,
+ * rate limiting, and proxying requests to the Electric server.
+ *
+ * @example
+ * ```ts
+ * import { makeSyncBackend } from '@livestore/sync-electric'
+ *
+ * const adapter = makePersistedAdapter({
+ *   sync: {
+ *     backend: makeSyncBackend({
+ *       endpoint: '/api/electric',
+ *     }),
+ *   },
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With separate endpoints for push/pull/ping
+ * const backend = makeSyncBackend({
+ *   endpoint: {
+ *     push: '/api/push-event',
+ *     pull: '/api/pull-events',
+ *     ping: '/api/ping',
+ *   },
+ *   ping: {
+ *     enabled: true,
+ *     requestInterval: 15_000, // 15 seconds
+ *   },
+ * })
+ * ```
+ *
+ * @see https://livestore.dev/docs/sync/electric for setup guide
+ */
 export const makeSyncBackend =
   ({ endpoint, ...options }: SyncBackendOptions): SyncBackend.SyncBackendConstructor<SyncMetadata> =>
   ({ storeId, payload }) =>

--- a/packages/@livestore/utils/src/guards.ts
+++ b/packages/@livestore/utils/src/guards.ts
@@ -1,8 +1,23 @@
+/** Type guard that narrows `T | undefined` to `T`. Useful for filtering arrays. */
 export const isNotUndefined = <T>(_: T | undefined): _ is T => _ !== undefined
 
+/** Type guard that narrows `T | null` to `T`. */
 export const isNotNull = <T>(_: T | null): _ is T => _ !== null
+
+/** Type guard that checks if a value is `undefined`. */
 export const isUndefined = <T>(_: T | undefined): _ is undefined => _ === undefined
 
+/** Type guard that checks if a value is `null` or `undefined`. */
 export const isNil = (val: any): val is null | undefined => val === null || val === undefined
 
+/**
+ * Type guard that narrows `T | undefined | null` to `T`.
+ * Commonly used to filter out nullish values from arrays.
+ *
+ * @example
+ * ```ts
+ * const values = [1, null, 2, undefined, 3]
+ * const nonNil = values.filter(isNotNil) // [1, 2, 3] (type: number[])
+ * ```
+ */
 export const isNotNil = <T>(val: T | undefined | null): val is T => val !== null && val !== undefined

--- a/packages/@livestore/utils/src/mod.ts
+++ b/packages/@livestore/utils/src/mod.ts
@@ -19,37 +19,102 @@ import type { Types } from 'effect'
 
 import { objectToString } from './misc.ts'
 
+/**
+ * Recursively expands type aliases for better IDE hover display.
+ *
+ * Transforms `{ a: string } & { b: number }` into `{ a: string; b: number }`.
+ */
 export type Prettify<T> = T extends infer U ? { [K in keyof U]: Prettify<U[K]> } : never
 
+/**
+ * Type-level equality check. Returns `true` if `A` and `B` are exactly the same type.
+ *
+ * @example
+ * ```ts
+ * type Test1 = TypeEq<string, string> // true
+ * type Test2 = TypeEq<string, number> // false
+ * type Test3 = TypeEq<{ a: 1 }, { a: 1 }> // true
+ * ```
+ */
 export type TypeEq<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
 
-/** `A` is subtype of `B` */
+/**
+ * Type-level subtype check. Returns `true` if `A` extends `B`.
+ *
+ * @example
+ * ```ts
+ * type Test1 = IsSubtype<'foo', string> // true
+ * type Test2 = IsSubtype<string, 'foo'> // false
+ * ```
+ */
 export type IsSubtype<A, B> = A extends B ? true : false
+
+/** Compile-time assertion that `T` is `true`. Useful for type tests. */
 export type AssertTrue<T extends true> = T
 
+/** Removes `readonly` modifier from all properties of `T`. */
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] }
+
+/** Recursively removes `readonly` modifier from all properties. */
 export type DeepWriteable<T> = { -readonly [P in keyof T]: DeepWriteable<T[P]> }
 
+/** Makes all properties of `T` nullable (allows `null`). */
 export type Nullable<T> = { [K in keyof T]: T[K] | null }
 
+/** Union of JavaScript primitive types. */
 export type Primitive = null | undefined | string | number | boolean | symbol | bigint
 
+/**
+ * Creates a union type that allows specific literals while still accepting the base type.
+ * Useful for string/number enums with autocomplete support.
+ *
+ * @example
+ * ```ts
+ * type Status = LiteralUnion<'pending' | 'active', string>
+ * // Allows 'pending', 'active', or any other string
+ * ```
+ */
 export type LiteralUnion<LiteralType, BaseType extends Primitive> = LiteralType | (BaseType & Record<never, never>)
 
+/** Extracts the value type for key `K` from object type `T`, or `never` if key doesn't exist. */
 export type GetValForKey<T, K> = K extends keyof T ? T[K] : never
 
+/** Accepts either a single value or a readonly array of values. */
 export type SingleOrReadonlyArray<T> = T | ReadonlyArray<T>
 
+/** Returns a Promise that resolves after `ms` milliseconds. */
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+/**
+ * Creates a mutable reference object with a `current` property.
+ * Similar to React's `useRef` but works outside of React.
+ *
+ * @example
+ * ```ts
+ * const counter = ref(0)
+ * counter.current += 1
+ * ```
+ */
 export const ref = <T>(val: T): { current: T } => ({ current: val })
 
+/**
+ * Calls a function `n` times with the current index.
+ *
+ * @example
+ * ```ts
+ * times(3, (i) => console.log(i)) // logs 0, 1, 2
+ * ```
+ */
 export const times = (n: number, fn: (index: number) => {}): void => {
   for (let i = 0; i < n; i++) {
     fn(i)
   }
 }
 
+/**
+ * Wraps a function call in a try/catch that triggers the debugger on error.
+ * Useful for debugging exceptions during development.
+ */
 export const debugCatch = <T>(try_: () => T): T => {
   try {
     return try_()
@@ -60,6 +125,10 @@ export const debugCatch = <T>(try_: () => T): T => {
   }
 }
 
+/**
+ * Recursively removes `undefined` values from an object or array in place.
+ * Mutates the input value.
+ */
 export const recRemoveUndefinedValues = (val: any): void => {
   if (Array.isArray(val)) {
     val.forEach(recRemoveUndefinedValues)
@@ -79,13 +148,24 @@ export const recRemoveUndefinedValues = (val: any): void => {
  */
 export const sluggify = (str: string, separator = '-') => str.replace(/[^a-zA-Z0-9]/g, separator)
 
+/**
+ * Creates a property accessor function for use in pipelines.
+ *
+ * @example
+ * ```ts
+ * const users = [{ name: 'Alice' }, { name: 'Bob' }]
+ * const names = users.map(prop('name')) // ['Alice', 'Bob']
+ * ```
+ */
 export const prop =
   <T extends {}, K extends keyof T>(key: K) =>
   (obj: T): T[K] =>
     obj[key]
 
+/** Capitalizes the first letter of a string. */
 export const capitalizeFirstLetter = (str: string): string => str.charAt(0).toUpperCase() + str.slice(1)
 
+/** Type guard that checks if a value is a readonly array. */
 export const isReadonlyArray = <I, T>(value: ReadonlyArray<I> | T): value is ReadonlyArray<I> => Array.isArray(value)
 
 /**
@@ -99,6 +179,14 @@ export function casesHandled(unexpectedCase: never): never {
   throw new Error(`A case was not handled for value: ${truncate(objectToString(unexpectedCase), 1000)}`)
 }
 
+/**
+ * Throws if the condition is false. Use for runtime assertions that should never fail.
+ *
+ * @example
+ * ```ts
+ * assertNever(user !== undefined, 'User must be loaded')
+ * ```
+ */
 export const assertNever = (failIfFalse: boolean, msg?: string): void => {
   if (failIfFalse === false) {
     // biome-ignore lint/suspicious/noDebugger: debugging
@@ -107,6 +195,14 @@ export const assertNever = (failIfFalse: boolean, msg?: string): void => {
   }
 }
 
+/**
+ * Identity function that triggers the debugger. Useful for debugging pipelines.
+ *
+ * @example
+ * ```ts
+ * data.pipe(transform, debuggerPipe, format) // Pauses debugger here
+ * ```
+ */
 export const debuggerPipe = <T>(val: T): T => {
   // biome-ignore lint/suspicious/noDebugger: debugging
   debugger
@@ -121,16 +217,40 @@ const truncate = (str: string, length: number): string => {
   }
 }
 
+/**
+ * Placeholder for unimplemented code paths. Triggers debugger and throws.
+ *
+ * @example
+ * ```ts
+ * const parseFormat = (format: Format) => {
+ *   switch (format) {
+ *     case 'json': return parseJson
+ *     case 'xml': return notYetImplemented('XML parsing')
+ *   }
+ * }
+ * ```
+ */
 export const notYetImplemented = (msg?: string): never => {
   // biome-ignore lint/suspicious/noDebugger: debugging
   debugger
   throw new Error(`Not yet implemented: ${msg}`)
 }
 
+/** A function that does nothing. Useful as a default callback. */
 export const noop = () => {}
 
+/** A function that returns a value of type `T`. */
 export type Thunk<T> = () => T
 
+/**
+ * If the input is a function, calls it and returns the result. Otherwise returns the value directly.
+ *
+ * @example
+ * ```ts
+ * unwrapThunk(5) // 5
+ * unwrapThunk(() => 5) // 5
+ * ```
+ */
 export const unwrapThunk = <T>(_: T | (() => T)): T => {
   if (typeof _ === 'function') {
     return (_ as any)()
@@ -139,6 +259,10 @@ export const unwrapThunk = <T>(_: T | (() => T)): T => {
   }
 }
 
+/**
+ * Transforms nullable fields (those that include `null`) into optional fields.
+ * Useful for converting database schemas to TypeScript types.
+ */
 export type NullableFieldsToOptional<T> = Types.Simplify<
   Partial<T> & {
     [K in keyof T as null extends T[K] ? K : never]?: Exclude<T[K], null>
@@ -147,12 +271,33 @@ export type NullableFieldsToOptional<T> = Types.Simplify<
   }
 >
 
-/** `end` is not included */
+/**
+ * Creates an array of numbers from `start` (inclusive) to `end` (exclusive).
+ *
+ * @example
+ * ```ts
+ * range(0, 5) // [0, 1, 2, 3, 4]
+ * range(3, 7) // [3, 4, 5, 6]
+ * ```
+ */
 export const range = (start: number, end: number): number[] => {
   const length = end - start
   return Array.from({ length }, (_, i) => start + i)
 }
 
+/**
+ * Rate-limits function calls to at most once per `ms` milliseconds.
+ * Trailing calls are preserved—if called during the wait period, the function
+ * will be called again after the timeout.
+ *
+ * @example
+ * ```ts
+ * const throttledSave = throttle(() => saveData(), 1000)
+ * throttledSave() // Executes immediately
+ * throttledSave() // Queued, executes after 1 second
+ * throttledSave() // Ignored (already queued)
+ * ```
+ */
 export const throttle = (fn: () => void, ms: number) => {
   let shouldWait = false
   let shouldCallAgain = false
@@ -179,13 +324,26 @@ export const throttle = (fn: () => void, ms: number) => {
   }
 }
 
+/**
+ * Generates a W3C Trace Context `traceparent` header from an OpenTelemetry span.
+ * @see https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
+ */
 export const getTraceParentHeader = (parentSpan: otel.Span) => {
   const spanContext = parentSpan.spanContext()
-  // Format: {version}-{trace_id}-{span_id}-{trace_flags}
-  // https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
   return `00-${spanContext.traceId}-${spanContext.spanId}-01`
 }
 
+/**
+ * Asserts that a tagged union value has a specific tag, narrowing its type.
+ * Throws if the tag doesn't match.
+ *
+ * @example
+ * ```ts
+ * type Result = { _tag: 'ok'; value: number } | { _tag: 'error'; message: string }
+ * const result: Result = ...
+ * const ok = assertTag(result, 'ok') // Type is { _tag: 'ok'; value: number }
+ * ```
+ */
 export const assertTag = <TObj extends { _tag: string }, TTag extends TObj['_tag']>(
   obj: TObj,
   tag: TTag,
@@ -197,6 +355,20 @@ export const assertTag = <TObj extends { _tag: string }, TTag extends TObj['_tag
   return obj as any
 }
 
+/**
+ * Memoizes a function by JSON-stringifying its arguments as the cache key.
+ * Suitable for functions with serializable arguments.
+ *
+ * @example
+ * ```ts
+ * const expensiveCalc = memoizeByStringifyArgs((a: number, b: number) => {
+ *   console.log('Computing...')
+ *   return a + b
+ * })
+ * expensiveCalc(1, 2) // logs 'Computing...', returns 3
+ * expensiveCalc(1, 2) // returns 3 (cached, no log)
+ * ```
+ */
 export const memoizeByStringifyArgs = <T extends (...args: any[]) => any>(fn: T): T => {
   const cache = new Map<string, ReturnType<T>>()
 
@@ -212,6 +384,18 @@ export const memoizeByStringifyArgs = <T extends (...args: any[]) => any>(fn: T)
   }) as any
 }
 
+/**
+ * Memoizes a single-argument function using reference equality for cache lookup.
+ * Suitable for functions where arguments are objects that should be compared by reference.
+ *
+ * @example
+ * ```ts
+ * const processUser = memoizeByRef((user: User) => expensiveTransform(user))
+ * processUser(userA) // Computes
+ * processUser(userA) // Returns cached (same reference)
+ * processUser(userB) // Computes (different reference)
+ * ```
+ */
 export const memoizeByRef = <T extends (arg: any) => any>(fn: T): T => {
   const cache = new Map<Parameters<T>[0], ReturnType<T>>()
 
@@ -226,15 +410,23 @@ export const memoizeByRef = <T extends (arg: any) => any>(fn: T): T => {
   }) as any
 }
 
+/** Type guard that checks if a value is a non-empty string. */
 export const isNonEmptyString = (str: string | undefined | null): str is string => {
   return typeof str === 'string' && str.length > 0
 }
 
+/** Type guard that checks if a value is a Promise (has a `then` method). */
 export const isPromise = (value: any): value is Promise<unknown> => typeof value?.then === 'function'
 
+/** Type guard that checks if a value is iterable (has a `Symbol.iterator` method). */
 export const isIterable = <T>(value: any): value is Iterable<T> => typeof value?.[Symbol.iterator] === 'function'
 
-/** This utility "lies" as a means of compat with libs that don't explicitly type optionals as unioned with `undefined`. */
+/**
+ * Type-level utility that removes `undefined` from all property types.
+ * Used for compatibility with libraries that don't type optionals as `| undefined`.
+ *
+ * Note: This is a type-level lie—the runtime value is unchanged.
+ */
 export const omitUndefineds = <T extends Record<keyof any, unknown>>(
   rec: T,
 ): {


### PR DESCRIPTION
## Summary

- Add comprehensive JSDoc documentation to core LiveStore reactive primitives (`signal`, `computed`, `LiveQuery`, `LiveQueryDef`)
- Document React hooks (`useStore`, `useClientDocument`, `LiveStoreContext`)
- Add documentation for store types (`Queryable`, `RefreshReason`, `SubscribeOptions`)
- Document utility functions in `@livestore/utils`

Documentation is written from an application builder's perspective with practical examples.

## Test plan

- [ ] TypeScript compilation passes
- [ ] Linting passes
- [ ] Documentation renders correctly in IDE tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)