### PR TITLE
feat(adapter-web): gracefully handle OPFS unavailability in private browsing

### DIFF
--- a/docs/.astro/content.d.ts
+++ b/docs/.astro/content.d.ts
@@ -1,7 +1,7 @@
 declare module 'astro:content' {
 	interface Render {
 		'.mdx': Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
+			Content: import('astro').MDXContent;
 			headings: import('astro').MarkdownHeading[];
 			remarkPluginFrontmatter: Record<string, any>;
 			components: import('astro').MDXInstance<{}>['components'];

--- a/docs/src/content/docs/platform-adapters/web-adapter.mdx
+++ b/docs/src/content/docs/platform-adapters/web-adapter.mdx
@@ -66,6 +66,41 @@ During development (`NODE_ENV !== 'production'`), LiveStore automatically copies
 
 LiveStore also uses `window.sessionStorage` to retain the identity of a client session (e.g. tab/window) across reloads.
 
+### Private browsing mode
+
+In Safari and Firefox private browsing mode, OPFS is not available due to browser restrictions. When this happens, LiveStore automatically falls back to in-memory storage. This means:
+
+- The app will continue to work normally during the session
+- Data will not persist across page reloads or tab closures
+- Sync functionality (if configured) will still work
+
+You can detect when the store is running in-memory mode using `store.storageMode`:
+
+```tsx
+if (store.storageMode === 'in-memory') {
+  // Show a warning to the user
+  showToast('Data will not be saved in private browsing mode')
+}
+```
+
+The `storageMode` property returns:
+- `'persisted'`: Data is being persisted to disk (e.g., via OPFS)
+- `'in-memory'`: Data is only stored in memory and will be lost on page refresh
+
+The boot status callback will also emit a `warning` stage with details about why persistence is unavailable:
+
+```tsx
+<LiveStoreProvider
+  // ...
+  renderLoading={(status) => {
+    if (status.stage === 'warning') {
+      console.warn(`Storage warning (${status.reason}): ${status.message}`)
+    }
+    return <div>Loading...</div>
+  }}
+/>
+```
+
 ### Resetting local persistence
 
 Resetting local persistence only clears data stored in the browser and does not affect any connected sync backend.

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -125,7 +125,11 @@ export const makeAdapter =
                   options,
                 }),
             },
-            initialState: { leaderHead: initialLeaderHead, migrationsReport: initialState.migrationsReport },
+            initialState: {
+              leaderHead: initialLeaderHead,
+              migrationsReport: initialState.migrationsReport,
+              storageMode: 'persisted',
+            },
             export: Effect.sync(() => dbState.export()),
             getEventlogData: Effect.sync(() => dbEventlog.export()),
             syncState: syncProcessor.syncState,

--- a/packages/@livestore/adapter-expo/src/index.ts
+++ b/packages/@livestore/adapter-expo/src/index.ts
@@ -312,7 +312,11 @@ const makeLeaderThread = ({
               options,
             }),
         },
-        initialState: { leaderHead: initialLeaderHead, migrationsReport: initialState.migrationsReport },
+        initialState: {
+          leaderHead: initialLeaderHead,
+          migrationsReport: initialState.migrationsReport,
+          storageMode: 'persisted',
+        },
         export: Effect.sync(() => db.export()),
         getEventlogData: Effect.sync(() => dbEventlog.export()),
         syncState: syncProcessor.syncState,

--- a/packages/@livestore/adapter-node/src/client-session/adapter.ts
+++ b/packages/@livestore/adapter-node/src/client-session/adapter.ts
@@ -413,7 +413,11 @@ const makeLocalLeaderThread = ({
                 options,
               }),
           },
-          initialState: { leaderHead: initialLeaderHead, migrationsReport: initialState.migrationsReport },
+          initialState: {
+            leaderHead: initialLeaderHead,
+            migrationsReport: initialState.migrationsReport,
+            storageMode: 'persisted',
+          },
           export: Effect.sync(() => dbState.export()),
           getEventlogData: Effect.sync(() => dbEventlog.export()),
           syncState: syncProcessor.syncState,
