### PR TITLE
test(integration): update repro-938 fixture to new multi-store API

### DIFF
--- a/tests/integration/src/tests/devtools/fixtures/repro-938/main.ts
+++ b/tests/integration/src/tests/devtools/fixtures/repro-938/main.ts
@@ -1,4 +1,4 @@
-import { LiveStoreProvider } from '@livestore/react'
+import { StoreRegistryProvider } from '@livestore/react'
 
 import { liveStoreAdapter } from './adapter.ts'
 import { schema } from './schema.ts'
@@ -6,7 +6,7 @@ import { schema } from './schema.ts'
 const snapshot = {
   schema: Boolean(schema),
   adapter: Boolean(liveStoreAdapter),
-  provider: typeof LiveStoreProvider === 'function',
+  provider: typeof StoreRegistryProvider === 'function',
 }
 
 const root = document.getElementById('root')


### PR DESCRIPTION
## Summary

- Updates the repro-938 Vite alias regression test fixture to use the new multi-store API
- Replaces `LiveStoreProvider` import with `StoreRegistryProvider`

## Context

The repro-938 test fixture verifies that Vite alias resolution works correctly with `@livestore/react` exports. As part of the multi-store API migration (#255), `LiveStoreProvider` was replaced with `StoreRegistryProvider`. This change aligns the test fixture with the new API.

## Changes

- `tests/integration/src/tests/devtools/fixtures/repro-938/main.ts`: Updated import and type check from `LiveStoreProvider` to `StoreRegistryProvider`

## Test plan

- [x] Verified commit is a clean cherry-pick from the original PR branch
- [ ] CI passes (integration tests)