### PR TITLE
chore: add tasks directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ scripts/.completions
 
 # Generated markdown bundle embedded into @livestore/livestore
 packages/@livestore/livestore/docs
+
+# Task context files
+tasks/


### PR DESCRIPTION
## Problem

Task context files need to be excluded from version control to keep the repository clean.

## Solution

Added the `tasks/` directory to `.gitignore` to prevent temporary task context files from being checked in.

## Validation

No tests needed for gitignore configuration change.