### PR TITLE
feat(query-builder): add JSON array containment operators

### DIFF
--- a/docs/src/content/_assets/code/reference/state/sql-queries/query-builder.ts
+++ b/docs/src/content/_assets/code/reference/state/sql-queries/query-builder.ts
@@ -1,10 +1,12 @@
 import { State } from '@livestore/livestore'
+import { Schema } from 'effect'
 
 const table = State.SQLite.table({
   name: 'my_table',
   columns: {
     id: State.SQLite.text({ primaryKey: true }),
     name: State.SQLite.text(),
+    tags: State.SQLite.json({ schema: Schema.Array(Schema.String), default: [] }),
   },
 })
 
@@ -14,6 +16,11 @@ table.where('name', '=', 'Alice')
 table.where({ name: 'Alice' })
 table.orderBy('name', 'desc').offset(10).limit(10)
 table.count().where('name', 'LIKE', '%Ali%')
+
+// JSON array containment queries
+// NOTE: These use SQLite's json_each() which cannot be indexed
+table.where({ tags: { op: 'JSON_CONTAINS', value: 'important' } })
+table.where({ tags: { op: 'JSON_NOT_CONTAINS', value: 'archived' } })
 
 // Write queries
 table.insert({ id: '123', name: 'Bob' })

--- a/docs/src/content/docs/building-with-livestore/state/sql-queries.mdx
+++ b/docs/src/content/docs/building-with-livestore/state/sql-queries.mdx
@@ -19,6 +19,22 @@ LiveStore supports arbitrary SQL queries on top of SQLite. In order for LiveStor
 
 <RawSqlSnippet />
 
