### PR TITLE
Fix recursive file watching by composing FileSystem with WatchBackend correctly

### DIFF
--- a/packages/@livestore/utils/src/node/mod.ts
+++ b/packages/@livestore/utils/src/node/mod.ts
@@ -52,8 +52,39 @@ export const OtelLiveDummy: Layer.Layer<OtelTracer.OtelTracer> = Layer.suspend((
 })
 
 /**
- * Layer that enables recursive file watching by combining the Node filesystem implementation with
- * the Parcel-based watch backend. Mirrored from Effect’s platform-node Parcel watcher layer:
- * https://github.com/Effect-TS/effect/blob/main/packages/platform-node/src/NodeFileSystem/ParcelWatcher.ts
+ * Layer that provides WatchBackend for recursive file watching via @parcel/watcher.
+ * This layer alone does NOT provide FileSystem - it only provides the watch backend.
+ *
+ * IMPORTANT: Layer ordering matters! When composing with NodeFileSystem.layer, use
+ * `NodeFileSystemWithWatch` instead, or ensure WatchBackend is available when FileSystem
+ * is constructed by using `Layer.provideMerge`:
+ *
+ * ```ts
+ * // ✅ CORRECT: Use the pre-composed layer
+ * Effect.provide(NodeFileSystemWithWatch)
+ *
+ * // ✅ CORRECT: Manual composition with Layer.provideMerge
+ * const layer = PlatformNode.NodeFileSystem.layer.pipe(Layer.provideMerge(NodeRecursiveWatchLayer))
+ * Effect.provide(layer)
+ *
+ * // ❌ WRONG: Chained Effect.provide - WatchBackend won't be used!
+ * Effect.provide(NodeRecursiveWatchLayer).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer))
+ * ```
+ *
+ * @see https://github.com/Effect-TS/effect/issues/5913
  */
 export const NodeRecursiveWatchLayer = ParcelWatcherLayer
+
+/**
+ * Pre-composed layer providing FileSystem with recursive file watching via @parcel/watcher.
+ * This is the recommended way to get a FileSystem that supports recursive watching.
+ *
+ * Use this layer when you need to watch files recursively (e.g., watching nested directories).
+ * Without recursive watching, Node.js's built-in fs.watch only detects changes in the
+ * immediate directory, not in subdirectories.
+ */
+export { NodeFileSystem } from '@effect/platform-node'
+
+import { NodeFileSystem } from '@effect/platform-node'
+
+export const NodeFileSystemWithWatch = NodeFileSystem.layer.pipe(Layer.provideMerge(ParcelWatcherLayer))

--- a/packages/@local/astro-tldraw/src/cli.ts
+++ b/packages/@local/astro-tldraw/src/cli.ts
@@ -2,7 +2,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { type Duration, Effect, FileSystem, type PlatformError, Schema, Stream } from '@livestore/utils/effect'
-import { NodeRecursiveWatchLayer } from '@livestore/utils/node'
+import { NodeFileSystemWithWatch } from '@livestore/utils/node'
 import {
   FileSystemError,
   getCacheEntry,
@@ -354,7 +354,7 @@ const watchDiagramsInternal = (
   })
 
 /** Watch diagrams directory for changes and rebuild on modifications */
