### PR TITLE
Add project-local zsh completions

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1760560333,
+        "lastModified": 1765663102,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0a4043938f540027e562c5a0feebbe6be872c3ea",
+        "rev": "2858d76996ef35d7c65843f278f5739d8e9014fc",
         "type": "github"
       },
       "original": {
@@ -19,10 +19,10 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
+        "lastModified": 1765121682,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
@@ -57,10 +57,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1760392170,
+        "lastModified": 1765464257,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "46d55f0aeb1d567a78223e69729734f3dca25a85",
+        "rev": "09e45f2598e1a8499c3594fe11ec2943f34fe509",
         "type": "github"
       },
       "original": {
@@ -77,10 +77,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1709087332,
+        "lastModified": 1762808025,
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {
@@ -91,10 +91,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760524057,
+        "lastModified": 1765472234,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
+        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -103,10 +103,19 @@ in
 
     export NODE_OPTIONS="--disable-warning=ExperimentalWarning"
 
-    # Project setup + completions
+    # Project setup + completions generation
     if [ -z "''${DEVENV_SKIP_SETUP:-}" ]; then
       bun run "$WORKSPACE_ROOT/scripts/standalone/setup.ts" || true
     fi
     [ -f "$WORKSPACE_ROOT/scripts/completions.sh" ] && source "$WORKSPACE_ROOT/scripts/completions.sh"
+
+    # Zsh completions: export FPATH with project-local completions prepended
+    # The FPATH env var syncs with zsh's fpath array automatically
+    if [ -d "$WORKSPACE_ROOT/scripts/.completions/zsh/site-functions" ]; then
+      # Avoid introducing an empty FPATH entry (e.g. trailing ':') when FPATH is unset/empty.
+      export FPATH="$WORKSPACE_ROOT/scripts/.completions/zsh/site-functions''${FPATH:+:''${FPATH}}"
+      # Export a marker so zsh knows to reload compinit
+      export LIVESTORE_ZSH_COMPLETIONS="$WORKSPACE_ROOT/scripts/.completions/zsh/site-functions"
+    fi
   '';
 }

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -3,23 +3,73 @@
 # TODO running `completions.sh` on initial repo setup fails because we haven't built the TS source yet which `mono` and `livestore` depend on
 # resulting in an error like https://share.cleanshot.com/3ZQWLFSm
 
-# (1) Generate completions
+# ============================================================================
+# Shell completion generation
+# ============================================================================
+# Generates shell completions for mono, livestore, and livestore-example-node-effect-cli CLIs.
+# Supports Fish and Zsh shells.
+#
+# Fish: Installed globally to ~/.config/fish/completions (works automatically)
+#
+# Zsh: Generated in project-local $WORKSPACE_ROOT/scripts/.completions/zsh/site-functions
+#      Requires one-time setup in ~/.zshrc (AFTER the direnv hook):
+#
+#        # Reload zsh completions when LIVESTORE_ZSH_COMPLETIONS is set by direnv
+#        typeset -gA _direnv_completions_loaded
+#        _direnv_completions_hook() {
+#          [[ -z "$LIVESTORE_ZSH_COMPLETIONS" ]] && return
+#          [[ -n "${_direnv_completions_loaded[$LIVESTORE_ZSH_COMPLETIONS]}" ]] && return
+#          _direnv_completions_loaded[$LIVESTORE_ZSH_COMPLETIONS]=1
+#          autoload -Uz compinit && compinit
+#        }
+#        autoload -Uz add-zsh-hook && add-zsh-hook precmd _direnv_completions_hook
+#
+# See also: https://github.com/direnv/direnv/issues/443
 
-# Fish
-# mkdir -p $WORKSPACE_ROOT/scripts/.completions/fish
-# bun $WORKSPACE_ROOT/scripts/mono.ts --completions=fish > $WORKSPACE_ROOT/scripts/.completions/fish/mono.fish
-# bun $WORKSPACE_ROOT/examples/node-effect-cli/src/main.ts --completions=fish > $WORKSPACE_ROOT/scripts/.completions/fish/livestore.fish
+maybe_generate_completions() {
+  local src="$1"
+  local shell="$2"
+  local out="$3"
 
-# Until direnv + fish provides loading completions from a local directory, we need to install them globally
-# See https://github.com/direnv/direnv/issues/443
-# This also didn't work `path_add fish_complete_path "$WORKSPACE_ROOT/scripts/.completions/fish"`
+  # Only regenerate when missing or stale to avoid doing work on every shell entry.
+  if [ ! -f "$out" ] || [ "$src" -nt "$out" ]; then
+    bun "$src" --completions="$shell" >"$out"
+  fi
+}
+
+# Fish completions (global install - no project-local support in fish+direnv)
 if command -v fish >/dev/null 2>&1; then
-    mkdir -p ~/.config/fish/completions
-    bun $WORKSPACE_ROOT/scripts/src/mono.ts --completions=fish > ~/.config/fish/completions/mono.fish
-    bun $WORKSPACE_ROOT/examples/node-effect-cli/src/main.ts --completions=fish > ~/.config/fish/completions/livestore-example-node-effect-cli.fish
-    bun $WORKSPACE_ROOT/packages/@livestore/cli/src/cli.ts --completions=fish > ~/.config/fish/completions/livestore.fish
+  mkdir -p "$HOME/.config/fish/completions"
+
+  maybe_generate_completions \
+    "$WORKSPACE_ROOT/scripts/src/mono.ts" \
+    "fish" \
+    "$HOME/.config/fish/completions/mono.fish"
+  maybe_generate_completions \
+    "$WORKSPACE_ROOT/examples/node-effect-cli/src/main.ts" \
+    "fish" \
+    "$HOME/.config/fish/completions/livestore-example-node-effect-cli.fish"
+  maybe_generate_completions \
+    "$WORKSPACE_ROOT/packages/@livestore/cli/src/cli.ts" \
+    "fish" \
+    "$HOME/.config/fish/completions/livestore.fish"
 fi
 
-# (2) Load completions
+# Zsh completions (project-local via FPATH, loaded in devenv.nix enterShell)
+if command -v zsh >/dev/null 2>&1; then
+  ZSH_COMPLETIONS_DIR="$WORKSPACE_ROOT/scripts/.completions/zsh/site-functions"
+  mkdir -p "$ZSH_COMPLETIONS_DIR"
 
-# export fish_complete_path="$WORKSPACE_ROOT/scripts/.completions/fish $fish_complete_path"
+  maybe_generate_completions \
+    "$WORKSPACE_ROOT/scripts/src/mono.ts" \
+    "zsh" \
+    "$ZSH_COMPLETIONS_DIR/_mono"
+  maybe_generate_completions \
+    "$WORKSPACE_ROOT/examples/node-effect-cli/src/main.ts" \
+    "zsh" \
+    "$ZSH_COMPLETIONS_DIR/_livestore-example-node-effect-cli"
+  maybe_generate_completions \
+    "$WORKSPACE_ROOT/packages/@livestore/cli/src/cli.ts" \
+    "zsh" \
+    "$ZSH_COMPLETIONS_DIR/_livestore"
+fi


### PR DESCRIPTION
## Problem
Zsh users don’t get shell completions for the repo CLIs when entering the devenv/direnv shell.

## Solution
Generate zsh completion files under scripts/.completions/zsh/site-functions and prepend that directory to FPATH via devenv.nix (avoiding empty FPATH entries), while caching generation to avoid rerunning on every shell entry.

## Validation
Typecheck: direnv exec . tsc --build tsconfig.dev.json --noEmit; lint: direnv exec . biome check .; tests: direnv exec . pnpm test fails in examples/web-todomvc-sync-cf with EADDRINUSE on inspector port 9236.

## Related issues
- None