### PR TITLE
fix(livestore): add StoreRegistry.dispose() and fix resource cleanup

### DIFF
--- a/packages/@livestore/livestore/src/effect/LiveStore.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.ts
@@ -34,12 +34,6 @@ export const makeLiveStoreContext = <TSchema extends LiveStoreSchema, TContext =
         ...omitUndefineds({ context, boot, disableDevtools, onBootStatus, syncPayload, syncPayloadSchema }),
       })
 
-      globalThis.__debugLiveStore ??= {}
-      if (Object.keys(globalThis.__debugLiveStore).length === 0) {
-        globalThis.__debugLiveStore._ = store
-      }
-      globalThis.__debugLiveStore[storeId] = store
-
       return { stage: 'running', store } as any as LiveStoreContextRunning['Type']
     }),
     Effect.tapErrorCause((cause) => Effect.flatMap(DeferredStoreContext, (def) => Deferred.failCause(def, cause))),
@@ -249,12 +243,6 @@ const makeStoreTag = <TSchema extends LiveStoreSchema, TStoreId extends string>(
             }),
           })
 
-          globalThis.__debugLiveStore ??= {}
-          if (Object.keys(globalThis.__debugLiveStore).length === 0) {
-            globalThis.__debugLiveStore._ = store
-          }
-          globalThis.__debugLiveStore[storeId] = store
-
           const ctx: RunningType = { stage: 'running', store: store as StoreClass<TSchema> }
 
           // Also fulfill the deferred if it exists in context
@@ -398,12 +386,6 @@ export const makeStoreContext =
               syncPayloadSchema: props.syncPayloadSchema,
             }),
           })
