### PR TITLE
refactor(react)!: remove StoreRegistry and storeOptions re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,8 @@
   }
 
   // After
-  import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+  import { StoreRegistry } from '@livestore/livestore'
+  import { StoreRegistryProvider, useStore } from '@livestore/react'
 
   const useAppStore = () => useStore({
     storeId: 'app-root',

--- a/contributor-docs/rfcs/0001-multi-store-api-design.md
+++ b/contributor-docs/rfcs/0001-multi-store-api-design.md
@@ -177,7 +177,7 @@ function storeOptions<TSchema extends LiveStoreSchema>(
 // src/stores/workspace/index.ts
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { schema, workspaceEvents, workspaceTables } from './schema.ts'
 import worker from './worker.ts?worker'
 
@@ -204,7 +204,7 @@ export const workspaceStoreOptions = storeOptions({
 // src/stores/issue/index.ts
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { issueEvents, issueTables, schema } from './schema.ts'
 import worker from './worker.ts?worker'
 
@@ -230,7 +230,7 @@ Instantiates the registry that coordinates caching, ref-counting, garbage collec
 **Example:**
 
 ```tsx
-import { StoreRegistry } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 
 const storeRegistry = new StoreRegistry({
@@ -250,13 +250,14 @@ Supplies a `StoreRegistry` instance to descendants via context.
 **Example:**
 
 ```tsx
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 
 
 export default function App({ children }: { children: React.ReactNode }) {
   const [storeRegistry] = useState(() => new StoreRegistry())
-  
+
   return <StoreRegistryProvider storeRegistry={storeRegistry}>{children}</StoreRegistryProvider>
 }
 ```
@@ -853,12 +854,11 @@ declare function useStore<TSchema extends LiveStoreSchema>(
 ```tsx
 import { useState, useMemo, Suspense } from "react";
 import { unstable_batchedUpdates as batchUpdates } from "react-dom";
+import { StoreRegistry, storeOptions } from "@livestore/livestore";
 import {
-  StoreRegistry,
   StoreRegistryProvider,
   useStoreRegistry,
   useStore,
-  storeOptions,
 } from "@livestore/react";
 import {
   workspaceSchema,

--- a/docs/src/content/_assets/code/data-modeling/todo-workspaces/App.tsx
+++ b/docs/src/content/_assets/code/data-modeling/todo-workspaces/App.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { type ReactNode, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 

--- a/docs/src/content/_assets/code/data-modeling/todo-workspaces/workspace.store.ts
+++ b/docs/src/content/_assets/code/data-modeling/todo-workspaces/workspace.store.ts
@@ -1,6 +1,6 @@
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { schema } from './workspace.schema.ts'
 import worker from './workspace.worker.ts?worker'
 

--- a/docs/src/content/_assets/code/getting-started/expo/Root.tsx
+++ b/docs/src/content/_assets/code/getting-started/expo/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { StatusBar } from 'expo-status-bar'
 import { type FC, Suspense, useState } from 'react'
 import { SafeAreaView, Text, View } from 'react-native'

--- a/docs/src/content/_assets/code/getting-started/react-web/Root.tsx
+++ b/docs/src/content/_assets/code/getting-started/react-web/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import type React from 'react'
 import { Suspense, useState } from 'react'
 

--- a/docs/src/content/_assets/code/patterns/auth/store-with-auth.tsx
+++ b/docs/src/content/_assets/code/patterns/auth/store-with-auth.tsx
@@ -1,6 +1,6 @@
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
-import type { LiveStoreSchema } from '@livestore/livestore'
-import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+import { type LiveStoreSchema, StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import { Suspense, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/App.tsx
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/App.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { type ReactNode, Suspense, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { ErrorBoundary } from 'react-error-boundary'

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/issue.store.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/issue.store.ts
@@ -1,5 +1,5 @@
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { schema } from './issue.schema.ts'
 
 // Define reusable store configuration with storeOptions()

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/minimal.tsx
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/minimal.tsx
@@ -1,6 +1,6 @@
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
-import { queryDb } from '@livestore/livestore'
-import { StoreRegistry, StoreRegistryProvider, storeOptions, useStore } from '@livestore/react'
+import { queryDb, StoreRegistry, storeOptions } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import { useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { schema, tables } from './issue.schema.ts'

--- a/docs/src/content/_assets/code/reference/opentelemetry/app.tsx
+++ b/docs/src/content/_assets/code/reference/opentelemetry/app.tsx
@@ -1,5 +1,6 @@
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
-import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import type { FC } from 'react'
 import { Suspense, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'

--- a/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/usage.tsx
+++ b/docs/src/content/_assets/code/reference/platform-adapters/expo-adapter/usage.tsx
@@ -1,6 +1,6 @@
 import { makePersistedAdapter } from '@livestore/adapter-expo'
-import { queryDb } from '@livestore/livestore'
-import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+import { queryDb, StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import { Suspense, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates, SafeAreaView, Text } from 'react-native'
 

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -244,7 +244,8 @@ Use the `component` prop on `createRootRoute` for `<StoreRegistryProvider>`:
 
 ```tsx
 import { Outlet, HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { Suspense, useState } from 'react'
 
 export const Route = createRootRoute({

--- a/docs/src/content/docs/patterns/storybook.mdx
+++ b/docs/src/content/docs/patterns/storybook.mdx
@@ -38,7 +38,8 @@ const LiveStoreDecorator = createLiveStoreDecorator()
 export const decorators = [LiveStoreDecorator]`,
 
   decorator: `import React, { Suspense, useState } from 'react'
-import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { schema } from './schema'

--- a/docs/src/content/docs/tutorial/3-read-and-write-todos-via-livestore.mdx
+++ b/docs/src/content/docs/tutorial/3-read-and-write-todos-via-livestore.mdx
@@ -193,7 +193,8 @@ Then, update `main.tsx` to wrap your `<App>` component inside the `<StoreRegistr
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { Suspense, useState } from 'react'
 
 const Root = () => {

--- a/examples/cf-chat/src/App.tsx
+++ b/examples/cf-chat/src/App.tsx
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import React, { Suspense, useRef, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { VersionBadge } from './components/VersionBadge.tsx'

--- a/examples/expo-linearlite/src/app/_layout.tsx
+++ b/examples/expo-linearlite/src/app/_layout.tsx
@@ -1,7 +1,8 @@
 import 'react-native-reanimated'
 import '../polyfill.ts'
 
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { Stack } from 'expo-router'
 import { Suspense, useState } from 'react'
 import { LogBox, Platform } from 'react-native'

--- a/examples/expo-todomvc-sync-cf/src/Root.tsx
+++ b/examples/expo-todomvc-sync-cf/src/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { StatusBar } from 'expo-status-bar'
 import { Suspense, useState } from 'react'
 import { StyleSheet, Text, View } from 'react-native'

--- a/examples/web-email-client/src/App.tsx
+++ b/examples/web-email-client/src/App.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { Suspense, useEffect, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { ErrorBoundary } from 'react-error-boundary'

--- a/examples/web-email-client/src/stores/mailbox/index.ts
+++ b/examples/web-email-client/src/stores/mailbox/index.ts
@@ -1,6 +1,7 @@
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions, useStore } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
+import { useStore } from '@livestore/react'
 import { schema } from './schema.ts'
 import worker from './worker.ts?worker'
 

--- a/examples/web-email-client/src/stores/thread/index.ts
+++ b/examples/web-email-client/src/stores/thread/index.ts
@@ -1,6 +1,6 @@
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { schema } from './schema.ts'
 import worker from './worker.ts?worker'
 

--- a/examples/web-multi-store/src/router.ts
+++ b/examples/web-multi-store/src/router.ts
@@ -1,4 +1,4 @@
-import { StoreRegistry } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
 import { createRouter } from '@tanstack/react-router'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 

--- a/examples/web-multi-store/src/routes/__root.tsx
+++ b/examples/web-multi-store/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import type { StoreRegistry } from '@livestore/react'
+import type { StoreRegistry } from '@livestore/livestore'
 import { createRootRouteWithContext, HeadContent, Link, Outlet, Scripts } from '@tanstack/react-router'
 import type { ReactNode } from 'react'
 import stylesheetUrl from '@/styles.css?url'

--- a/examples/web-multi-store/src/stores/issue/index.ts
+++ b/examples/web-multi-store/src/stores/issue/index.ts
@@ -1,7 +1,7 @@
 import { makeAdapter as makeNodeAdapter } from '@livestore/adapter-node'
 import { makePersistedAdapter as makeWebPersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { createIsomorphicFn } from '@tanstack/react-start'
 import { issueEvents, issueTables, schema } from './schema.ts'
 import worker from './worker.ts?worker'

--- a/examples/web-multi-store/src/stores/workspace/index.ts
+++ b/examples/web-multi-store/src/stores/workspace/index.ts
@@ -1,7 +1,7 @@
 import { makeAdapter as makeNodeAdapter } from '@livestore/adapter-node'
 import { makePersistedAdapter as makeWebPersistedAdapter } from '@livestore/adapter-web'
 import sharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { storeOptions } from '@livestore/react'
+import { storeOptions } from '@livestore/livestore'
 import { createIsomorphicFn } from '@tanstack/react-start'
 import { schema, workspaceEvents, workspaceTables } from './schema.ts'
 import worker from './worker.ts?worker'

--- a/examples/web-todomvc-experimental/src/Root.tsx
+++ b/examples/web-todomvc-experimental/src/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { FPSMeter } from '@overengineering/fps-meter'
 import type React from 'react'
 import { Suspense, useState } from 'react'

--- a/examples/web-todomvc-react-router/src/Root.tsx
+++ b/examples/web-todomvc-react-router/src/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { FPSMeter } from '@overengineering/fps-meter'
 import type React from 'react'
 import { Suspense, useEffect, useState } from 'react'

--- a/examples/web-todomvc-redwood/src/app/todomvc/TodoApp.tsx
+++ b/examples/web-todomvc-redwood/src/app/todomvc/TodoApp.tsx
@@ -2,7 +2,8 @@
 
 import 'todomvc-app-css/index.css'
 
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { FPSMeter } from '@overengineering/fps-meter'
 import type React from 'react'
 import { Suspense, useState } from 'react'

--- a/examples/web-todomvc-sync-cf/src/Root.tsx
+++ b/examples/web-todomvc-sync-cf/src/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { FPSMeter } from '@overengineering/fps-meter'
 import type React from 'react'
 import { Suspense, useState } from 'react'

--- a/examples/web-todomvc-sync-electric/src/router.ts
+++ b/examples/web-todomvc-sync-electric/src/router.ts
@@ -1,4 +1,4 @@
-import { StoreRegistry } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
 import { createRouter } from '@tanstack/react-router'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { routeTree } from './routeTree.gen.ts'

--- a/examples/web-todomvc-sync-electric/src/routes/__root.tsx
+++ b/examples/web-todomvc-sync-electric/src/routes/__root.tsx
@@ -1,4 +1,5 @@
-import { type StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import type { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
 import type * as React from 'react'
 import { Suspense } from 'react'

--- a/examples/web-todomvc-sync-s2/src/routes/__root.tsx
+++ b/examples/web-todomvc-sync-s2/src/routes/__root.tsx
@@ -1,4 +1,5 @@
-import { type StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import type { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
 import type * as React from 'react'
 import { Suspense } from 'react'

--- a/examples/web-todomvc/src/Root.tsx
+++ b/examples/web-todomvc/src/Root.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { FPSMeter } from '@overengineering/fps-meter'
 import type React from 'react'
 import { Suspense, useState } from 'react'

--- a/packages/@livestore/react/src/mod.ts
+++ b/packages/@livestore/react/src/mod.ts
@@ -1,4 +1,3 @@
-export { StoreRegistry, storeOptions } from '@livestore/livestore'
 export { LiveList, type LiveListProps } from './experimental/components/LiveList.tsx'
 export * from './StoreRegistryContext.tsx'
 export type {

--- a/tests/integration/src/tests/devtools/fixtures/repro-731/main.ts
+++ b/tests/integration/src/tests/devtools/fixtures/repro-731/main.ts
@@ -1,4 +1,4 @@
-import { StoreRegistry } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
 
 import { liveStoreAdapter } from './adapter.ts'
 import { schema } from './schema.ts'

--- a/tests/integration/src/tests/playwright/fixtures/adapter-web/Root.tsx
+++ b/tests/integration/src/tests/playwright/fixtures/adapter-web/Root.tsx
@@ -1,6 +1,7 @@
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import LiveStoreSharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import React, { memo, Suspense, useState } from 'react'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 import { ErrorBoundary } from 'react-error-boundary'

--- a/tests/integration/src/tests/playwright/fixtures/devtools/todomvc/Root.tsx
+++ b/tests/integration/src/tests/playwright/fixtures/devtools/todomvc/Root.tsx
@@ -1,6 +1,7 @@
 import 'todomvc-app-css/index.css'
 
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import type React from 'react'
 import { Suspense, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'

--- a/tests/integration/src/tests/playwright/fixtures/devtools/two-stores/Root.tsx
+++ b/tests/integration/src/tests/playwright/fixtures/devtools/two-stores/Root.tsx
@@ -1,6 +1,7 @@
 import { makeInMemoryAdapter, makePersistedAdapter } from '@livestore/adapter-web'
 import LiveStoreSharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
-import { StoreRegistry, StoreRegistryProvider, useStore } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import { Suspense, useState } from 'react'
 import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
 

--- a/tests/perf-eventlog/test-app/src/main.tsx
+++ b/tests/perf-eventlog/test-app/src/main.tsx
@@ -1,4 +1,5 @@
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { Suspense, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { DEFAULT_EVENT_BATCH_SIZE, EventControls } from './components/EventControls.tsx'

--- a/tests/perf/test-app/src/main.tsx
+++ b/tests/perf/test-app/src/main.tsx
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/nursery: testing */
 /** biome-ignore-all lint/correctness/useUniqueElementIds: it's ok for testing */
-import { StoreRegistry, StoreRegistryProvider } from '@livestore/react'
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import React, { StrictMode, Suspense, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 


### PR DESCRIPTION
## Summary

- Remove convenience re-exports of `StoreRegistry` and `storeOptions` from `@livestore/react`
- These framework-agnostic primitives now only come from `@livestore/livestore`
- Clarifies API surface: `@livestore/react` exports only React-specific bindings

## Breaking Change

Import `StoreRegistry` and `storeOptions` from `@livestore/livestore` instead of `@livestore/react`:

```typescript
// Before
import { StoreRegistry, StoreRegistryProvider, storeOptions } from '@livestore/react'

// After
import { StoreRegistry, storeOptions } from '@livestore/livestore'
import { StoreRegistryProvider } from '@livestore/react'
```

## Test plan

- [x] TypeScript compilation passes (`mono ts`)
- [x] Linting passes (`mono lint`)
- [x] All docs, examples, and tests updated to use correct imports