@@ -561,6 +565,7 @@ const makeWorkerLeaderThread = ({
         initialState: {
           leaderHead: initialLeaderHead,
           migrationsReport: bootResult.migrationsReport,
+          storageMode: 'persisted',
         },
         export: runInWorker(new WorkerSchema.LeaderWorkerInnerExport()).pipe(
           Effect.timeout(10_000),

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -278,7 +278,11 @@ const makeLeaderThread = ({
               options,
             }),
         },
-        initialState: { leaderHead: initialLeaderHead, migrationsReport: initialState.migrationsReport },
+        initialState: {
+          leaderHead: initialLeaderHead,
+          migrationsReport: initialState.migrationsReport,
+          storageMode: 'in-memory',
+        },
         export: Effect.sync(() => dbState.export()),
         getEventlogData: Effect.sync(() => dbEventlog.export()),
         syncState: syncProcessor.syncState,

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -491,7 +491,11 @@ export const makePersistedAdapter =
             ),
         },
 
-        initialState: { leaderHead: initialLeaderHead, migrationsReport },
+        initialState: {
+          leaderHead: initialLeaderHead,
+          migrationsReport,
+          storageMode: opfsWarning === undefined ? 'persisted' : 'in-memory',
+        },
 
         getEventlogData: runInWorker(new WorkerSchema.LeaderWorkerInnerExportEventlog()).pipe(
           Effect.timeout(10_000),

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -1,4 +1,4 @@
-import type { Adapter, ClientSession, LockStatus } from '@livestore/common'
+import type { Adapter, BootWarningReason, ClientSession, LockStatus } from '@livestore/common'
 import {
   IntentionalShutdownCause,
   liveStoreVersion,
@@ -29,7 +29,7 @@ import {
   Worker,
   WorkerError,
 } from '@livestore/utils/effect'
-import { BrowserWorker, Opfs, WebLock } from '@livestore/utils/effect/browser'
+import { BrowserWorker, Opfs, WebError, WebLock } from '@livestore/utils/effect/browser'
 import { nanoid } from '@livestore/utils/nanoid'
 import {
   readPersistedStateDbFromClientSession,
@@ -168,10 +168,21 @@ export const makePersistedAdapter =
 
       const shutdownChannel = yield* makeShutdownChannel(storeId)
 
-      if (options.resetPersistence === true) {
+      // Check OPFS availability early and notify user if storage is unavailable (e.g. private browsing)
+      const opfsWarning = yield* checkOpfsAvailability
+      if (opfsWarning !== undefined) {
+        yield* Effect.logWarning('[@livestore/adapter-web:client-session] OPFS unavailable', opfsWarning)
+      }
+
+      if (options.resetPersistence === true && opfsWarning === undefined) {
         yield* shutdownChannel.send(IntentionalShutdownCause.make({ reason: 'adapter-reset' }))
 
         yield* resetPersistedDataFromClientSession({ storageOptions, storeId })
+      } else if (options.resetPersistence === true) {
+        yield* Effect.logWarning(
+          '[@livestore/adapter-web:client-session] Skipping persistence reset because storage is unavailable',
+          opfsWarning,
+        )
       }
 
       // Note on fast-path booting:
@@ -181,7 +192,7 @@ export const makePersistedAdapter =
       // We need to be extra careful though to not run into any race conditions or inconsistencies.
       // TODO also verify persisted data
       const dataFromFile =
-        options.experimental?.disableFastPath === true
+        options.experimental?.disableFastPath === true || opfsWarning !== undefined
           ? undefined
           : yield* readPersistedStateDbFromClientSession({ storageOptions, storeId, schema }).pipe(
               Effect.tapError((error) =>
@@ -583,4 +594,30 @@ const ensureBrowserRequirements = Effect.gen(function* () {
     validate(typeof window === 'undefined', 'window'),
     validate(typeof sessionStorage === 'undefined', 'sessionStorage'),
   ])
+})
+
+/**
+ * Attempts to access OPFS and returns a warning if unavailable.
+ *
+ * Common failure scenarios:
+ * - Safari/Firefox private browsing: SecurityError or NotAllowedError
+ * - Permission denied: NotAllowedError
+ * - Quota exceeded: QuotaExceededError
+ */
+const checkOpfsAvailability = Effect.gen(function* () {
+  const opfs = yield* Opfs.Opfs
+  return yield* opfs.getRootDirectoryHandle.pipe(
+    Effect.as(undefined),
+    Effect.catchAll((error) => {
+      const reason: BootWarningReason =
+        Schema.is(WebError.SecurityError)(error) || Schema.is(WebError.NotAllowedError)(error)
+          ? 'private-browsing'
+          : 'storage-unavailable'
+      const message =
+        reason === 'private-browsing'
+          ? 'Storage unavailable in private browsing mode. LiveStore will continue without persistence.'
+          : 'Storage access denied. LiveStore will continue without persistence.'
+      return Effect.succeed({ reason, message } as const)
+    }),
+  )
 })

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -1,4 +1,4 @@
-import type { SqliteDb, SyncOptions } from '@livestore/common'
+import type { BootStatus, BootWarningReason, SqliteDb, SyncOptions } from '@livestore/common'
 import { Devtools, LogConfig, UnknownError } from '@livestore/common'
 import type { DevtoolsOptions, StreamEventsOptions } from '@livestore/common/leader-thread'
 import {
@@ -22,12 +22,12 @@ import {
   Layer,
   OtelTracer,
   Scheduler,
-  type Schema,
+  Schema,
   Stream,
   TaskTracing,
   WorkerRunner,
 } from '@livestore/utils/effect'
-import { BrowserWorkerRunner, Opfs } from '@livestore/utils/effect/browser'
+import { BrowserWorkerRunner, Opfs, WebError } from '@livestore/utils/effect/browser'
 import type * as otel from '@opentelemetry/api'
 
 import { cleanupOldStateDbFiles, getStateDbFileName, sanitizeOpfsDir } from '../common/persisted-sqlite.ts'
@@ -118,13 +118,28 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
       Effect.gen(function* () {
         const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
         const makeSqliteDb = sqliteDbFactory({ sqlite3 })
-        const opfsDirectory = yield* sanitizeOpfsDir(storageOptions.directory, storeId)
         const runtime = yield* Effect.runtime<never>()
 
-        const makeDb = (kind: 'state' | 'eventlog') =>
+        // Check OPFS availability and determine storage mode
+        const opfsCheck = yield* checkOpfsAvailability
+        const useOpfs = opfsCheck === undefined
+
+        // Track boot warning to emit later
+        let bootWarning: BootStatus | undefined
+        if (!useOpfs) {
+          yield* Effect.logWarning(
+            '[@livestore/adapter-web:worker] OPFS unavailable, using in-memory storage',
+            opfsCheck,
+          )
+          bootWarning = { stage: 'warning', ...opfsCheck }
+        }
+
+        const opfsDirectory = useOpfs ? yield* sanitizeOpfsDir(storageOptions.directory, storeId) : undefined
+
+        const makeOpfsDb = (kind: 'state' | 'eventlog') =>
           makeSqliteDb({
             _tag: 'opfs',
-            opfsDirectory,
+            opfsDirectory: opfsDirectory!,
             fileName: kind === 'state' ? getStateDbFileName(schema) : 'eventlog.db',
             configureDb: (db) =>
               configureConnection(db, {
@@ -137,10 +152,17 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
               }).pipe(Effect.provide(runtime), Effect.runSync),
           }).pipe(Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)))
 
-        // Might involve some async work, so we're running them concurrently
-        const [dbState, dbEventlog] = yield* Effect.all([makeDb('state'), makeDb('eventlog')], {
-          concurrency: 2,
-        })
+        const makeInMemoryDb = () =>
+          makeSqliteDb({
+            _tag: 'in-memory',
+            configureDb: (db) =>
+              configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
+          }).pipe(Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)))
+
+        // Use OPFS if available, otherwise fall back to in-memory
+        const [dbState, dbEventlog] = useOpfs
+          ? yield* Effect.all([makeOpfsDb('state'), makeOpfsDb('eventlog')], { concurrency: 2 })
+          : yield* Effect.all([makeInMemoryDb(), makeInMemoryDb()], { concurrency: 2 })
 
         // Clean up old state database files after successful database creation
         // This prevents OPFS file pool capacity exhaustion from accumulated state db files after schema changes/migrations
@@ -167,6 +189,7 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
           shutdownChannel,
           syncPayloadEncoded,
           syncPayloadSchema,
+          ...(bootWarning !== undefined ? { bootWarning } : {}),
         })
       }).pipe(
         Effect.tapCauseLogPretty,
@@ -301,3 +324,29 @@ const makeDevtoolsOptions = ({
       }),
     }
   })
