### PR TITLE
Add hierarchical structure to llms.txt generation

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -18,6 +18,7 @@ import starlightLinksValidator from 'starlight-links-validator'
 import starlightSidebarTopics from 'starlight-sidebar-topics'
 import starlightTypeDoc from 'starlight-typedoc'
 import { getBranchName } from './src/data/data.ts'
+import { docsSidebar, toStarlightSidebar } from './src/data/sidebar.ts'
 import { rehypeExternalLinks } from './src/plugins/rehype/externalLinks.js'
 import { remarkGithubIssueLinks } from './src/plugins/remark/githubIssueLinks.js'
 import { createCopyPageClipboardFallbackIntegration } from './src/plugins/starlight/contextual-menu-fallback/plugin.ts'
@@ -110,69 +111,12 @@ export default defineConfig({
             link: '/',
             icon: 'open-book',
             items: [
-              'index',
-              {
-                label: 'Getting Started',
-                autogenerate: { directory: 'getting-started' },
-              },
-              {
-                label: 'Tutorial',
-                autogenerate: { directory: 'tutorial' },
-              },
-              {
-                label: 'Evaluating LiveStore',
-                autogenerate: { directory: 'evaluation' },
-              },
-              {
-                label: 'Data Modeling',
-                autogenerate: { directory: 'data-modeling' },
-              },
-              // TODO bring back when fixed https://github.com/HiDeoo/starlight-auto-sidebar/issues/4
-              // Until when we're manually maintaining the sidebar for reference
-              // {
-              //   label: 'Reference',
-              //   autogenerate: { directory: 'reference' },
-              // },
-              {
-                label: 'Reference',
-                items: [
-                  'reference/concepts',
-                  'reference/store',
-                  'reference/reactivity-system',
-                  'reference/events',
-                  'reference/devtools',
-                  'reference/debugging',
-                  'reference/opentelemetry',
-                  'reference/cli',
-                  'reference/mcp',
-                  { label: 'State', autogenerate: { directory: 'reference/state' } },
-                  {
-                    label: 'Syncing',
-                    items: [
-                      'reference/syncing',
-                      'reference/syncing/server-side-clients',
-                      { label: 'Sync Provider', autogenerate: { directory: 'reference/syncing/sync-provider' } },
-                    ],
-                  },
-                  { label: 'Platform Adapters', autogenerate: { directory: 'reference/platform-adapters' } },
-                  { label: 'Framework Integrations', autogenerate: { directory: 'reference/framework-integrations' } },
-                ],
-              },
-              {
-                label: 'Patterns',
-                autogenerate: { directory: 'patterns' },
-              },
-              {
-                label: 'Miscellaneous',
-                autogenerate: { directory: 'misc' },
-              },
+              // Sidebar structure is defined in ./src/data/sidebar.ts
+              // to be shared with llms.txt generators
+              ...toStarlightSidebar(docsSidebar),
               {
                 label: 'Changelog',
                 link: '/changelog',
-              },
-              {
-                label: 'Contributing',
-                autogenerate: { directory: 'contributing' },
               },
             ],
           },

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "exports": {
-    "./multi-code-markdown": "./src/utils/multi-code-markdown.ts"
+    "./multi-code-markdown": "./src/utils/multi-code-markdown.ts",
+    "./sidebar": "./src/data/sidebar.ts"
   },
   "dependencies": {
     "@astrojs/check": "0.9.4",

--- a/docs/src/components/LlmsShort.astro
+++ b/docs/src/components/LlmsShort.astro
@@ -1,18 +1,55 @@
 ---
-import { loadLlmsDocs, toLlmsEntries } from '../utils/llms.ts'
+import { docsSidebar, type TSidebarItem } from '../data/sidebar.ts'
+import { loadLlmsDocs, type TLlmsEntry, toLlmsEntries } from '../utils/llms.ts'
 
 /**
  * Embeddable LLMS summary section for MDX pages; render-free for `curl` thanks
  * to the markdown route wiring.
+ *
+ * Uses the shared sidebar config to render a hierarchical structure matching
+ * the website navigation.
  */
 
 type TProps = {
   readonly showHeading?: boolean
 }
 
+type TLlmsDoc = Awaited<ReturnType<typeof loadLlmsDocs>>[number]
+
 const { showHeading = true } = Astro.props as TProps
 const docs = await loadLlmsDocs()
 const entries = toLlmsEntries({ docs, site: Astro.site ?? null })
+
+const docsMap = new Map<string, TLlmsEntry>()
+for (const entry of entries) {
+  docsMap.set(entry.slug, entry)
+}
+
+const docBySlug = new Map<string, TLlmsDoc>()
+for (const doc of docs) {
+  const slug = doc.id.replace(/\.(md|mdx)$/u, '').replace(/\/index$/u, '')
+  docBySlug.set(slug, doc)
+}
+
+const getDocsForDirectory = (directory: string): TLlmsEntry[] => {
+  const normalizedDirectory = directory.endsWith('/') ? directory.slice(0, -1) : directory
+  const prefix = `${normalizedDirectory}/`
+
+  return entries
+    .filter((entry) => {
+      if (entry.slug === normalizedDirectory) return true
+      if (!entry.slug.startsWith(prefix)) return false
+      const remaining = entry.slug.slice(prefix.length)
+      return !remaining.includes('/')
+    })
+    .sort((a, b) => {
+      const docA = docBySlug.get(a.slug)
+      const docB = docBySlug.get(b.slug)
+      const orderA = docA?.data.sidebar?.order ?? 999
+      const orderB = docB?.data.sidebar?.order ?? 999
+      return orderA - orderB
+    })
+}
 ---
 <section>
   {showHeading ? <h2>LiveStore Documentation for LLMs</h2> : null}
@@ -25,13 +62,108 @@ const entries = toLlmsEntries({ docs, site: Astro.site ?? null })
   <ul>
     <li>Most LiveStore APIs are synchronous and don't need <code>await</code></li>
   </ul>
-  <h3>Docs</h3>
-  <ul>
-    {entries.map((entry) => (
-      <li>
-        <a href={entry.href}>{entry.title}</a>
-        {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
-      </li>
-    ))}
-  </ul>
+  {docsSidebar.map((item) => {
+    if (item._tag === 'link') {
+      const entry = docsMap.get(item.slug)
+      return entry ? (
+        <ul>
+          <li>
+            <a href={entry.href}>{entry.title}</a>
+            {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
+          </li>
+        </ul>
+      ) : null
+    }
+    if (item._tag === 'autoGroup') {
+      const dirDocs = getDocsForDirectory(item.directory)
+      return (
+        <>
+          <h3>{item.label}</h3>
+          <ul>
+            {dirDocs.map((entry) => (
+              <li>
+                <a href={entry.href}>{entry.title}</a>
+                {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </>
+      )
+    }
+    if (item._tag === 'group') {
+      return (
+        <>
+          <h3>{item.label}</h3>
+          {item.items.map((subItem) => {
+            if (subItem._tag === 'link') {
+              const entry = docsMap.get(subItem.slug)
+              return entry ? (
+                <ul>
+                  <li>
+                    <a href={entry.href}>{entry.title}</a>
+                    {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
+                  </li>
+                </ul>
+              ) : null
+            }
+            if (subItem._tag === 'autoGroup') {
+              const dirDocs = getDocsForDirectory(subItem.directory)
+              return (
+                <>
+                  <h4>{subItem.label}</h4>
+                  <ul>
+                    {dirDocs.map((entry) => (
+                      <li>
+                        <a href={entry.href}>{entry.title}</a>
+                        {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )
+            }
+            if (subItem._tag === 'group') {
+              return (
+                <>
+                  <h4>{subItem.label}</h4>
+                  <ul>
+                    {subItem.items.map((nestedItem) => {
+                      if (nestedItem._tag === 'link') {
+                        const entry = docsMap.get(nestedItem.slug)
+                        return entry ? (
+                          <li>
+                            <a href={entry.href}>{entry.title}</a>
+                            {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
+                          </li>
+                        ) : null
+                      }
+                      if (nestedItem._tag === 'autoGroup') {
+                        const dirDocs = getDocsForDirectory(nestedItem.directory)
+                        return (
+                          <>
+                            <h5>{nestedItem.label}</h5>
+                            <ul>
+                              {dirDocs.map((entry) => (
+                                <li>
+                                  <a href={entry.href}>{entry.title}</a>
+                                  {entry.description.length > 0 ? <span>{`: ${entry.description}`}</span> : null}
+                                </li>
+                              ))}
+                            </ul>
+                          </>
+                        )
+                      }
+                      return null
+                    })}
+                  </ul>
+                </>
+              )
+            }
+            return null
+          })}
+        </>
+      )
+    }
+    return null
+  })}
 </section>

--- a/docs/src/components/LlmsShort.astro
+++ b/docs/src/components/LlmsShort.astro
@@ -1,5 +1,5 @@
 ---
-import { docsSidebar, type TSidebarItem } from '../data/sidebar.ts'
+import { docsSidebar } from '../data/sidebar.ts'
 import { loadLlmsDocs, type TLlmsEntry, toLlmsEntries } from '../utils/llms.ts'
 
 /**

--- a/docs/src/data/sidebar.ts
+++ b/docs/src/data/sidebar.ts
@@ -96,6 +96,7 @@ export const docsSidebar: ReadonlyArray<TSidebarItem> = [
   ]),
   autoGroup('Patterns', 'patterns'),
   autoGroup('Miscellaneous', 'misc'),
+  link('changelog', 'Changelog'),
   autoGroup('Contributing', 'contributing'),
 ]
 
@@ -106,7 +107,7 @@ export const docsSidebar: ReadonlyArray<TSidebarItem> = [
 const toStarlightItem = (item: TSidebarItem): unknown => {
   switch (item._tag) {
     case 'link':
-      return item.label ? { label: item.label, slug: item.slug } : item.slug
+      return item.label ? { label: item.label, link: item.slug } : item.slug
     case 'autoGroup':
       return {
         label: item.label,

--- a/docs/src/data/sidebar.ts
+++ b/docs/src/data/sidebar.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared sidebar configuration used by both Starlight and llms.txt generators.
+ * This ensures the docs structure is consistent across the website and LLM exports.
+ */
+
+/**
+ * Represents a single doc page entry (no children).
+ */
+export type TSidebarLink = {
+  readonly _tag: 'link'
+  /** Slug path relative to content/docs (e.g. 'getting-started/react-web') */
+  readonly slug: string
+  /** Optional label override (if not provided, uses the doc's title) */
+  readonly label?: string
+}
+
+/**
+ * A group that auto-generates items from a directory.
+ * This is the shorthand form where the group label and autogenerate are combined.
+ */
+export type TSidebarAutoGroup = {
+  readonly _tag: 'autoGroup'
+  readonly label: string
+  readonly directory: string
+  readonly collapsed?: boolean
+}
+
+/**
+ * A group of items with a label and nested items.
+ */
+export type TSidebarGroup = {
+  readonly _tag: 'group'
+  readonly label: string
+  readonly items: ReadonlyArray<TSidebarItem>
+  /** If true, this group is collapsed by default in the UI */
+  readonly collapsed?: boolean
+}
+
+export type TSidebarItem = TSidebarLink | TSidebarGroup | TSidebarAutoGroup
+
+/** Helper to create a link item */
+export const link = (slug: string, label?: string): TSidebarLink =>
+  label !== undefined ? { _tag: 'link', slug, label } : { _tag: 'link', slug }
+
+/**
+ * Helper to create a group that auto-generates items from a directory.
+ * This is the shorthand for `{ label, autogenerate: { directory } }`.
+ */
+export const autoGroup = (
+  label: string,
+  directory: string,
+  options?: { readonly collapsed?: boolean },
+): TSidebarAutoGroup => {
+  const base = { _tag: 'autoGroup' as const, label, directory }
+  return options?.collapsed !== undefined ? { ...base, collapsed: options.collapsed } : base
+}
+
+/** Helper to create a group with explicit items */
+export const group = (
+  label: string,
+  items: ReadonlyArray<TSidebarItem>,
+  options?: { readonly collapsed?: boolean },
+): TSidebarGroup => {
+  const base = { _tag: 'group' as const, label, items }
+  return options?.collapsed !== undefined ? { ...base, collapsed: options.collapsed } : base
+}
+
+/**
+ * Main docs sidebar structure (non-API docs).
+ * This defines the hierarchical order and grouping of documentation pages.
+ */
+export const docsSidebar: ReadonlyArray<TSidebarItem> = [
+  link('index'),
+  autoGroup('Getting Started', 'getting-started'),
+  autoGroup('Tutorial', 'tutorial'),
+  autoGroup('Evaluating LiveStore', 'evaluation'),
+  autoGroup('Data Modeling', 'data-modeling'),
+  group('Reference', [
+    link('reference/concepts'),
+    link('reference/store'),
+    link('reference/reactivity-system'),
+    link('reference/events'),
+    link('reference/devtools'),
+    link('reference/debugging'),
+    link('reference/opentelemetry'),
+    link('reference/cli'),
+    link('reference/mcp'),
+    autoGroup('State', 'reference/state'),
+    group('Syncing', [
+      link('reference/syncing'),
+      link('reference/syncing/server-side-clients'),
+      autoGroup('Sync Provider', 'reference/syncing/sync-provider'),
+    ]),
+    autoGroup('Platform Adapters', 'reference/platform-adapters'),
+    autoGroup('Framework Integrations', 'reference/framework-integrations'),
+  ]),
+  autoGroup('Patterns', 'patterns'),
+  autoGroup('Miscellaneous', 'misc'),
+  autoGroup('Contributing', 'contributing'),
+]
+
+/**
+ * Converts the sidebar config to Starlight's sidebar format.
+ * Used by astro.config.ts.
+ */
+const toStarlightItem = (item: TSidebarItem): unknown => {
+  switch (item._tag) {
+    case 'link':
+      return item.label ? { label: item.label, slug: item.slug } : item.slug
+    case 'autoGroup':
+      return {
+        label: item.label,
+        autogenerate: { directory: item.directory },
+        ...(item.collapsed !== undefined ? { collapsed: item.collapsed } : {}),
+      }
+    case 'group':
+      return {
+        label: item.label,
+        items: toStarlightSidebar(item.items),
+        ...(item.collapsed !== undefined ? { collapsed: item.collapsed } : {}),
+      }
+  }
+}
+
+export const toStarlightSidebar = (items: ReadonlyArray<TSidebarItem>): ReadonlyArray<unknown> =>
+  items.map(toStarlightItem)

--- a/docs/src/utils/llms.ts
+++ b/docs/src/utils/llms.ts
@@ -1,9 +1,13 @@
 import type { CollectionEntry } from 'astro:content'
 import { getCollection } from 'astro:content'
+import { docsSidebar, type TSidebarItem } from '../data/sidebar.ts'
 
 /**
  * Utilities for producing LLMS listings reused across API endpoints, markdown
  * exports, and MDX embeds so they never drift apart.
+ *
+ * The hierarchical structure is derived from the shared sidebar config in
+ * `src/data/sidebar.ts` to ensure consistency with the website navigation.
  */
 
 type TLlmsDoc = CollectionEntry<'docs'>
@@ -12,6 +16,7 @@ type TLlmsEntry = {
   readonly title: string
   readonly description: string
   readonly href: string
+  readonly slug: string
 }
 
 type TRenderOptions = {
@@ -50,6 +55,9 @@ const resolveHref = (path: string, site: URL | string | null | undefined): strin
 
 const toDocPath = (entry: TLlmsDoc): string => entry.id.replace(/\.(md|mdx)$/u, '').replace(/\/index$/u, '')
 
+/** Convert a doc path to a slug (for matching against sidebar config) */
+const toSlug = (entry: TLlmsDoc): string => toDocPath(entry)
+
 export const loadLlmsDocs = async (): Promise<ReadonlyArray<TLlmsDoc>> =>
   getCollection('docs', (entry) => !isApiDoc(entry))
 
@@ -61,14 +69,136 @@ export const toLlmsEntries = ({ docs, site }: TToEntriesOptions): ReadonlyArray<
       title: doc.data.title,
       description: doc.data.description ?? '',
       href,
+      slug: toSlug(doc),
     }
   })
 
+/** Creates a map from slug to doc entry for fast lookup */
+const createDocsMap = (entries: ReadonlyArray<TLlmsEntry>): Map<string, TLlmsEntry> => {
+  const map = new Map<string, TLlmsEntry>()
+  for (const entry of entries) {
+    map.set(entry.slug, entry)
+  }
+  return map
+}
+
+/** Get docs that match a directory prefix, sorted by frontmatter order */
+const getDocsForDirectory = (
+  directory: string,
+  entries: ReadonlyArray<TLlmsEntry>,
+  docs: ReadonlyArray<TLlmsDoc>,
+): ReadonlyArray<TLlmsEntry> => {
+  const prefix = directory.endsWith('/') ? directory : `${directory}/`
+
+  // Create a map from slug to original doc for order info
+  const docBySlug = new Map<string, TLlmsDoc>()
+  for (const doc of docs) {
+    docBySlug.set(toSlug(doc), doc)
+  }
+
+  return entries
+    .filter((entry) => {
+      // Match docs in this directory but not nested subdirectories
+      if (!entry.slug.startsWith(prefix)) return false
+      const remaining = entry.slug.slice(prefix.length)
+      // Don't include nested items (they'll be handled by their own autogenerate)
+      return !remaining.includes('/')
+    })
+    .sort((a, b) => {
+      const docA = docBySlug.get(a.slug)
+      const docB = docBySlug.get(b.slug)
+      const orderA = docA?.data.sidebar?.order ?? 999
+      const orderB = docB?.data.sidebar?.order ?? 999
+      return orderA - orderB
+    })
+}
+
+type TRenderContext = {
+  readonly docsMap: Map<string, TLlmsEntry>
+  readonly allEntries: ReadonlyArray<TLlmsEntry>
+  readonly docs: ReadonlyArray<TLlmsDoc>
+  readonly depth: number
+}
+
+const renderDocLink = (entry: TLlmsEntry): string => {
+  const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
+  return `- [${entry.title}](${entry.href}/)${suffix}`
+}
+
 /**
- * Render the short list snippet shared between llms.txt, MDX embeds, and the
- * markdown fallback route.
+ * Recursively renders sidebar items into hierarchical markdown.
+ * Groups become headings, links become list items.
  */
-const renderLlmsList = ({ docs, site }: TToEntriesOptions): string =>
+const renderSidebarItems = (items: ReadonlyArray<TSidebarItem>, ctx: TRenderContext): string => {
+  const lines: string[] = []
+
+  for (const item of items) {
+    switch (item._tag) {
+      case 'link': {
+        const entry = ctx.docsMap.get(item.slug)
+        if (entry) {
+          lines.push(renderDocLink(entry))
+        }
+        break
+      }
+
+      case 'autoGroup': {
+        // Auto-generated group with heading and docs from directory
+        const headingLevel = Math.min(ctx.depth + 2, 6)
+        const heading = '#'.repeat(headingLevel)
+        lines.push('')
+        lines.push(`${heading} ${item.label}`)
+        lines.push('')
+
+        const dirDocs = getDocsForDirectory(item.directory, ctx.allEntries, ctx.docs)
+        for (const entry of dirDocs) {
+          lines.push(renderDocLink(entry))
+        }
+        break
+      }
+
+      case 'group': {
+        // Group with explicit items
+        const headingLevel = Math.min(ctx.depth + 2, 6)
+        const heading = '#'.repeat(headingLevel)
+        lines.push('')
+        lines.push(`${heading} ${item.label}`)
+        lines.push('')
+
+        // Render nested items with increased depth
+        const nested = renderSidebarItems(item.items, { ...ctx, depth: ctx.depth + 1 })
+        if (nested.trim().length > 0) {
+          lines.push(nested)
+        }
+        break
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Render the hierarchical docs list following the sidebar structure.
+ */
+const renderLlmsListHierarchical = ({ docs, site }: TToEntriesOptions): string => {
+  const entries = toLlmsEntries({ docs, site })
+  const docsMap = createDocsMap(entries)
+
+  const ctx: TRenderContext = {
+    docsMap,
+    allEntries: entries,
+    docs,
+    depth: 0,
+  }
+
+  return renderSidebarItems(docsSidebar, ctx)
+}
+
+/**
+ * Render the flat list snippet (legacy format, still used for LlmsShort embeds).
+ */
+const renderLlmsListFlat = ({ docs, site }: TToEntriesOptions): string =>
   toLlmsEntries({ docs, site })
     .map((entry) => {
       const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
@@ -77,8 +207,17 @@ const renderLlmsList = ({ docs, site }: TToEntriesOptions): string =>
     .join('')
 
 export const renderLlmsText = ({ docs, site }: TRenderOptions): string => {
-  const docsSection = renderLlmsList({ docs, site })
-  return `# LiveStore Documentation for LLMs\n\n> LiveStore is a client-centric local-first data layer for high-performance apps based on SQLite and event-sourcing.\n\n## Notes\n\n- Most LiveStore APIs are synchronous and don't need \`await\`\n\n## Docs\n\n${docsSection}\n`
+  const docsSection = renderLlmsListHierarchical({ docs, site })
+  return `# LiveStore Documentation for LLMs
+
+> LiveStore is a client-centric local-first data layer for high-performance apps based on SQLite and event-sourcing.
+
+## Notes
+
+- Most LiveStore APIs are synchronous and don't need \`await\`
+
+${docsSection}
+`
 }
 
 const LLMS_SHORT_PATTERN = /<LlmsShort[^>]*\/>/g
@@ -92,6 +231,9 @@ export const replaceLlmsShortPlaceholders = ({ markdown, docs, site }: TReplaceO
    * Populate the inline list so consumers fetching `/index.md` (LLMs, curl) see
    * the same links as the rendered MDX page.
    */
-  const docsSection = renderLlmsList({ docs, site }).trimEnd()
+  const docsSection = renderLlmsListFlat({ docs, site }).trimEnd()
   return markdown.replace(LLMS_SHORT_PATTERN, `${docsSection}\n`)
 }
+
+/** Re-export sidebar config for use in docs-export.ts */
+export { docsSidebar, type TSidebarItem } from '../data/sidebar.ts'

--- a/docs/src/utils/llms.ts
+++ b/docs/src/utils/llms.ts
@@ -12,7 +12,7 @@ import { docsSidebar, type TSidebarItem } from '../data/sidebar.ts'
 
 type TLlmsDoc = CollectionEntry<'docs'>
 
-type TLlmsEntry = {
+export type TLlmsEntry = {
   readonly title: string
   readonly description: string
   readonly href: string

--- a/docs/src/utils/llms.ts
+++ b/docs/src/utils/llms.ts
@@ -199,17 +199,6 @@ const renderLlmsListHierarchical = ({ docs, site }: TToEntriesOptions): string =
   return renderSidebarItems(docsSidebar, ctx)
 }
 
-/**
- * Render the flat list snippet (legacy format, still used for LlmsShort embeds).
- */
-const renderLlmsListFlat = ({ docs, site }: TToEntriesOptions): string =>
-  toLlmsEntries({ docs, site })
-    .map((entry) => {
-      const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
-      return `- [${entry.title}](${entry.href})${suffix}\n`
-    })
-    .join('')
-
 export const renderLlmsText = ({ docs, site }: TRenderOptions): string => {
   const docsSection = renderLlmsListHierarchical({ docs, site })
   return `# LiveStore Documentation for LLMs
@@ -235,7 +224,7 @@ export const replaceLlmsShortPlaceholders = ({ markdown, docs, site }: TReplaceO
    * Populate the inline list so consumers fetching `/index.md` (LLMs, curl) see
    * the same links as the rendered MDX page.
    */
-  const docsSection = renderLlmsListFlat({ docs, site }).trimEnd()
+  const docsSection = renderLlmsListHierarchical({ docs, site }).trimEnd()
   return markdown.replace(LLMS_SHORT_PATTERN, `${docsSection}\n`)
 }
 

--- a/docs/src/utils/llms.ts
+++ b/docs/src/utils/llms.ts
@@ -88,7 +88,8 @@ const getDocsForDirectory = (
   entries: ReadonlyArray<TLlmsEntry>,
   docs: ReadonlyArray<TLlmsDoc>,
 ): ReadonlyArray<TLlmsEntry> => {
-  const prefix = directory.endsWith('/') ? directory : `${directory}/`
+  const normalizedDirectory = directory.endsWith('/') ? directory.slice(0, -1) : directory
+  const prefix = `${normalizedDirectory}/`
 
   // Create a map from slug to original doc for order info
   const docBySlug = new Map<string, TLlmsDoc>()
@@ -98,6 +99,9 @@ const getDocsForDirectory = (
 
   return entries
     .filter((entry) => {
+      // Include the directory index page (e.g. "getting-started")
+      if (entry.slug === normalizedDirectory) return true
+
       // Match docs in this directory but not nested subdirectories
       if (!entry.slug.startsWith(prefix)) return false
       const remaining = entry.slug.slice(prefix.length)
@@ -122,7 +126,7 @@ type TRenderContext = {
 
 const renderDocLink = (entry: TLlmsEntry): string => {
   const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
-  return `- [${entry.title}](${entry.href}/)${suffix}`
+  return `- [${entry.title}](${entry.href})${suffix}`
 }
 
 /**
@@ -202,7 +206,7 @@ const renderLlmsListFlat = ({ docs, site }: TToEntriesOptions): string =>
   toLlmsEntries({ docs, site })
     .map((entry) => {
       const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
-      return `- [${entry.title}](${entry.href}/)${suffix}\n`
+      return `- [${entry.title}](${entry.href})${suffix}\n`
     })
     .join('')
 

--- a/scripts/src/commands/docs-export.ts
+++ b/scripts/src/commands/docs-export.ts
@@ -4,6 +4,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { Effect, FileSystem, type PlatformError, Schema } from '@livestore/utils/effect'
 import { Cli } from '@livestore/utils/node'
 import { transformMultiCodeDocument } from '@local/docs/multi-code-markdown'
+import { docsSidebar, type TSidebarItem } from '@local/docs/sidebar'
 
 export const exportMarkdownCommand = Cli.Command.make(
   'export-markdown',
@@ -44,6 +45,7 @@ export const exportMarkdownCommand = Cli.Command.make(
         title: doc.title,
         description: doc.description,
         slug: doc.slug,
+        sidebarOrder: doc.sidebarOrder,
       }))
 
     const exportEffect = Effect.gen(function* () {
@@ -69,10 +71,16 @@ export const exportMarkdownCommand = Cli.Command.make(
 
       if (includeLlms) {
         const fs = yield* FileSystem.FileSystem
-        const llmsList = renderLlmsList({ docs: llmsDocs, site: null })
-        const llmsBody =
-          "# LiveStore Documentation for LLMs\n\n> LiveStore is a client-centric local-first data layer for high-performance apps based on SQLite and event-sourcing.\n\n## Notes\n\n- Most LiveStore APIs are synchronous and don't need `await`\n\n## Docs\n\n" +
-          llmsList
+        const llmsList = renderLlmsListHierarchical({ docs: llmsDocs, site: null })
+        const llmsBody = `# LiveStore Documentation for LLMs
+
+> LiveStore is a client-centric local-first data layer for high-performance apps based on SQLite and event-sourcing.
+
+## Notes
+
+- Most LiveStore APIs are synchronous and don't need \`await\`
+
+${llmsList}`
         yield* fs.writeFileString(path.join(outputDir, 'llms.txt'), `${llmsBody.trimEnd()}\n`)
       }
 
@@ -94,11 +102,20 @@ type DocMeta = {
   readonly title: string
   readonly description: string | undefined
   readonly body: string
+  readonly sidebarOrder: number | undefined
 }
 
 type TLlmsDoc = {
   readonly title: string
   readonly description: string | undefined
+  readonly slug: string
+  readonly sidebarOrder: number | undefined
+}
+
+type TLlmsEntry = {
+  readonly title: string
+  readonly description: string
+  readonly href: string
   readonly slug: string
 }
 
@@ -131,20 +148,26 @@ const collectMarkdownEntries = (
 
 const parseFrontmatter = (
   source: string,
-): { readonly title: string | undefined; readonly description: string | undefined; readonly body: string } => {
+): {
+  readonly title: string | undefined
+  readonly description: string | undefined
+  readonly sidebarOrder: number | undefined
+  readonly body: string
+} => {
   if (!source.startsWith('---')) {
-    return { title: undefined, description: undefined, body: source }
+    return { title: undefined, description: undefined, sidebarOrder: undefined, body: source }
   }
 
   const endIndex = source.indexOf('\n---', 3)
   if (endIndex === -1) {
-    return { title: undefined, description: undefined, body: source }
+    return { title: undefined, description: undefined, sidebarOrder: undefined, body: source }
   }
 
   const frontmatterRaw = source.slice(3, endIndex).trim()
   const body = source.slice(endIndex + 4)
   const titleMatch = frontmatterRaw.match(/^\s*title:\s*(.+)$/m)
   const descriptionMatch = frontmatterRaw.match(/^\s*description:\s*(.+)$/m)
+  const orderMatch = frontmatterRaw.match(/^\s*order:\s*(\d+)/m)
 
   const clean = (value: string | undefined) => {
     if (!value) return undefined
@@ -156,6 +179,7 @@ const parseFrontmatter = (
   return {
     title: clean(titleMatch?.[1]),
     description: clean(descriptionMatch?.[1]),
+    sidebarOrder: orderMatch?.[1] !== undefined ? Number.parseInt(orderMatch[1], 10) : undefined,
     body,
   }
 }
@@ -180,7 +204,7 @@ const loadDocs = (
 
     for (const filePath of entries) {
       const raw = yield* fs.readFileString(filePath)
-      const { title, description, body } = parseFrontmatter(raw)
+      const { title, description, sidebarOrder, body } = parseFrontmatter(raw)
       const slug = toSlug(filePath, contentRoot)
       const derivedTitle = title ?? (slug === '' ? 'LiveStore' : (slug.split('/').pop() ?? 'LiveStore'))
 
@@ -189,6 +213,7 @@ const loadDocs = (
         slug,
         title: derivedTitle,
         description,
+        sidebarOrder,
         body,
       })
     }
@@ -212,7 +237,152 @@ const resolveHref = (value: string, site: URL | string | null | undefined): stri
   return value.length === 0 ? '/' : `/${value}`
 }
 
-const renderLlmsList = ({
+const toLlmsEntries = ({
+  docs,
+  site,
+}: {
+  readonly docs: ReadonlyArray<TLlmsDoc>
+  readonly site: URL | string | null
+}): ReadonlyArray<TLlmsEntry> =>
+  docs.map((doc) => ({
+    title: doc.title,
+    description: doc.description ?? '',
+    href: resolveHref(doc.slug, site),
+    slug: doc.slug,
+  }))
+
+/** Creates a map from slug to doc entry for fast lookup */
+const createDocsMap = (entries: ReadonlyArray<TLlmsEntry>): Map<string, TLlmsEntry> => {
+  const map = new Map<string, TLlmsEntry>()
+  for (const entry of entries) {
+    map.set(entry.slug, entry)
+  }
+  return map
+}
+
+/** Get docs that match a directory prefix, sorted by frontmatter order */
+const getDocsForDirectory = (
+  directory: string,
+  entries: ReadonlyArray<TLlmsEntry>,
+  docs: ReadonlyArray<TLlmsDoc>,
+): ReadonlyArray<TLlmsEntry> => {
+  const prefix = directory.endsWith('/') ? directory : `${directory}/`
+
+  // Create a map from slug to original doc for order info
+  const docBySlug = new Map<string, TLlmsDoc>()
+  for (const doc of docs) {
+    docBySlug.set(doc.slug, doc)
+  }
+
+  return entries
+    .filter((entry) => {
+      // Match docs in this directory but not nested subdirectories
+      if (!entry.slug.startsWith(prefix)) return false
+      const remaining = entry.slug.slice(prefix.length)
+      // Don't include nested items (they'll be handled by their own autogenerate)
+      return !remaining.includes('/')
+    })
+    .sort((a, b) => {
+      const docA = docBySlug.get(a.slug)
+      const docB = docBySlug.get(b.slug)
+      const orderA = docA?.sidebarOrder ?? 999
+      const orderB = docB?.sidebarOrder ?? 999
+      return orderA - orderB
+    })
+}
+
+type TRenderContext = {
+  readonly docsMap: Map<string, TLlmsEntry>
+  readonly allEntries: ReadonlyArray<TLlmsEntry>
+  readonly docs: ReadonlyArray<TLlmsDoc>
+  readonly depth: number
+}
+
+const renderDocLink = (entry: TLlmsEntry): string => {
+  const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
+  return `- [${entry.title}](${entry.href}/)${suffix}`
+}
+
+/**
+ * Recursively renders sidebar items into hierarchical markdown.
+ * Groups become headings, links become list items.
+ */
+const renderSidebarItems = (items: ReadonlyArray<TSidebarItem>, ctx: TRenderContext): string => {
+  const lines: string[] = []
+
+  for (const item of items) {
+    switch (item._tag) {
+      case 'link': {
+        const entry = ctx.docsMap.get(item.slug)
+        if (entry) {
+          lines.push(renderDocLink(entry))
+        }
+        break
+      }
+
+      case 'autoGroup': {
+        // Auto-generated group with heading and docs from directory
+        const headingLevel = Math.min(ctx.depth + 2, 6)
+        const heading = '#'.repeat(headingLevel)
+        lines.push('')
+        lines.push(`${heading} ${item.label}`)
+        lines.push('')
+
+        const dirDocs = getDocsForDirectory(item.directory, ctx.allEntries, ctx.docs)
+        for (const entry of dirDocs) {
+          lines.push(renderDocLink(entry))
+        }
+        break
+      }
+
+      case 'group': {
+        // Group with explicit items
+        const headingLevel = Math.min(ctx.depth + 2, 6)
+        const heading = '#'.repeat(headingLevel)
+        lines.push('')
+        lines.push(`${heading} ${item.label}`)
+        lines.push('')
+
+        // Render nested items with increased depth
+        const nested = renderSidebarItems(item.items, { ...ctx, depth: ctx.depth + 1 })
+        if (nested.trim().length > 0) {
+          lines.push(nested)
+        }
+        break
+      }
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Render the hierarchical docs list following the sidebar structure.
+ */
+const renderLlmsListHierarchical = ({
+  docs,
+  site,
+}: {
+  readonly docs: ReadonlyArray<TLlmsDoc>
+  readonly site: URL | string | null
+}): string => {
+  const entries = toLlmsEntries({ docs, site })
+  const docsMap = createDocsMap(entries)
+
+  const ctx: TRenderContext = {
+    docsMap,
+    allEntries: entries,
+    docs,
+    depth: 0,
+  }
+
+  return renderSidebarItems(docsSidebar, ctx)
+}
+
+/**
+ * Render the flat list snippet (legacy format, still used for LlmsShort embeds).
+ */
+const renderLlmsListFlat = ({
   docs,
   site,
 }: {
@@ -239,7 +409,7 @@ const replaceLlmsShortPlaceholders = ({
   if (!markdown.includes('<LlmsShort')) {
     return markdown
   }
-  const docsSection = renderLlmsList({ docs, site }).trimEnd()
+  const docsSection = renderLlmsListFlat({ docs, site }).trimEnd()
   return markdown.replace(LLMS_SHORT_PATTERN, `${docsSection}\n`)
 }
 

--- a/scripts/src/commands/docs-export.ts
+++ b/scripts/src/commands/docs-export.ts
@@ -169,6 +169,36 @@ const parseFrontmatter = (
   const descriptionMatch = frontmatterRaw.match(/^\s*description:\s*(.+)$/m)
   const orderMatch = frontmatterRaw.match(/^\s*order:\s*(\d+)/m)
 
+  const sidebarOrder = (() => {
+    const lines = frontmatterRaw.split(/\r?\n/)
+    let sidebarIndent: number | undefined
+
+    for (const line of lines) {
+      const indent = line.match(/^\s*/u)?.[0].length ?? 0
+      const trimmed = line.trim()
+
+      if (trimmed.startsWith('sidebar:')) {
+        sidebarIndent = indent
+        continue
+      }
+
+      if (sidebarIndent === undefined) continue
+
+      // Exit once indentation decreases back to or above the sidebar block
+      if (indent <= sidebarIndent) {
+        sidebarIndent = undefined
+        continue
+      }
+
+      if (trimmed.startsWith('order:')) {
+        const value = Number.parseInt(trimmed.slice('order:'.length).trim(), 10)
+        return Number.isNaN(value) ? undefined : value
+      }
+    }
+
+    return undefined
+  })()
+
   const clean = (value: string | undefined) => {
     if (!value) return undefined
     const trimmed = value.trim()
@@ -179,7 +209,12 @@ const parseFrontmatter = (
   return {
     title: clean(titleMatch?.[1]),
     description: clean(descriptionMatch?.[1]),
-    sidebarOrder: orderMatch?.[1] !== undefined ? Number.parseInt(orderMatch[1], 10) : undefined,
+    sidebarOrder:
+      sidebarOrder !== undefined
+        ? sidebarOrder
+        : orderMatch?.[1] !== undefined
+          ? Number.parseInt(orderMatch[1], 10)
+          : undefined,
     body,
   }
 }
@@ -266,7 +301,8 @@ const getDocsForDirectory = (
   entries: ReadonlyArray<TLlmsEntry>,
   docs: ReadonlyArray<TLlmsDoc>,
 ): ReadonlyArray<TLlmsEntry> => {
-  const prefix = directory.endsWith('/') ? directory : `${directory}/`
+  const normalizedDirectory = directory.endsWith('/') ? directory.slice(0, -1) : directory
+  const prefix = `${normalizedDirectory}/`
 
   // Create a map from slug to original doc for order info
   const docBySlug = new Map<string, TLlmsDoc>()
@@ -276,6 +312,7 @@ const getDocsForDirectory = (
 
   return entries
     .filter((entry) => {
+      if (entry.slug === normalizedDirectory) return true
       // Match docs in this directory but not nested subdirectories
       if (!entry.slug.startsWith(prefix)) return false
       const remaining = entry.slug.slice(prefix.length)
@@ -300,7 +337,7 @@ type TRenderContext = {
 
 const renderDocLink = (entry: TLlmsEntry): string => {
   const suffix = entry.description.length > 0 ? `: ${entry.description}` : ''
-  return `- [${entry.title}](${entry.href}/)${suffix}`
+  return `- [${entry.title}](${entry.href})${suffix}`
 }
 
 /**
@@ -393,7 +430,7 @@ const renderLlmsListFlat = ({
     .map((doc) => {
       const href = resolveHref(doc.slug, site)
       const suffix = doc.description && doc.description.length > 0 ? `: ${doc.description}` : ''
-      return `- [${doc.title}](${href}/)${suffix}\n`
+      return `- [${doc.title}](${href})${suffix}\n`
     })
     .join('')
 

--- a/scripts/src/commands/docs-export.ts
+++ b/scripts/src/commands/docs-export.ts
@@ -419,21 +419,6 @@ const renderLlmsListHierarchical = ({
 /**
  * Render the flat list snippet (legacy format, still used for LlmsShort embeds).
  */
-const renderLlmsListFlat = ({
-  docs,
-  site,
-}: {
-  readonly docs: ReadonlyArray<TLlmsDoc>
-  readonly site: URL | string | null
-}) =>
-  docs
-    .map((doc) => {
-      const href = resolveHref(doc.slug, site)
-      const suffix = doc.description && doc.description.length > 0 ? `: ${doc.description}` : ''
-      return `- [${doc.title}](${href})${suffix}\n`
-    })
-    .join('')
-
 const replaceLlmsShortPlaceholders = ({
   markdown,
   docs,
@@ -446,7 +431,7 @@ const replaceLlmsShortPlaceholders = ({
   if (!markdown.includes('<LlmsShort')) {
     return markdown
   }
-  const docsSection = renderLlmsListFlat({ docs, site }).trimEnd()
+  const docsSection = renderLlmsListHierarchical({ docs, site }).trimEnd()
   return markdown.replace(LLMS_SHORT_PATTERN, `${docsSection}\n`)
 }
 


### PR DESCRIPTION
## Summary

- Introduces a shared sidebar configuration (`docs/src/data/sidebar.ts`) that defines the hierarchical structure of documentation pages
- The llms.txt now renders documentation with proper markdown headings reflecting the sidebar hierarchy instead of a flat list
- Both the website navigation and LLM exports now use the same structure, ensuring consistency

## Problem

The llms.txt was generated with an arbitrary flat order of docs without any hierarchical structure, making it harder for LLMs to understand the organization of the documentation.

## Solution

- Created a typed sidebar DSL with three item types: `link(slug)`, `autoGroup(label, directory)`, and `group(label, items)`
- Updated `astro.config.ts` to use the shared config via `toStarlightSidebar(docsSidebar)`
- Updated both `llms.ts` and `docs-export.ts` to render docs with hierarchical markdown headings

## New llms.txt format

```markdown
# LiveStore Documentation for LLMs

> LiveStore is a client-centric...

## Notes
- Most LiveStore APIs are synchronous...

- [LiveStore](/)

## Getting Started
- [React Web](/getting-started/react-web/)
...

## Reference
- [Concepts](/reference/concepts/)
...

### State
- [SQLite Schema](/reference/state/sqlite-schema/)
...
```

## Test plan

- [x] TypeScript builds successfully (`mono ts`)
- [x] Linting passes (`mono lint`)
- [ ] Docs dev server starts without sidebar config errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)