### PR TITLE
fix(adapter-web): use sync OPFS writes for Safari 18.x compatibility

### DIFF
--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
@@ -192,8 +192,20 @@ export const cleanupOldStateDbFiles: (options: {
       const archiveFileData = yield* vfs.readFilePayload(fileName)
 
       const archiveFileName = `${Date.now()}-${fileName}`
+      const archivePath = `${opfsDirectory}/archive/${archiveFileName}`
+      const archiveData = new Uint8Array(archiveFileData)
 
-      yield* Opfs.writeFile(`${opfsDirectory}/archive/${archiveFileName}`, new Uint8Array(archiveFileData))
+      // Prefer writeFile (atomic) when createWritable is available (Chrome, Firefox, Safari 26+),
+      // fall back to syncWriteFile (non-atomic) for Safari 18.x compatibility.
+      // TODO: Remove feature detection and use writeFile directly when Safari >= 26 is widely available.
+      const supportsCreateWritable =
+        typeof FileSystemFileHandle !== 'undefined' && 'createWritable' in FileSystemFileHandle.prototype
+
+      if (supportsCreateWritable) {
+        yield* Opfs.writeFile(archivePath, archiveData)
+      } else {
+        yield* Opfs.syncWriteFile(archivePath, archiveData)
+      }
     }
 
     const vfsResultCode = yield* Effect.try({

--- a/packages/@livestore/utils/src/browser/Opfs/utils.ts
+++ b/packages/@livestore/utils/src/browser/Opfs/utils.ts
@@ -210,6 +210,9 @@ export const getMetadata = Effect.fn('@livestore/utils:Opfs.getMetadata')(functi
  *
  * @param path - Slash-delimited file path.
  * @param data - Bytes to persist.
+ *
+ * @remarks
+ * - Only available in Safari 26 or higher (as of Dec 2025, not yet widely available).
  */
 export const writeFile = Effect.fn('@livestore/utils:Opfs.writeFile')(function* (path: string, data: Uint8Array) {
   if (isRootPath(path)) {
@@ -234,10 +237,10 @@ export const writeFile = Effect.fn('@livestore/utils:Opfs.writeFile')(function* 
 })
 
 /**
- * Synchronously write bytes to the target file handle, truncating any existing content.
+ * Synchronously write bytes to an OPFS path, creating or replacing the target file.
  *
- * @param handle - Sync access handle to overwrite.
- * @param buffer - Raw data to persist.
+ * @param path - Slash-delimited file path.
+ * @param data - Bytes to persist.
  * @returns Effect that resolves once every byte is flushed to durable storage.
  *
  * @remarks
@@ -246,25 +249,38 @@ export const writeFile = Effect.fn('@livestore/utils:Opfs.writeFile')(function* 
  *   For atomic replacement, prefer `writeFile` or a temp-file pattern with two prepared handles.
  */
 export const syncWriteFile = Effect.fn('@livestore/utils:Opfs.syncWriteFile')(function* (
-  handle: FileSystemSyncAccessHandle,
-  buffer: AllowSharedBufferSource,
+  path: string,
+  data: Uint8Array,
 ) {
-  const bytes = ArrayBuffer.isView(buffer)
-    ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
-    : new Uint8Array(buffer as ArrayBufferLike)
-
-  yield* Opfs.syncTruncate(handle, 0)
-
-  let offset = 0
-  while (offset < bytes.byteLength) {
-    const wrote = yield* Opfs.syncWrite(handle, bytes.subarray(offset), { at: offset })
-    if (wrote === 0) {
-      return yield* new OpfsError({
-        message: `Short write: wrote ${offset} of ${bytes.byteLength} bytes.`,
-      })
-    }
-    offset += Number(wrote)
+  if (isRootPath(path)) {
+    return yield* new OpfsError({
+      message: `Invalid OPFS path '${path}': cannot write file directly to the OPFS root`,
+    })
   }
 
-  yield* Opfs.syncFlush(handle)
+  const pathSegments = yield* parsePathSegments(path)
+  const { parentSegments, leafSegment: fileName } = splitPathSegments(pathSegments)
+
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const parentDirHandle = yield* traverseDirectoryPath(parentSegments)
+      const fileHandle = yield* Opfs.getFileHandle(parentDirHandle, fileName, { create: true })
+      const syncHandle = yield* Opfs.createSyncAccessHandle(fileHandle)
+
+      yield* Opfs.syncTruncate(syncHandle, 0)
+
+      let offset = 0
+      while (offset < data.byteLength) {
+        const wrote = yield* Opfs.syncWrite(syncHandle, data.subarray(offset), { at: offset })
+        if (wrote === 0) {
+          return yield* new OpfsError({
+            message: `Short write: wrote ${offset} of ${data.byteLength} bytes.`,
+          })
+        }
+        offset += Number(wrote)
+      }
+
+      yield* Opfs.syncFlush(syncHandle)
+    }),
+  )
 })


### PR DESCRIPTION
## Summary

- Refactored `syncWriteFile` in `utils.ts` to accept `(path: string, data: Uint8Array)` instead of `(handle: FileSystemSyncAccessHandle, buffer: AllowSharedBufferSource)`
- Updated `cleanupOldStateDbFiles` to conditionally use the best available API:
  - `Opfs.writeFile()` (atomic, crash-safe) when `createWritable` is available (Chrome, Firefox, Safari 26+)
  - `Opfs.syncWriteFile()` (non-atomic) as fallback for Safari 18.x compatibility

This fixes the Safari 18.x error where `FileSystemFileHandle.createWritable()` is not available (only supported in Safari 26+). The sync API (`createSyncAccessHandle`) is supported in Safari 15.2+ and works in dedicated workers.

## Test plan

- [x] Verify migration and cleanup works on Safari 18.x
- [x] Verify no regressions on Chrome/Firefox

Fixes #905