+
+/**
+ * Attempts to access OPFS and returns a warning if unavailable.
+ *
+ * Common failure scenarios:
+ * - Safari/Firefox private browsing: SecurityError or NotAllowedError
+ * - Permission denied: NotAllowedError
+ * - Quota exceeded: QuotaExceededError
+ */
+const checkOpfsAvailability = Effect.gen(function* () {
+  const opfs = yield* Opfs.Opfs
+  return yield* opfs.getRootDirectoryHandle.pipe(
+    Effect.as(undefined),
+    Effect.catchAll((error) => {
+      const reason: BootWarningReason =
+        Schema.is(WebError.SecurityError)(error) || Schema.is(WebError.NotAllowedError)(error)
+          ? 'private-browsing'
+          : 'storage-unavailable'
+      const message =
+        reason === 'private-browsing'
+          ? 'Storage unavailable in private browsing mode. LiveStore will continue without persistence.'
+          : 'Storage access denied. LiveStore will continue without persistence.'
+      return Effect.succeed({ reason, message } as const)
+    }),
+  )
+})

--- a/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
+++ b/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
@@ -1,5 +1,6 @@
 import type { Effect, Stream, Subscribable } from '@livestore/utils/effect'
 
+import type { StorageMode } from './adapter-types.ts'
 import type { MigrationsReport } from './defs.ts'
 import type * as Devtools from './devtools/mod.ts'
 import type { UnknownError } from './errors.ts'
