### PR TITLE
docs(claude): document dev as the default branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Use the `mono` CLI for common workflows:
 
 ## Git
 
+- The default branch of this repository is `dev`.
 - Before committing, run `direnv exec . mono lint --fix` to auto-fix most linting errors. Make sure there are no type check/lint errors.
 
 ### Branch Naming Conventions


### PR DESCRIPTION
## Summary

- Documents that `dev` is the default branch of the repository in CLAUDE.md

This helps Claude Code correctly target PRs and use the appropriate base branch for new feature branches. Without this explicit documentation, Claude often defaults to `main` (a common convention) rather than the actual default branch.

## Test plan

- N/A (documentation change only)