-
-          globalThis.__debugLiveStore ??= {}
-          if (Object.keys(globalThis.__debugLiveStore).length === 0) {
-            globalThis.__debugLiveStore._ = store
-          }
-          globalThis.__debugLiveStore[storeId] = store
 
           const ctx: RunningType = { stage: 'running', store: store as StoreClass<TSchema> }
 

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -155,6 +155,12 @@ export class StoreRegistry {
   readonly #runtime: Runtime.Runtime<Scope.Scope | OtelTracer.OtelTracer>
 
   /**
+   * Disposal callback for the runtime created by the registry.
+   * Undefined when caller provided their own runtime (caller owns cleanup in that case).
+   */
+  readonly #disposeOwnedRuntime: (() => Promise<void>) | undefined
+
+  /**
    * In-flight loading promises keyed by storeId.
    * Ensures concurrent `getOrLoadPromise` calls receive the same Promise reference.
    */
@@ -174,9 +180,13 @@ export class StoreRegistry {
    * ```
    */
   constructor(config: StoreRegistryConfig = {}) {
-    this.#runtime =
-      config.runtime ??
-      ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy)).runtimeEffect.pipe(Effect.runSync)
+    if (config.runtime) {
+      this.#runtime = config.runtime
+    } else {
+      const ownedRuntime = ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy))
+      this.#runtime = ownedRuntime.runtimeEffect.pipe(Effect.runSync)
+      this.#disposeOwnedRuntime = () => ownedRuntime.dispose()
+    }
 
     this.#rcMap = RcMap.make({
       lookup: ({ options }: StoreCacheKey) => {
@@ -337,6 +347,25 @@ export class StoreRegistry {
     } catch {
       // Do nothing; preload is best-effort
     }
+  }
+
+  /**
+   * Disposes the registry and all its managed stores, immediately releasing resources
+   * (database connections, WebSocket connections, web workers, etc.).
+   *
+   * Most applications should use a single `StoreRegistry` and don't need to call
+   * this method. It's only necessary when creating multiple short-lived registries to
+   * immediately release resources and avoid conflicts with subsequent registries.
+   *
+   * @returns A promise that resolves when disposal is complete
+   *
+   * @remarks
+   * - No-op if a custom `runtime` was provided to the constructor (caller owns cleanup)
+   * - Idempotent: safe to call multiple times
+   * - After disposal, the registry should not be used
+   */
+  dispose = async (): Promise<void> => {
+    await this.#disposeOwnedRuntime?.()
   }
 }
 

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -161,11 +161,6 @@ export class StoreRegistry {
   readonly #loadingPromises: Map<string, Promise<Store<any, any>>> = new Map()
 
   /**
-   * Default options merged into all store configurations at load time.
-   */
-  readonly #defaultOptions: StoreRegistryConfig['defaultOptions']
-
-  /**
    * Creates a new StoreRegistry instance.
    *
    * @example
@@ -179,7 +174,6 @@ export class StoreRegistry {
    * ```
    */
   constructor(config: StoreRegistryConfig = {}) {
-    this.#defaultOptions = config.defaultOptions
     this.#runtime =
       config.runtime ??
       ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy)).runtimeEffect.pipe(Effect.runSync)
@@ -187,7 +181,7 @@ export class StoreRegistry {
     this.#rcMap = RcMap.make({
       lookup: ({ options }: StoreCacheKey) => {
         // Merge registry defaults with call-site options (call-site takes precedence)
-        const mergedOptions = { ...this.#defaultOptions, ...options }
+        const mergedOptions = { ...config.defaultOptions, ...options }
         return createStore(mergedOptions).pipe(
           Effect.catchAllDefect((cause) => UnknownError.make({ cause })),
           Effect.withSpan(`StoreRegistry.lookup:${mergedOptions.storeId}`),

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -420,6 +420,16 @@ export const createStore = <
 
       yield* Deferred.succeed(storeDeferred, store as any as Store)
 
+      // Expose store on globalThis for console debugging
+      globalThis.__debugLiveStore ??= {}
+      globalThis.__debugLiveStore[storeId] = store
+
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          delete globalThis.__debugLiveStore?.[storeId]
+        }),
+      )
+
       return store
     }).pipe(
       Effect.withSpan('createStore', { attributes: { debugInstanceId, storeId } }),

--- a/packages/@livestore/react/src/useStore.ts
+++ b/packages/@livestore/react/src/useStore.ts
@@ -73,13 +73,6 @@ export const useStore = <
 
   const store = storeOrPromise instanceof Promise ? React.use(storeOrPromise) : storeOrPromise
 
-  // Expose store on the global object for browser console debugging.
-  globalThis.__debugLiveStore ??= {}
-  if (Object.keys(globalThis.__debugLiveStore).length === 0) {
-    globalThis.__debugLiveStore._ = store
-  }
-  globalThis.__debugLiveStore[options.debug?.instanceId ?? options.storeId] = store
-
   return withReactApi(store)
 }
 


### PR DESCRIPTION
## Summary

- Add explicit `dispose()` method to `StoreRegistry` for deterministic resource cleanup
- Prevent reference cycle between `StoreRegistry` and its internal runtime to allow proper GC
- Centralize `__debugLiveStore` registration in `createStore` with cleanup on store disposal

Fixes #969
Supersedes #968

## Problem

When a `StoreRegistry` becomes unreachable (e.g., React component unmounts), its Effect scopes remain open, keeping WebSocket connections and browser locks alive indefinitely. This happens because:

1. **No explicit cleanup API** - There was no way to dispose registry resources without waiting for GC
2. **Reference cycle** - The registry held a reference to its runtime, which held a reference back to the registry via store callbacks, preventing GC from reclaiming it
3. **Debug leaks** - `globalThis.__debugLiveStore` accumulated store references that were never cleaned up

## Solution

1. **`StoreRegistry.dispose()`** - New method that immediately closes all managed store scopes and releases resources (database connections, WebSocket connections, web workers). Idempotent and no-op when a custom runtime is provided (caller owns cleanup).

2. **Break reference cycle** - Restructure internal callbacks to avoid holding strong references from the runtime back to the registry.

3. **Centralize debug registration** - Move `__debugLiveStore` setup from framework layers (React/Effect) to `createStore`, using `Effect.addFinalizer` for automatic cleanup when stores are disposed.

## Test plan

- [x] Existing `StoreRegistry` tests pass
- [x] TypeScript compilation succeeds
- [ ] Manual verification with reproduction app