@@ -25,6 +26,12 @@ export interface ClientSessionLeaderThreadProxy {
     readonly leaderHead: EventSequenceNumber.Client.Composite
     /** The migrations report from the leader thread */
     readonly migrationsReport: MigrationsReport
+    /**
+     * Indicates how data is being stored.
+     * - `persisted`: Data is persisted to disk (e.g., via OPFS)
+     * - `in-memory`: Data is only stored in memory and will be lost on page refresh (e.g., private browsing)
+     */
+    readonly storageMode: StorageMode
   }
   export: Effect.Effect<Uint8Array<ArrayBuffer>, UnknownError>
   getEventlogData: Effect.Effect<Uint8Array<ArrayBuffer>, UnknownError>

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -60,6 +60,16 @@ export const BootStateProgress = Schema.Struct({
 export const BootWarningReason = Schema.Literal('private-browsing', 'storage-unavailable', 'unknown')
 export type BootWarningReason = typeof BootWarningReason.Type
 
+/**
+ * Describes the storage mode the store is operating in.
+ *
+ * @remarks
+ * - `persisted`: Data is persisted to disk (e.g., via OPFS)
+ * - `in-memory`: Data is only stored in memory and will be lost on page refresh
+ */
+export const StorageMode = Schema.Literal('persisted', 'in-memory')
+export type StorageMode = typeof StorageMode.Type
+
 export const BootStatus = Schema.Union(
   Schema.Struct({ stage: Schema.Literal('loading') }),
   Schema.Struct({ stage: Schema.Literal('migrating'), progress: BootStateProgress }),

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -49,12 +49,32 @@ export const BootStateProgress = Schema.Struct({
   total: Schema.Number,
 })
 
+/**
+ * Describes known reasons why LiveStore boot may encounter storage issues.
+ *
+ * @remarks
+ * - `private-browsing`: OPFS unavailable due to private/incognito browsing mode (Safari, Firefox)
+ * - `storage-unavailable`: OPFS access denied for other reasons (permissions, quota)
+ * - `unknown`: Unexpected error during storage initialization
+ */
+export const BootWarningReason = Schema.Literal('private-browsing', 'storage-unavailable', 'unknown')
+export type BootWarningReason = typeof BootWarningReason.Type
+
 export const BootStatus = Schema.Union(
   Schema.Struct({ stage: Schema.Literal('loading') }),
   Schema.Struct({ stage: Schema.Literal('migrating'), progress: BootStateProgress }),
   Schema.Struct({ stage: Schema.Literal('rehydrating'), progress: BootStateProgress }),
   Schema.Struct({ stage: Schema.Literal('syncing'), progress: BootStateProgress }),
   Schema.Struct({ stage: Schema.Literal('done') }),
+  /**
+   * Indicates a non-fatal issue occurred during boot that may degrade functionality.
+   * LiveStore continues running but without full capabilities (e.g., no persistence).
+   */
+  Schema.Struct({
+    stage: Schema.Literal('warning'),
+    reason: BootWarningReason,
+    message: Schema.String,
+  }),
 ).annotations({ title: 'BootStatus' })
 
 export type BootStatus = typeof BootStatus.Type

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -55,6 +55,8 @@ export interface MakeLeaderThreadLayerParams {
   dbEventlog: LeaderSqliteDb
   devtoolsOptions: DevtoolsOptions
   shutdownChannel: ShutdownChannel
+  /** Boot warning to emit (e.g., OPFS unavailable in private browsing) */
+  bootWarning?: BootStatus
   params?: {
     localPushBatchSize?: number
     backendPushBatchSize?: number
@@ -80,6 +82,7 @@ export const makeLeaderThreadLayer = ({
   dbEventlog,
   devtoolsOptions,
   shutdownChannel,
+  bootWarning,
   params,
   testing,
 }: MakeLeaderThreadLayerParams): Layer.Layer<LeaderThreadCtx, UnknownError, Scope.Scope | HttpClient.HttpClient> =>
@@ -88,6 +91,11 @@ export const makeLeaderThreadLayer = ({
       syncPayloadEncoded === undefined ? undefined : yield* Schema.decodeUnknown(syncPayloadSchema)(syncPayloadEncoded)
 
     const bootStatusQueue = yield* Queue.unbounded<BootStatus>().pipe(Effect.acquireRelease(Queue.shutdown))
+
+    // Emit boot warning if present (e.g., OPFS unavailable in private browsing)
+    if (bootWarning !== undefined) {
+      yield* Queue.offer(bootStatusQueue, bootWarning)
+    }
 
     const dbEventlogMissing = !hasEventlogTables(dbEventlog)
 

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -15,6 +15,7 @@ import {
   prepareBindValues,
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
+  type StorageMode,
   UnknownError,
 } from '@livestore/common'
 import type { StreamEventsOptions } from '@livestore/common/leader-thread'
@@ -158,6 +159,24 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   readonly networkStatus: ClientSession['leaderThread']['networkStatus']
 
   /**
+   * Indicates how data is being stored.
+   *
+   * - `persisted`: Data is persisted to disk (e.g., via OPFS on web, SQLite file on native)
+   * - `in-memory`: Data is only stored in memory and will be lost on page refresh
+   *
+   * The store operates in `in-memory` mode when persistent storage is unavailable,
+   * such as in Safari/Firefox private browsing mode where OPFS is restricted.
+   *
+   * @example
+   * ```tsx
+   * if (store.storageMode === 'in-memory') {
+   *   showWarning('Data will not be persisted in private browsing mode')
+   * }
+   * ```
+   */
+  readonly storageMode: StorageMode
+
+  /**
    * Store internals. Not part of the public API — shapes and semantics may change without notice.
    */
   readonly [StoreInternalsSymbol]: StoreInternals
@@ -182,6 +201,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     this.context = context
     this.params = params
     this.networkStatus = clientSession.leaderThread.networkStatus
+    this.storageMode = clientSession.leaderThread.initialState.storageMode
 
     const reactivityGraph = makeReactivityGraph()
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -343,6 +343,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         initialState: {
           leaderHead: baseHead,
           migrationsReport: { migrations: [] },
+          storageMode: 'persisted',
         },
         export: Effect.dieMessage('not implemented'),
         getEventlogData: Effect.dieMessage('not implemented'),
@@ -519,6 +520,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
           initialState: {
             leaderHead: EventSequenceNumber.Client.ROOT,
             migrationsReport: { migrations: [] },
+            storageMode: 'persisted',
           },
           events: {
             push: () => Effect.void,


### PR DESCRIPTION
## Summary

- Detect when OPFS is unavailable (e.g., Safari/Firefox private browsing) and fall back to in-memory storage
- Add `warning` stage to `BootStatus` to notify users of degraded functionality
- LiveStore continues running without persistence instead of failing silently

## Changes

- `packages/@livestore/common/src/adapter-types.ts`: Added `BootWarningReason` type and `warning` stage to `BootStatus`
- `packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts`: Added OPFS availability check
- `packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts`: Added OPFS fallback to in-memory databases
- `packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts`: Added `bootWarning` parameter

## Test plan

- [x] TypeScript builds without errors
- [x] Linting passes
- [x] Unit tests pass
- [ ] Manual test in Safari private browsing mode

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)