### PR TITLE
Fix Effect.try catch callback type error

### DIFF
--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -34,7 +34,7 @@ const listSnapshotPackages = (cwd: string) =>
         Effect.flatMap((content) =>
           Effect.try({
             try: () => JSON.parse(content) as { name?: unknown; private?: unknown },
-            catch: (cause) => cause as unknown,
+            catch: (cause) => new Error(`Failed to parse ${packageJsonPath}`, { cause }),
           }),
         ),
         Effect.either,


### PR DESCRIPTION
## Problem

TypeScript warning TS31 was raised in `scripts/src/commands/release.ts:35` due to an unchecked error type in the `Effect.try` catch callback. The callback was returning `cause as unknown` instead of a properly typed error.

## Solution

Replaced the unchecked cast with a properly typed `Error` that wraps the original cause. This follows Effect best practices and makes error handling more explicit and type-safe.

## Validation

- TypeScript build passes with no warnings
- Lint checks pass
- Change is consistent with error handling patterns used elsewhere in the codebase (e.g., `update-deps.ts`)