### PR TITLE
Fix otel noop tracer to use cuid instead of crypto.randomUUID

### DIFF
--- a/packages/@livestore/utils/src/NoopTracer.ts
+++ b/packages/@livestore/utils/src/NoopTracer.ts
@@ -1,4 +1,6 @@
 /** biome-ignore-all lint/complexity/noArguments: using arguments is fine here */
+
+import { cuid } from '@livestore/utils/cuid'
 import type * as otel from '@opentelemetry/api'
 
 export const makeNoopSpan = () => {
@@ -22,8 +24,8 @@ export const makeNoopSpan = () => {
     },
     spanContext: () => {
       return {
-        traceId: `livestore-noop-trace-id${crypto.randomUUID()}`,
-        spanId: `livestore-noop-span-id${crypto.randomUUID()}`,
+        traceId: `livestore-noop-trace-id${cuid()}`,
+        spanId: `livestore-noop-span-id${cuid()}`,
       }
     },
     _duration: [0, 0],


### PR DESCRIPTION
## Problem

The OTEL noop tracer uses `crypto.randomUUID()` to generate trace and span IDs, which crashes in Expo/React Native environments where this API is not available.

## Solution

Replace `crypto.randomUUID()` with `cuid()` from the existing `@livestore/utils/cuid` package. The cuid library is already set up with platform-specific implementations via package exports:
- Browser: Uses `globalThis.crypto.getRandomValues()` with React Native detection
- Node: Uses `node:crypto.randomBytes()`

This provides Expo compatibility without any additional dependencies.

## Validation

TypeScript compilation passes, linting passes, and the change is minimal and focused.