### PR TITLE
fix(livestore): add proper global type for __debugLiveStore

### DIFF
--- a/packages/@livestore/livestore/src/ambient.d.ts
+++ b/packages/@livestore/livestore/src/ambient.d.ts
@@ -1,10 +1,3 @@
-// interface Window {
-//   [key: `__debug${string}`]: any
-// }
-
-var __debugLiveStore: any
-var __debugLiveStoreUtils: any
-
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -43,6 +43,11 @@ import type {
 } from './store-types.ts'
 import { StoreInternalsSymbol } from './store-types.ts'
 
+declare global {
+  /** Store instances for console debugging */
+  var __debugLiveStore: Record<string, Store<any, any>> | undefined
+}
+
 /**
  * @deprecated Use `makeStoreContext()` from `@livestore/livestore/effect` instead.
  * This service doesn't preserve schema types. See the Effect integration docs for migration.

--- a/packages/@livestore/react/src/ambient.d.ts
+++ b/packages/@livestore/react/src/ambient.d.ts
@@ -1,1 +1,0 @@
-var __debugLiveStore: any


### PR DESCRIPTION
## Summary

- Adds proper `declare global` type declaration for `__debugLiveStore` in `create-store.ts`, fixing TS7017 errors when accessing `globalThis.__debugLiveStore`
- Removes redundant ambient declarations from `ambient.d.ts` files that weren't properly extending `globalThis`

## Test plan

- [x] `mono ts` passes without errors
- [x] `mono lint` passes