### PR TITLE
fix(livestore): auto-dispose StoreRegistry runtime on garbage collection

### DIFF
--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -187,6 +187,12 @@ export class StoreRegistry {
   readonly #defaultOptions: StoreRegistryConfig['defaultOptions']
 
   /**
+   * Function to dispose the managed runtime, if this registry owns it.
+   * Undefined when a custom runtime was provided (user owns cleanup).
+   */
+  readonly #disposeRuntime: (() => Promise<void>) | undefined
+
+  /**
    * Creates a new StoreRegistry instance.
    *
    * @example
@@ -205,13 +211,15 @@ export class StoreRegistry {
     if (config.runtime) {
       // User provided a runtime - they own it, no automatic cleanup
       this.#runtime = config.runtime
+      this.#disposeRuntime = undefined
     } else {
       // Create runtime and register for automatic cleanup when this registry is GC'd.
       // The closure captures managedRuntime; when this StoreRegistry is GC'd, dispose is called,
       // which closes the runtime's scope and cascades to shut down all managed stores.
       const managedRuntime = ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy))
       this.#runtime = managedRuntime.runtimeEffect.pipe(Effect.runSync)
-      runtimeFinalizationRegistry.register(this, () => managedRuntime.dispose())
+      this.#disposeRuntime = () => managedRuntime.dispose()
+      runtimeFinalizationRegistry.register(this, this.#disposeRuntime)
     }
 
     // Copy defaultOptions to a local variable so the lookup closure doesn't capture `this`.
@@ -376,6 +384,45 @@ export class StoreRegistry {
       await this.getOrLoadPromise(options)
     } catch {
       // Do nothing; preload is best-effort
+    }
+  }
+
+  /**
+   * Disposes the registry and all its managed stores.
+   *
+   * Call this method when the registry is no longer needed to immediately release resources
+   * (database connections, WebSocket connections, etc.).
+   *
+   * Most applications should use a single, long-lived `StoreRegistry` and don't need to call
+   * this method. It's only necessary when creating multiple short-lived registries (e.g., one per client island)
+   * to immediately release resources and avoid lock conflicts with subsequent registries.
+   *
+   * @remarks
+   * - Has no effect if a custom runtime was provided (caller owns cleanup in that case)
+   * - Safe to call multiple times; subsequent calls are no-ops
+   * - After disposal, the registry should not be used
+   * - The {@link FinalizationRegistry} cleanup is unregistered to avoid double-disposal
+   *
+   * @example
+   * ```tsx
+   * function MyComponent() {
+   *   const [storeRegistry] = useState(() => new StoreRegistry())
+   *
+   *   useEffect(() => {
+   *     return () => {
+   *       void storeRegistry.dispose()
+   *     }
+   *   }, [storeRegistry])
+   *
+   *   // ...
+   * }
+   * ```
+   */
+  dispose = async (): Promise<void> => {
+    if (this.#disposeRuntime) {
+      // Unregister from `FinalizationRegistry` to avoid double-disposal
+      runtimeFinalizationRegistry.unregister(this)
+      await this.#disposeRuntime()
     }
   }
 }

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -137,6 +137,27 @@ class StoreCacheKey implements Equal.Equal {
 }
 
 /**
+ * Finalization registry used for automatic disposal of resources when a {@link StoreRegistry} instance is garbage collected.
+ *
+ * When a `StoreRegistry` goes out of scope (e.g., React component unmounts), JavaScript's garbage
+ * collector eventually reclaims it. This `FinalizationRegistry` ensures that the associated `ManagedRuntime` is
+ * disposed, which closes all store scopes, shutting them down and releasing resources to avoid resource leaks.
+ *
+ * Without this, garbage collection of a `StoreRegistry` would not trigger Effect finalizers, leaving store resources
+ * open indefinitely.
+ *
+ * @remarks
+ * - Finalization callbacks are not guaranteed to run, and timing is non-deterministic. This is acceptable for resource
+ * cleanup but should not be relied upon for essential program logic.
+ * - When passing a custom runtime to `StoreRegistry`, the caller is responsible for ensuring it is properly disposed.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry | FinalizationRegistry}
+ */
+const runtimeFinalizationRegistry = new FinalizationRegistry<() => Promise<void>>(
+  (disposeRuntime) => void disposeRuntime(),
+)
+
+/**
  * Store Registry coordinating store loading, caching, and retention
  *
  * @public
@@ -180,9 +201,18 @@ export class StoreRegistry {
    */
   constructor(config: StoreRegistryConfig = {}) {
     this.#defaultOptions = config.defaultOptions
-    this.#runtime =
-      config.runtime ??
-      ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy)).runtimeEffect.pipe(Effect.runSync)
+
+    if (config.runtime) {
+      // User provided a runtime - they own it, no automatic cleanup
+      this.#runtime = config.runtime
+    } else {
+      // Create runtime and register for automatic cleanup when this registry is GC'd.
+      // The closure captures managedRuntime; when this StoreRegistry is GC'd, dispose is called,
+      // which closes the runtime's scope and cascades to shut down all managed stores.
+      const managedRuntime = ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy))
+      this.#runtime = managedRuntime.runtimeEffect.pipe(Effect.runSync)
+      runtimeFinalizationRegistry.register(this, () => managedRuntime.dispose())
+    }
 
     this.#rcMap = RcMap.make({
       lookup: ({ options }: StoreCacheKey) => {

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -148,7 +148,7 @@ class StoreCacheKey implements Equal.Equal {
  *
  * @remarks
  * - Finalization callbacks are not guaranteed to run, and timing is non-deterministic. This is acceptable for resource
- * cleanup but should not be relied upon for essential program logic.
+ *   cleanup but should not be relied upon for essential program logic.
  * - When passing a custom runtime to `StoreRegistry`, the caller is responsible for ensuring it is properly disposed.
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry | FinalizationRegistry}
@@ -214,10 +214,14 @@ export class StoreRegistry {
       runtimeFinalizationRegistry.register(this, () => managedRuntime.dispose())
     }
 
+    // Copy defaultOptions to a local variable so the lookup closure doesn't capture `this`.
+    // Capturing `this` creates a reference cycle that prevents the garbage collection of `StoreRegistry`.
+    const defaultOptions = this.#defaultOptions
+
     this.#rcMap = RcMap.make({
       lookup: ({ options }: StoreCacheKey) => {
         // Merge registry defaults with call-site options (call-site takes precedence)
-        const mergedOptions = { ...this.#defaultOptions, ...options }
+        const mergedOptions = { ...defaultOptions, ...options }
         return createStore(mergedOptions).pipe(
           Effect.catchAllDefect((cause) => UnknownError.make({ cause })),
           Effect.withSpan(`StoreRegistry.lookup:${mergedOptions.storeId}`),


### PR DESCRIPTION
## Summary

- Use `FinalizationRegistry` to automatically dispose the `ManagedRuntime` when a `StoreRegistry` instance is garbage collected
- Ensures store resources (including WebSocket connections) are properly released when the registry goes out of scope

Fixes #961

## Problem

When a `StoreRegistry` goes out of scope (e.g., React component unmounts), JavaScript's garbage collector reclaims it, but this doesn't trigger Effect finalizers. This leaves WebSocket connections and other store resources open indefinitely.

## Solution

Register each `StoreRegistry` with a module-level `FinalizationRegistry`. When the registry is GC'd, the callback disposes the `ManagedRuntime`, which closes all store scopes and releases resources.

## Test plan

- [x] All existing `StoreRegistry` tests pass
- [ ] Manual verification with reproduction app: https://github.com/bohdanbirdie/livestore-ws-termination-issue

**Why no unit test for FinalizationRegistry:**

Direct testing of `FinalizationRegistry` behavior is not practical because:
- GC timing is non-deterministic and varies by environment/memory pressure
- `global.gc()` (with `--expose-gc` flag) doesn't guarantee finalization callbacks run immediately
- Per ECMAScript spec, finalization callbacks are not guaranteed to run at all

The `FinalizationRegistry` acts as a safety net for resource cleanup when the registry is garbage collected. Testing this would require forcing GC and observing side effects, which is inherently unreliable.