+## JSON array containment
+
+For JSON array columns, you can use `JSON_CONTAINS` and `JSON_NOT_CONTAINS` operators to check if an array contains (or doesn't contain) a specific value:
+
+```ts
+// Find items with a specific tag
+table.where({ tags: { op: 'JSON_CONTAINS', value: 'important' } })
+
+// Find items without a specific tag
+table.where({ tags: { op: 'JSON_NOT_CONTAINS', value: 'archived' } })
+```
+
+:::caution[Performance consideration]
+These operators use SQLite's `json_each()` table-valued function which **cannot be indexed** and requires a full table scan. For large tables with frequent lookups, consider denormalizing the data into a separate indexed table.
+:::
+
 ## Best practices
 
 - Query results should be treated as immutable/read-only

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -128,15 +128,25 @@ export type QueryBuilder<
 
 export namespace QueryBuilder {
   export type Any = QueryBuilder<any, any, any>
-  export type WhereOps = WhereOps.Equality | WhereOps.Order | WhereOps.Like | WhereOps.In
+  export type WhereOps = WhereOps.Equality | WhereOps.Order | WhereOps.Like | WhereOps.In | WhereOps.JsonArray
 
   export namespace WhereOps {
     export type Equality = '=' | '!='
     export type Order = '<' | '>' | '<=' | '>='
     export type Like = 'LIKE' | 'NOT LIKE' | 'ILIKE' | 'NOT ILIKE'
     export type In = 'IN' | 'NOT IN'
+    /**
+     * Operators for checking if a JSON array column contains a value.
+     *
+     * ⚠️ **Performance note**: These operators use SQLite's `json_each()` table-valued function
+     * which **cannot be indexed** and requires a full table scan. For large tables with frequent
+     * lookups, consider denormalizing the data into a separate indexed table.
+     *
+     * @see https://sqlite.org/json1.html#jeach
+     */
+    export type JsonArray = 'JSON_CONTAINS' | 'JSON_NOT_CONTAINS'
 
-    export type SingleValue = Equality | Order | Like
+    export type SingleValue = Equality | Order | Like | JsonArray
     export type MultiValue = In
   }
 
@@ -155,14 +165,26 @@ export namespace QueryBuilder {
     | 'returning'
     | 'onConflict'
 
+  /** Extracts the element type from an array type, or returns never if not an array */
+  type ArrayElement<T> = T extends ReadonlyArray<infer E> ? E : never
+
   export type WhereParams<TTableDef extends TableDefBase> = Partial<{
     [K in keyof TTableDef['sqliteDef']['columns']]:
       | TTableDef['sqliteDef']['columns'][K]['schema']['Type']
-      | { op: QueryBuilder.WhereOps.SingleValue; value: TTableDef['sqliteDef']['columns'][K]['schema']['Type'] }
+      | {
+          op: Exclude<QueryBuilder.WhereOps.SingleValue, QueryBuilder.WhereOps.JsonArray>
+          value: TTableDef['sqliteDef']['columns'][K]['schema']['Type']
+        }
       | {
           op: QueryBuilder.WhereOps.MultiValue
           value: ReadonlyArray<TTableDef['sqliteDef']['columns'][K]['schema']['Type']>
         }
+      | (ArrayElement<TTableDef['sqliteDef']['columns'][K]['schema']['Type']> extends never
+          ? never
+          : {
+              op: QueryBuilder.WhereOps.JsonArray
+              value: ArrayElement<TTableDef['sqliteDef']['columns'][K]['schema']['Type']>
+            })
       | undefined
   }>
 

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -1,10 +1,73 @@
 import { shouldNeverHappen } from '@livestore/utils'
-import { Schema } from '@livestore/utils/effect'
+import { Schema, SchemaAST } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../../adapter-types.ts'
 import type { SqlValue } from '../../../../util.ts'
 import type { State } from '../../../mod.ts'
 import type { QueryBuilderAst } from './api.ts'
+
+/**
+ * Extracts array element schema from a JSON array transformation AST.
+ * Returns the element schema, or undefined if not a JSON array transformation.
+ */
+const extractArrayElementFromTransformation = (ast: SchemaAST.AST): Schema.Schema.Any | undefined => {
+  if (!SchemaAST.isTransformation(ast)) return undefined
+
+  const toAst = ast.to
+  // Check if the "to" side is a TupleType (Effect's internal representation of Array)
+  if (!SchemaAST.isTupleType(toAst)) return undefined
+
+  // For Schema.Array, rest contains { type: AST } elements - get the first one's type
+  const restElement = toAst.rest[0]
+  if (restElement === undefined) return undefined
+
+  return Schema.make(restElement.type)
+}
+
+/**
+ * For JSON array columns, extracts the element schema from Schema.parseJson(Schema.Array(ElementSchema)).
+ * Also handles nullable JSON arrays (Schema.NullOr(Schema.parseJson(Schema.Array(...)))).
+ * Returns the element schema, or undefined if the column is not a JSON array.
+ */
+const getJsonArrayElementSchema = (colSchema: Schema.Schema.Any): Schema.Schema.Any | undefined => {
+  const ast = colSchema.ast
+
+  // Case 1: Direct transformation (non-nullable JSON array)
+  // Schema.parseJson(Schema.Array(ElementSchema)) creates a Transformation AST
+  if (SchemaAST.isTransformation(ast)) {
+    return extractArrayElementFromTransformation(ast)
+  }
+
+  // Case 2: Nullable JSON array - Schema.NullOr wraps the parseJson in a Union
+  // Structure: Union([Transformation (JSON array), Literal (null)])
+  if (SchemaAST.isUnion(ast)) {
+    for (const member of ast.types) {
+      const result = extractArrayElementFromTransformation(member)
+      if (result !== undefined) return result
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Encodes a JSON array element to the representation returned by SQLite's json_each().
+ * Objects/arrays are stringified so they match json_each's TEXT representation.
+ */
+const encodeJsonArrayElementValue = (elementSchema: Schema.Schema.Any, value: unknown): SqlValue => {
+  const encoded = Schema.encodeSync(elementSchema as Schema.Schema<unknown, SqlValue>)(value)
+
+  if (encoded === null) return null
+  if (typeof encoded === 'object') {
+    // Objects and arrays need to be JSON-stringified to match json_each() output
+    return JSON.stringify(encoded)
+  }
+  if (typeof encoded === 'boolean') {
+    return encoded ? 1 : 0
+  }
+
+  return encoded
+}
 
 // Helper functions for SQL generation
 const quoteIdentifier = (identifier: string): string => `"${identifier.replace(/"/g, '""')}"`
@@ -33,6 +96,23 @@ const formatWhereClause = (
       const colDef = tableDef.sqliteDef.columns[col]
       if (colDef === undefined) {
         throw new Error(`Column ${col} not found`)
+      }
+
+      // Handle JSON array containment operators
+      if (op === 'JSON_CONTAINS' || op === 'JSON_NOT_CONTAINS') {
+        const elementSchema = getJsonArrayElementSchema(colDef.schema)
+        if (elementSchema === undefined) {
+          throw new Error(
+            `${op} operator can only be used on JSON array columns, but column "${col}" is not a JSON array`,
+          )
+        }
+
+        const existsOp = op === 'JSON_CONTAINS' ? 'EXISTS' : 'NOT EXISTS'
+        // Encode the element value using the element schema
+        // Objects are JSON-stringified to match json_each() output
+        const encodedValue = encodeJsonArrayElementValue(elementSchema, value)
+        bindValues.push(encodedValue)
+        return `${existsOp} (SELECT 1 FROM json_each(${quotedCol}) WHERE value = ?)`
       }
 
       // Handle array values for IN/NOT IN operators

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
@@ -81,7 +81,22 @@ const selections = State.SQLite.table({
   },
 })
 
-const db = { todos, todosWithIntId, comments, issue, selections, UiState, UiStateWithDefaultId }
+const Source = Schema.Literal('google', 'linkedin', 'facebook')
+const ProfileAttribute = Schema.Struct({ key: Schema.String, value: Schema.String })
+
+const personProfiles = State.SQLite.table({
+  name: 'person_profiles',
+  columns: {
+    personId: State.SQLite.text({ primaryKey: true }),
+    sources: State.SQLite.json({ schema: Schema.Array(Source), default: [] }),
+    tags: State.SQLite.json({ schema: Schema.Array(Schema.String), default: [] }),
+    attributes: State.SQLite.json({ schema: Schema.Array(ProfileAttribute), default: [] }),
+    /** Nullable JSON array column for testing JSON_CONTAINS on nullable columns */
+    optionalTags: State.SQLite.json({ schema: Schema.Array(Schema.String), nullable: true }),
+  },
+})
+
+const db = { todos, todosWithIntId, comments, issue, selections, UiState, UiStateWithDefaultId, personProfiles }
 
 const dump = (qb: QueryBuilder<any, any, any>) => ({
   bindValues: qb.asSql().bindValues,
@@ -363,6 +378,131 @@ describe('query builder', () => {
           "schema": "ReadonlyArray<todos>",
         }
       `)
+    })
+
+    it('should handle JSON_CONTAINS operator for JSON array columns', () => {
+      expect(
+        dump(db.personProfiles.where({ sources: { op: 'JSON_CONTAINS', value: 'google' } })),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "google",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE EXISTS (SELECT 1 FROM json_each("sources") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+
+      // With select
+      expect(
+        dump(db.personProfiles.select('personId').where({ sources: { op: 'JSON_CONTAINS', value: 'linkedin' } })),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "linkedin",
+          ],
+          "query": "SELECT "personId" FROM 'person_profiles' WHERE EXISTS (SELECT 1 FROM json_each("sources") WHERE value = ?)",
+          "schema": "ReadonlyArray<({ readonly personId: string } <-> string)>",
+        }
+      `)
+
+      // With plain string array column
+      expect(
+        dump(db.personProfiles.where({ tags: { op: 'JSON_CONTAINS', value: 'important' } })),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "important",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE EXISTS (SELECT 1 FROM json_each("tags") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+    })
+
+    it('should handle JSON_NOT_CONTAINS operator for JSON array columns', () => {
+      expect(
+        dump(db.personProfiles.where({ sources: { op: 'JSON_NOT_CONTAINS', value: 'google' } })),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "google",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE NOT EXISTS (SELECT 1 FROM json_each("sources") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+    })
+
+    it('should JSON-stringify object elements for JSON_CONTAINS', () => {
+      expect(
+        dump(
+          db.personProfiles.where({
+            attributes: { op: 'JSON_CONTAINS', value: { key: 'language', value: 'typescript' } },
+          }),
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "{"key":"language","value":"typescript"}",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE EXISTS (SELECT 1 FROM json_each("attributes") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+    })
+
+    it('should handle combining JSON_CONTAINS with other WHERE clauses', () => {
+      expect(
+        dump(
+          db.personProfiles
+            .where({ sources: { op: 'JSON_CONTAINS', value: 'google' } })
+            .where({ sources: { op: 'JSON_NOT_CONTAINS', value: 'facebook' } }),
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "google",
+            "facebook",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE EXISTS (SELECT 1 FROM json_each("sources") WHERE value = ?) AND NOT EXISTS (SELECT 1 FROM json_each("sources") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+    })
+
+    it('should handle JSON_CONTAINS on nullable JSON array columns', () => {
+      expect(
+        dump(db.personProfiles.where({ optionalTags: { op: 'JSON_CONTAINS', value: 'important' } })),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "important",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE EXISTS (SELECT 1 FROM json_each("optionalTags") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+
+      // With JSON_NOT_CONTAINS
+      expect(
+        dump(db.personProfiles.where({ optionalTags: { op: 'JSON_NOT_CONTAINS', value: 'archived' } })),
+      ).toMatchInlineSnapshot(`
+        {
+          "bindValues": [
+            "archived",
+          ],
+          "query": "SELECT * FROM 'person_profiles' WHERE NOT EXISTS (SELECT 1 FROM json_each("optionalTags") WHERE value = ?)",
+          "schema": "ReadonlyArray<person_profiles>",
+        }
+      `)
+    })
+
+    it('should throw error when using JSON_CONTAINS on non-JSON array column', () => {
+      expect(() =>
+        // Type system prevents this at compile time for non-array columns, but test runtime check
+        dump(db.todos.where({ status: { op: 'JSON_CONTAINS', value: 'active' } } as any)),
+      ).toThrow('JSON_CONTAINS operator can only be used on JSON array columns')
     })
   })
 


### PR DESCRIPTION
## Problem

GitHub issue #921 requested support for querying JSON array columns in the query builder. Users needed a type-safe way to check if a JSON array contains or doesn't contain specific values.

## Solution

Implemented `JSON_CONTAINS` and `JSON_NOT_CONTAINS` operators for JSON array columns. These operators use SQLite's `json_each()` table-valued function for element-wise comparison. The operators are prefixed with `JSON_` to clearly indicate they use SQLite JSON functions and their performance characteristics (full table scan, not indexable).

**Key changes:**
- Added `WhereOps.JsonArray` type with `JSON_CONTAINS` and `JSON_NOT_CONTAINS`
- Implemented type-safe `where()` method that only allows these operators on actual array columns, with the value being the element type
- Added SQL generation using `EXISTS/NOT EXISTS` subqueries with `json_each()`
- Added comprehensive documentation with performance caution

## Validation

- 30+ unit tests pass, including new tests for JSON operators
- TypeScript build passes with strict type checking
- Linting and formatting passes
- Documentation snippets compile successfully

## Related issues

- #921