-export const watchDiagrams = (options: WatchDiagramsOptions): Effect.Effect<void, never, FileSystem.FileSystem> => {
+export const watchDiagrams = (options: WatchDiagramsOptions): Effect.Effect<void, never> => {
   const { debounce, initialBuild, onRebuild, ...baseOptions } = options
   const normalizedWatch = normalizeWatchOptions({
     ...(debounce !== undefined ? { debounce } : {}),
@@ -363,7 +363,11 @@ export const watchDiagrams = (options: WatchDiagramsOptions): Effect.Effect<void
   })
   return watchDiagramsInternal(baseOptions, normalizedWatch).pipe(
     Effect.withSpan('tldraw.watch-diagrams'),
-    Effect.provide(NodeRecursiveWatchLayer),
+    /**
+     * Must use NodeFileSystemWithWatch to ensure recursive file watching works correctly.
+     * @see https://github.com/Effect-TS/effect/issues/5913
+     */
+    Effect.provide(NodeFileSystemWithWatch),
   )
 }
 

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.ts
@@ -97,7 +97,7 @@ import * as astroExpressiveCodeModuleStatic from 'astro-expressive-code'
  */
 
 import { type Duration, Effect, FileSystem, type PlatformError, Schema, Stream } from '@livestore/utils/effect'
-import { Cli, NodeRecursiveWatchLayer } from '@livestore/utils/node'
+import { Cli, NodeFileSystemWithWatch } from '@livestore/utils/node'
 import type { ExpressiveCodeBlockOptions } from 'expressive-code'
 import type {
   Element as THastElement,
@@ -1718,7 +1718,11 @@ export const watchSnippets = (options: WatchSnippetsOptions = {}) => {
   })
   return watchSnippetsInternal(resolved, normalizedWatch).pipe(
     Effect.withSpan('astro-twoslash-code/watch-snippets'),
-    Effect.provide(NodeRecursiveWatchLayer),
+    /**
+     * Must use NodeFileSystemWithWatch to ensure recursive file watching works correctly.
+     * @see https://github.com/Effect-TS/effect/issues/5913
+     */
+    Effect.provide(NodeFileSystemWithWatch),
   )
 }
 
@@ -1744,7 +1748,11 @@ export const createSnippetsCommand = ({
 
   const watchHandler = watchSnippetsInternal(resolved, normalizeWatchOptions({})).pipe(
     Effect.withSpan('astro-twoslash-code/cli/snippets-watch'),
-    Effect.provide(NodeRecursiveWatchLayer),
+    /**
+     * Must use NodeFileSystemWithWatch to ensure recursive file watching works correctly.
+     * @see https://github.com/Effect-TS/effect/issues/5913
+     */
+    Effect.provide(NodeFileSystemWithWatch),
     Effect.asVoid,
   )
 

--- a/packages/@local/astro-twoslash-code/src/integration/astro-twoslash-code.ts
+++ b/packages/@local/astro-twoslash-code/src/integration/astro-twoslash-code.ts
@@ -73,8 +73,7 @@ export const createAstroTwoslashCodeIntegration = (options: AstroTwoslashCodeOpt
         await runSnippetBuild()
 
         if (resolvedBuildOptions && watchFiber === null) {
-          const watchEffect = watchSnippets(resolvedBuildOptions)
-          watchFiber = Effect.runFork(watchEffect.pipe(Effect.provide(PlatformNode.NodeFileSystem.layer)))
+          watchFiber = Effect.runFork(watchSnippets(resolvedBuildOptions))
         }
       },
       'astro:build:start': async (_context: BuildStartContext) => {


### PR DESCRIPTION
## Problem

Issue #914: Snippet modifications weren't triggering rebuilds during docs dev server. The root cause was improper Effect layer ordering when composing FileSystem with recursive watch support.

## Solution

The issue occurred because `NodeFileSystem.layer` checks for `WatchBackend` at construction time via `Effect.serviceOption`. When using chained `Effect.provide()` calls, outer layers are constructed first, so `WatchBackend` wasn't available, causing the filesystem to fall back to Node.js's built-in `fs.watch` which is **not recursive**.

Created `NodeFileSystemWithWatch` layer that correctly composes both via `Layer.provideMerge`, ensuring `WatchBackend` is available when `FileSystem` is constructed. Updated all watch functions (`watchSnippets`, `watchDiagrams`, `createSnippetsCommand`) to provide this layer internally, so callers don't need to know about the implementation detail.

## Validation

- All 12 snippet render tests pass
- All 8 tldraw watch tests pass  
- All 1 snippet watch test passes
- Manual test confirms watch now correctly detects file changes in nested directories and triggers rebuilds

## Related issues

- #914
- Effect-TS/effect#5913