### PR TITLE
feat: add sync status API for health checks and sync indicators

### DIFF
--- a/docs/src/content/docs/building-with-livestore/store.mdx
+++ b/docs/src/content/docs/building-with-livestore/store.mdx
@@ -90,6 +90,60 @@ For more Effect patterns including Effect Atom integration, see the [Effect patt
 
 You can create and use multiple stores in the same app. This can be useful when breaking up your data model into smaller pieces.
 
+## Sync Status
+
+LiveStore provides APIs to monitor the synchronization status between the client session and the leader thread. This is useful for displaying sync indicators or performing health checks.
+
+### SyncStatus type
+
+```ts
+type SyncStatus = {
+  localHead: string      // e.g., "e5.2" or "e5.2r1"
+  upstreamHead: string   // e.g., "e3"
+  pendingCount: number   // Number of events pending sync
+  isSynced: boolean      // true when pendingCount === 0
+}
+```
+
+### `store.syncStatus()`
+
+Returns the current sync status synchronously.
+
+```ts
+const status = store.syncStatus()
+if (!status.isSynced) {
+  console.log(`${status.pendingCount} events pending sync`)
+}
+```
+
+### `store.subscribeSyncStatus(callback)`
+
+Subscribes to sync status changes. The callback is invoked immediately with the current status and whenever the sync state changes.
+
+```ts
+const unsubscribe = store.subscribeSyncStatus((status) => {
+  updateUI(status.isSynced ? 'Synced' : 'Syncing...')
+})
+
+// Later, stop listening
+unsubscribe()
+```
+
+### `store.syncStatusStream()`
+
+Returns an Effect Stream of sync status updates. For Effect-based workflows.
+
+```ts
+import { Effect, Stream } from 'effect'
+
+store.syncStatusStream().pipe(
+  Stream.tap((status) => Effect.log(`Sync: ${status.isSynced}`)),
+  Stream.runDrain,
+)
+```
+
+For React, see [`store.useSyncStatus()`](/framework-integrations/react-integration#storeusesyncstatus).
+
 ## Development/debugging helpers
 
 A store instance also exposes a `_dev` property that contains some helpful methods for development. For convenience you can access a store on `globalThis`/`window` like via `__debugLiveStore.default._dev` (`default` is the store id):

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -178,6 +178,48 @@ React.useState-like hook for client-document tables.
 - Works only with tables defined via `State.SQLite.clientDocument()`
 - If the table has a default id, the `id` argument is optional
 
+### `store.useSyncStatus()`
+
+React hook that subscribes to sync status changes. Re-renders the component when sync status changes.
+
+```tsx
+function SyncIndicator() {
+  const store = useStore(storeOptions)
+  const status = store.useSyncStatus()
+  
+  return <span>{status.isSynced ? '✓ Synced' : `Syncing (${status.pendingCount} pending)...`}</span>
+}
+```
+
+Returns a `SyncStatus` object:
+- `localHead` - The most recent event sequence number in the client session
+- `upstreamHead` - The confirmed head from the leader thread
+- `pendingCount` - Number of events pending synchronization
+- `isSynced` - Whether all local events have been synced
+
+### `store.syncStatus()`
+
+Returns the current synchronization status (non-reactive, synchronous).
+
+```ts
+const status = store.syncStatus()
+// { localHead: 'e5.2', upstreamHead: 'e3', pendingCount: 2, isSynced: false }
+```
+
+This is useful for one-off health checks outside of React components.
+
+### `store.subscribeSyncStatus(callback)`
+
+Subscribes to sync status changes (callback-based, for non-React usage).
+
+```ts
+const unsubscribe = store.subscribeSyncStatus((status) => {
+  console.log(status.isSynced ? 'Synced' : 'Syncing...')
+})
+```
+
+Returns an unsubscribe function.
+
 ### `new StoreRegistry(config?)`
 
 Creates a registry that coordinates store loading, caching, and retention.

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -191,45 +191,7 @@ function SyncIndicator() {
 }
 ```
 
-Returns a `SyncStatus` object:
-- `localHead` - The most recent event sequence number in the client session
-- `upstreamHead` - The confirmed head from the leader thread
-- `pendingCount` - Number of events pending synchronization
-- `isSynced` - Whether all local events have been synced
-
-### `store.syncStatus()`
-
-Returns the current synchronization status (non-reactive, synchronous).
-
-```ts
-const status = store.syncStatus()
-// { localHead: 'e5.2', upstreamHead: 'e3', pendingCount: 2, isSynced: false }
-```
-
-This is useful for one-off health checks outside of React components.
-
-### `store.subscribeSyncStatus(callback)`
-
-Subscribes to sync status changes (callback-based, for non-React usage).
-
-```ts
-const unsubscribe = store.subscribeSyncStatus((status) => {
-  console.log(status.isSynced ? 'Synced' : 'Syncing...')
-})
-```
-
-Returns an unsubscribe function.
-
-### `store.syncStatusStream()`
-
-Returns an Effect Stream of sync status updates. For Effect-based workflows.
-
-```ts
-store.syncStatusStream().pipe(
-  Stream.tap((status) => Effect.log(`Sync: ${status.isSynced}`)),
-  Stream.runDrain,
-)
-```
+For the `SyncStatus` type and non-React APIs (`syncStatus()`, `subscribeSyncStatus()`, `syncStatusStream()`), see the [Store documentation](/building-with-livestore/store#sync-status).
 
 ### `new StoreRegistry(config?)`
 

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -220,6 +220,17 @@ const unsubscribe = store.subscribeSyncStatus((status) => {
 
 Returns an unsubscribe function.
 
+### `store.syncStatusStream()`
+
+Returns an Effect Stream of sync status updates. For Effect-based workflows.
+
+```ts
+store.syncStatusStream().pipe(
+  Stream.tap((status) => Effect.log(`Sync: ${status.isSynced}`)),
+  Stream.runDrain,
+)
+```
+
 ### `new StoreRegistry(config?)`
 
 Creates a registry that coordinates store loading, caching, and retention.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "packageManager": "pnpm@10.17.1",
   "pnpm": {
     "patchedDependencies": {
-      "knip@5.79.0": "patches/knip@5.79.0.patch",
+      "knip@5.80.0": "patches/knip@5.80.0.patch",
       "starlight-contextual-menu@0.1.3": "patches/starlight-contextual-menu@0.1.3.patch",
       "starlight-markdown@0.1.5": "patches/starlight-markdown@0.1.5.patch"
     },

--- a/packages/@livestore/cli/src/__tests__/fixtures/.gitignore
+++ b/packages/@livestore/cli/src/__tests__/fixtures/.gitignore
@@ -1,0 +1,1 @@
+.tmp-test-configs/

--- a/packages/@livestore/cli/src/__tests__/fixtures/mock-config.ts
+++ b/packages/@livestore/cli/src/__tests__/fixtures/mock-config.ts
@@ -7,6 +7,9 @@ import { Effect, FileSystem, type Mailbox, Schema } from '@livestore/utils/effec
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// Use package-local temp directory for test config files to ensure proper module resolution
+const tmpDir = path.join(__dirname, '.tmp-test-configs')
+
 const items = State.SQLite.table({
   name: 'items',
   columns: {
@@ -33,7 +36,6 @@ const state = State.SQLite.makeState({
 
 export const schema = makeSchema({ state, events })
 
-const tmpDir = path.join(process.cwd(), 'tmp', 'cli-sync-tests')
 const schemaModuleUrl = pathToFileURL(path.join(__dirname, 'mock-config.ts')).href
 
 /** Generates a per-test config module exporting schema, a mock backend, and connection event taps. */

--- a/packages/@livestore/cli/vitest.config.ts
+++ b/packages/@livestore/cli/vitest.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
   },
   test: {
     name: '@livestore/cli',
+    include: ['src/**/*.test.ts'],
   },
 })

--- a/packages/@livestore/common/vitest.config.ts
+++ b/packages/@livestore/common/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   test: {
-    name: '@livestore/common-cf',
+    name: '@livestore/common',
     include: ['src/**/*.test.ts'],
   },
 })

--- a/packages/@livestore/livestore/src/mod.ts
+++ b/packages/@livestore/livestore/src/mod.ts
@@ -58,6 +58,7 @@ export {
   type StoreInternals,
   StoreInternalsSymbol,
   type SubscribeOptions,
+  type SyncStatus,
   type Unsubscribe,
 } from './store/store-types.ts'
 export { exposeDebugUtils } from './utils/dev.ts'

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -416,3 +416,42 @@ export const isLiveQueryInstance = (value: unknown): value is LiveQuery<any> => 
  */
 export const isQueryable = (value: unknown): value is Queryable<unknown> =>
   isQueryBuilder(value) || isLiveQueryInstance(value) || isLiveQueryDef(value)
+
+/**
+ * Represents the current synchronization status of the store.
+ *
+ * This provides visibility into the sync state between the client session
+ * and the leader thread, allowing applications to show sync indicators
+ * or determine backend health.
+ *
+ * @example
+ * ```ts
+ * const status = store.syncStatus()
+ * if (status.isSynced) {
+ *   console.log('All changes synced')
+ * } else {
+ *   console.log(`${status.pendingCount} events pending sync`)
+ * }
+ * ```
+ */
+export type SyncStatus = {
+  /**
+   * The local head sequence number (most recent event in the client session).
+   * Represented as a string in the format "e{global}.{client}" (e.g., "e5.2").
+   */
+  localHead: string
+  /**
+   * The upstream head sequence number (what the leader thread has confirmed).
+   * Represented as a string in the format "e{global}" (e.g., "e3").
+   */
+  upstreamHead: string
+  /**
+   * Number of events pending synchronization to the leader thread.
+   */
+  pendingCount: number
+  /**
+   * Whether the client session is fully synced with the leader thread.
+   * True when there are no pending events (pendingCount === 0).
+   */
+  isSynced: boolean
+}

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -56,6 +56,7 @@ import {
   StoreInternalsSymbol,
   type StoreOtel,
   type SubscribeOptions,
+  type SyncStatus,
   type Unsubscribe,
 } from './store-types.ts'
 
@@ -936,6 +937,103 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
       Stream.catchTag('ParseError', (cause) => Stream.fail(UnknownError.make({ cause }))),
       Stream.tapError((error) => Effect.logError('Error in eventsStream', error)),
     )
+  }
+
+  /**
+   * Returns the current synchronization status of the store.
+   *
+   * This is a synchronous operation that returns the sync state between the
+   * client session and the leader thread. Use this to display sync indicators
+   * or check if local changes have been pushed to the leader.
+   *
+   * @example
+   * ```ts
+   * const status = store.syncStatus()
+   * console.log(status.isSynced ? 'Synced' : `${status.pendingCount} pending`)
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Health check for backend connectivity
+   * const status = store.syncStatus()
+   * if (!status.isSynced && status.pendingCount > 100) {
+   *   console.warn('Large backlog of unsynced events')
+   * }
+   * ```
+   */
+  syncStatus = (): SyncStatus => {
+    this.checkShutdown('syncStatus')
+
+    const syncState = this[StoreInternalsSymbol].syncProcessor.syncState.pipe(Effect.runSync)
+    const localHead = syncState.localHead
+    const upstreamHead = syncState.upstreamHead
+    const pendingCount = syncState.pending.length
+
+    return {
+      localHead: `e${localHead.global}${localHead.client > 0 ? `.${localHead.client}` : ''}`,
+      upstreamHead: `e${upstreamHead.global}${upstreamHead.client > 0 ? `.${upstreamHead.client}` : ''}`,
+      pendingCount,
+      isSynced: pendingCount === 0,
+    }
+  }
+
+  /**
+   * Subscribes to sync status changes.
+   *
+   * The callback is invoked immediately with the current status and then
+   * whenever the sync state changes (e.g., when events are pushed or confirmed).
+   *
+   * @param onUpdate - Callback invoked with the current sync status
+   * @returns Unsubscribe function to stop receiving updates
+   *
+   * @example
+   * ```ts
+   * const unsubscribe = store.subscribeSyncStatus((status) => {
+   *   updateUI(status.isSynced ? 'Synced' : 'Syncing...')
+   * })
+   *
+   * // Later, stop listening
+   * unsubscribe()
+   * ```
+   *
+   * @example
+   * ```ts
+   * // React usage (in a custom hook or effect)
+   * useEffect(() => {
+   *   return store.subscribeSyncStatus((status) => {
+   *     setSyncState(status)
+   *   })
+   * }, [store])
+   * ```
+   */
+  subscribeSyncStatus = (onUpdate: (status: SyncStatus) => void): Unsubscribe => {
+    this.checkShutdown('subscribeSyncStatus')
+
+    const makeSyncStatus = (syncState: { localHead: any; upstreamHead: any; pending: readonly any[] }): SyncStatus => {
+      const localHead = syncState.localHead
+      const upstreamHead = syncState.upstreamHead
+      const pendingCount = syncState.pending.length
+
+      return {
+        localHead: `e${localHead.global}${localHead.client > 0 ? `.${localHead.client}` : ''}`,
+        upstreamHead: `e${upstreamHead.global}${upstreamHead.client > 0 ? `.${upstreamHead.client}` : ''}`,
+        pendingCount,
+        isSynced: pendingCount === 0,
+      }
+    }
+
+    const initialSyncState = this[StoreInternalsSymbol].syncProcessor.syncState.pipe(Effect.runSync)
+    onUpdate(makeSyncStatus(initialSyncState))
+
+    const fiber = this[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
+      Stream.tap((syncState) => Effect.sync(() => onUpdate(makeSyncStatus(syncState)))),
+      Stream.runDrain,
+      this.runEffectFork,
+    )
+
+    return () => {
+      Fiber.interrupt(fiber).pipe(Runtime.runFork(this[StoreInternalsSymbol].effectContext.runtime))
+    }
   }
 
   /**

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -20,7 +20,7 @@ import {
 } from '@livestore/common'
 import type { StreamEventsOptions } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
-import { LiveStoreEvent, resolveEventDef, SystemTables } from '@livestore/common/schema'
+import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '@livestore/common/schema'
 import { assertNever, isDevEnv, omitUndefineds, shouldNeverHappen } from '@livestore/utils'
 import type { Scope } from '@livestore/utils/effect'
 import {
@@ -965,13 +965,11 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     this.checkShutdown('syncStatus')
 
     const syncState = this[StoreInternalsSymbol].syncProcessor.syncState.pipe(Effect.runSync)
-    const localHead = syncState.localHead
-    const upstreamHead = syncState.upstreamHead
     const pendingCount = syncState.pending.length
 
     return {
-      localHead: `e${localHead.global}${localHead.client > 0 ? `.${localHead.client}` : ''}`,
-      upstreamHead: `e${upstreamHead.global}${upstreamHead.client > 0 ? `.${upstreamHead.client}` : ''}`,
+      localHead: EventSequenceNumber.Client.toString(syncState.localHead),
+      upstreamHead: EventSequenceNumber.Client.toString(syncState.upstreamHead),
       pendingCount,
       isSynced: pendingCount === 0,
     }
@@ -1009,14 +1007,16 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   subscribeSyncStatus = (onUpdate: (status: SyncStatus) => void): Unsubscribe => {
     this.checkShutdown('subscribeSyncStatus')
 
-    const makeSyncStatus = (syncState: { localHead: any; upstreamHead: any; pending: readonly any[] }): SyncStatus => {
-      const localHead = syncState.localHead
-      const upstreamHead = syncState.upstreamHead
+    const makeSyncStatus = (syncState: {
+      localHead: EventSequenceNumber.Client.Composite
+      upstreamHead: EventSequenceNumber.Client.Composite
+      pending: readonly any[]
+    }): SyncStatus => {
       const pendingCount = syncState.pending.length
 
       return {
-        localHead: `e${localHead.global}${localHead.client > 0 ? `.${localHead.client}` : ''}`,
-        upstreamHead: `e${upstreamHead.global}${upstreamHead.client > 0 ? `.${upstreamHead.client}` : ''}`,
+        localHead: EventSequenceNumber.Client.toString(syncState.localHead),
+        upstreamHead: EventSequenceNumber.Client.toString(syncState.upstreamHead),
         pendingCount,
         isSynced: pendingCount === 0,
       }

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -976,6 +976,29 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   }
 
   /**
+   * Returns an Effect Stream of sync status updates.
+   *
+   * Emits the current status immediately and then whenever the sync state changes.
+   * Use this for Effect-based workflows or when you need more control over the stream.
+   *
+   * @example
+   * ```ts
+   * store.syncStatusStream().pipe(
+   *   Stream.tap((status) => Effect.log(`Sync status: ${status.isSynced}`)),
+   *   Stream.runDrain,
+   * )
+   * ```
+   */
+  syncStatusStream = (): Stream.Stream<SyncStatus> => {
+    const syncStateSubscribable = this[StoreInternalsSymbol].syncProcessor.syncState
+
+    return Stream.concat(
+      Stream.fromEffect(syncStateSubscribable.pipe(Effect.map(this.makeSyncStatus))),
+      syncStateSubscribable.changes.pipe(Stream.map(this.makeSyncStatus)),
+    )
+  }
+
+  /**
    * Subscribes to sync status changes.
    *
    * The callback is invoked immediately with the current status and then
@@ -993,46 +1016,33 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * // Later, stop listening
    * unsubscribe()
    * ```
-   *
-   * @example
-   * ```ts
-   * // React usage (in a custom hook or effect)
-   * useEffect(() => {
-   *   return store.subscribeSyncStatus((status) => {
-   *     setSyncState(status)
-   *   })
-   * }, [store])
-   * ```
    */
   subscribeSyncStatus = (onUpdate: (status: SyncStatus) => void): Unsubscribe => {
     this.checkShutdown('subscribeSyncStatus')
 
-    const makeSyncStatus = (syncState: {
-      localHead: EventSequenceNumber.Client.Composite
-      upstreamHead: EventSequenceNumber.Client.Composite
-      pending: readonly any[]
-    }): SyncStatus => {
-      const pendingCount = syncState.pending.length
-
-      return {
-        localHead: EventSequenceNumber.Client.toString(syncState.localHead),
-        upstreamHead: EventSequenceNumber.Client.toString(syncState.upstreamHead),
-        pendingCount,
-        isSynced: pendingCount === 0,
-      }
-    }
-
-    const initialSyncState = this[StoreInternalsSymbol].syncProcessor.syncState.pipe(Effect.runSync)
-    onUpdate(makeSyncStatus(initialSyncState))
-
-    const fiber = this[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
-      Stream.tap((syncState) => Effect.sync(() => onUpdate(makeSyncStatus(syncState)))),
+    const fiber = this.syncStatusStream().pipe(
+      Stream.tap((status) => Effect.sync(() => onUpdate(status))),
       Stream.runDrain,
       this.runEffectFork,
     )
 
     return () => {
       Fiber.interrupt(fiber).pipe(Runtime.runFork(this[StoreInternalsSymbol].effectContext.runtime))
+    }
+  }
+
+  private makeSyncStatus = (syncState: {
+    localHead: EventSequenceNumber.Client.Composite
+    upstreamHead: EventSequenceNumber.Client.Composite
+    pending: readonly any[]
+  }): SyncStatus => {
+    const pendingCount = syncState.pending.length
+
+    return {
+      localHead: EventSequenceNumber.Client.toString(syncState.localHead),
+      upstreamHead: EventSequenceNumber.Client.toString(syncState.upstreamHead),
+      pendingCount,
+      isSynced: pendingCount === 0,
     }
   }
 

--- a/packages/@livestore/livestore/vitest.config.ts
+++ b/packages/@livestore/livestore/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  test: {
+    name: '@livestore/livestore',
+    include: ['src/**/*.test.ts'],
+  },
   resolve: {
     alias: {
       '@livestore/wa-sqlite/dist/wa-sqlite.mjs': '@livestore/wa-sqlite/dist/wa-sqlite.node.mjs',

--- a/packages/@livestore/react/src/mod.ts
+++ b/packages/@livestore/react/src/mod.ts
@@ -11,4 +11,5 @@ export {
 } from './useClientDocument.ts'
 export { useQuery, useQueryRef } from './useQuery.ts'
 export { type ReactApi, useStore, withReactApi } from './useStore.ts'
+export { useSyncStatus } from './useSyncStatus.ts'
 export { useStackInfo } from './utils/stack-info.ts'

--- a/packages/@livestore/react/src/useStore.ts
+++ b/packages/@livestore/react/src/useStore.ts
@@ -1,10 +1,11 @@
 import type { LiveStoreSchema } from '@livestore/common/schema'
-import type { RegistryStoreOptions, Store } from '@livestore/livestore'
+import type { RegistryStoreOptions, Store, SyncStatus } from '@livestore/livestore'
 import type { Schema } from '@livestore/utils/effect'
 import React from 'react'
 import { useStoreRegistry } from './StoreRegistryContext.tsx'
 import { useClientDocument } from './useClientDocument.ts'
 import { useQuery } from './useQuery.ts'
+import { useSyncStatus } from './useSyncStatus.ts'
 
 /**
  * Returns a store instance augmented with hooks (`store.useQuery()` and `store.useClientDocument()`) for reactive queries.
@@ -94,6 +95,8 @@ export type ReactApi = {
   useQuery: typeof useQuery
   /** Hook for reading and writing client-document tables with React state semantics */
   useClientDocument: typeof useClientDocument
+  /** Hook for subscribing to sync status changes */
+  useSyncStatus: () => SyncStatus
 }
 
 /**
@@ -112,5 +115,9 @@ export const withReactApi = <TSchema extends LiveStoreSchema, TContext = {}>(
 
   // @ts-expect-error TODO properly implement this
   store.useClientDocument = (table, idOrOptions, options) => useClientDocument(table, idOrOptions, options, { store })
+
+  // @ts-expect-error TODO properly implement this
+  store.useSyncStatus = () => useSyncStatus({ store })
+
   return store as Store<TSchema, TContext> & ReactApi
 }

--- a/packages/@livestore/react/src/useSyncStatus.ts
+++ b/packages/@livestore/react/src/useSyncStatus.ts
@@ -1,0 +1,33 @@
+import type { Store, SyncStatus } from '@livestore/livestore'
+import React from 'react'
+
+/**
+ * React hook that subscribes to sync status changes.
+ *
+ * Returns the current synchronization status between the client session and
+ * the leader thread. The component re-renders whenever the sync status changes.
+ *
+ * @example
+ * ```tsx
+ * function SyncIndicator() {
+ *   const status = store.useSyncStatus()
+ *   return <span>{status.isSynced ? '✓ Synced' : `Syncing (${status.pendingCount} pending)...`}</span>
+ * }
+ * ```
+ *
+ * @param options - Options containing the store instance
+ * @returns The current sync status
+ */
+export const useSyncStatus = (options: { store: Store<any> }): SyncStatus => {
+  const { store } = options
+
+  const [status, setStatus] = React.useState<SyncStatus>(() => store.syncStatus())
+
+  React.useEffect(() => {
+    return store.subscribeSyncStatus(setStatus)
+  }, [store])
+
+  React.useDebugValue(`LiveStore:useSyncStatus:${status.isSynced ? 'synced' : 'pending'}`)
+
+  return status
+}

--- a/packages/@livestore/react/vitest.config.ts
+++ b/packages/@livestore/react/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   test: {
+    name: '@livestore/react',
+    include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}'],
     // Try node environment with DOM globals for React tests
     environment: 'node',
     setupFiles: ['./test/setup.ts'],

--- a/packages/@livestore/sqlite-wasm/vitest.config.ts
+++ b/packages/@livestore/sqlite-wasm/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    name: '@livestore/sqlite-wasm',
+    include: ['src/**/*.test.ts'],
     poolOptions: {
       workers: {
         wrangler: {

--- a/packages/@livestore/sync-s2/vitest.config.ts
+++ b/packages/@livestore/sync-s2/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   test: {
-    name: '@livestore/common-cf',
+    name: '@livestore/sync-s2',
     include: ['src/**/*.test.ts'],
   },
 })

--- a/packages/@livestore/utils-dev/src/node/DockerComposeService/DockerComposeService.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerComposeService/DockerComposeService.ts
@@ -20,6 +20,8 @@ export class DockerComposeError extends Schema.TaggedError<DockerComposeError>()
 export interface DockerComposeArgs {
   readonly cwd: string
   readonly serviceName?: string
+  /** Unique project name to isolate this compose instance. If not provided, a random one is generated. */
+  readonly projectName?: string
 }
 
 export interface StartOptions {
@@ -52,20 +54,27 @@ export interface DockerComposeOperations {
   readonly logs: (
     options?: LogsOptions,
   ) => Stream.Stream<string, DockerComposeError | PlatformError.PlatformError, Scope.Scope>
+  /** The unique project name used to isolate this compose instance */
+  readonly projectName: string
 }
+
+const generateProjectName = (): string => `ls-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
 export class DockerComposeService extends Effect.Service<DockerComposeService>()('DockerComposeService', {
   scoped: (args: DockerComposeArgs) =>
     Effect.gen(function* () {
       const { cwd, serviceName } = args
+      const projectName = args.projectName ?? generateProjectName()
 
       const commandExecutorContext = yield* Effect.context<CommandExecutor.CommandExecutor>()
+
+      const baseComposeArgs = ['-p', projectName]
 
       const pull = Effect.gen(function* () {
         yield* Effect.log(`Pulling Docker Compose images in ${cwd}`)
 
         // TODO (@IMax153) Refactor the effect command related code below as there is probably a much more elegant way to accomplish what we want here in a more effect idiomatic way.
-        const pullCommand = Command.make('docker', 'compose', 'pull').pipe(
+        const pullCommand = Command.make('docker', 'compose', ...baseComposeArgs, 'pull').pipe(
           Command.workingDirectory(cwd),
           Command.stdout('pipe'),
           Command.stderr('pipe'),
@@ -123,11 +132,11 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
           const { detached = true, healthCheck } = options
 
           // Build start command
-          const baseArgs = ['docker', 'compose', 'up']
-          if (detached) baseArgs.push('-d')
-          if (serviceName) baseArgs.push(serviceName)
+          const startArgs = ['docker', 'compose', ...baseComposeArgs, 'up']
+          if (detached) startArgs.push('-d')
+          if (serviceName) startArgs.push(serviceName)
 
-          const command = yield* Command.make(baseArgs[0]!, ...baseArgs.slice(1)).pipe(
+          const command = yield* Command.make(startArgs[0]!, ...startArgs.slice(1)).pipe(
             Command.workingDirectory(cwd),
             Command.env(options.env ?? {}),
             Command.stderr('inherit'),
@@ -171,8 +180,8 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
         yield* Effect.log(`Stopping Docker Compose services in ${cwd}`)
 
         const stopCommand = serviceName
-          ? Command.make('docker', 'compose', 'stop', serviceName)
-          : Command.make('docker', 'compose', 'stop')
+          ? Command.make('docker', 'compose', ...baseComposeArgs, 'stop', serviceName)
+          : Command.make('docker', 'compose', ...baseComposeArgs, 'stop')
 
         yield* stopCommand.pipe(
           Command.workingDirectory(cwd),
@@ -197,13 +206,13 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
         Effect.gen(function* () {
           const { follow = false, tail, since } = options
 
-          const baseArgs = ['docker', 'compose', 'logs']
-          if (follow) baseArgs.push('-f')
-          if (tail) baseArgs.push('--tail', tail.toString())
-          if (since) baseArgs.push('--since', since)
-          if (serviceName) baseArgs.push(serviceName)
+          const logsArgs = ['docker', 'compose', ...baseComposeArgs, 'logs']
+          if (follow) logsArgs.push('-f')
+          if (tail) logsArgs.push('--tail', tail.toString())
+          if (since) logsArgs.push('--since', since)
+          if (serviceName) logsArgs.push(serviceName)
 
-          const command = yield* Command.make(baseArgs[0]!, ...baseArgs.slice(1)).pipe(
+          const command = yield* Command.make(logsArgs[0]!, ...logsArgs.slice(1)).pipe(
             Command.workingDirectory(cwd),
             Command.start,
             Effect.catchAll((cause) =>
@@ -238,12 +247,12 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
         Effect.gen(function* () {
           yield* Effect.log(`Tearing down Docker Compose services in ${cwd}`)
 
-          const baseArgs = ['docker', 'compose', 'down']
-          if (options?.volumes) baseArgs.push('-v')
-          if (options?.removeOrphans) baseArgs.push('--remove-orphans')
-          if (serviceName) baseArgs.push(serviceName)
+          const downArgs = ['docker', 'compose', ...baseComposeArgs, 'down']
+          if (options?.volumes) downArgs.push('-v')
+          if (options?.removeOrphans) downArgs.push('--remove-orphans')
+          if (serviceName) downArgs.push(serviceName)
 
-          yield* Command.make(baseArgs[0]!, ...baseArgs.slice(1)).pipe(
+          yield* Command.make(downArgs[0]!, ...downArgs.slice(1)).pipe(
             Command.workingDirectory(cwd),
             Command.env(options?.env ?? {}),
             Command.exitCode,
@@ -263,7 +272,15 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
           yield* Effect.log(`Docker Compose services torn down successfully`)
         }).pipe(Effect.withSpan('downDockerCompose'))
 
-      return { pull, start, stop, down, logs }
+      // Register cleanup finalizer to ensure containers are removed when scope closes
+      yield* Effect.addFinalizer(() =>
+        down({ volumes: true, removeOrphans: true }).pipe(
+          Effect.tap(() => Effect.log(`Docker Compose cleanup completed for project ${projectName}`)),
+          Effect.catchAll((error) => Effect.log(`Docker Compose cleanup failed for project ${projectName}: ${error}`)),
+        ),
+      )
+
+      return { pull, start, stop, down, logs, projectName }
     }),
 }) {}
 

--- a/packages/@livestore/utils-dev/vitest.config.ts
+++ b/packages/@livestore/utils-dev/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   test: {
-    name: '@livestore/common-cf',
+    name: '@livestore/utils-dev',
     include: ['src/**/*.test.ts'],
   },
 })

--- a/packages/@livestore/utils/vitest.config.ts
+++ b/packages/@livestore/utils/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   test: {
-    name: '@livestore/common-cf',
+    name: '@livestore/utils',
     include: ['src/**/*.test.ts'],
   },
 })

--- a/packages/@livestore/webmesh/vitest.config.ts
+++ b/packages/@livestore/webmesh/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   test: {
-    name: '@livestore/common-cf',
+    name: '@livestore/webmesh',
     include: ['src/**/*.test.ts'],
   },
 })

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.render.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.render.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 
 import { shouldNeverHappen } from '@livestore/utils'
 import { Effect } from '@livestore/utils/effect'
@@ -39,11 +39,9 @@ let docsRenderer: TRenderer
 let docsPaths: ReturnType<typeof resolveProjectPaths>
 
 beforeAll(async () => {
-  const modulePath = path.join(
-    workspaceRoot,
-    'node_modules/.pnpm/twoslash@0.2.12_typescript@5.9.2/node_modules/twoslash/dist/index.mjs',
-  )
-  const module = await import(pathToFileURL(modulePath).href)
+  // Resolve twoslash dynamically via expressive-code-twoslash's dependencies
+  const twoslashPath = import.meta.resolve('twoslash', import.meta.resolve('expressive-code-twoslash'))
+  const module = await import(twoslashPath)
   twoslasher = module.twoslasher as TTwoslasher
 
   examplePaths = resolveProjectPaths(exampleProjectRoot)

--- a/patches/README.md
+++ b/patches/README.md
@@ -10,7 +10,7 @@ This patch adds option normalization plus an `injectMarkdownRoutes` flag so our 
 ### starlight-markdown@0.1.5.patch
 This patch makes the upstream integration idempotent by skipping route injection after the first run. Third-party plugins (including the contextual menu) register the integration multiple times, and without this guard Astro sees the same static route twice and aborts the build.
 
-### knip@5.79.0.patch
+### knip@5.80.0.patch
 Treat package imports that resolve outside the configured knip root as external dependencies, so workspace links to parent repos don't get flagged as unused. See https://github.com/webpro-nl/knip/issues/1428. This is currently only needed when LiveStore is embedded in another monorepo.
 
 ## Sample format

--- a/patches/knip@5.80.0.patch
+++ b/patches/knip@5.80.0.patch
@@ -1,7 +1,6 @@
-diff --git a/dist/graph/build.js b/dist/graph/build.js
 --- a/dist/graph/build.js
 +++ b/dist/graph/build.js
-@@ -303,11 +303,17 @@
+@@ -303,12 +303,20 @@
              for (const _import of file.imports.imports) {
                  if (_import.filePath) {
                      const packageName = getPackageNameFromModuleSpecifier(_import.specifier);
@@ -10,7 +9,6 @@ diff --git a/dist/graph/build.js b/dist/graph/build.js
 -                        const principal = getPrincipalByFilePath(_import.filePath);
 -                        if (principal && !isGitIgnored(_import.filePath)) {
 -                            principal.addProgramPath(_import.filePath);
--                        }
 +                    if (packageName) {
 +                        // Treat workspace links outside the knip root as external deps to avoid false unused warnings.
 +                        const relativePath = relative(options.cwd, _import.filePath);
@@ -18,7 +16,7 @@ diff --git a/dist/graph/build.js b/dist/graph/build.js
 +                        const isWorkspaceImport = isInternalWorkspace(packageName);
 +                        if (isWorkspaceImport || isOutsideCwd) {
 +                            file.imports.external.add({ ..._import, specifier: packageName });
-+                        }
+                         }
 +                        if (isWorkspaceImport) {
 +                            const principal = getPrincipalByFilePath(_import.filePath);
 +                            if (principal && !isGitIgnored(_import.filePath)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,9 +180,9 @@ overrides:
   puppeteer: 23.11.1
 
 patchedDependencies:
-  knip@5.79.0:
-    hash: 8d7c600785235d3bed6f9b7899a2f9ff31cb2b274f8f4a3fced22df73ed5f295
-    path: patches/knip@5.79.0.patch
+  knip@5.80.0:
+    hash: deecfd9ef9113112cfad6ededfcbe1f12b7269c5fc082724e91c4a476bac7cb7
+    path: patches/knip@5.80.0.patch
   starlight-contextual-menu@0.1.3:
     hash: 102253fd3bdb5ceed9522afe86d06341e63052dd22c734bdd9a2af790abc0545
     path: patches/starlight-contextual-menu@0.1.3.patch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2807,7 +2807,7 @@ importers:
         specifier: ^7.7.0
         version: 7.7.1
       knip:
-        specifier: 5.80.0
+        specifier: ^5.80.0
         version: 5.80.0(patch_hash=deecfd9ef9113112cfad6ededfcbe1f12b7269c5fc082724e91c4a476bac7cb7)(@types/node@25.0.3)(typescript@5.9.3)
       semver:
         specifier: ^7.7.3
@@ -6169,7 +6169,6 @@ packages:
   '@oclif/screen@3.0.8':
     resolution: {integrity: sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==}
     engines: {node: '>=12.0.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oozcitak/dom@2.0.2':
     resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
@@ -7207,10 +7206,14 @@ packages:
   '@react-native/babel-preset@0.81.5':
     resolution: {integrity: sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==}
     engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/codegen@0.81.4':
     resolution: {integrity: sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==}
     engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/codegen@0.81.5':
     resolution: {integrity: sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==}
@@ -9324,7 +9327,6 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -11885,11 +11887,9 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -12050,7 +12050,6 @@ packages:
 
   hast@1.0.0:
     resolution: {integrity: sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA==}
-    deprecated: Renamed to rehype
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
@@ -12256,7 +12255,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -12726,7 +12724,6 @@ packages:
   keygrip@1.1.0:
     resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
     engines: {node: '>= 0.6'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
@@ -12941,7 +12938,6 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -13750,7 +13746,6 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -14526,7 +14521,6 @@ packages:
   puppeteer@23.11.1:
     resolution: {integrity: sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==}
     engines: {node: '>=18'}
-    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   pure-rand@6.1.0:
@@ -15123,12 +15117,10 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   rimraf@5.0.10:
@@ -15706,7 +15698,6 @@ packages:
 
   sudo-prompt@9.1.1:
     resolution: {integrity: sha512-es33J1g2HjMpyAhz8lOR+ICmXXAqTuKbuXuUWLhOLew20oN9oUCgCJx615U/v7aioZg7IX5lIh9x34vwneu4pA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
@@ -16850,7 +16841,6 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -19677,7 +19667,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -19848,7 +19838,7 @@ snapshots:
       '@expo/json-file': 10.0.7
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
       resolve-from: 5.0.0
       semver: 7.7.3
       xml2js: 0.6.0
@@ -22644,11 +22634,12 @@ snapshots:
 
   '@react-native/assets-registry@0.81.5': {}
 
-  '@react-native/babel-plugin-codegen@0.81.4':
+  '@react-native/babel-plugin-codegen@0.81.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@react-native/codegen': 0.81.4
+      '@react-native/codegen': 0.81.4(@babel/core@7.28.5)
     transitivePeerDependencies:
+      - '@babel/core'
       - supports-color
 
   '@react-native/babel-plugin-codegen@0.81.5':
@@ -22701,14 +22692,14 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
       '@babel/template': 7.27.2
-      '@react-native/babel-plugin-codegen': 0.81.4
+      '@react-native/babel-plugin-codegen': 0.81.4(@babel/core@7.28.5)
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.28.5)
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/babel-preset@0.81.5':
+  '@react-native/babel-preset@0.81.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.28.5)
@@ -22758,7 +22749,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.81.4':
+  '@react-native/codegen@0.81.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
@@ -22767,8 +22758,6 @@ snapshots:
       invariant: 2.2.4
       nullthrows: 1.1.1
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@react-native/codegen@0.81.5':
     dependencies:
@@ -26364,7 +26353,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
-      '@react-native/babel-preset': 0.81.5
+      '@react-native/babel-preset': 0.81.5(@babel/core@7.28.5)
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
@@ -26374,7 +26363,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
+      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -26396,7 +26385,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
-      '@react-native/babel-preset': 0.81.5
+      '@react-native/babel-preset': 0.81.5(@babel/core@7.28.5)
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
@@ -33263,7 +33252,7 @@ snapshots:
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.4
-      '@react-native/codegen': 0.81.4
+      '@react-native/codegen': 0.81.4(@babel/core@7.28.5)
       '@react-native/community-cli-plugin': 0.81.4
       '@react-native/gradle-plugin': 0.81.4
       '@react-native/js-polyfills': 0.81.4
@@ -33310,7 +33299,7 @@ snapshots:
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.4
-      '@react-native/codegen': 0.81.4
+      '@react-native/codegen': 0.81.4(@babel/core@7.28.5)
       '@react-native/community-cli-plugin': 0.81.4
       '@react-native/gradle-plugin': 0.81.4
       '@react-native/js-polyfills': 0.81.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2807,8 +2807,8 @@ importers:
         specifier: ^7.7.0
         version: 7.7.1
       knip:
-        specifier: ^5.79.0
-        version: 5.79.0(@types/node@25.0.3)(typescript@5.9.3)
+        specifier: 5.80.0
+        version: 5.80.0(patch_hash=deecfd9ef9113112cfad6ededfcbe1f12b7269c5fc082724e91c4a476bac7cb7)(@types/node@25.0.3)(typescript@5.9.3)
       semver:
         specifier: ^7.7.3
         version: 7.7.3
@@ -5112,7 +5112,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@54.0.10':
     resolution: {integrity: sha512-iw9gAnN6+PKWWLIyYmiskY/wzZjuFMctunqGXuC8BGATWgtr/HpzjVqWbcL3KIX/GvEBCCh74Tkckrh+Ylxh5Q==}
@@ -12743,8 +12743,8 @@ packages:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
 
-  knip@5.79.0:
-    resolution: {integrity: sha512-rcg+mNdqm6UiTuRVyy6UuuHw1n4ABMpNXDtrfGaCeUtJoRBAvAENIebr8YMtOz6XE7iVHZ8+rY7skgEtosczhQ==}
+  knip@5.80.0:
+    resolution: {integrity: sha512-K/Ga2f/SHEUXXriVdaw2GfeIUJ5muwdqusHGkCtaG/1qeMmQJiuwZj9KnPxaDbnYPAu8RWjYYh8Nyb+qlJ3d8A==}
     engines: {node: '>=18.18.0'}
     hasBin: true
     peerDependencies:
@@ -30238,7 +30238,7 @@ snapshots:
 
   klona@2.0.6: {}
 
-  knip@5.79.0(@types/node@25.0.3)(typescript@5.9.3):
+  knip@5.80.0(patch_hash=deecfd9ef9113112cfad6ededfcbe1f12b7269c5fc082724e91c4a476bac7cb7)(@types/node@25.0.3)(typescript@5.9.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@types/node': 25.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7206,14 +7206,10 @@ packages:
   '@react-native/babel-preset@0.81.5':
     resolution: {integrity: sha512-UoI/x/5tCmi+pZ3c1+Ypr1DaRMDLI3y+Q70pVLLVgrnC3DHsHRIbHcCHIeG/IJvoeFqFM2sTdhSOLJrf8lOPrA==}
     engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
 
   '@react-native/codegen@0.81.4':
     resolution: {integrity: sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==}
     engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
 
   '@react-native/codegen@0.81.5':
     resolution: {integrity: sha512-a2TDA03Up8lpSa9sh5VRGCQDXgCTOyDOFH+aqyinxp1HChG8uk89/G+nkJ9FPd0rqgi25eCTR16TWdS3b+fA6g==}
@@ -19667,7 +19663,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -19838,7 +19834,7 @@ snapshots:
       '@expo/json-file': 10.0.7
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3(supports-color@8.1.1)
-      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
       resolve-from: 5.0.0
       semver: 7.7.3
       xml2js: 0.6.0
@@ -22634,12 +22630,11 @@ snapshots:
 
   '@react-native/assets-registry@0.81.5': {}
 
-  '@react-native/babel-plugin-codegen@0.81.4(@babel/core@7.28.5)':
+  '@react-native/babel-plugin-codegen@0.81.4':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@react-native/codegen': 0.81.4(@babel/core@7.28.5)
+      '@react-native/codegen': 0.81.4
     transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   '@react-native/babel-plugin-codegen@0.81.5':
@@ -22692,14 +22687,14 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
       '@babel/template': 7.27.2
-      '@react-native/babel-plugin-codegen': 0.81.4(@babel/core@7.28.5)
+      '@react-native/babel-plugin-codegen': 0.81.4
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.28.5)
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/babel-preset@0.81.5(@babel/core@7.28.5)':
+  '@react-native/babel-preset@0.81.5':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.28.5)
@@ -22749,7 +22744,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.81.4(@babel/core@7.28.5)':
+  '@react-native/codegen@0.81.4':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
@@ -22758,6 +22753,8 @@ snapshots:
       invariant: 2.2.4
       nullthrows: 1.1.1
       yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@react-native/codegen@0.81.5':
     dependencies:
@@ -26353,7 +26350,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
-      '@react-native/babel-preset': 0.81.5(@babel/core@7.28.5)
+      '@react-native/babel-preset': 0.81.5
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
@@ -26363,7 +26360,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.12(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.10)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -26385,7 +26382,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-react': 7.28.5(@babel/core@7.28.5)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
-      '@react-native/babel-preset': 0.81.5(@babel/core@7.28.5)
+      '@react-native/babel-preset': 0.81.5
       babel-plugin-react-compiler: 1.0.0
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
@@ -33252,7 +33249,7 @@ snapshots:
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.4
-      '@react-native/codegen': 0.81.4(@babel/core@7.28.5)
+      '@react-native/codegen': 0.81.4
       '@react-native/community-cli-plugin': 0.81.4
       '@react-native/gradle-plugin': 0.81.4
       '@react-native/js-polyfills': 0.81.4
@@ -33299,7 +33296,7 @@ snapshots:
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.4
-      '@react-native/codegen': 0.81.4(@babel/core@7.28.5)
+      '@react-native/codegen': 0.81.4
       '@react-native/community-cli-plugin': 0.81.4
       '@react-native/gradle-plugin': 0.81.4
       '@react-native/js-polyfills': 0.81.4

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,7 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "^7.7.0",
-    "knip": "^5.79.0",
+    "knip": "5.80.0",
     "semver": "^7.7.3",
     "yaml": "^2.8.1"
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,7 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "^7.7.0",
-    "knip": "5.80.0",
+    "knip": "^5.80.0",
     "semver": "^7.7.3",
     "yaml": "^2.8.1"
   }

--- a/tests/integration/src/tests/playwright/misc-tests.play.ts
+++ b/tests/integration/src/tests/playwright/misc-tests.play.ts
@@ -44,7 +44,7 @@ test(
       })
 
       expect(exit).toStrictEqual(
-        Exit.fail(UnknownError.make({ cause: new Error('Boom!', { cause: { name: 'Error', message: 'Boom!' } }) })),
+        Exit.fail(UnknownError.make({ cause: new Error('Boom!', { cause: { name: 'TestError', message: 'Boom!' } }) })),
       )
     }),
   ),

--- a/tests/integration/src/tests/playwright/misc-tests.play.ts
+++ b/tests/integration/src/tests/playwright/misc-tests.play.ts
@@ -43,9 +43,12 @@ test(
         schema: Bridge.ResultStoreBootError,
       })
 
-      expect(exit).toStrictEqual(
-        Exit.fail(UnknownError.make({ cause: new Error('Boom!', { cause: { name: 'TestError', message: 'Boom!' } }) })),
-      )
+      // The TestError class is serialized with name: 'TestError', so we need to match that
+      const expectedError = new Error('Boom!')
+      expectedError.name = 'TestError'
+      ;(expectedError as any).cause = { name: 'TestError', message: 'Boom!' }
+
+      expect(exit).toStrictEqual(Exit.fail(UnknownError.make({ cause: expectedError })))
     }),
   ),
 )

--- a/tests/package-common/vitest.config.ts
+++ b/tests/package-common/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineProject } from 'vitest/config'
 
 export default defineProject({
   test: {
-    name: '@livestore/common-cf',
+    name: '@local/tests-package-common',
     include: ['src/**/*.test.ts'],
   },
 })

--- a/tests/sync-provider/vitest.config.ts
+++ b/tests/sync-provider/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     testTimeout: 60000,
+    include: ['src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Problem

Addresses #966 - Users need visibility into sync state to determine backend health and display sync indicators in their UI.

## Solution

Added three new APIs to expose the sync status between client session and leader thread:

### Core APIs (`@livestore/livestore`)

- **`store.syncStatus()`** - Synchronous method returning current sync status
- **`store.subscribeSyncStatus(callback)`** - Callback-based subscription for sync status changes

### React Hook (`@livestore/react`)

- **`store.useSyncStatus()`** - React hook for reactive sync status updates

### SyncStatus Type

```ts
type SyncStatus = {
  localHead: string      // e.g., "e5.2" or "e5.2r1" (with rebase generation)
  upstreamHead: string   // e.g., "e3"
  pendingCount: number
  isSynced: boolean
}
```

### Example Usage

```tsx
function SyncIndicator() {
  const store = useStore(storeOptions)
  const status = store.useSyncStatus()
  
  return <span>{status.isSynced ? '✓ Synced' : `Syncing (${status.pendingCount} pending)...`}</span>
}
```

## Design Decisions

- Uses session's `upstreamHead` as proxy for leader state (synchronous, no async worker hop needed)
- Exposes session→leader sync level by default (what users care about for "is my data synced?")
- Uses `EventSequenceNumber.Client.toString()` for head formatting to preserve rebase generation (e.g., `e5.2r1`)

## Validation

- TypeScript builds successfully
- Documentation updated in react-integration.mdx

Closes #966
