### PR TITLE
Handle WebChannel acks without listen backpressure

### DIFF
--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
@@ -1,10 +1,41 @@
 import * as Vitest from '@effect/vitest'
-import { Effect, Schema, Stream } from 'effect'
+import { Effect, type Either, Option, Schema, Stream } from 'effect'
 import { JSDOM } from 'jsdom'
 
-import * as WebChannel from '../../browser/WebChannelBrowser.ts'
+import * as WebChannelBrowser from '../../browser/WebChannelBrowser.ts'
+import * as WebChannel from './WebChannel.ts'
+
+const takeFirstRight = <A, E, R>(stream: Stream.Stream<Either.Either<A, unknown>, E, R>) =>
+  stream.pipe(
+    Stream.filterMap((msg) => (msg._tag === 'Right' ? Option.some(msg.right) : Option.none())),
+    Stream.runHead,
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.fail(new Error('Expected at least one Right message')),
+        onSome: (value) => Effect.succeed(value),
+      }),
+    ),
+  )
 
 Vitest.describe('WebChannel', () => {
+  Vitest.describe('messagePortChannelWithAck', () => {
+    Vitest.scopedLive('should ack even when the receiver is not yet listening', () =>
+      Effect.gen(function* () {
+        const mc = new MessageChannel()
+
+        const channelAToB = yield* WebChannel.messagePortChannelWithAck({ port: mc.port1, schema: Schema.Number })
+        const channelBToA = yield* WebChannel.messagePortChannelWithAck({ port: mc.port2, schema: Schema.Number })
+
+        // Regression test for https://github.com/livestorejs/livestore/issues/262:
+        // `send` must not depend on the receiver pulling `listen` immediately, otherwise the first message can hang.
+        yield* channelAToB.send(1).pipe(Effect.timeout(100))
+
+        const msgFromA = yield* takeFirstRight<number, never, never>(channelBToA.listen)
+        Vitest.expect(msgFromA).toEqual(1)
+      }),
+    )
+  })
+
   Vitest.describe('windowChannel', () => {
     Vitest.scopedLive('should work with 2 windows', () =>
       Effect.gen(function* () {
@@ -12,19 +43,14 @@ Vitest.describe('WebChannel', () => {
         const windowB = new JSDOM().window as unknown as globalThis.Window
 
         const codeSideA = Effect.gen(function* () {
-          const channelToB = yield* WebChannel.windowChannel({
+          const channelToB = yield* WebChannelBrowser.windowChannel({
             listenWindow: windowA,
             sendWindow: windowB,
             ids: { own: 'a', other: 'b' },
             schema: Schema.Number,
           })
 
-          const msgFromBFiber = yield* channelToB.listen.pipe(
-            Stream.flatten(),
-            Stream.runHead,
-            Effect.flatten,
-            Effect.fork,
-          )
+          const msgFromBFiber = yield* channelToB.listen.pipe(takeFirstRight<number, never, never>, Effect.fork)
 
           yield* channelToB.send(1)
 
@@ -32,19 +58,14 @@ Vitest.describe('WebChannel', () => {
         })
 
         const codeSideB = Effect.gen(function* () {
-          const channelToA = yield* WebChannel.windowChannel({
+          const channelToA = yield* WebChannelBrowser.windowChannel({
             listenWindow: windowB,
             sendWindow: windowA,
             ids: { own: 'b', other: 'a' },
             schema: Schema.Number,
           })
 
-          const msgFromAFiber = yield* channelToA.listen.pipe(
-            Stream.flatten(),
-            Stream.runHead,
-            Effect.flatten,
-            Effect.fork,
-          )
+          const msgFromAFiber = yield* channelToA.listen.pipe(takeFirstRight<number, never, never>, Effect.fork)
 
           yield* channelToA.send(2)
 
@@ -60,19 +81,14 @@ Vitest.describe('WebChannel', () => {
         const window = new JSDOM().window as unknown as globalThis.Window
 
         const codeSideA = Effect.gen(function* () {
-          const channelToB = yield* WebChannel.windowChannel({
+          const channelToB = yield* WebChannelBrowser.windowChannel({
             listenWindow: window,
             sendWindow: window,
             ids: { own: 'a', other: 'b' },
             schema: Schema.Number,
           })
 
-          const msgFromBFiber = yield* channelToB.listen.pipe(
-            Stream.flatten(),
-            Stream.runHead,
-            Effect.flatten,
-            Effect.fork,
-          )
+          const msgFromBFiber = yield* channelToB.listen.pipe(takeFirstRight<number, never, never>, Effect.fork)
 
           yield* channelToB.send(1)
 
@@ -80,19 +96,14 @@ Vitest.describe('WebChannel', () => {
         })
 
         const codeSideB = Effect.gen(function* () {
-          const channelToA = yield* WebChannel.windowChannel({
+          const channelToA = yield* WebChannelBrowser.windowChannel({
             listenWindow: window,
             sendWindow: window,
             ids: { own: 'b', other: 'a' },
             schema: Schema.Number,
           })
 
-          const msgFromAFiber = yield* channelToA.listen.pipe(
-            Stream.flatten(),
-            Stream.runHead,
-            Effect.flatten,
-            Effect.fork,
-          )
+          const msgFromAFiber = yield* channelToA.listen.pipe(takeFirstRight<number, never, never>, Effect.fork)
 
           yield* channelToA.send(2)
 

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
@@ -1,4 +1,4 @@
-import { Deferred, Either, Exit, GlobalValue, identity, Option, PubSub, Queue, Scope } from 'effect'
+import { Deferred, Either, Exit, GlobalValue, identity, PubSub, Queue, Scope } from 'effect'
 import type { DurationInput } from 'effect/Duration'
 
 import { shouldNeverHappen } from '../../misc.ts'
@@ -136,6 +136,15 @@ export const messagePortChannelWithAck: <MsgListen, MsgSend, MsgListenEncoded, M
       type RequestId = string
       const requestAckMap = new Map<RequestId, Deferred.Deferred<void>>()
 
+      /**
+       * We buffer decoded payload messages in a queue and handle acks eagerly via `port.onmessage`.
+       *
+       * Rationale: If we process messages only inside a `Stream.fromEventListener(...).pipe(Stream.runDrain)`
+       * fiber, acks depend on a consumer pulling `listen` (or on an "open channel" drain starting in time).
+       * This can lead to hangs during very early handshakes (see #262).
+       */
+      const listenQueue = yield* Queue.unbounded<Either.Either<any, any>>().pipe(Effect.acquireRelease(Queue.shutdown))
+
       const ChannelRequest = Schema.TaggedStruct('ChannelRequest', {
         id: Schema.String,
         payload: Schema.Union(schema.listen, schema.send),
@@ -154,65 +163,88 @@ export const messagePortChannelWithAck: <MsgListen, MsgSend, MsgListenEncoded, M
         id: debugId,
       }
 
-      const send = (message: any) =>
-        Effect.gen(function* () {
+      const onMessage = (event: MessageEvent) => {
+        const decoded = Schema.decodeEither(ChannelMessage)(event.data)
+        if (decoded._tag === 'Left') {
+          Queue.unsafeOffer(listenQueue, Either.left(decoded.left))
+          return
+        }
+
+        const msg = decoded.right
+
+        switch (msg._tag) {
+          case 'ChannelRequestAck': {
+            const deferred = requestAckMap.get(msg.reqId)
+            if (deferred !== undefined) {
+              Deferred.unsafeDone(deferred, Effect.void)
+            }
+            return
+          }
+          case 'ChannelRequest': {
+            debugInfo.listenTotal++
+
+            port.postMessage(Schema.encodeSync(ChannelMessage)({ _tag: 'ChannelRequestAck', reqId: msg.id }))
+
+            Queue.unsafeOffer(listenQueue, Either.right(msg.payload))
+            return
+          }
+        }
+      }
+
+      port.onmessage = onMessage
+
+      // TODO also handle `messageerror` (if we can get access to the raw payload)
+      port.onmessageerror = () => {
+        // no-op
+      }
+
+      const send = (message: any) => {
+        let requestId: RequestId | undefined
+        return Effect.gen(function* () {
           debugInfo.sendTotal++
           debugInfo.sendPending++
 
-          const id = crypto.randomUUID()
-          const [messageEncoded, transferables] = yield* Schema.encodeWithTransferables(ChannelMessage)({
-            _tag: 'ChannelRequest',
-            id,
-            payload: message,
-          })
+          requestId = crypto.randomUUID()
 
           const ack = yield* Deferred.make<void>()
-          requestAckMap.set(id, ack)
+          requestAckMap.set(requestId, ack)
+
+          const [messageEncoded, transferables] = yield* Schema.encodeWithTransferables(ChannelMessage)({
+            _tag: 'ChannelRequest',
+            id: requestId,
+            payload: message,
+          })
 
           port.postMessage(messageEncoded, transferables)
 
           yield* ack
-
-          requestAckMap.delete(id)
-
-          debugInfo.sendPending--
-        })
-
-      // TODO re-implement this via `port.onmessage`
-      // https://github.com/livestorejs/livestore/issues/262
-      const listen = Stream.fromEventListener<MessageEvent>(port, 'message').pipe(
-        // Stream.onStart(Effect.log(`${label}:listen:start`)),
-        // Stream.tap((_) => Effect.log(`${label}:message`, _.data)),
-        Stream.map((_) => Schema.decodeEither(ChannelMessage)(_.data)),
-        Stream.tap((msg) =>
-          Effect.gen(function* () {
-            if (msg._tag === 'Right') {
-              if (msg.right._tag === 'ChannelRequestAck') {
-                yield* Deferred.succeed(requestAckMap.get(msg.right.reqId)!, void 0)
-              } else if (msg.right._tag === 'ChannelRequest') {
-                debugInfo.listenTotal++
-                port.postMessage(Schema.encodeSync(ChannelMessage)({ _tag: 'ChannelRequestAck', reqId: msg.right.id }))
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (requestId !== undefined) {
+                requestAckMap.delete(requestId)
               }
-            }
-          }),
-        ),
-        Stream.filterMap((msg) =>
-          msg._tag === 'Left'
-            ? Option.some(msg as any)
-            : msg.right._tag === 'ChannelRequest'
-              ? Option.some(Either.right(msg.right.payload))
-              : Option.none(),
-        ),
-        (_) => _ as Stream.Stream<Either.Either<any, any>>,
-        listenToDebugPing(label),
-      )
+              debugInfo.sendPending--
+            }),
+          ),
+        )
+      }
+
+      const listen = Stream.fromQueue(listenQueue, { maxChunkSize: 1 }).pipe(listenToDebugPing(label)) as Stream.Stream<
+        Either.Either<any, any>
+      >
 
       port.start()
 
       const closedDeferred = yield* Deferred.make<void>().pipe(Effect.acquireRelease(Deferred.done(Exit.void)))
       const supportsTransferables = true
 
-      yield* Effect.addFinalizer(() => Effect.try(() => port.close()).pipe(Effect.ignoreLogged))
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          port.onmessage = null
+          port.onmessageerror = null
+        }).pipe(Effect.andThen(Effect.try(() => port.close()).pipe(Effect.ignoreLogged))),
+      )
 
       return {
         [WebChannelSymbol]: WebChannelSymbol,

--- a/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
@@ -277,13 +277,7 @@ export const makeDirectChannelInternal = ({
 
             // span?.addEvent(`loser side: sending ping`)
 
-            // There seems to be some scenario where the initial ping message is lost.
-            // As a workaround until we find the root cause, we're retrying the ping a few times.
-            // TODO write a test that reproduces this issue and fix the root cause ()
-            // https://github.com/livestorejs/livestore/issues/262
-            yield* channel
-              .send(MeshSchema.DirectChannelPing.make({}))
-              .pipe(Effect.timeout(10), Effect.retry({ times: 2 }))
+            yield* channel.send(MeshSchema.DirectChannelPing.make({}))
 
             // span?.addEvent(`loser side: waiting for pong`)
 


### PR DESCRIPTION
## Problem
WebChannel message ports could hang when the sender emitted before the receiver began listening, and the direct-channel ping retried to mask the issue.

## Solution
Handle acks eagerly via MessagePort.onmessage with a buffered queue, add a regression test for the early-send scenario, and simplify direct channel ping sending now that the root cause is addressed.

## Note
⚠️ Please review carefully: this is a tradeoff change (eager ack + buffering) and needs confirmation that the altered backpressure behavior is acceptable.

## Validation
- direnv exec . mono ts
- direnv exec . mono lint --fix
- direnv exec . mono test unit

## Related issues
- #262
