### PR TITLE
Fix query builder IN operator typing for array operands

### DIFF
--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -242,7 +242,12 @@ export namespace QueryBuilder {
       ): QueryBuilder<TResult, TTableDef, TWithout | 'row' | 'select'>
       <TColName extends keyof TTableDef['sqliteDef']['columns']>(
         col: TColName,
-        op: QueryBuilder.WhereOps,
+        op: QueryBuilder.WhereOps.MultiValue,
+        value: ReadonlyArray<TTableDef['sqliteDef']['columns'][TColName]['schema']['Type']>,
+      ): QueryBuilder<TResult, TTableDef, TWithout | 'row' | 'select'>
+      <TColName extends keyof TTableDef['sqliteDef']['columns']>(
+        col: TColName,
+        op: QueryBuilder.WhereOps.SingleValue,
         value: TTableDef['sqliteDef']['columns'][TColName]['schema']['Type'],
       ): QueryBuilder<TResult, TTableDef, TWithout | 'row' | 'select'>
     }


### PR DESCRIPTION
## Problem
The query builder’s `where` overload for explicit operators typed the value parameter as a single column type even for `IN`/`NOT IN`, leading to type errors when passing arrays despite runtime expecting an array.

## Solution
Add distinct overloads so `IN`/`NOT IN` require readonly array operands while other operators still accept single values, aligning the API type with runtime behaviour.

## Testing
- pnpm exec biome check packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
- pnpm exec tsc -p tsconfig.dev.json --noEmit --pretty false

Fixes #911.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935873d2e348329b9ffec24a7dd89e9)