### PR TITLE
fixes for things I noticed on a fresh checkout of the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-docs/src/content/docs/contributing/contributing.md
+docs/src/content/docs/sustainable-open-source/contributing/info.md

--- a/packages/@livestore/webmesh/src/node.ts
+++ b/packages/@livestore/webmesh/src/node.ts
@@ -552,7 +552,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
             schema,
             queue: channelQueue,
             sendPacket,
-            simulation,
+            ...(simulation !== undefined ? { simulation } : {}),
           })
 
           channelMap.set(channelKey, { queue: channelQueue, debugInfo: { channel, target } })


### PR DESCRIPTION
<!-- Use a title that captures the problem and the approach, e.g. "Fix backlog replay flake by stabilizing event helper" -->

## Problem

Just a few things that I noticed when initially checking out the repo on my work computer.

## Solution

* fix 'tsc --build tsconfig.dev.json' (used in devenv shell startup)
  * this was causing error messages to be printed when starting up a new shell in a clean clone of the repo
  * This probably doesn't affect you most of the time, because the webmesh package has `exactOptionalPropertyTypes` explicitly turned off. My guess is that builds within that dir would pass and leave around cached files that would make the main top level build skip over these files? I didn't dig too hard.
* Fix CONTRIBUTING.md symlink
  * I guess this was moved when the docs site was updated, and that broke the symlink.
  * Interestingly, this is caught if you run `biome lint` at the top level of the repo. If you want me to, I can fix the other `biome lint` errors, and add that to the CI and/or precommit hook, so this can't regress. 

## Validation

* `tsc --build tsconfig.dev.json --clean && tsc --build tsconfig.dev.json`
* `head CHANGELOG.md`
