### PR TITLE
Simplify CLI commands and use type-safe config snippet

### DIFF
--- a/docs/src/content/_assets/code/reference/cli/config.ts
+++ b/docs/src/content/_assets/code/reference/cli/config.ts
@@ -1,0 +1,14 @@
+import { makeWsSync } from '@livestore/sync-cf/client'
+
+// Re-export your app's schema (adjust path to your project)
+export { schema } from './schema.ts'
+
+// Provide a sync backend constructor
+export const syncBackend = makeWsSync({
+  url: process.env.LIVESTORE_SYNC_URL ?? 'ws://localhost:8787',
+})
+
+// Optionally, pass an auth payload (must be JSON-serializable)
+export const syncPayload = {
+  authToken: process.env.LIVESTORE_SYNC_AUTH_TOKEN,
+}

--- a/docs/src/content/_assets/code/reference/cli/schema.ts
+++ b/docs/src/content/_assets/code/reference/cli/schema.ts
@@ -1,0 +1,18 @@
+import { makeSchema, State } from '@livestore/livestore'
+
+const events = {}
+
+const tables = {
+  todos: State.SQLite.table({
+    name: 'todos',
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      text: State.SQLite.text(),
+      completed: State.SQLite.boolean({ default: false }),
+    },
+  }),
+}
+
+const state = State.SQLite.makeState({ tables, materializers: {} })
+
+export const schema = makeSchema({ events, state })

--- a/docs/src/content/docs/reference/cli.mdx
+++ b/docs/src/content/docs/reference/cli.mdx
@@ -3,6 +3,8 @@ title: LiveStore CLI
 description: Command-line interface for LiveStore project scaffolding and development tools.
 ---
 
+import CliConfigSnippet from '../../_assets/code/reference/cli/config.ts?snippet'
+
 The LiveStore CLI provides tools for creating new projects and integrating with AI assistants through MCP (Model Context Protocol).
 
 :::caution[Experimental - Not Production Ready]
@@ -25,36 +27,36 @@ npx @livestore/cli --help            # Use with npx
 
 ## Commands
 
-### `bunx @livestore/cli new-project`
+### `livestore new-project`
 Create a new LiveStore project from available examples.
 
 ```bash
 # Interactive selection
-bunx @livestore/cli new-project
+livestore new-project
 
 # Specify example and path
-bunx @livestore/cli new-project --example web-todomvc my-project
+livestore new-project --example web-todomvc my-project
 
 # Use specific branch
-bunx @livestore/cli new-project --branch dev
+livestore new-project --branch dev
 ```
 
-### `bunx @livestore/cli mcp`
+### `livestore mcp`
 MCP server tools for AI assistant integration. See [MCP Integration](/reference/mcp) for details.
 
 ```bash
 # Start MCP server
-bunx @livestore/cli mcp
+livestore mcp
 
 # Available subcommands
-bunx @livestore/cli mcp coach    # AI coaching assistant (requires API key env var)
-bunx @livestore/cli mcp tools    # Development tools server
+livestore mcp coach    # AI coaching assistant (requires API key env var)
+livestore mcp tools    # Development tools server
 
 # Coach command requires API key - check implementation for specific variable name
-# Example: OPENAI_API_KEY=your_key bunx @livestore/cli mcp coach
+# Example: OPENAI_API_KEY=your_key livestore mcp coach
 ```
 
-### `bunx @livestore/cli sync`
+### `livestore sync`
 Import and export events from the sync backend. Useful for backup, migration, and debugging.
 
 #### Export
@@ -62,7 +64,7 @@ Import and export events from the sync backend. Useful for backup, migration, an
 Export all events from the sync backend to a JSON file:
 
 ```bash
-bunx @livestore/cli sync export \
+livestore sync export \
   --config livestore-cli.config.ts \
   --store-id my-store \
   events.json
@@ -94,7 +96,7 @@ Exported 127 events to /path/to/events.json
 Import events from a JSON file to the sync backend:
 
 ```bash
-bunx @livestore/cli sync import \
+livestore sync import \
   --config livestore-cli.config.ts \
   --store-id my-store \
   events.json
@@ -133,20 +135,7 @@ Successfully imported 127 events
 
 Both MCP and sync commands require a config file (conventionally named `livestore-cli.config.ts`) that exports:
 
-```ts
-// Export your app's schema
-export { schema } from './src/livestore/schema.ts'
-
-// Provide a sync backend constructor
-export const syncBackend = makeWsSync({
-  url: process.env.LIVESTORE_SYNC_URL ?? 'ws://localhost:8787'
-})
-
-// Optionally, pass an auth payload (must be JSON-serializable)
-export const syncPayload = {
-  authToken: process.env.LIVESTORE_SYNC_AUTH_TOKEN
-}
-```
+<CliConfigSnippet />
 
 ## Global Options
 


### PR DESCRIPTION
## Problem

The CLI documentation was using verbose `bunx @livestore/cli <command>` syntax for command examples, and the config file was an inline code block that wasn't type-checked.

## Solution

Simplified command references to `livestore <command>` for cleaner, more readable documentation. Migrated the config file to a proper type-safe snippet imported from a dedicated module, improving maintainability and ensuring the code is always valid.

## Validation

- Rebuilt documentation snippets successfully (146 bundles rendered)
- Config snippet compiles without errors and is type-checked
- All CLI command examples updated consistently