### PR TITLE
Add deprecation warnings for events and fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,31 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
   Pure materializers ensure deterministic replay during sync, improve test reliability, and make debugging predictable.
 
+- **Event deprecation support:** Mark entire events or individual fields as deprecated to guide schema evolution. When deprecated events are created or deprecated fields have values, a warning is logged to help teams migrate away from legacy patterns (#956).
+
+  ```typescript
+  import { Events } from '@livestore/livestore'
+  import { Schema } from 'effect'
+  import { deprecated } from '@livestore/common/schema'
+
+  // Field-level deprecation
+  const todoUpdated = Events.synced({
+    name: 'v1.TodoUpdated',
+    schema: Schema.Struct({
+      id: Schema.String,
+      title: Schema.optional(Schema.String).pipe(deprecated("Use 'text' instead")),
+      text: Schema.optional(Schema.String),
+    }),
+  })
+
+  // Event-level deprecation
+  const todoRenamed = Events.synced({
+    name: 'v1.TodoRenamed',
+    schema: Schema.Struct({ id: Schema.String, name: Schema.String }),
+    deprecated: "Use 'v1.TodoUpdated' instead",
+  })
+  ```
+
 #### API & DX
 
 - **Store:** `store.networkStatus` now surfaces sync backend connectivity so apps can read the latest status or subscribe directly; the signal is no longer re-exposed on client sessions (livestorejs/livestore#394).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
   Pure materializers ensure deterministic replay during sync, improve test reliability, and make debugging predictable.
 
-- **Event deprecation support:** Mark entire events or individual fields as deprecated to guide schema evolution. When deprecated events are created or deprecated fields have values, a warning is logged to help teams migrate away from legacy patterns (#956).
+- **Event deprecation support:** Mark entire events or individual fields as deprecated to guide schema evolution. When deprecated events are committed or deprecated fields have values, a warning is logged via Effect's logging system to help teams migrate away from legacy patterns (#956).
 
   ```typescript
   import { Events } from '@livestore/livestore'

--- a/packages/@livestore/common/src/leader-thread/materialize-event.ts
+++ b/packages/@livestore/common/src/leader-thread/materialize-event.ts
@@ -3,6 +3,7 @@ import { Effect, Option, ReadonlyArray, Schema } from '@livestore/utils/effect'
 
 import { MaterializeError, MaterializerHashMismatchError, type SqliteDb } from '../adapter-types.ts'
 import { getExecStatementsFromMaterializer, hashMaterializerResults } from '../materializer-helper.ts'
+import { logDeprecationWarnings } from '../schema/EventDef/deprecated.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, resolveEventDef, SystemTables, UNKNOWN_EVENT_SCHEMA_HASH } from '../schema/mod.ts'
 import { insertRow } from '../sql-queries/index.ts'
@@ -61,6 +62,9 @@ export const makeMaterializeEvent = ({
         }
 
         const { eventDef, materializer } = resolution
+
+        // Log deprecation warnings for deprecated events/fields
+        yield* logDeprecationWarnings(eventDef, eventEncoded.args as Record<string, unknown>)
 
         const execArgsArr = getExecStatementsFromMaterializer({
           eventDef,

--- a/packages/@livestore/common/src/schema/EventDef/define.ts
+++ b/packages/@livestore/common/src/schema/EventDef/define.ts
@@ -31,7 +31,6 @@
 import { shouldNeverHappen } from '@livestore/utils'
 import { Schema } from '@livestore/utils/effect'
 
-import { findDeprecatedFieldsWithValues, warnDeprecatedEvent, warnDeprecatedField } from './deprecated.ts'
 import type { EventDef } from './event-def.ts'
 import type { EventDefFactInput, EventDefFacts } from './facts.ts'
 
@@ -73,7 +72,7 @@ export type DefineEventOptions<TTo, TDerived extends boolean = false> = {
 
   /**
    * Marks the entire event as deprecated with a reason message.
-   * When this event is created, a warning will be logged.
+   * When this event is committed, a warning will be logged.
    *
    * @example
    * ```ts
@@ -116,18 +115,6 @@ export const defineEvent = <TName extends string, TType, TEncoded = TType, TDeri
     if (res._tag === 'Left') {
       shouldNeverHappen(`Invalid event args for event '${name}':`, res.left.message, '\n')
     }
-
-    // Check for event-level deprecation
-    if (options.deprecated) {
-      warnDeprecatedEvent(name, options.deprecated)
-    }
-
-    // Check for deprecated fields with values
-    const deprecatedFields = findDeprecatedFieldsWithValues(schema, args as Record<string, unknown>)
-    for (const { field, reason } of deprecatedFields) {
-      warnDeprecatedField(name, field, reason)
-    }
-
     return { name: name, args }
   }
 
@@ -153,6 +140,7 @@ export const defineEvent = <TName extends string, TType, TEncoded = TType, TDeri
           }
         : undefined,
       derived: options?.derived ?? false,
+      deprecated: options?.deprecated,
     } satisfies EventDef.Any['options'],
   })
 

--- a/packages/@livestore/common/src/schema/EventDef/define.ts
+++ b/packages/@livestore/common/src/schema/EventDef/define.ts
@@ -31,6 +31,7 @@
 import { shouldNeverHappen } from '@livestore/utils'
 import { Schema } from '@livestore/utils/effect'
 
