### PR TITLE
Fix ?reset by recursive OPFS delete

### DIFF
--- a/examples/web-todomvc-custom-elements/src/main.ts
+++ b/examples/web-todomvc-custom-elements/src/main.ts
@@ -13,10 +13,19 @@ export const html = (strings: TemplateStringsArray, ...values: unknown[]) =>
   parseTemplate(String.raw({ raw: strings }, ...values))
 export const css = (strings: TemplateStringsArray, ...values: unknown[]) => String.raw({ raw: strings }, ...values)
 
+const resetPersistence = import.meta.env.DEV && new URLSearchParams(window.location.search).get('reset') !== null
+
+if (resetPersistence) {
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.delete('reset')
+  window.history.replaceState(undefined, '', `${window.location.pathname}?${searchParams.toString()}`)
+}
+
 const adapter = makePersistedAdapter({
   storage: { type: 'opfs' },
   worker: LiveStoreWorker,
   sharedWorker: LiveStoreSharedWorker,
+  resetPersistence,
 })
 
 const syncPayload = { authToken: 'insecure-token-change-me' }

--- a/examples/web-todomvc-custom-elements/tests/todomvc.spec.ts
+++ b/examples/web-todomvc-custom-elements/tests/todomvc.spec.ts
@@ -25,4 +25,37 @@ test.describe('TodoMVC (custom-elements)', () => {
       todoText,
     )
   })
+
+  test('supports `?reset` after writing OPFS data', async ({ baseURL, page }) => {
+    if (!baseURL) throw new Error('baseURL is required')
+
+    await page.goto(baseURL)
+
+    const input = page.locator('todo-list').locator('input[placeholder="What needs to be done?"]')
+    await expect(input).toBeVisible({ timeout: 30_000 })
+
+    const draftText = `Playwright draft ${Date.now()}`
+
+    // Persist draft text (clientDocument) so we can assert it gets cleared by `?reset`.
+    await input.fill(draftText)
+    await expect(input).toHaveValue(draftText)
+
+    // Sanity-check persistence: on a normal reload, the draft text should come back.
+    await page.reload()
+    await expect(input).toHaveValue(draftText)
+
+    await page.goto(`${baseURL}?reset`)
+
+    const inputAfterReset = page.locator('todo-list').locator('input[placeholder="What needs to be done?"]')
+    await expect(inputAfterReset).toBeVisible({ timeout: 30_000 })
+
+    expect(page.url()).not.toContain('reset')
+
+    // Assert LiveStore state was reset: the persisted clientDocument draft should be cleared.
+    await expect(inputAfterReset).toHaveValue('')
+
+    // Double-check by reloading without `?reset` again: draft must stay cleared.
+    await page.reload()
+    await expect(inputAfterReset).toHaveValue('')
+  })
 })

--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
@@ -88,7 +88,7 @@ export const resetPersistedDataFromClientSession = Effect.fn(
 )(
   function* ({ storageOptions, storeId }: { storageOptions: WorkerSchema.StorageType; storeId: string }) {
     const directory = yield* sanitizeOpfsDir(storageOptions.directory, storeId)
-    yield* Opfs.remove(directory).pipe(
+    yield* Opfs.remove(directory, { recursive: true }).pipe(
       // We ignore NotFoundError here as it may not exist or have already been deleted
       Effect.catchTag('@livestore/utils/Web/NotFoundError', () => Effect.void),
     )


### PR DESCRIPTION
## Problem
`?reset` could fail on web persisted adapter when the OPFS directory is non-empty, throwing InvalidModificationError.

## Solution
Delete the store directory recursively during adapter reset, and wire `resetPersistence` handling into the web-todomvc-custom-elements example.

## Validation
`CI=1 pnpm test` in `examples/web-todomvc-custom-elements`.

## Related issues
- #949

---
PR created by Conductor agent on behalf of @schickling.