### PR TITLE
feat(wa-sqlite): ability to execute() multiple dependent SQL statements in the same sql string

### DIFF
--- a/packages/@livestore/wa-sqlite/src/sqlite-api.js
+++ b/packages/@livestore/wa-sqlite/src/sqlite-api.js
@@ -842,6 +842,102 @@ export function Factory(Module) {
       return stmts;
   };
 
+  /**
+   * Iterate over SQL statements one at a time (synchronous generator version).
+   * 
+   * This is similar to upstream wa-sqlite's async generator pattern, but uses
+   * a synchronous generator to avoid async overhead. Unlike statements(), this
+   * prepares each statement lazily as you iterate, which allows later statements
+   * to depend on earlier ones (e.g., CREATE TABLE then INSERT INTO that table).
+   * 
+   * @param {number} db - Database handle
+   * @param {string} sql - SQL string containing one or more statements
+   * @param {Object} options - Options object
+   * @param {boolean} options.unscoped - If true, caller is responsible for finalizing statements
+   * @param {number} options.flags - Flags to pass to sqlite3_prepare_v3
+   * @returns {Generator<number>} Generator that yields statement handles
+   * 
+   * @example
+   * for (const stmt of sqlite3._iterStatements(db, sql, { unscoped: true })) {
+   *   sqlite3.step(stmt);
+   *   sqlite3.finalize(stmt);
+   * }
+   * 
+   * @private This is an internal API that may change without notice
+   */
+  sqlite3._iterStatements = function*(db, sql, options = {}) {
+    verifyDatabase(db);
+
+    const prepare = Module.cwrap(
+      'sqlite3_prepare_v3',
+      'number',
+      ['number', 'number', 'number', 'number', 'number', 'number'],
+      { async: false });
+
+    // Encode SQL string to UTF-8.
+    const utf8 = textEncoder.encode(sql);
+
+    // Copy encoded string to WebAssembly memory. The SQLite docs say
+    // zero-termination is a minor optimization so add room for that.
+    // Also add space for the statement handle and SQL tail pointer.
+    const allocSize = utf8.byteLength - (utf8.byteLength % 4) + 12;
+    const pzHead = Module._sqlite3_malloc(allocSize);
+    const pzEnd = pzHead + utf8.byteLength + 1;
+    Module.HEAPU8.set(utf8, pzHead);
+    Module.HEAPU8[pzEnd - 1] = 0;
+
+    // Use extra space for the statement handle and SQL tail pointer.
+    const pStmt = pzHead + allocSize - 8;
+    const pzTail = pzHead + allocSize - 4;
+
+    const onFinally = [];
+    try {
+      // Encode is already done above, add cleanup
+      onFinally.push(() => Module._sqlite3_free(pzHead));
+
+      // Ensure that statement handles are not leaked.
+      let stmt;
+      function maybeFinalize() {
+        if (stmt && !options.unscoped) {
+          sqlite3.finalize(stmt);
+        }
+        stmt = 0;
+      }
+      onFinally.push(maybeFinalize);
+      
+      // Loop over statements, preparing and yielding one at a time.
+      Module.setValue(pzTail, pzHead, '*');
+      do {
+        // Reclaim resources for the previous iteration.
+        maybeFinalize();
+
+        // Call sqlite3_prepare_v3() for the next statement.
+        const zTail = Module.getValue(pzTail, '*');
+        const rc = prepare(
+          db,
+          zTail,
+          pzEnd - zTail,
+          options.flags || 0,
+          pStmt,
+          pzTail);
+
+        if (rc !== SQLite.SQLITE_OK) {
+          check('sqlite3_prepare_v3', rc, db);
+        }
+        
+        stmt = Module.getValue(pStmt, '*');
+        if (stmt) {
+          mapStmtToDB.set(stmt, db);
+          yield stmt;
+        }
+      } while (stmt);
+    } finally {
+      while (onFinally.length) {
+        onFinally.pop()();
+      }
+    }
+  };
+
   sqlite3.step = (function() {
     const fname = 'sqlite3_step';
     const f = Module.cwrap(fname, ...decl('n:n'), { async });

--- a/packages/@livestore/wa-sqlite/src/types/index.d.ts
+++ b/packages/@livestore/wa-sqlite/src/types/index.d.ts
@@ -814,6 +814,29 @@ interface SQLiteAPI {
   statements(db: number, sql: string, options?: SQLitePrepareOptions): ReadonlyArray<number>;
 
   /**
+   * Iterate over SQL statements one at a time (synchronous generator version).
+   * 
+   * This is similar to upstream wa-sqlite's async generator pattern, but uses
+   * a synchronous generator to avoid async overhead. Unlike statements(), this
+   * prepares each statement lazily as you iterate, which allows later statements
+   * to depend on earlier ones (e.g., CREATE TABLE then INSERT INTO that table).
+   * 
+   * @param db - Database handle
+   * @param sql - SQL string containing one or more statements
+   * @param options - Options object
+   * @returns Generator that yields statement handles
+   * 
+   * @example
+   * for (const stmt of sqlite3._iterStatements(db, sql, { unscoped: true })) {
+   *   sqlite3.step(stmt);
+   *   sqlite3.finalize(stmt);
+   * }
+   * 
+   * @private This is an internal API that may change without notice
+   */
+  _iterStatements(db: number, sql: string, options?: SQLitePrepareOptions): Generator<number>;
+
+  /**
    * Evaluate an SQL statement
    * @see https://www.sqlite.org/c3ref/step.html
    * @param stmt prepared statement pointer

--- a/tests/wa-sqlite/test/lib/lib.ts
+++ b/tests/wa-sqlite/test/lib/lib.ts
@@ -18,7 +18,10 @@ export type SynchronousDatabase = {
   execute(
     queryStr: string,
     bindValues?: PreparedBindValues | undefined,
-    options?: { onRowsChanged?: (rowsChanged: number) => void },
+    options?: {
+      onRowsChanged?: (rowsChanged: number) => void
+      multiStatementWithSchemaChanges?: boolean
+    },
   ): void
   select<T>(queryStr: string, bindValues?: PreparedBindValues | undefined): ReadonlyArray<T>
   export(): Uint8Array
@@ -138,9 +141,30 @@ export const makeSynchronousDatabase = (sqlite3: SQLiteAPI, db: number): Synchro
     },
     export: () => exportDb(sqlite3, db),
     execute: (queryStr, bindValues, options) => {
-      const stmt = syncDb.prepare(queryStr)
-      stmt.execute(bindValues, options)
-      stmt.finalize()
+      if (options?.multiStatementWithSchemaChanges) {
+        // Use _iterStatements to support multiple statements where later ones
+        // depend on earlier ones (e.g., CREATE TABLE then INSERT)
+        for (const stmt of sqlite3._iterStatements(db, queryStr.trim(), { unscoped: true })) {
+          try {
+            if (bindValues !== undefined && Object.keys(bindValues).length > 0) {
+              sqlite3.bind_collection(stmt, bindValues as any)
+            }
+
+            sqlite3.step(stmt)
+
+            if (options?.onRowsChanged) {
+              options.onRowsChanged(sqlite3.changes(db))
+            }
+          } finally {
+            sqlite3.finalize(stmt)
+          }
+        }
+      } else {
+        // Default behavior
+        const stmt = syncDb.prepare(queryStr)
+        stmt.execute(bindValues, options)
+        stmt.finalize()
+      }
     },
     select: (queryStr, bindValues) => {
       const stmt = syncDb.prepare(queryStr)

--- a/tests/wa-sqlite/test/lib/sqlite-utils.ts
+++ b/tests/wa-sqlite/test/lib/sqlite-utils.ts
@@ -94,19 +94,50 @@ export const select = (
   return results
 }
 
+/**
+ * Execute one or more SQL statements.
+ *
+ * @param sqlite3 - SQLite API instance
+ * @param dbPointer - Database pointer
+ * @param query - SQL string containing one or more statements
+ * @param bindValues - Optional bind values (only applied to first statement if multiple)
+ * @param options - Execution options
+ * @param options.multiStatementWithSchemaChanges - If true, uses _iterStatements() to prepare
+ *   statements one at a time, allowing later statements to depend on earlier ones (e.g., CREATE
+ *   TABLE then INSERT). Default is false for backward compatibility.
+ */
 export const exec = (
   sqlite3: WaSqlite.SQLiteAPI,
   dbPointer: number,
   query: string,
   bindValues?: PreparedBindValues,
+  options?: { multiStatementWithSchemaChanges?: boolean },
 ) => {
-  const stmt = prepare(sqlite3, dbPointer, query)
-  stmt.execute(bindValues ?? {}, {
-    onRowsChanged: (changes: number) => {
-      return changes
-    },
-  })
-  stmt.finalize()
+  if (options?.multiStatementWithSchemaChanges) {
+    // Use _iterStatements to prepare and execute statements one at a time.
+    // This allows later statements to depend on earlier ones (e.g., CREATE TABLE then INSERT).
+    for (const stmt of sqlite3._iterStatements(dbPointer, query, { unscoped: true })) {
+      try {
+        // Only bind values to the first statement
+        if (bindValues !== undefined && Object.keys(bindValues).length > 0) {
+          sqlite3.bind_collection(stmt, bindValues as any)
+        }
+
+        sqlite3.step(stmt)
+      } finally {
+        sqlite3.finalize(stmt)
+      }
+    }
+  } else {
+    // Default behavior: use statements() which prepares all statements upfront
+    const stmt = prepare(sqlite3, dbPointer, query)
+    stmt.execute(bindValues ?? {}, {
+      onRowsChanged: (changes: number) => {
+        return changes
+      },
+    })
+    stmt.finalize()
+  }
 }
 
 export const prepare = (sqlite3: WaSqlite.SQLiteAPI, dbPointer: number, queryStr: string) => {

--- a/tests/wa-sqlite/test/unit/basic-sqlite-api.test.ts
+++ b/tests/wa-sqlite/test/unit/basic-sqlite-api.test.ts
@@ -161,4 +161,25 @@ describe('Basic SQLite Synchronous API', () => {
 
     expect(rowsChanged).toBe(2)
   })
+
+  it('should execute multiple statements in a single SQL string with multiStatementWithSchemaChanges option', () => {
+    // Execute multiple statements where the first creates a table and the second uses it
+    // This requires multiStatementWithSchemaChanges: true to prepare statements one at a time
+    syncDb.execute(
+      `
+      CREATE TABLE numbers (id INTEGER PRIMARY KEY, value INTEGER);
+      INSERT INTO numbers (value) VALUES (42);
+      INSERT INTO numbers (value) VALUES (100);
+    `,
+      undefined,
+      { multiStatementWithSchemaChanges: true },
+    )
+
+    // Query the table to verify all statements were executed
+    const numbers = syncDb.select<{ id: number; value: number }>('SELECT * FROM numbers ORDER BY id')
+
+    expect(numbers).toHaveLength(2)
+    expect(numbers[0]).toEqual({ id: 1, value: 42 })
+    expect(numbers[1]).toEqual({ id: 2, value: 100 })
+  })
 })


### PR DESCRIPTION
This is a bit of a tenuous one. If this isn't something that livestore will ever need then I'm happy for it to be closed.

## Context

I made an advent of code UI for sqlite (https://github.com/alsuren/aoc-sqlite). I make it execute the user-provided queries in the browser without any backend. I had an initial implementation based on the official sqlite wasm build, and that was working fine (even if the user's solution included creating tables). 

For funzies, I decided to rewrite the UI using livestore. I didn't want to end up shipping two copies of sqlite, so I switched the execution engine to livestore's fork of wa-sqlite as well. 

## Problem

When executing a query string that contains multiple statements, if the first one creates a table and the second one tries to reference that table, livestore's sqlite engine will crap out while trying to prepare the second statement (because the table doesn't exist until the first query is executed).

For example:

```
      CREATE TABLE numbers (id INTEGER PRIMARY KEY, value INTEGER);
      INSERT INTO numbers (value) VALUES (42);
```

Upstream wa-sqlite doesn't have this problem because it uses an async iterator to prepare and execute the statements in sequence.

I haven't looked into how upstream wa-sqlite deals with making prepared statements from strings containing multiple statements (this seems to be a thing that the livestore wa-sqlite can do).

As an extra data point, Durable Objects doesn't have this problem, because it also only ever prepares one statement at a time. It's worth noting that in durable objects, if you prepare a string with multiple statements in it, it will syncronously execute all statements apart from the first one, and then hand you back only the last statement as a prepared statement (I think this is in workerd.

## Solution

How does this change resolve the problem? Mention trade-offs when relevant. Did you consider any other solution ideas?

I decided not to be brave here, so I added a multiStatementWithSchemaChanges option to make execute() behave more like upstream wa-sqlite (prepare and execute each statement before moving on to the next).

- Add multiStatementWithSchemaChanges option to exec() and syncDb.execute() helper functions to opt into the new behavior
- Add private _iterStatements() generator in wa-sqlite that lazily prepares statements one at a time, following upstream wa-sqlite's pattern
- Add test demonstrating multi-statement execution with schema changes
- Default behavior unchanged for backward compatibility (requires explicit opt-in)

If I was braver, I might consider making this the default behaviour of execute(). I am a bit concerned about potential performance regressions though, so I would need to benchmark the new solution against the old one (you might consider this patch as an intermediate step on this journey, because it should allow benchmarking one implementation against the other).

As an aside: I noticed that you are looking for a maintainer for the livestore wa-sqlite fork. I might be interested in helping out a bit there. I will reach out on discord. This PR as it stands takes the livestore fork further away from upstream, but the braver version would take us closer again.


## Validation

What did you do to verify the change (tests, manual checks, or "not run" with reasoning)?

I started with a test exercising the problem.

- [x] Independently, I will make a `pnpm patch` in my aoc-sqlite repo and make sure that it solves the problem.