+import { findDeprecatedFieldsWithValues, warnDeprecatedEvent, warnDeprecatedField } from './deprecated.ts'
 import type { EventDef } from './event-def.ts'
 import type { EventDefFactInput, EventDefFacts } from './facts.ts'
 
@@ -69,6 +70,21 @@ export type DefineEventOptions<TTo, TDerived extends boolean = false> = {
    * @default false
    */
   derived?: TDerived
+
+  /**
+   * Marks the entire event as deprecated with a reason message.
+   * When this event is created, a warning will be logged.
+   *
+   * @example
+   * ```ts
+   * Events.synced({
+   *   name: 'v1.TodoRenamed',
+   *   schema: Schema.Struct({ id: Schema.String, name: Schema.String }),
+   *   deprecated: "Use 'v1.TodoUpdated' instead",
+   * })
+   * ```
+   */
+  deprecated?: string
 }
 
 /**
@@ -100,6 +116,18 @@ export const defineEvent = <TName extends string, TType, TEncoded = TType, TDeri
     if (res._tag === 'Left') {
       shouldNeverHappen(`Invalid event args for event '${name}':`, res.left.message, '\n')
     }
+
+    // Check for event-level deprecation
+    if (options.deprecated) {
+      warnDeprecatedEvent(name, options.deprecated)
+    }
+
+    // Check for deprecated fields with values
+    const deprecatedFields = findDeprecatedFieldsWithValues(schema, args as Record<string, unknown>)
+    for (const { field, reason } of deprecatedFields) {
+      warnDeprecatedField(name, field, reason)
+    }
+
     return { name: name, args }
   }
 

--- a/packages/@livestore/common/src/schema/EventDef/deprecated.test.ts
+++ b/packages/@livestore/common/src/schema/EventDef/deprecated.test.ts
@@ -1,0 +1,256 @@
+import { Schema } from '@livestore/utils/effect'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { synced } from './define.ts'
+import {
+  DeprecatedId,
+  deprecated,
+  findDeprecatedFieldsWithValues,
+  getDeprecatedReason,
+  isDeprecated,
+  resetDeprecationWarnings,
+} from './deprecated.ts'
+
+describe('deprecated annotations', () => {
+  describe('deprecated helper', () => {
+    test('should add deprecation annotation to schema', () => {
+      const schema = Schema.String.pipe(deprecated('Use newField instead'))
+
+      expect(isDeprecated(schema)).toBe(true)
+      expect(getDeprecatedReason(schema)).toMatchObject({ _tag: 'Some', value: 'Use newField instead' })
+    })
+
+    test('should work with optional fields in a Struct', () => {
+      const struct = Schema.Struct({
+        oldField: Schema.optional(Schema.String).pipe(deprecated('Legacy field')),
+      })
+
+      // The deprecation annotation is on the property signature, not a Schema,
+      // so we test it through findDeprecatedFieldsWithValues
+      const result = findDeprecatedFieldsWithValues(struct, { oldField: 'value' })
+      expect(result).toEqual([{ field: 'oldField', reason: 'Legacy field' }])
+    })
+
+    test('should preserve the schema annotation symbol', () => {
+      const schema = Schema.String.pipe(deprecated('Test reason'))
+      const annotations = schema.ast.annotations as Record<symbol, unknown>
+
+      expect(annotations[DeprecatedId]).toBe('Test reason')
+    })
+  })
+
+  describe('isDeprecated', () => {
+    test('should return true for deprecated schemas', () => {
+      const schema = Schema.String.pipe(deprecated('Old field'))
+      expect(isDeprecated(schema)).toBe(true)
+    })
+
+    test('should return false for non-deprecated schemas', () => {
+      expect(isDeprecated(Schema.String)).toBe(false)
+      expect(isDeprecated(Schema.Number)).toBe(false)
+    })
+  })
+
+  describe('findDeprecatedFieldsWithValues', () => {
+    test('should find deprecated fields that have values', () => {
+      const schema = Schema.Struct({
+        id: Schema.String,
+        oldTitle: Schema.optional(Schema.String).pipe(deprecated("Use 'title' instead")),
+        title: Schema.optional(Schema.String),
+      })
+
+      const result = findDeprecatedFieldsWithValues(schema, {
+        id: 'test-id',
+        oldTitle: 'Some old title',
+        title: 'New title',
+      })
+
+      expect(result).toEqual([{ field: 'oldTitle', reason: "Use 'title' instead" }])
+    })
+
+    test('should not include deprecated fields that are undefined', () => {
+      const schema = Schema.Struct({
+        id: Schema.String,
+        oldField: Schema.optional(Schema.String).pipe(deprecated('Deprecated')),
+      })
+
+      const result = findDeprecatedFieldsWithValues(schema, {
+        id: 'test-id',
+        // oldField is undefined (not provided)
+      })
+
+      expect(result).toEqual([])
+    })
+
+    test('should find multiple deprecated fields', () => {
+      const schema = Schema.Struct({
+        id: Schema.String,
+        oldA: Schema.optional(Schema.String).pipe(deprecated('Use newA')),
+        oldB: Schema.optional(Schema.Number).pipe(deprecated('Use newB')),
+        newA: Schema.optional(Schema.String),
+        newB: Schema.optional(Schema.Number),
+      })
+
+      const result = findDeprecatedFieldsWithValues(schema, {
+        id: 'test-id',
+        oldA: 'value A',
+        oldB: 42,
+      })
+
+      expect(result).toHaveLength(2)
+      expect(result).toContainEqual({ field: 'oldA', reason: 'Use newA' })
+      expect(result).toContainEqual({ field: 'oldB', reason: 'Use newB' })
+    })
+
+    test('should handle non-struct schemas gracefully', () => {
+      const schema = Schema.String
+      const result = findDeprecatedFieldsWithValues(schema, {})
+      expect(result).toEqual([])
+    })
+  })
+})
+
+describe('deprecation warnings', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetDeprecationWarnings()
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
+  })
+
+  describe('event-level deprecation', () => {
+    test('should log warning when deprecated event is created', () => {
+      const deprecatedEvent = synced({
+        name: 'v1.OldEvent',
+        schema: Schema.Struct({ id: Schema.String }),
+        deprecated: "Use 'v2.NewEvent' instead",
+      })
+
+      deprecatedEvent({ id: 'test-id' })
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[LiveStore] Deprecated event 'v1.OldEvent': Use 'v2.NewEvent' instead",
+      )
+    })
+
+    test('should only log warning once per event (deduplication)', () => {
+      const deprecatedEvent = synced({
+        name: 'v1.DedupeEvent',
+        schema: Schema.Struct({ id: Schema.String }),
+        deprecated: 'Deprecated',
+      })
+
+      deprecatedEvent({ id: '1' })
+      deprecatedEvent({ id: '2' })
+      deprecatedEvent({ id: '3' })
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('should not log warning for non-deprecated events', () => {
+      const normalEvent = synced({
+        name: 'v1.NormalEvent',
+        schema: Schema.Struct({ id: Schema.String }),
+      })
+
+      normalEvent({ id: 'test-id' })
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('field-level deprecation', () => {
+    test('should log warning when deprecated field has value', () => {
+      const eventWithDeprecatedField = synced({
+        name: 'v1.EventWithOldField',
+        schema: Schema.Struct({
+          id: Schema.String,
+          oldTitle: Schema.optional(Schema.String).pipe(deprecated("Use 'title' instead")),
+          title: Schema.optional(Schema.String),
+        }),
+      })
+
+      eventWithDeprecatedField({ id: 'test-id', oldTitle: 'Old value' })
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[LiveStore] Deprecated field 'oldTitle' in event 'v1.EventWithOldField': Use 'title' instead",
+      )
+    })
+
+    test('should not log warning when deprecated field is undefined', () => {
+      const eventWithDeprecatedField = synced({
+        name: 'v1.EventWithUnusedOldField',
+        schema: Schema.Struct({
+          id: Schema.String,
+          oldField: Schema.optional(Schema.String).pipe(deprecated('Deprecated')),
+        }),
+      })
+
+      eventWithDeprecatedField({ id: 'test-id' })
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    })
+
+    test('should only log field warning once (deduplication)', () => {
+      const eventWithDeprecatedField = synced({
+        name: 'v1.EventWithDedupeField',
+        schema: Schema.Struct({
+          id: Schema.String,
+          oldField: Schema.optional(Schema.String).pipe(deprecated('Old')),
+        }),
+      })
+
+      eventWithDeprecatedField({ id: '1', oldField: 'a' })
+      eventWithDeprecatedField({ id: '2', oldField: 'b' })
+      eventWithDeprecatedField({ id: '3', oldField: 'c' })
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('should log warnings for multiple deprecated fields', () => {
+      const eventWithMultipleDeprecated = synced({
+        name: 'v1.MultiDeprecated',
+        schema: Schema.Struct({
+          id: Schema.String,
+          oldA: Schema.optional(Schema.String).pipe(deprecated('Use newA')),
+          oldB: Schema.optional(Schema.String).pipe(deprecated('Use newB')),
+        }),
+      })
+
+      eventWithMultipleDeprecated({ id: 'test', oldA: 'a', oldB: 'b' })
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[LiveStore] Deprecated field 'oldA' in event 'v1.MultiDeprecated': Use newA",
+      )
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[LiveStore] Deprecated field 'oldB' in event 'v1.MultiDeprecated': Use newB",
+      )
+    })
+  })
+
+  describe('combined event and field deprecation', () => {
+    test('should log both event and field warnings', () => {
+      const fullyDeprecatedEvent = synced({
+        name: 'v1.FullyDeprecated',
+        schema: Schema.Struct({
+          id: Schema.String,
+          oldField: Schema.optional(Schema.String).pipe(deprecated('Field deprecated')),
+        }),
+        deprecated: 'Event deprecated',
+      })
+
+      fullyDeprecatedEvent({ id: 'test', oldField: 'value' })
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2)
+      expect(consoleWarnSpy).toHaveBeenCalledWith("[LiveStore] Deprecated event 'v1.FullyDeprecated': Event deprecated")
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[LiveStore] Deprecated field 'oldField' in event 'v1.FullyDeprecated': Field deprecated",
+      )
+    })
+  })
+})

--- a/packages/@livestore/common/src/schema/EventDef/deprecated.test.ts
+++ b/packages/@livestore/common/src/schema/EventDef/deprecated.test.ts
@@ -1,256 +1,128 @@
-import { Schema } from '@livestore/utils/effect'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { Effect, Logger, Schema } from '@livestore/utils/effect'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
 import { synced } from './define.ts'
 import {
-  DeprecatedId,
   deprecated,
   findDeprecatedFieldsWithValues,
   getDeprecatedReason,
   isDeprecated,
+  logDeprecationWarnings,
   resetDeprecationWarnings,
 } from './deprecated.ts'
 
 describe('deprecated annotations', () => {
-  describe('deprecated helper', () => {
-    test('should add deprecation annotation to schema', () => {
-      const schema = Schema.String.pipe(deprecated('Use newField instead'))
-
-      expect(isDeprecated(schema)).toBe(true)
-      expect(getDeprecatedReason(schema)).toMatchObject({ _tag: 'Some', value: 'Use newField instead' })
-    })
-
-    test('should work with optional fields in a Struct', () => {
-      const struct = Schema.Struct({
-        oldField: Schema.optional(Schema.String).pipe(deprecated('Legacy field')),
-      })
-
-      // The deprecation annotation is on the property signature, not a Schema,
-      // so we test it through findDeprecatedFieldsWithValues
-      const result = findDeprecatedFieldsWithValues(struct, { oldField: 'value' })
-      expect(result).toEqual([{ field: 'oldField', reason: 'Legacy field' }])
-    })
-
-    test('should preserve the schema annotation symbol', () => {
-      const schema = Schema.String.pipe(deprecated('Test reason'))
-      const annotations = schema.ast.annotations as Record<symbol, unknown>
-
-      expect(annotations[DeprecatedId]).toBe('Test reason')
-    })
+  test('adds deprecation annotation to schema', () => {
+    const schema = Schema.String.pipe(deprecated('Use newField instead'))
+    expect(isDeprecated(schema)).toBe(true)
+    expect(getDeprecatedReason(schema)._tag).toBe('Some')
   })
 
-  describe('isDeprecated', () => {
-    test('should return true for deprecated schemas', () => {
-      const schema = Schema.String.pipe(deprecated('Old field'))
-      expect(isDeprecated(schema)).toBe(true)
+  test('works with optional fields in Struct', () => {
+    const struct = Schema.Struct({
+      oldField: Schema.optional(Schema.String).pipe(deprecated('Legacy')),
     })
-
-    test('should return false for non-deprecated schemas', () => {
-      expect(isDeprecated(Schema.String)).toBe(false)
-      expect(isDeprecated(Schema.Number)).toBe(false)
-    })
+    expect(findDeprecatedFieldsWithValues(struct, { oldField: 'x' })).toEqual([{ field: 'oldField', reason: 'Legacy' }])
   })
 
-  describe('findDeprecatedFieldsWithValues', () => {
-    test('should find deprecated fields that have values', () => {
-      const schema = Schema.Struct({
-        id: Schema.String,
-        oldTitle: Schema.optional(Schema.String).pipe(deprecated("Use 'title' instead")),
-        title: Schema.optional(Schema.String),
-      })
+  test('non-deprecated schemas return false', () => {
+    expect(isDeprecated(Schema.String)).toBe(false)
+  })
 
-      const result = findDeprecatedFieldsWithValues(schema, {
-        id: 'test-id',
-        oldTitle: 'Some old title',
-        title: 'New title',
-      })
-
-      expect(result).toEqual([{ field: 'oldTitle', reason: "Use 'title' instead" }])
+  test('ignores deprecated fields without values', () => {
+    const schema = Schema.Struct({
+      id: Schema.String,
+      old: Schema.optional(Schema.String).pipe(deprecated('x')),
     })
+    expect(findDeprecatedFieldsWithValues(schema, { id: '1' })).toEqual([])
+  })
 
-    test('should not include deprecated fields that are undefined', () => {
-      const schema = Schema.Struct({
-        id: Schema.String,
-        oldField: Schema.optional(Schema.String).pipe(deprecated('Deprecated')),
-      })
-
-      const result = findDeprecatedFieldsWithValues(schema, {
-        id: 'test-id',
-        // oldField is undefined (not provided)
-      })
-
-      expect(result).toEqual([])
+  test('finds multiple deprecated fields', () => {
+    const schema = Schema.Struct({
+      a: Schema.optional(Schema.String).pipe(deprecated('A')),
+      b: Schema.optional(Schema.String).pipe(deprecated('B')),
     })
-
-    test('should find multiple deprecated fields', () => {
-      const schema = Schema.Struct({
-        id: Schema.String,
-        oldA: Schema.optional(Schema.String).pipe(deprecated('Use newA')),
-        oldB: Schema.optional(Schema.Number).pipe(deprecated('Use newB')),
-        newA: Schema.optional(Schema.String),
-        newB: Schema.optional(Schema.Number),
-      })
-
-      const result = findDeprecatedFieldsWithValues(schema, {
-        id: 'test-id',
-        oldA: 'value A',
-        oldB: 42,
-      })
-
-      expect(result).toHaveLength(2)
-      expect(result).toContainEqual({ field: 'oldA', reason: 'Use newA' })
-      expect(result).toContainEqual({ field: 'oldB', reason: 'Use newB' })
-    })
-
-    test('should handle non-struct schemas gracefully', () => {
-      const schema = Schema.String
-      const result = findDeprecatedFieldsWithValues(schema, {})
-      expect(result).toEqual([])
-    })
+    const result = findDeprecatedFieldsWithValues(schema, { a: '1', b: '2' })
+    expect(result).toHaveLength(2)
   })
 })
 
-describe('deprecation warnings', () => {
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+describe('logDeprecationWarnings', () => {
+  let logs: unknown[][]
 
   beforeEach(() => {
     resetDeprecationWarnings()
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logs = []
   })
 
-  afterEach(() => {
-    consoleWarnSpy.mockRestore()
+  afterEach(() => resetDeprecationWarnings())
+
+  const run = (effect: Effect.Effect<void>) =>
+    Effect.runSync(
+      effect.pipe(
+        Effect.provide(
+          Logger.replace(
+            Logger.defaultLogger,
+            Logger.make(({ message }) => logs.push(message as unknown[])),
+          ),
+        ),
+      ),
+    )
+
+  test('logs event deprecation warning', () => {
+    const event = synced({ name: 'Old', schema: Schema.Struct({ id: Schema.String }), deprecated: 'Use New' })
+    run(logDeprecationWarnings(event, { id: '1' }))
+    expect(logs).toEqual([['@livestore/schema:deprecated-event', { event: 'Old', reason: 'Use New' }]])
   })
 
-  describe('event-level deprecation', () => {
-    test('should log warning when deprecated event is created', () => {
-      const deprecatedEvent = synced({
-        name: 'v1.OldEvent',
-        schema: Schema.Struct({ id: Schema.String }),
-        deprecated: "Use 'v2.NewEvent' instead",
-      })
-
-      deprecatedEvent({ id: 'test-id' })
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[LiveStore] Deprecated event 'v1.OldEvent': Use 'v2.NewEvent' instead",
-      )
+  test('logs field deprecation warning', () => {
+    const event = synced({
+      name: 'Ev',
+      schema: Schema.Struct({ old: Schema.optional(Schema.String).pipe(deprecated('Use new')) }),
     })
-
-    test('should only log warning once per event (deduplication)', () => {
-      const deprecatedEvent = synced({
-        name: 'v1.DedupeEvent',
-        schema: Schema.Struct({ id: Schema.String }),
-        deprecated: 'Deprecated',
-      })
-
-      deprecatedEvent({ id: '1' })
-      deprecatedEvent({ id: '2' })
-      deprecatedEvent({ id: '3' })
-
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
-    })
-
-    test('should not log warning for non-deprecated events', () => {
-      const normalEvent = synced({
-        name: 'v1.NormalEvent',
-        schema: Schema.Struct({ id: Schema.String }),
-      })
-
-      normalEvent({ id: 'test-id' })
-
-      expect(consoleWarnSpy).not.toHaveBeenCalled()
-    })
+    run(logDeprecationWarnings(event, { old: 'x' }))
+    expect(logs).toEqual([['@livestore/schema:deprecated-field', { event: 'Ev', field: 'old', reason: 'Use new' }]])
   })
 
-  describe('field-level deprecation', () => {
-    test('should log warning when deprecated field has value', () => {
-      const eventWithDeprecatedField = synced({
-        name: 'v1.EventWithOldField',
-        schema: Schema.Struct({
-          id: Schema.String,
-          oldTitle: Schema.optional(Schema.String).pipe(deprecated("Use 'title' instead")),
-          title: Schema.optional(Schema.String),
-        }),
-      })
-
-      eventWithDeprecatedField({ id: 'test-id', oldTitle: 'Old value' })
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[LiveStore] Deprecated field 'oldTitle' in event 'v1.EventWithOldField': Use 'title' instead",
-      )
-    })
-
-    test('should not log warning when deprecated field is undefined', () => {
-      const eventWithDeprecatedField = synced({
-        name: 'v1.EventWithUnusedOldField',
-        schema: Schema.Struct({
-          id: Schema.String,
-          oldField: Schema.optional(Schema.String).pipe(deprecated('Deprecated')),
-        }),
-      })
-
-      eventWithDeprecatedField({ id: 'test-id' })
-
-      expect(consoleWarnSpy).not.toHaveBeenCalled()
-    })
-
-    test('should only log field warning once (deduplication)', () => {
-      const eventWithDeprecatedField = synced({
-        name: 'v1.EventWithDedupeField',
-        schema: Schema.Struct({
-          id: Schema.String,
-          oldField: Schema.optional(Schema.String).pipe(deprecated('Old')),
-        }),
-      })
-
-      eventWithDeprecatedField({ id: '1', oldField: 'a' })
-      eventWithDeprecatedField({ id: '2', oldField: 'b' })
-      eventWithDeprecatedField({ id: '3', oldField: 'c' })
-
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
-    })
-
-    test('should log warnings for multiple deprecated fields', () => {
-      const eventWithMultipleDeprecated = synced({
-        name: 'v1.MultiDeprecated',
-        schema: Schema.Struct({
-          id: Schema.String,
-          oldA: Schema.optional(Schema.String).pipe(deprecated('Use newA')),
-          oldB: Schema.optional(Schema.String).pipe(deprecated('Use newB')),
-        }),
-      })
-
-      eventWithMultipleDeprecated({ id: 'test', oldA: 'a', oldB: 'b' })
-
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(2)
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[LiveStore] Deprecated field 'oldA' in event 'v1.MultiDeprecated': Use newA",
-      )
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[LiveStore] Deprecated field 'oldB' in event 'v1.MultiDeprecated': Use newB",
-      )
-    })
+  test('deduplicates event warnings', () => {
+    const event = synced({ name: 'Dup', schema: Schema.Struct({ id: Schema.String }), deprecated: 'x' })
+    run(logDeprecationWarnings(event, { id: '1' }))
+    run(logDeprecationWarnings(event, { id: '2' }))
+    expect(logs).toHaveLength(1)
   })
 
-  describe('combined event and field deprecation', () => {
-    test('should log both event and field warnings', () => {
-      const fullyDeprecatedEvent = synced({
-        name: 'v1.FullyDeprecated',
-        schema: Schema.Struct({
-          id: Schema.String,
-          oldField: Schema.optional(Schema.String).pipe(deprecated('Field deprecated')),
-        }),
-        deprecated: 'Event deprecated',
-      })
-
-      fullyDeprecatedEvent({ id: 'test', oldField: 'value' })
-
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(2)
-      expect(consoleWarnSpy).toHaveBeenCalledWith("[LiveStore] Deprecated event 'v1.FullyDeprecated': Event deprecated")
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        "[LiveStore] Deprecated field 'oldField' in event 'v1.FullyDeprecated': Field deprecated",
-      )
+  test('deduplicates field warnings', () => {
+    const event = synced({
+      name: 'DupField',
+      schema: Schema.Struct({ old: Schema.optional(Schema.String).pipe(deprecated('x')) }),
     })
+    run(logDeprecationWarnings(event, { old: 'a' }))
+    run(logDeprecationWarnings(event, { old: 'b' }))
+    expect(logs).toHaveLength(1)
+  })
+
+  test('no warning for non-deprecated event', () => {
+    const event = synced({ name: 'Normal', schema: Schema.Struct({ id: Schema.String }) })
+    run(logDeprecationWarnings(event, { id: '1' }))
+    expect(logs).toHaveLength(0)
+  })
+
+  test('no warning when deprecated field is undefined', () => {
+    const event = synced({
+      name: 'Unused',
+      schema: Schema.Struct({ old: Schema.optional(Schema.String).pipe(deprecated('x')) }),
+    })
+    run(logDeprecationWarnings(event, {}))
+    expect(logs).toHaveLength(0)
+  })
+
+  test('logs both event and field warnings', () => {
+    const event = synced({
+      name: 'Both',
+      schema: Schema.Struct({ old: Schema.optional(Schema.String).pipe(deprecated('F')) }),
+      deprecated: 'E',
+    })
+    run(logDeprecationWarnings(event, { old: 'x' }))
+    expect(logs).toHaveLength(2)
   })
 })

--- a/packages/@livestore/common/src/schema/EventDef/deprecated.ts
+++ b/packages/@livestore/common/src/schema/EventDef/deprecated.ts
@@ -1,0 +1,162 @@
+/**
+ * Deprecation Annotations for Events
+ *
+ * This module provides utilities for marking event fields and entire events as deprecated.
+ * When a deprecated field is used or a deprecated event is created, a warning is logged.
+ *
+ * @example
+ * ```ts
+ * import { Events } from '@livestore/livestore'
+ * import { Schema } from 'effect'
+ * import { deprecated } from '@livestore/common/schema'
+ *
+ * // Field-level deprecation
+ * const todoUpdated = Events.synced({
+ *   name: 'v1.TodoUpdated',
+ *   schema: Schema.Struct({
+ *     id: Schema.String,
+ *     title: Schema.optional(Schema.String).pipe(deprecated("Use 'text' instead")),
+ *     text: Schema.optional(Schema.String),
+ *   }),
+ * })
+ *
+ * // Event-level deprecation
+ * const todoRenamed = Events.synced({
+ *   name: 'v1.TodoRenamed',
+ *   schema: Schema.Struct({ id: Schema.String, name: Schema.String }),
+ *   deprecated: "Use 'v1.TodoUpdated' instead",
+ * })
+ * ```
+ * @module
+ */
+
+import type { Schema } from '@livestore/utils/effect'
+import { Option, SchemaAST } from '@livestore/utils/effect'
+
+/** Symbol used to mark schemas as deprecated. */
+export const DeprecatedId = Symbol.for('livestore/schema/annotations/deprecated')
+
+/** Type for objects that have an annotations method (Schemas and PropertySignatures). */
+type Annotatable<T> = T & { annotations: (annotations: Record<symbol, unknown>) => T }
+
+/**
+ * Marks a schema field as deprecated with a reason message.
+ * When an event is created with a deprecated field that has a value,
+ * a warning will be logged.
+ *
+ * Works with both Schema types and PropertySignatures (from Schema.optional).
+ *
+ * @param reason - Explanation of why this field is deprecated and what to use instead
+ * @returns A function that adds the deprecation annotation to the schema
+ *
+ * @example
+ * ```ts
+ * const schema = Schema.Struct({
+ *   oldField: Schema.optional(Schema.String).pipe(deprecated("Use 'newField' instead")),
+ *   newField: Schema.optional(Schema.String),
+ * })
+ * ```
+ */
+export const deprecated =
+  (reason: string) =>
+  <T>(schema: Annotatable<T>): T =>
+    schema.annotations({ [DeprecatedId]: reason })
+
+/**
+ * Checks if a schema has a deprecation annotation.
+ *
+ * @param schema - The schema to check
+ * @returns The deprecation reason if deprecated, None otherwise
+ */
+export const getDeprecatedReason = <A, I, R>(schema: Schema.Schema<A, I, R>): Option.Option<string> =>
+  SchemaAST.getAnnotation<string>(DeprecatedId)(schema.ast)
+
+/**
+ * Checks if a schema is deprecated.
+ *
+ * @param schema - The schema to check
+ * @returns true if the schema is deprecated
+ */
+export const isDeprecated = <A, I, R>(schema: Schema.Schema<A, I, R>): boolean =>
+  Option.isSome(getDeprecatedReason(schema))
+
+/**
+ * Finds deprecated fields with values in the given event arguments.
+ * This walks through a Struct schema and checks each property for deprecation.
+ *
+ * @param schema - The event schema (expected to be a Struct)
+ * @param args - The event arguments
+ * @returns Array of objects containing field name and deprecation reason
+ */
+export const findDeprecatedFieldsWithValues = (
+  schema: Schema.Schema.All,
+  args: Record<string, unknown>,
+): Array<{ field: string; reason: string }> => {
+  const result: Array<{ field: string; reason: string }> = []
+  const ast = schema.ast
+
+  // Handle TypeLiteral (Struct) schemas
+  if (ast._tag === 'TypeLiteral') {
+    for (const prop of ast.propertySignatures) {
+      const fieldName = String(prop.name)
+      const fieldValue = args[fieldName]
+
+      // Only check fields that have a value (not undefined)
+      if (fieldValue !== undefined) {
+        // Check deprecation on the property signature itself (for Schema.optional(...).pipe(deprecated(...)))
+        const propAnnotations = prop.annotations as Record<symbol, unknown> | undefined
+        const deprecationReason = propAnnotations?.[DeprecatedId] as string | undefined
+
+        // Also check deprecation on the type (for direct field deprecation)
+        const typeDeprecation = SchemaAST.getAnnotation<string>(DeprecatedId)(prop.type)
+
+        const reason = deprecationReason ?? (Option.isSome(typeDeprecation) ? typeDeprecation.value : undefined)
+        if (reason !== undefined) {
+          result.push({ field: fieldName, reason })
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+/** Set of event names that have already logged deprecation warnings. */
+const warnedDeprecatedEvents = new Set<string>()
+
+/** Map of event+field combinations that have already logged deprecation warnings. */
+const warnedDeprecatedFields = new Set<string>()
+
+/**
+ * Logs a deprecation warning for an event, deduplicating repeated warnings.
+ *
+ * @param eventName - The name of the deprecated event
+ * @param reason - The deprecation reason
+ */
+export const warnDeprecatedEvent = (eventName: string, reason: string): void => {
+  if (warnedDeprecatedEvents.has(eventName)) return
+  warnedDeprecatedEvents.add(eventName)
+  console.warn(`[LiveStore] Deprecated event '${eventName}': ${reason}`)
+}
+
+/**
+ * Logs a deprecation warning for a field, deduplicating repeated warnings.
+ *
+ * @param eventName - The name of the event containing the deprecated field
+ * @param fieldName - The name of the deprecated field
+ * @param reason - The deprecation reason
+ */
+export const warnDeprecatedField = (eventName: string, fieldName: string, reason: string): void => {
+  const key = `${eventName}:${fieldName}`
+  if (warnedDeprecatedFields.has(key)) return
+  warnedDeprecatedFields.add(key)
+  console.warn(`[LiveStore] Deprecated field '${fieldName}' in event '${eventName}': ${reason}`)
+}
+
+/**
+ * Resets the deprecation warning state. Useful for testing.
+ */
+export const resetDeprecationWarnings = (): void => {
+  warnedDeprecatedEvents.clear()
+  warnedDeprecatedFields.clear()
+}

--- a/packages/@livestore/common/src/schema/EventDef/deprecated.ts
+++ b/packages/@livestore/common/src/schema/EventDef/deprecated.ts
@@ -2,7 +2,7 @@
  * Deprecation Annotations for Events
  *
  * This module provides utilities for marking event fields and entire events as deprecated.
- * When a deprecated field is used or a deprecated event is created, a warning is logged.
+ * When a deprecated field is used or a deprecated event is committed, a warning is logged.
  *
  * @example
  * ```ts
@@ -31,17 +31,16 @@
  */
 
 import type { Schema } from '@livestore/utils/effect'
-import { Option, SchemaAST } from '@livestore/utils/effect'
+import { Effect, Option, SchemaAST } from '@livestore/utils/effect'
+
+import type { EventDef } from './event-def.ts'
 
 /** Symbol used to mark schemas as deprecated. */
 export const DeprecatedId = Symbol.for('livestore/schema/annotations/deprecated')
 
-/** Type for objects that have an annotations method (Schemas and PropertySignatures). */
-type Annotatable<T> = T & { annotations: (annotations: Record<symbol, unknown>) => T }
-
 /**
  * Marks a schema field as deprecated with a reason message.
- * When an event is created with a deprecated field that has a value,
+ * When an event is committed with a deprecated field that has a value,
  * a warning will be logged.
  *
  * Works with both Schema types and PropertySignatures (from Schema.optional).
@@ -59,7 +58,7 @@ type Annotatable<T> = T & { annotations: (annotations: Record<symbol, unknown>) 
  */
 export const deprecated =
   (reason: string) =>
-  <T>(schema: Annotatable<T>): T =>
+  <T extends { annotations: (annotations: { readonly [DeprecatedId]?: string }) => T }>(schema: T): T =>
     schema.annotations({ [DeprecatedId]: reason })
 
 /**
@@ -128,30 +127,44 @@ const warnedDeprecatedEvents = new Set<string>()
 const warnedDeprecatedFields = new Set<string>()
 
 /**
- * Logs a deprecation warning for an event, deduplicating repeated warnings.
+ * Logs deprecation warnings for an event using Effect.logWarning.
+ * Checks both event-level and field-level deprecation, with deduplication.
  *
- * @param eventName - The name of the deprecated event
- * @param reason - The deprecation reason
+ * @param eventDef - The event definition to check
+ * @param args - The event arguments
+ * @returns An Effect that logs warnings for any deprecations found
  */
-export const warnDeprecatedEvent = (eventName: string, reason: string): void => {
-  if (warnedDeprecatedEvents.has(eventName)) return
-  warnedDeprecatedEvents.add(eventName)
-  console.warn(`[LiveStore] Deprecated event '${eventName}': ${reason}`)
-}
+export const logDeprecationWarnings = (
+  eventDef: EventDef.AnyWithoutFn,
+  args: Record<string, unknown>,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const eventName = eventDef.name
 
-/**
- * Logs a deprecation warning for a field, deduplicating repeated warnings.
- *
- * @param eventName - The name of the event containing the deprecated field
- * @param fieldName - The name of the deprecated field
- * @param reason - The deprecation reason
- */
-export const warnDeprecatedField = (eventName: string, fieldName: string, reason: string): void => {
-  const key = `${eventName}:${fieldName}`
-  if (warnedDeprecatedFields.has(key)) return
-  warnedDeprecatedFields.add(key)
-  console.warn(`[LiveStore] Deprecated field '${fieldName}' in event '${eventName}': ${reason}`)
-}
+    // Check for event-level deprecation
+    const eventDeprecation = eventDef.options.deprecated
+    if (eventDeprecation !== undefined && !warnedDeprecatedEvents.has(eventName)) {
+      warnedDeprecatedEvents.add(eventName)
+      yield* Effect.logWarning('@livestore/schema:deprecated-event', {
+        event: eventName,
+        reason: eventDeprecation,
+      })
+    }
+
+    // Check for deprecated fields with values
+    const deprecatedFields = findDeprecatedFieldsWithValues(eventDef.schema, args)
+    for (const { field, reason } of deprecatedFields) {
+      const key = `${eventName}:${field}`
+      if (!warnedDeprecatedFields.has(key)) {
+        warnedDeprecatedFields.add(key)
+        yield* Effect.logWarning('@livestore/schema:deprecated-field', {
+          event: eventName,
+          field,
+          reason,
+        })
+      }
+    }
+  })
 
 /**
  * Resets the deprecation warning state. Useful for testing.

--- a/packages/@livestore/common/src/schema/EventDef/event-def.ts
+++ b/packages/@livestore/common/src/schema/EventDef/event-def.ts
@@ -51,6 +51,11 @@ export type EventDef<TName extends string, TType, TEncoded = TType, TDerived ext
 
     /** Whether this is a derived event. Derived events cannot have materializers. */
     derived: TDerived
+
+    /**
+     * Deprecation reason for this event. When set, a warning is logged at commit time.
+     */
+    deprecated: string | undefined
   }
 
   /**

--- a/packages/@livestore/common/src/schema/EventDef/mod.ts
+++ b/packages/@livestore/common/src/schema/EventDef/mod.ts
@@ -1,4 +1,5 @@
 export * from './define.ts'
+export * from './deprecated.ts'
 export * from './event-def.ts'
 export * from './facts.ts'
 export * from './materializer.ts'

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -98,7 +98,9 @@ export const clientDocument = <
       value: options.partialSet ? Schema.partial(valueSchema) : valueSchema,
     }).annotations({ title: `${name}Set:Args` }),
   })
-  Object.defineProperty(setEventDef, 'options', { value: { derived: true, clientOnly: true, facts: undefined } })
+  Object.defineProperty(setEventDef, 'options', {
+    value: { derived: true, clientOnly: true, facts: undefined, deprecated: undefined },
+  })
 
   const clientDocumentTableDefTrait: ClientDocumentTableDef.Trait<
     TName,
@@ -544,7 +546,7 @@ export namespace ClientDocumentTableDef {
       readonly name: `${TName}Set`
       readonly args: { id: string; value: TType }
     }
-    readonly options: { derived: true; clientOnly: true; facts: undefined }
+    readonly options: { derived: true; clientOnly: true; facts: undefined; deprecated: undefined }
   }
 
   export type SetEventDef<TName extends string, TType, TOptions extends ClientDocumentTableOptions<TType>> = EventDef<


### PR DESCRIPTION
Support marking entire events or individual schema fields as deprecated.
When deprecated events are created or deprecated fields have values,
a warning is logged to help teams migrate away from legacy patterns.

- Add `deprecated()` annotation helper for field-level deprecation
- Add `deprecated` option to `Events.synced/clientOnly` for event-level deprecation
- Emit warnings at event creation time with deduplication
- Export utilities from @livestore/common/schema

Closes #956