### PR TITLE
feat(sync-cf): add header forwarding for cookie-based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ Key improvements include streaming pull operations (faster initial sync), a two-
 - WebSocket transport: Introduced message chunking limits to stay under platform constraints (#687).
 - Reliability: Retry and backoff on push errors, restart push on advance, and add regression tests (#639).
 - Resilience: Improve sync provider robustness and align test helpers for CI and local development (#682, #646).
+- Header forwarding: Added `forwardHeaders` option to `makeDurableObject()` for cookie-based authentication. Headers are stored in WebSocket attachments to survive hibernation and accessible via `context.headers` in `onPush`/`onPull` callbacks (#929).
 
 ##### S2 sync backend
 

--- a/docs/.astro/content.d.ts
+++ b/docs/.astro/content.d.ts
@@ -1,7 +1,7 @@
 declare module 'astro:content' {
 	interface Render {
 		'.mdx': Promise<{
-			Content: import('astro').MarkdownInstance<{}>['Content'];
+			Content: import('astro').MDXContent;
 			headings: import('astro').MarkdownHeading[];
 			remarkPluginFrontmatter: Record<string, any>;
 			components: import('astro').MDXInstance<{}>['components'];

--- a/docs/src/content/_assets/code/patterns/auth/cookie-auth.ts
+++ b/docs/src/content/_assets/code/patterns/auth/cookie-auth.ts
@@ -1,0 +1,90 @@
+import { makeDurableObject, makeWorker } from '@livestore/sync-cf/cf-worker'
+
+export class SyncBackendDO extends makeDurableObject({
+  // Forward Cookie and Authorization headers to onPush/onPull callbacks
+  forwardHeaders: ['Cookie', 'Authorization'],
+
+  onPush: async (message, context) => {
+    const { storeId, headers } = context
+
+    // Access forwarded headers in callbacks
+    const cookie = headers?.get('cookie')
+    const _authorization = headers?.get('authorization')
+
+    if (cookie) {
+      // Parse session from cookie (example with better-auth)
+      const sessionToken = parseCookie(cookie, 'session_token')
+      const session = await getSessionFromToken(sessionToken)
+
+      if (!session) {
+        throw new Error('Invalid session')
+      }
+
+      console.log('Push from user:', session.userId, 'store:', storeId)
+    }
+
+    console.log('onPush', message.batch)
+  },
+
+  onPull: async (message, context) => {
+    const { storeId, headers } = context
+
+    // Same header access in onPull
+    const cookie = headers?.get('cookie')
+
+    if (cookie) {
+      const sessionToken = parseCookie(cookie, 'session_token')
+      const session = await getSessionFromToken(sessionToken)
+
+      if (!session) {
+        throw new Error('Invalid session')
+      }
+
+      console.log('Pull from user:', session.userId, 'store:', storeId)
+    }
+
+    console.log('onPull', message)
+  },
+}) {}
+
+export default makeWorker({
+  syncBackendBinding: 'SYNC_BACKEND_DO',
+  // Optional: validate at worker level using headers
+  validatePayload: async (_payload, context) => {
+    const { headers } = context
+    const cookie = headers.get('cookie')
+
+    if (cookie) {
+      const sessionToken = parseCookie(cookie, 'session_token')
+      const session = await getSessionFromToken(sessionToken)
+
+      if (!session) {
+        throw new Error('Unauthorized: Invalid session')
+      }
+    }
+  },
+  enableCORS: true,
+})
+
+// --- Helper functions (implement based on your auth library) ---
+
+function parseCookie(cookieHeader: string, name: string): string | undefined {
+  const cookies = cookieHeader.split(';').map((c) => c.trim())
+  for (const cookie of cookies) {
+    const [key, value] = cookie.split('=')
+    if (key === name) return value
+  }
+  return undefined
+}
+
+interface Session {
+  userId: string
+  email: string
+}
+
+async function getSessionFromToken(_token: string | undefined): Promise<Session | null> {
+  // Implement session lookup using your auth library
+  // Example with better-auth:
+  // return await auth.api.getSession({ headers: { cookie: `session_token=${token}` } })
+  return { userId: 'user-123', email: 'user@example.com' }
+}

--- a/docs/src/content/docs/patterns/auth.mdx
+++ b/docs/src/content/docs/patterns/auth.mdx
@@ -6,6 +6,7 @@ sidebar:
 import PassAuthPayloadSnippet from '../../_assets/code/patterns/auth/pass-auth-payload.ts?snippet'
 import LiveStoreProviderSnippet from '../../_assets/code/patterns/auth/live-store-provider.tsx?snippet'
 import KeepPayloadCanonicalSnippet from '../../_assets/code/patterns/auth/keep-payload-canonical.ts?snippet'
+import CookieAuthSnippet from '../../_assets/code/patterns/auth/cookie-auth.ts?snippet'
 
 
 LiveStore doesn't include built-in authentication or authorization support, but you can implement it in your app's logic.
@@ -41,6 +42,41 @@ When you rely on `syncPayload`, treat it as untrusted input. Decode the token in
 - The HTTP transport does not forward payloads today; embed the necessary authorization context directly in the events or move those clients to WebSocket/DO-RPC if you must rely on shared payload metadata.
 
 You can extend `ensureAuthorized` to project additional claims, memoise verification per `authToken`, or enforce application-specific policies without changing LiveStore internals.
+
+## Cookie-based authentication
+
+If you prefer cookie-based authentication (e.g., with [better-auth](https://www.better-auth.com/)), you can forward HTTP headers to your `onPush` and `onPull` callbacks using the `forwardHeaders` option.
+
+### Why forward headers?
+
+Passing tokens in URL parameters (`syncPayload`) exposes them in browser history, server logs, and referrer headers. Cookie-based auth avoids these issues since cookies are sent automatically with each request and aren't logged in URLs.
+
+### Example
+
+The following example forwards `Cookie` and `Authorization` headers to the Durable Object callbacks:
+
+<CookieAuthSnippet />
+
+### How it works
+
+1. **Configure `forwardHeaders`** in `makeDurableObject()` to specify which headers to forward.
+2. **Headers are stored** in the WebSocket attachment during connection upgrade, surviving hibernation.
+3. **Access headers** via `context.headers` in `onPush` and `onPull` callbacks.
+4. **Worker-level validation** can also access headers via `context.headers` in `validatePayload`.
+
+### Custom header extraction
+
+For more control, pass a function to `forwardHeaders`:
+
+```typescript
+export class SyncBackendDO extends makeDurableObject({
+  forwardHeaders: (request) => ({
+    'x-user-id': request.headers.get('x-user-id') ?? '',
+    'x-session': request.headers.get('cookie')?.split('session=')[1]?.split(';')[0] ?? '',
+  }),
+  // ...
+}) {}
+```
 
 ## Client identity vs user identity
 

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -17,6 +17,7 @@
 
 import { notYetImplemented, omitUndefineds } from '@livestore/utils'
 import {
+  Context,
   constVoid,
   Effect,
   Exit,
@@ -33,6 +34,13 @@ import {
 import type * as CfTypes from '../cf-types.ts'
 
 /**
+ * Context service providing access to the current WebSocket.
+ * This is useful for reading WebSocket attachment data (e.g., forwarded headers)
+ * inside RPC handlers.
+ */
+export class WsContext extends Context.Tag('WsContext')<WsContext, { readonly ws: CfTypes.WebSocket }>() {}
+
+/**
  * Configuration options for setting up WebSocket RPC on a Durable Object.
  */
 export interface DurableObjectWebSocketRpcConfig {
@@ -44,8 +52,22 @@ export interface DurableObjectWebSocketRpcConfig {
    * - 'accept': Use traditional WebSocket handling (not yet implemented)
    */
   webSocketMode: 'hibernate' | 'accept'
-  /** Effect RPC layer that defines the available RPC methods and handlers */
-  rpcLayer: Layer.Layer<never, never, RpcServer.Protocol>
+  /**
+   * Effect RPC layer that requires `RpcServer.Protocol` (and `WsContext` if used)
+   * and provides the RPC server runtime.
+   *
+   * This is typically created by:
+   * ```typescript
+   * RpcServer.layer(MyRpcs).pipe(Layer.provide(handlersLayer))
+   * ```
+   *
+   * `WsContext` is provided by the WebSocket protocol layer, so handlers can access
+   * WebSocket attachment data (e.g., forwarded headers stored after WebSocket upgrade).
+   *
+   * The layer requirements (`RIn`) must be a subset of `RpcServer.Protocol | WsContext`,
+   * which are both provided by the WebSocket protocol layer.
+   */
+  rpcLayer: Layer.Layer<never, never, RpcServer.Protocol | WsContext>
   /** Function to get access to incoming requests */
   onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
   mainLayer?: Layer.Layer<never, never, never>
@@ -221,13 +243,16 @@ export interface WsRpcServerArgs {
  * This layer handles the low-level WebSocket protocol details for RPC communication,
  * including message serialization, routing, and error handling.
  *
+ * Also provides `WsContext` with the current WebSocket so handlers can access
+ * WebSocket attachment data (e.g., forwarded headers).
+ *
  * @param args Configuration for WebSocket RPC protocol
- * @returns Effect layer that provides RPC server protocol functionality
+ * @returns Effect layer that provides RPC server protocol functionality and WsContext
  *
  * @internal This is typically used internally by `setupDurableObjectWebSocketRpc`
  */
 export const layerRpcServerWebsocket = (args: WsRpcServerArgs) =>
-  Layer.scoped(RpcServer.Protocol, makeSocketProtocol(args))
+  Layer.mergeAll(Layer.scoped(RpcServer.Protocol, makeSocketProtocol(args)), Layer.succeed(WsContext, { ws: args.ws }))
 
 /**
  * Creates the low-level RPC protocol implementation for WebSocket communication.

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -16,6 +16,7 @@ import {
 } from '@livestore/utils/effect'
 import {
   type Env,
+  extractForwardedHeaders,
   type MakeDurableObjectClassOptions,
   matchSyncRequest,
   type SyncBackendRpcInterface,
@@ -155,16 +156,20 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
           throw new Error(`Transport ${transport} is not enabled (based on \`options.enabledTransports\`)`)
         }
 
+        // Extract headers to forward based on configuration (available for all transports)
+        const headers = extractForwardedHeaders(request, options?.forwardHeaders)
+
         if (transport === 'http') {
-          return yield* this.handleHttp(request)
+          return yield* this.handleHttp(request, headers)
         }
 
         if (transport === 'ws') {
           const { 0: client, 1: server } = new WebSocketPair()
 
           // Since we're using websocket hibernation, we need to remember the storeId for subsequent `webSocketMessage` calls
+          // Also store forwarded headers so they're available after hibernation resume
           server.serializeAttachment(
-            Schema.encodeSync(WebSocketAttachmentSchema)({ storeId, payload, pullRequestIds: [] }),
+            Schema.encodeSync(WebSocketAttachmentSchema)({ storeId, payload, pullRequestIds: [], headers }),
           )
 
           // See https://developers.cloudflare.com/durable-objects/examples/websocket-hibernation-server
@@ -220,10 +225,11 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
      *
      * Requires the `enable_request_signal` compatibility flag to properly support `pull` streaming responses
      */
-    private handleHttp = (request: CfTypes.Request) =>
+    private handleHttp = (request: CfTypes.Request, forwardedHeaders: Record<string, string> | undefined) =>
       createHttpRpcHandler({
         request,
         responseHeaders: options?.http?.responseHeaders,
+        forwardedHeaders,
       }).pipe(Effect.withSpan('@livestore/sync-cf:durable-object:handleHttp'))
 
     private runEffectAsPromise = <T, E = never>(effect: Effect.Effect<T, E, Scope.Scope>): Promise<T> =>

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -3,6 +3,7 @@ import { splitChunkBySize } from '@livestore/common/sync'
 import { Chunk, Effect, Option, Schema, Stream } from '@livestore/utils/effect'
 import { MAX_PULL_EVENTS_PER_MESSAGE, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SyncMessage } from '../../common/mod.ts'
+import type { ForwardedHeaders } from '../shared.ts'
 import { DoCtx } from './layer.ts'
 
 const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
@@ -16,15 +17,22 @@ const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
 // DO RPC:
 // - Further chunks will be emitted manually in `push.ts`
 // - If the client sends a `Interrupt` RPC message, TODO
-export const makeEndingPullStream = (
-  req: SyncMessage.PullRequest,
-  payload: Schema.JsonValue | undefined,
-): Stream.Stream<SyncMessage.PullResponse, InvalidPullError, DoCtx> =>
+export const makeEndingPullStream = ({
+  req,
+  payload,
+  headers,
+}: {
+  req: SyncMessage.PullRequest
+  payload: Schema.JsonValue | undefined
+  headers: ForwardedHeaders | undefined
+}): Stream.Stream<SyncMessage.PullResponse, InvalidPullError, DoCtx> =>
   Effect.gen(function* () {
     const { doOptions, backendId, storeId, storage } = yield* DoCtx
 
     if (doOptions?.onPull) {
-      yield* Effect.tryAll(() => doOptions!.onPull!(req, { storeId, payload })).pipe(UnknownError.mapToUnknownError)
+      yield* Effect.tryAll(() => doOptions!.onPull!(req, { storeId, payload, headers })).pipe(
+        UnknownError.mapToUnknownError,
+      )
     }
 
     if (req.cursor._tag === 'Some' && req.cursor.value.backendId !== backendId) {

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -10,7 +10,13 @@ import { type CfTypes, emitStreamResponse } from '@livestore/common-cf'
 import { Chunk, Effect, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
 import { MAX_PUSH_EVENTS_PER_REQUEST, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SyncMessage } from '../../common/mod.ts'
-import { type Env, type MakeDurableObjectClassOptions, type StoreId, WebSocketAttachmentSchema } from '../shared.ts'
+import {
+  type Env,
+  type ForwardedHeaders,
+  type MakeDurableObjectClassOptions,
+  type StoreId,
+  WebSocketAttachmentSchema,
+} from '../shared.ts'
 import { DoCtx } from './layer.ts'
 
 const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
@@ -19,12 +25,14 @@ type PullBatchItem = SyncMessage.PullResponse['batch'][number]
 export const makePush =
   ({
     payload,
+    headers,
     options,
     storeId,
     ctx,
     env,
   }: {
     payload: Schema.JsonValue | undefined
+    headers: ForwardedHeaders | undefined
     options: MakeDurableObjectClassOptions | undefined
     storeId: StoreId
     ctx: CfTypes.DurableObjectState
@@ -40,7 +48,7 @@ export const makePush =
       }
 
       if (options?.onPush) {
-        yield* Effect.tryAll(() => options.onPush!(pushRequest, { storeId, payload })).pipe(
+        yield* Effect.tryAll(() => options.onPush!(pushRequest, { storeId, payload, headers })).pipe(
           UnknownError.mapToUnknownError,
         )
       }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -49,7 +49,8 @@ export const createDoRpcHandler = (
             })
           }
 
-          return makeEndingPullStream(req, req.payload)
+          // DO-RPC doesn't have HTTP headers context - headers are undefined
+          return makeEndingPullStream({ req, payload: req.payload, headers: undefined })
         }).pipe(
           Stream.unwrap,
           Stream.map((res) => ({
@@ -63,7 +64,8 @@ export const createDoRpcHandler = (
       'SyncDoRpc.Push': (req) =>
         Effect.gen(this, function* () {
           const { doOptions, ctx, env, storeId } = yield* DoCtx
-          const push = makePush({ storeId, payload: req.payload, options: doOptions, ctx, env })
+          // DO-RPC doesn't have HTTP headers context - headers are undefined
+          const push = makePush({ storeId, payload: req.payload, headers: undefined, options: doOptions, ctx, env })
 
           return yield* push(req)
         }).pipe(

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
@@ -2,6 +2,7 @@ import type { CfTypes } from '@livestore/common-cf'
 import { Effect, HttpApp, Layer, RpcSerialization, RpcServer } from '@livestore/utils/effect'
 import { SyncHttpRpc } from '../../../common/http-rpc-schema.ts'
 import * as SyncMessage from '../../../common/sync-message-types.ts'
+import { headersRecordToMap } from '../../shared.ts'
 import { DoCtx } from '../layer.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
@@ -9,12 +10,14 @@ import { makePush } from '../push.ts'
 export const createHttpRpcHandler = ({
   request,
   responseHeaders,
+  forwardedHeaders,
 }: {
   request: CfTypes.Request
   responseHeaders?: Record<string, string>
+  forwardedHeaders?: Record<string, string>
 }) =>
   Effect.gen(function* () {
-    const handlerLayer = createHttpRpcLayer
+    const handlerLayer = createHttpRpcLayer(forwardedHeaders)
     const httpApp = RpcServer.toHttpApp(SyncHttpRpc).pipe(Effect.provide(handlerLayer))
     const webHandler = yield* httpApp.pipe(Effect.map(HttpApp.toWebHandler))
 
@@ -31,15 +34,17 @@ export const createHttpRpcHandler = ({
     return response
   }).pipe(Effect.withSpan('createHttpRpcHandler'))
 
-const createHttpRpcLayer =
+const createHttpRpcLayer = (forwardedHeaders: Record<string, string> | undefined) => {
+  const headers = headersRecordToMap(forwardedHeaders)
+
   // TODO implement admin requests
-  SyncHttpRpc.toLayer({
-    'SyncHttpRpc.Pull': (req) => makeEndingPullStream(req, req.payload),
+  return SyncHttpRpc.toLayer({
+    'SyncHttpRpc.Pull': (req) => makeEndingPullStream({ req, payload: req.payload, headers }),
 
     'SyncHttpRpc.Push': (req) =>
       Effect.gen(function* () {
         const { ctx, env, doOptions, storeId } = yield* DoCtx
-        const push = makePush({ payload: undefined, options: doOptions, storeId, ctx, env })
+        const push = makePush({ payload: undefined, headers, options: doOptions, storeId, ctx, env })
 
         return yield* push(req)
       }),
@@ -49,3 +54,4 @@ const createHttpRpcLayer =
     Layer.provideMerge(RpcServer.layerProtocolHttp({ path: '/http-rpc' })),
     Layer.provideMerge(RpcSerialization.layerJson),
   )
+}

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -1,26 +1,30 @@
 import { InvalidPullError, InvalidPushError } from '@livestore/common'
-import { Effect, identity, Layer, RpcServer, Stream } from '@livestore/utils/effect'
+import { WsContext } from '@livestore/common-cf'
+import { Effect, identity, Layer, RpcServer, Schema, Stream } from '@livestore/utils/effect'
 import { SyncWsRpc } from '../../../common/ws-rpc-schema.ts'
+import { headersRecordToMap, WebSocketAttachmentSchema } from '../../shared.ts'
 import { DoCtx, type DoCtxInput } from '../layer.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
 
 export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) => {
-  // TODO implement admin requests
   const handlersLayer = SyncWsRpc.toLayer({
     'SyncWsRpc.Pull': (req) =>
-      makeEndingPullStream(req, req.payload).pipe(
-        // Needed to keep the stream alive on the client side for phase 2 (i.e. not send the `Exit` stream RPC message)
-        req.live ? Stream.concat(Stream.never) : identity,
-        Stream.provideLayer(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
-        Stream.mapError((cause) => (cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause }))),
-        // Stream.tapErrorCause(Effect.log),
-      ),
+      Effect.gen(function* () {
+        const headers = yield* getForwardedHeaders
+        return makeEndingPullStream({ req, payload: req.payload, headers }).pipe(
+          // Needed to keep the stream alive on the client side for phase 2 (i.e. not send the `Exit` stream RPC message)
+          req.live ? Stream.concat(Stream.never) : identity,
+          Stream.provideLayer(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
+          Stream.mapError((cause) => (cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause }))),
+        )
+      }).pipe(Stream.unwrap),
     'SyncWsRpc.Push': (req) =>
       Effect.gen(function* () {
         const { doOptions, storeId, ctx, env } = yield* DoCtx
+        const headers = yield* getForwardedHeaders
 
-        const push = makePush({ options: doOptions, storeId, payload: req.payload, ctx, env })
+        const push = makePush({ options: doOptions, storeId, payload: req.payload, headers, ctx, env })
 
         return yield* push(req)
       }).pipe(
@@ -32,3 +36,18 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
 
   return RpcServer.layer(SyncWsRpc).pipe(Layer.provide(handlersLayer))
 }
+
+/** Extracts forwarded headers from the WebSocket attachment */
+const getForwardedHeaders = Effect.gen(function* () {
+  const { ws } = yield* WsContext
+  const attachment = ws.deserializeAttachment()
+  const decoded = Schema.decodeUnknownEither(WebSocketAttachmentSchema)(attachment)
+  if (decoded._tag === 'Left') {
+    yield* Effect.logError('Failed to decode WebSocket attachment for forwarded headers', { error: decoded.left })
+    ws.close(1011, 'invalid-attachment')
+    return yield* Effect.die('Invalid WebSocket attachment (headers decode failed)')
+  }
+
+  const headers = headersRecordToMap(decoded.right.headers)
+  return headers
+})

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -7,17 +7,61 @@ import { SearchParamsSchema, SyncMessage } from '../common/mod.ts'
 
 export type Env = {}
 
+/** Headers forwarded from the request to callbacks */
+export type ForwardedHeaders = ReadonlyMap<string, string>
+
+/**
+ * Configuration for forwarding request headers to DO callbacks.
+ * - `string[]`: List of header names to forward (case-insensitive)
+ * - `(request) => Record<string, string>`: Custom extraction function (sync)
+ */
+export type ForwardHeadersOption = readonly string[] | ((request: CfTypes.Request) => Record<string, string>)
+
+/** Context passed to onPush/onPull callbacks */
+export type CallbackContext = {
+  storeId: StoreId
+  payload?: Schema.JsonValue
+  /** Headers forwarded from the request (only present if `forwardHeaders` is configured) */
+  headers?: ForwardedHeaders
+}
+
 export type MakeDurableObjectClassOptions = {
-  onPush?: (
-    message: SyncMessage.PushRequest,
-    context: { storeId: StoreId; payload?: Schema.JsonValue },
-  ) => Effect.SyncOrPromiseOrEffect<void>
+  onPush?: (message: SyncMessage.PushRequest, context: CallbackContext) => Effect.SyncOrPromiseOrEffect<void>
   onPushRes?: (message: SyncMessage.PushAck | InvalidPushError) => Effect.SyncOrPromiseOrEffect<void>
-  onPull?: (
-    message: SyncMessage.PullRequest,
-    context: { storeId: StoreId; payload?: Schema.JsonValue },
-  ) => Effect.SyncOrPromiseOrEffect<void>
+  onPull?: (message: SyncMessage.PullRequest, context: CallbackContext) => Effect.SyncOrPromiseOrEffect<void>
   onPullRes?: (message: SyncMessage.PullResponse | InvalidPullError) => Effect.SyncOrPromiseOrEffect<void>
+
+  /**
+   * Forward request headers to `onPush`/`onPull` callbacks for authentication.
+   *
+   * This enables cookie-based or header-based authentication patterns where
+   * you need access to request headers inside the Durable Object.
+   *
+   * @example Forward specific headers by name (case-insensitive)
+   * ```ts
+   * makeDurableObject({
+   *   forwardHeaders: ['cookie', 'authorization'],
+   *   onPush: async (message, { headers }) => {
+   *     const cookie = headers?.get('cookie')
+   *     const session = await validateSession(cookie)
+   *   },
+   * })
+   * ```
+   *
+   * @example Custom extraction function for derived values
+   * ```ts
+   * makeDurableObject({
+   *   forwardHeaders: (request) => ({
+   *     'x-user-id': request.headers.get('x-user-id') ?? '',
+   *     'x-session': request.headers.get('cookie')?.split('session=')[1]?.split(';')[0] ?? '',
+   *   }),
+   *   onPush: async (message, { headers }) => {
+   *     const userId = headers?.get('x-user-id')
+   *   },
+   * })
+   * ```
+   */
+  forwardHeaders?: ForwardHeadersOption
   /**
    * Storage engine for event persistence.
    * - Default: `{ _tag: 'do-sqlite' }` (Durable Object SQLite)
@@ -137,5 +181,39 @@ export const WebSocketAttachmentSchema = Schema.parseJson(
     // Different for each websocket connection
     payload: Schema.optional(Schema.JsonValue),
     pullRequestIds: Schema.Array(Schema.String),
+    // Headers forwarded from the initial request (via forwardHeaders option)
+    headers: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
   }),
 )
+
+/** Helper to extract headers from a request based on the forwardHeaders option */
+export const extractForwardedHeaders = (
+  request: CfTypes.Request,
+  forwardHeaders: ForwardHeadersOption | undefined,
+): Record<string, string> | undefined => {
+  if (forwardHeaders === undefined) {
+    return undefined
+  }
+
+  if (typeof forwardHeaders === 'function') {
+    return forwardHeaders(request)
+  }
+
+  // Array of header names - extract them case-insensitively
+  const result: Record<string, string> = {}
+  for (const name of forwardHeaders) {
+    const value = request.headers.get(name)
+    if (value !== null) {
+      result[name.toLowerCase()] = value
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+/** Convert a headers record to a ReadonlyMap */
+export const headersRecordToMap = (headers: Record<string, string> | undefined): ForwardedHeaders | undefined => {
+  if (headers === undefined) {
+    return undefined
+  }
+  return new Map(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]))
+}

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -4,7 +4,7 @@ import type { HelperTypes } from '@livestore/common-cf'
 import { Effect, Schema } from '@livestore/utils/effect'
 import type { CfTypes, SearchParams } from '../common/mod.ts'
 import type { CfDeclare } from './mod.ts'
-import { type Env, matchSyncRequest } from './shared.ts'
+import { type Env, type ForwardedHeaders, matchSyncRequest } from './shared.ts'
 
 // NOTE We need to redeclare runtime types here to avoid type conflicts with the lib.dom Response type.
 declare class Response extends CfDeclare.Response {}
@@ -18,6 +18,13 @@ export type CFWorker<TEnv extends Env = Env, _T extends CfTypes.Rpc.DurableObjec
   ) => Promise<CfTypes.Response>
 }
 
+/** Context passed to validatePayload callback */
+export type ValidatePayloadContext = {
+  storeId: string
+  /** Request headers (raw, not filtered by forwardHeaders) */
+  headers: ForwardedHeaders
+}
+
 /**
  * Options accepted by {@link makeWorker}. The Durable Object binding has to be
  * supplied explicitly so we never fall back to deprecated defaults when Cloudflare config changes.
@@ -28,20 +35,29 @@ export type MakeWorkerOptions<TEnv extends Env = Env, TSyncPayload = Schema.Json
    */
   syncBackendBinding: HelperTypes.ExtractDurableObjectKeys<TEnv>
   /**
-   * Validates the payload during WebSocket connection establishment.
-   * Note: This runs only at connection time, not for individual push events.
-   * For push event validation, use the `onPush` callback in the Durable Object.
-   */
-  /**
    * Optionally pass a schema to decode the client-provided payload into a typed object
    * before calling {@link validatePayload}. If omitted, the raw JSON value is forwarded.
    */
   syncPayloadSchema?: Schema.Schema<TSyncPayload>
   /**
    * Validates the (optionally decoded) payload during WebSocket connection establishment.
-   * If {@link syncPayloadSchema} is provided, `payload` will be of the schema’s inferred type.
+   * If {@link syncPayloadSchema} is provided, `payload` will be of the schema's inferred type.
+   *
+   * The context includes request headers for cookie-based or header-based authentication.
+   *
+   * @example Cookie-based authentication
+   * ```ts
+   * validatePayload: async (payload, { storeId, headers }) => {
+   *   const cookie = headers.get('cookie')
+   *   const session = await validateSessionFromCookie(cookie)
+   *   if (!session) throw new Error('Unauthorized')
+   * }
+   * ```
+   *
+   * Note: This runs only at connection time, not for individual push events.
+   * For push event validation, use the `onPush` callback in the Durable Object.
    */
-  validatePayload?: (payload: TSyncPayload, context: { storeId: string }) => void | Promise<void>
+  validatePayload?: (payload: TSyncPayload, context: ValidatePayloadContext) => void | Promise<void>
   /** @default false */
   enableCORS?: boolean
 }
@@ -117,37 +133,33 @@ export const makeWorker = <
   }
 }
 
+/** Convert CF Request headers to a ForwardedHeaders map */
+const requestHeadersToMap = (request: CfTypes.Request): ForwardedHeaders => {
+  const result = new Map<string, string>()
+  request.headers.forEach((value, key) => {
+    result.set(key.toLowerCase(), value)
+  })
+  return result
+}
+
 /**
  * Handles LiveStore sync requests (e.g. with search params `?storeId=...&transport=...`).
  *
- * @example
+ * @example Token-based authentication
  * ```ts
  * const validatePayload = (payload: Schema.JsonValue | undefined, context: { storeId: string }) => {
- *   console.log(`Validating connection for store: ${context.storeId}`)
  *   if (payload?.authToken !== 'insecure-token-change-me') {
  *     throw new Error('Invalid auth token')
  *   }
  * }
+ * ```
  *
- * export default {
- *   fetch: async (request, env, ctx) => {
- *     const searchParams = matchSyncRequest(request)
- *
- *     // Is LiveStore sync request
- *     if (searchParams !== undefined) {
- *       return handleSyncRequest({
- *         request,
- *         searchParams,
- *         env,
- *         ctx,
- *         syncBackendBinding: 'SYNC_BACKEND_DO',
- *         headers: {},
- *         validatePayload,
- *       })
- *     }
- *
- *     return new Response('Invalid path', { status: 400 })
- *   }
+ * @example Cookie-based authentication
+ * ```ts
+ * const validatePayload = async (payload: Schema.JsonValue | undefined, { storeId, headers }) => {
+ *   const cookie = headers.get('cookie')
+ *   const session = await validateSessionFromCookie(cookie)
+ *   if (!session) throw new Error('Unauthorized')
  * }
  * ```
  *
@@ -180,6 +192,9 @@ export const handleSyncRequest = <
 }): Promise<CfTypes.Response> =>
   Effect.gen(function* () {
     if (validatePayload !== undefined) {
+      // Convert request headers to a Map for the validation context
+      const requestHeaders = requestHeadersToMap(request)
+
       // Always decode with the supplied schema when present, even if payload is undefined.
       // This ensures required payloads are enforced by the schema.
       if (syncPayloadSchema !== undefined) {
@@ -191,7 +206,7 @@ export const handleSyncRequest = <
         }
 
         const result = yield* Effect.promise(async () =>
-          validatePayload(decodedEither.right as TSyncPayload, { storeId }),
+          validatePayload(decodedEither.right as TSyncPayload, { storeId, headers: requestHeaders }),
         ).pipe(UnknownError.mapToUnknownError, Effect.either)
 
         if (result._tag === 'Left') {
@@ -199,10 +214,9 @@ export const handleSyncRequest = <
           return new Response(result.left.toString(), { status: 400, headers })
         }
       } else {
-        const result = yield* Effect.promise(async () => validatePayload(payload as TSyncPayload, { storeId })).pipe(
-          UnknownError.mapToUnknownError,
-          Effect.either,
-        )
+        const result = yield* Effect.promise(async () =>
+          validatePayload(payload as TSyncPayload, { storeId, headers: requestHeaders }),
+        ).pipe(UnknownError.mapToUnknownError, Effect.either)
 
         if (result._tag === 'Left') {
           console.error('Invalid payload (validation failed)', result.left)


### PR DESCRIPTION
## Problem

JWT tokens passed in URL search params (`syncPayload`) expose sensitive auth data in browser history, server logs, and referrer headers. LiveStore sync callbacks had no way to access request headers, making cookie-based authentication patterns (like better-auth) impossible to implement securely.

## Solution

Introduced a flexible `forwardHeaders` option in `makeDurableObject()` that selectively forwards HTTP headers to `onPush`, `onPull`, and `validatePayload` callbacks. Headers are stored in WebSocket attachment data during connection upgrade, surviving hibernation. Users can specify headers as a string array or provide a custom extraction function for maximum flexibility.

All three transport modes (WebSocket, HTTP, DO-RPC) support header forwarding, with DO-RPC using `undefined` since direct HTTP headers aren't available in that context.

## Validation

- TypeScript builds without errors
- Lint and format checks pass
- Documentation updated with cookie-based auth section and complete example
- All three transport layers tested with header passing