### PR TITLE
Unify SQL `BindValues` type across codebase

### DIFF
--- a/packages/@livestore/adapter-web/src/common/connection.ts
+++ b/packages/@livestore/adapter-web/src/common/connection.ts
@@ -1,11 +1,10 @@
 import type { PreparedBindValues, SqliteDb } from '@livestore/common'
-import { prepareBindValues, SqliteError } from '@livestore/common'
-import type { BindValues } from '@livestore/common/sql-queries'
+import { prepareQueryBindValues, SqliteError, type SqlQueryBindParams } from '@livestore/common'
 import type { WaSqlite } from '@livestore/sqlite-wasm'
 import { Effect } from '@livestore/utils/effect'
 
-export const execSql = (sqliteDb: SqliteDb, sql: string, bind: BindValues) => {
-  const bindValues = prepareBindValues(bind, sql)
+export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlQueryBindParams) => {
+  const bindValues = prepareQueryBindValues(bind, sql)
   return Effect.try({
     try: () => sqliteDb.execute(sql, bindValues),
     catch: (cause) =>

--- a/packages/@livestore/adapter-web/src/common/connection.ts
+++ b/packages/@livestore/adapter-web/src/common/connection.ts
@@ -1,10 +1,10 @@
 import type { PreparedBindValues, SqliteDb } from '@livestore/common'
-import { prepareQueryBindValues, SqliteError, type SqlQueryBindParams } from '@livestore/common'
+import { prepareBindValues, type SqlBindParams, SqliteError } from '@livestore/common'
 import type { WaSqlite } from '@livestore/sqlite-wasm'
 import { Effect } from '@livestore/utils/effect'
 
-export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlQueryBindParams) => {
-  const bindValues = prepareQueryBindValues(bind, sql)
+export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlBindParams) => {
+  const bindValues = prepareBindValues(bind, sql)
   return Effect.try({
     try: () => sqliteDb.execute(sql, bindValues),
     catch: (cause) =>

--- a/packages/@livestore/adapter-web/src/common/connection.ts
+++ b/packages/@livestore/adapter-web/src/common/connection.ts
@@ -1,5 +1,5 @@
 import type { PreparedBindValues, SqliteDb } from '@livestore/common'
-import { prepareBindValues, type BindValues, SqliteError } from '@livestore/common'
+import { type BindValues, prepareBindValues, SqliteError } from '@livestore/common'
 import type { WaSqlite } from '@livestore/sqlite-wasm'
 import { Effect } from '@livestore/utils/effect'
 

--- a/packages/@livestore/adapter-web/src/common/connection.ts
+++ b/packages/@livestore/adapter-web/src/common/connection.ts
@@ -1,9 +1,9 @@
 import type { PreparedBindValues, SqliteDb } from '@livestore/common'
-import { prepareBindValues, type SqlBindParams, SqliteError } from '@livestore/common'
+import { prepareBindValues, type BindValues, SqliteError } from '@livestore/common'
 import type { WaSqlite } from '@livestore/sqlite-wasm'
 import { Effect } from '@livestore/utils/effect'
 
-export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlBindParams) => {
+export const execSql = (sqliteDb: SqliteDb, sql: string, bind: BindValues) => {
   const bindValues = prepareBindValues(bind, sql)
   return Effect.try({
     try: () => sqliteDb.execute(sql, bindValues),

--- a/packages/@livestore/cli/src/commands/mcp-tool-handlers.ts
+++ b/packages/@livestore/cli/src/commands/mcp-tool-handlers.ts
@@ -150,7 +150,7 @@ export const schema = Schema.create({
 
   // Execute a raw SQL query against the local client DB
   livestore_instance_query: Effect.fnUntraced(function* ({ sql, bindValues }) {
-    return yield* Runtime.query({ sql, bindValues })
+    return yield* Runtime.query({ sql, ...(bindValues !== undefined ? { bindValues } : {}) })
   }),
 
   // Validate and commit events

--- a/packages/@livestore/cli/src/commands/mcp-tool-handlers.ts
+++ b/packages/@livestore/cli/src/commands/mcp-tool-handlers.ts
@@ -150,7 +150,7 @@ export const schema = Schema.create({
 
   // Execute a raw SQL query against the local client DB
   livestore_instance_query: Effect.fnUntraced(function* ({ sql, bindValues }) {
-    return yield* Runtime.query({ sql, ...(bindValues !== undefined ? { bindValues } : {}) })
+    return yield* Runtime.query({ sql, bindValues })
   }),
 
   // Validate and commit events

--- a/packages/@livestore/cli/src/commands/mcp-tools-defs.ts
+++ b/packages/@livestore/cli/src/commands/mcp-tools-defs.ts
@@ -1,3 +1,4 @@
+import { SqlValueSchema } from '@livestore/common'
 import { Schema, Tool, Toolkit } from '@livestore/utils/effect'
 import { coachTool } from './mcp-coach.ts'
 
@@ -138,12 +139,15 @@ Returns on success:
 }`,
     parameters: {
       sql: Schema.String.annotations({ description: 'The SQL query to execute' }),
-      bindValues: Schema.Union(
-        Schema.Array(Schema.JsonValue),
-        Schema.Record({ key: Schema.String, value: Schema.JsonValue }),
-      ).annotations({
-        description: 'Bind values for the SQL query (array or record). Record keys must not start with $.',
-      }),
+      bindValues: Schema.optional(
+        Schema.Union(
+          Schema.Array(SqlValueSchema),
+          Schema.Record({ key: Schema.String, value: SqlValueSchema }),
+        ).annotations({
+          description:
+            'Bind values for the SQL query (array or record). Record keys must not start with $. Values must be string, number, or null. Booleans are not supported; use 0/1 instead.',
+        }),
+      ),
     },
     success: Schema.Struct({
       rows: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.JsonValue })),

--- a/packages/@livestore/cli/src/commands/mcp-tools-defs.ts
+++ b/packages/@livestore/cli/src/commands/mcp-tools-defs.ts
@@ -1,4 +1,4 @@
-import { SqlValueSchema } from '@livestore/common'
+import { SqlBindValueSchema } from '@livestore/common'
 import { Schema, Tool, Toolkit } from '@livestore/utils/effect'
 import { coachTool } from './mcp-coach.ts'
 
@@ -141,8 +141,8 @@ Returns on success:
       sql: Schema.String.annotations({ description: 'The SQL query to execute' }),
       bindValues: Schema.optional(
         Schema.Union(
-          Schema.Array(SqlValueSchema),
-          Schema.Record({ key: Schema.String, value: SqlValueSchema }),
+          Schema.Array(SqlBindValueSchema),
+          Schema.Record({ key: Schema.String, value: SqlBindValueSchema }),
         ).annotations({
           description:
             'Bind values for the SQL query (array or record). Record keys must not start with $. Values must be string, number, or null. Booleans are not supported; use 0/1 instead.',

--- a/packages/@livestore/cli/src/mcp-runtime/runtime.ts
+++ b/packages/@livestore/cli/src/mcp-runtime/runtime.ts
@@ -2,7 +2,7 @@ import { makeAdapter as makeNodeAdapter } from '@livestore/adapter-node'
 import { UnknownError } from '@livestore/common'
 import { LiveStoreEvent, SystemTables } from '@livestore/common/schema'
 import type { Store } from '@livestore/livestore'
-import { createStorePromise, type BindValues } from '@livestore/livestore'
+import { type BindValues, createStorePromise } from '@livestore/livestore'
 import { Effect, FetchHttpClient, Layer, Option, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 

--- a/packages/@livestore/cli/src/mcp-runtime/runtime.ts
+++ b/packages/@livestore/cli/src/mcp-runtime/runtime.ts
@@ -2,7 +2,7 @@ import { makeAdapter as makeNodeAdapter } from '@livestore/adapter-node'
 import { UnknownError } from '@livestore/common'
 import { LiveStoreEvent, SystemTables } from '@livestore/common/schema'
 import type { Store } from '@livestore/livestore'
-import { createStorePromise, type SqlBindParams } from '@livestore/livestore'
+import { createStorePromise, type BindValues } from '@livestore/livestore'
 import { Effect, FetchHttpClient, Layer, Option, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
@@ -102,7 +102,7 @@ export const status = Effect.gen(function* () {
   }
 }).pipe(Effect.withSpan('mcp-runtime:status'))
 
-export const query = ({ sql, bindValues }: { sql: string; bindValues?: SqlBindParams }) =>
+export const query = ({ sql, bindValues }: { sql: string; bindValues?: BindValues }) =>
   Effect.gen(function* () {
     const opt = yield* getStore
     if (opt._tag === 'None') {

--- a/packages/@livestore/cli/src/mcp-runtime/runtime.ts
+++ b/packages/@livestore/cli/src/mcp-runtime/runtime.ts
@@ -2,7 +2,7 @@ import { makeAdapter as makeNodeAdapter } from '@livestore/adapter-node'
 import { UnknownError } from '@livestore/common'
 import { LiveStoreEvent, SystemTables } from '@livestore/common/schema'
 import type { Store } from '@livestore/livestore'
-import { createStorePromise } from '@livestore/livestore'
+import { createStorePromise, type SqlBindParams } from '@livestore/livestore'
 import { Effect, FetchHttpClient, Layer, Option, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
@@ -102,7 +102,7 @@ export const status = Effect.gen(function* () {
   }
 }).pipe(Effect.withSpan('mcp-runtime:status'))
 
-export const query = ({ sql, bindValues }: { sql: string; bindValues?: readonly any[] | Record<string, unknown> }) =>
+export const query = ({ sql, bindValues }: { sql: string; bindValues?: SqlBindParams }) =>
   Effect.gen(function* () {
     const opt = yield* getStore
     if (opt._tag === 'None') {
@@ -110,7 +110,7 @@ export const query = ({ sql, bindValues }: { sql: string; bindValues?: readonly 
     }
     const s = opt.value
 
-    const rows = s.query({ query: sql, bindValues: (bindValues as any) ?? [] }) as Array<Record<string, unknown>>
+    const rows = s.query({ query: sql, bindValues: bindValues ?? [] }) as Array<Record<string, unknown>>
     const jsonRows = rows.map((r) => Object.fromEntries(Object.entries(r).map(([k, v]) => [k, v as Schema.JsonValue])))
     return { rows: jsonRows, rowCount: jsonRows.length }
   }).pipe(Effect.withSpan('mcp-runtime:query'))

--- a/packages/@livestore/cli/src/mcp-runtime/runtime.ts
+++ b/packages/@livestore/cli/src/mcp-runtime/runtime.ts
@@ -102,7 +102,7 @@ export const status = Effect.gen(function* () {
   }
 }).pipe(Effect.withSpan('mcp-runtime:status'))
 
-export const query = ({ sql, bindValues }: { sql: string; bindValues?: BindValues }) =>
+export const query = ({ sql, bindValues }: { sql: string; bindValues: BindValues | undefined }) =>
   Effect.gen(function* () {
     const opt = yield* getStore
     if (opt._tag === 'None') {

--- a/packages/@livestore/common/src/leader-thread/connection.ts
+++ b/packages/@livestore/common/src/leader-thread/connection.ts
@@ -3,9 +3,8 @@ import { Effect } from '@livestore/utils/effect'
 
 import type { SqliteDb } from '../adapter-types.ts'
 import { SqliteError } from '../adapter-types.ts'
-import type { BindValues } from '../sql-queries/index.ts'
-import type { PreparedBindValues } from '../util.ts'
-import { prepareBindValues, sql } from '../util.ts'
+import type { PreparedBindValues, SqlQueryBindParams } from '../util.ts'
+import { prepareQueryBindValues, sql } from '../util.ts'
 
 // TODO
 namespace WaSqlite {
@@ -68,8 +67,8 @@ export const configureConnection = (sqliteDb: SqliteDb, { foreignKeys, lockingMo
     {},
   )
 
-export const execSql = (sqliteDb: SqliteDb, sql: string, bind: BindValues) => {
-  const bindValues = prepareBindValues(bind, sql)
+export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlQueryBindParams) => {
+  const bindValues = prepareQueryBindValues(bind, sql)
   return Effect.try({
     try: () => sqliteDb.execute(sql, bindValues),
     catch: (cause) =>

--- a/packages/@livestore/common/src/leader-thread/connection.ts
+++ b/packages/@livestore/common/src/leader-thread/connection.ts
@@ -3,8 +3,8 @@ import { Effect } from '@livestore/utils/effect'
 
 import type { SqliteDb } from '../adapter-types.ts'
 import { SqliteError } from '../adapter-types.ts'
-import type { PreparedBindValues, SqlQueryBindParams } from '../util.ts'
-import { prepareQueryBindValues, sql } from '../util.ts'
+import type { PreparedBindValues, SqlBindParams } from '../util.ts'
+import { prepareBindValues, sql } from '../util.ts'
 
 // TODO
 namespace WaSqlite {
@@ -67,8 +67,8 @@ export const configureConnection = (sqliteDb: SqliteDb, { foreignKeys, lockingMo
     {},
   )
 
-export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlQueryBindParams) => {
-  const bindValues = prepareQueryBindValues(bind, sql)
+export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlBindParams) => {
+  const bindValues = prepareBindValues(bind, sql)
   return Effect.try({
     try: () => sqliteDb.execute(sql, bindValues),
     catch: (cause) =>

--- a/packages/@livestore/common/src/leader-thread/connection.ts
+++ b/packages/@livestore/common/src/leader-thread/connection.ts
@@ -3,7 +3,7 @@ import { Effect } from '@livestore/utils/effect'
 
 import type { SqliteDb } from '../adapter-types.ts'
 import { SqliteError } from '../adapter-types.ts'
-import type { PreparedBindValues, SqlBindParams } from '../util.ts'
+import type { BindValues, PreparedBindValues } from '../util.ts'
 import { prepareBindValues, sql } from '../util.ts'
 
 // TODO
@@ -67,7 +67,7 @@ export const configureConnection = (sqliteDb: SqliteDb, { foreignKeys, lockingMo
     {},
   )
 
-export const execSql = (sqliteDb: SqliteDb, sql: string, bind: SqlBindParams) => {
+export const execSql = (sqliteDb: SqliteDb, sql: string, bind: BindValues) => {
   const bindValues = prepareBindValues(bind, sql)
   return Effect.try({
     try: () => sqliteDb.execute(sql, bindValues),

--- a/packages/@livestore/common/src/leader-thread/eventlog.ts
+++ b/packages/@livestore/common/src/leader-thread/eventlog.ts
@@ -12,8 +12,7 @@ import {
 import { sessionChangesetMetaTable } from '../schema/state/sqlite/system-tables/state-tables.ts'
 import { migrateTable } from '../schema-management/migrations.ts'
 import { insertRow, updateRows } from '../sql-queries/sql-queries.ts'
-import type { PreparedBindValues } from '../util.ts'
-import { sql } from '../util.ts'
+import { prepareBindValues, sql } from '../util.ts'
 import { execSql } from './connection.ts'
 import type { InitialSyncInfo, StreamEventsOptions } from './types.ts'
 import { LeaderThreadCtx, STREAM_EVENTS_BATCH_SIZE_DEFAULT } from './types.ts'
@@ -216,10 +215,11 @@ export const insertIntoEventlog = (
   Effect.gen(function* () {
     // Check history consistency during LS_DEV
     if (LS_DEV && eventEncoded.parentSeqNum.global !== EventSequenceNumber.Client.ROOT.global) {
+      const query = `SELECT COUNT(*) as count FROM ${EVENTLOG_META_TABLE} WHERE seqNumGlobal = ? AND seqNumClient = ?`
       const parentEventExists =
         dbEventlog.select<{ count: number }>(
-          `SELECT COUNT(*) as count FROM ${EVENTLOG_META_TABLE} WHERE seqNumGlobal = ? AND seqNumClient = ?`,
-          [eventEncoded.parentSeqNum.global, eventEncoded.parentSeqNum.client] as any as PreparedBindValues,
+          query,
+          prepareBindValues([eventEncoded.parentSeqNum.global, eventEncoded.parentSeqNum.client], query),
         )[0]!.count === 1
 
       if (parentEventExists === false) {

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -1,4 +1,4 @@
-import { isDevEnv, isNil, isReadonlyArray } from '@livestore/utils'
+import { isDevEnv, isReadonlyArray } from '@livestore/utils'
 import { Hash, Option, Schema } from '@livestore/utils/effect'
 
 import type { SqliteDb } from './adapter-types.ts'
@@ -37,10 +37,6 @@ export const getExecStatementsFromMaterializer = ({
           args: Schema.decodeUnknownSync(eventDef.schema)(event.encoded!.args),
         }
       : event.decoded
-
-  const _eventArgsEncoded = isNil(event.decoded?.args)
-    ? undefined
-    : Schema.encodeUnknownSync(eventDef.schema)(event.decoded!.args)
 
   const query: MaterializerContextQuery = (
     rawQueryOrQueryBuilder:

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -9,8 +9,7 @@ import type { LiveStoreSchema } from './schema/schema.ts'
 import type { QueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import { isQueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import { getResultSchema } from './schema/state/sqlite/query-builder/impl.ts'
-import type { BindValues } from './sql-queries/sql-queries.ts'
-import type { ParamsObject, PreparedBindValues } from './util.ts'
+import type { ParamsObject, PreparedBindValues, SqlQueryBindParams } from './util.ts'
 import { prepareBindValues } from './util.ts'
 
 export const getExecStatementsFromMaterializer = ({
@@ -123,7 +122,7 @@ const fromMaterializerResult = (
   materializerResult: MaterializerResult | ReadonlyArray<MaterializerResult>,
 ): ReadonlyArray<{
   sql: string
-  bindValues: BindValues
+  bindValues: SqlQueryBindParams
   writeTables: ReadonlySet<string> | undefined
 }> => {
   if (isReadonlyArray(materializerResult)) {
@@ -131,9 +130,9 @@ const fromMaterializerResult = (
   }
   if (isQueryBuilder(materializerResult)) {
     const { query, bindValues, usedTables } = materializerResult.asSql()
-    return [{ sql: query, bindValues: bindValues as BindValues, writeTables: usedTables }]
+    return [{ sql: query, bindValues: bindValues as SqlQueryBindParams, writeTables: usedTables }]
   } else if (typeof materializerResult === 'string') {
-    return [{ sql: materializerResult, bindValues: {} as BindValues, writeTables: undefined }]
+    return [{ sql: materializerResult, bindValues: {} as SqlQueryBindParams, writeTables: undefined }]
   } else {
     return [
       {

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -9,7 +9,7 @@ import type { LiveStoreSchema } from './schema/schema.ts'
 import type { QueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import { isQueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import { getResultSchema } from './schema/state/sqlite/query-builder/impl.ts'
-import type { ParamsObject, PreparedBindValues, SqlQueryBindParams } from './util.ts'
+import type { ParamsObject, PreparedBindValues, SqlBindParams } from './util.ts'
 import { prepareBindValues } from './util.ts'
 
 export const getExecStatementsFromMaterializer = ({
@@ -72,13 +72,12 @@ export const getExecStatementsFromMaterializer = ({
   )
 
   return statementResults.map((statementRes) => {
-    const statementSql = statementRes.sql
-
-    const bindValues = typeof statementRes === 'string' ? eventArgsEncoded : statementRes.bindValues
-
-    const writeTables = typeof statementRes === 'string' ? undefined : statementRes.writeTables
-
-    return { statementSql, bindValues: prepareBindValues(bindValues ?? {}, statementSql), writeTables }
+    const { sql: statementSql, bindValues, writeTables } = statementRes
+    return {
+      statementSql,
+      bindValues: prepareBindValues(bindValues ?? {}, statementSql),
+      writeTables,
+    }
   })
 }
 
@@ -122,7 +121,7 @@ const fromMaterializerResult = (
   materializerResult: MaterializerResult | ReadonlyArray<MaterializerResult>,
 ): ReadonlyArray<{
   sql: string
-  bindValues: SqlQueryBindParams
+  bindValues: SqlBindParams
   writeTables: ReadonlySet<string> | undefined
 }> => {
   if (isReadonlyArray(materializerResult)) {
@@ -130,9 +129,9 @@ const fromMaterializerResult = (
   }
   if (isQueryBuilder(materializerResult)) {
     const { query, bindValues, usedTables } = materializerResult.asSql()
-    return [{ sql: query, bindValues: bindValues as SqlQueryBindParams, writeTables: usedTables }]
+    return [{ sql: query, bindValues, writeTables: usedTables }]
   } else if (typeof materializerResult === 'string') {
-    return [{ sql: materializerResult, bindValues: {} as SqlQueryBindParams, writeTables: undefined }]
+    return [{ sql: materializerResult, bindValues: {}, writeTables: undefined }]
   } else {
     return [
       {

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -9,7 +9,7 @@ import type { LiveStoreSchema } from './schema/schema.ts'
 import type { QueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import { isQueryBuilder } from './schema/state/sqlite/query-builder/api.ts'
 import { getResultSchema } from './schema/state/sqlite/query-builder/impl.ts'
-import type { ParamsObject, PreparedBindValues, SqlBindParams } from './util.ts'
+import type { BindValues, ParamsObject, PreparedBindValues } from './util.ts'
 import { prepareBindValues } from './util.ts'
 
 export const getExecStatementsFromMaterializer = ({
@@ -121,7 +121,7 @@ const fromMaterializerResult = (
   materializerResult: MaterializerResult | ReadonlyArray<MaterializerResult>,
 ): ReadonlyArray<{
   sql: string
-  bindValues: SqlBindParams
+  bindValues: BindValues
   writeTables: ReadonlySet<string> | undefined
 }> => {
   if (isReadonlyArray(materializerResult)) {

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -38,7 +38,7 @@ export const getExecStatementsFromMaterializer = ({
         }
       : event.decoded
 
-  const eventArgsEncoded = isNil(event.decoded?.args)
+  const _eventArgsEncoded = isNil(event.decoded?.args)
     ? undefined
     : Schema.encodeUnknownSync(eventDef.schema)(event.decoded!.args)
 

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -5,8 +5,7 @@ import { type SqliteDb, UnknownError } from './adapter-types.ts'
 import type { MaterializeEvent } from './leader-thread/mod.ts'
 import type { EventDef, LiveStoreSchema } from './schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from './schema/mod.ts'
-import type { PreparedBindValues } from './util.ts'
-import { sql } from './util.ts'
+import { prepareBindValues, sql } from './util.ts'
 
 export const rematerializeFromEventlog = ({
   dbEventlog,
@@ -110,10 +109,9 @@ LIMIT ${CHUNK_SIZE}
           )
         : EventSequenceNumber.Client.ROOT
       const nextItem = Chunk.fromIterable(
-        stmt.select<SystemTables.EventlogMetaRow>({
-          $seqNumGlobal: lastId?.global,
-          $seqNumClient: lastId?.client,
-        } as any as PreparedBindValues),
+        stmt.select<SystemTables.EventlogMetaRow>(
+          prepareBindValues({ seqNumGlobal: lastId.global, seqNumClient: lastId.client }, stmt.sql),
+        ),
       )
       const prevItem = Chunk.isChunk(item) ? item : Chunk.empty()
       return Option.some([prevItem, nextItem])

--- a/packages/@livestore/common/src/schema/EventDef/materializer.ts
+++ b/packages/@livestore/common/src/schema/EventDef/materializer.ts
@@ -28,9 +28,7 @@
  */
 
 import type { SingleOrReadonlyArray } from '@livestore/utils'
-
-import type { BindValues } from '../../sql-queries/sql-queries.ts'
-import type { ParamsObject } from '../../util.ts'
+import type { ParamsObject, SqlQueryBindParams } from '../../util.ts'
 import type * as LiveStoreEvent from '../LiveStoreEvent/mod.ts'
 import type { QueryBuilder } from '../state/sqlite/query-builder/mod.ts'
 import type { EventDef } from './event-def.ts'
@@ -47,7 +45,7 @@ import type { EventDefFacts } from './facts.ts'
 export type MaterializerResult =
   | {
       sql: string
-      bindValues: BindValues
+      bindValues: SqlQueryBindParams
       writeTables?: ReadonlySet<string>
     }
   | QueryBuilder.Any

--- a/packages/@livestore/common/src/schema/EventDef/materializer.ts
+++ b/packages/@livestore/common/src/schema/EventDef/materializer.ts
@@ -28,7 +28,7 @@
  */
 
 import type { SingleOrReadonlyArray } from '@livestore/utils'
-import type { ParamsObject, SqlQueryBindParams } from '../../util.ts'
+import type { ParamsObject, SqlBindParams } from '../../util.ts'
 import type * as LiveStoreEvent from '../LiveStoreEvent/mod.ts'
 import type { QueryBuilder } from '../state/sqlite/query-builder/mod.ts'
 import type { EventDef } from './event-def.ts'
@@ -45,7 +45,7 @@ import type { EventDefFacts } from './facts.ts'
 export type MaterializerResult =
   | {
       sql: string
-      bindValues: SqlQueryBindParams
+      bindValues: SqlBindParams
       writeTables?: ReadonlySet<string>
     }
   | QueryBuilder.Any

--- a/packages/@livestore/common/src/schema/EventDef/materializer.ts
+++ b/packages/@livestore/common/src/schema/EventDef/materializer.ts
@@ -28,7 +28,7 @@
  */
 
 import type { SingleOrReadonlyArray } from '@livestore/utils'
-import type { ParamsObject, SqlBindParams } from '../../util.ts'
+import type { BindValues, ParamsObject } from '../../util.ts'
 import type * as LiveStoreEvent from '../LiveStoreEvent/mod.ts'
 import type { QueryBuilder } from '../state/sqlite/query-builder/mod.ts'
 import type { EventDef } from './event-def.ts'
@@ -45,7 +45,7 @@ import type { EventDefFacts } from './facts.ts'
 export type MaterializerResult =
   | {
       sql: string
-      bindValues: SqlBindParams
+      bindValues: BindValues
       writeTables?: ReadonlySet<string>
     }
   | QueryBuilder.Any

--- a/packages/@livestore/common/src/schema/EventDef/materializer.ts
+++ b/packages/@livestore/common/src/schema/EventDef/materializer.ts
@@ -39,8 +39,17 @@ import type { EventDefFacts } from './facts.ts'
  *
  * Can be one of:
  * - A QueryBuilder operation (recommended for type safety)
- * - A raw SQL string
+ * - A raw SQL string (executed as-is with no bind values; use the object form
+ *   or QueryBuilder if you need parameters)
  * - An object with SQL, bind values, and optional write table tracking
+ *
+ * @example Using raw SQL with parameters (object form required):
+ * ```ts
+ * 'v1.TodoRenamed': ({ id, text }) => ({
+ *   sql: 'UPDATE todos SET text = :text WHERE id = :id',
+ *   bindValues: { id, text },
+ * })
+ * ```
  */
 export type MaterializerResult =
   | {

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -3,7 +3,7 @@ import type { Option, Types } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../adapter-types.ts'
-import { type BindValues, sql } from '../../../util.ts'
+import { type BindValues, type SqlBindValue, sql } from '../../../util.ts'
 import type { EventDef, Materializer } from '../../EventDef/mod.ts'
 import { defineEvent, defineMaterializer } from '../../EventDef/mod.ts'
 import { SqliteDsl } from './db-schema/mod.ts'
@@ -285,21 +285,21 @@ export const deriveEventAndMaterializer = ({
     const schemaProps = Schema.getResolvedPropertySignatures(valueSchema)
     if (schemaProps.length === 0 || partialSet === false) {
       const valueColJsonSchema = Schema.parseJson(valueSchema)
-      const encodedInsertValue = Schema.encodeSyncDebug(valueColJsonSchema)(value ?? defaultValue)
-      const encodedUpdateValue = Schema.encodeSyncDebug(valueColJsonSchema)(value)
+      const encodedInsertValue: string = Schema.encodeSyncDebug(valueColJsonSchema)(value ?? defaultValue)
+      const encodedUpdateValue: string = Schema.encodeSyncDebug(valueColJsonSchema)(value)
 
       return {
         sql: `INSERT INTO '${name}' (id, value) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET value = ?`,
-        bindValues: [id, encodedInsertValue, encodedUpdateValue] as BindValues,
+        bindValues: [id, encodedInsertValue, encodedUpdateValue],
         writeTables: new Set([name]),
       }
     } else {
       const valueColJsonSchema = Schema.parseJson(Schema.partial(valueSchema))
 
-      const encodedInsertValue = Schema.encodeSyncDebug(valueColJsonSchema)(mergeDefaultValues(defaultValue, value))
+      const encodedInsertValue: string = Schema.encodeSyncDebug(valueColJsonSchema)(mergeDefaultValues(defaultValue, value))
 
       let jsonSetSql = 'value'
-      const setBindValues: unknown[] = []
+      const setBindValues: SqlBindValue[] = []
 
       const keys = Object.keys(value)
       const partialUpdateSchema = valueSchema.pipe(Schema.pick(...keys))
@@ -328,7 +328,7 @@ export const deriveEventAndMaterializer = ({
 
       return {
         sql: sqlQuery,
-        bindValues: [id, encodedInsertValue, ...setBindValues] as BindValues,
+        bindValues: [id, encodedInsertValue, ...setBindValues],
         writeTables: new Set([name]),
       }
     }

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -3,7 +3,7 @@ import type { Option, Types } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../adapter-types.ts'
-import { sql } from '../../../util.ts'
+import { type SqlBindParams, sql } from '../../../util.ts'
 import type { EventDef, Materializer } from '../../EventDef/mod.ts'
 import { defineEvent, defineMaterializer } from '../../EventDef/mod.ts'
 import { SqliteDsl } from './db-schema/mod.ts'
@@ -290,7 +290,7 @@ export const deriveEventAndMaterializer = ({
 
       return {
         sql: `INSERT INTO '${name}' (id, value) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET value = ?`,
-        bindValues: [id, encodedInsertValue, encodedUpdateValue],
+        bindValues: [id, encodedInsertValue, encodedUpdateValue] as SqlBindParams,
         writeTables: new Set([name]),
       }
     } else {
@@ -328,7 +328,7 @@ export const deriveEventAndMaterializer = ({
 
       return {
         sql: sqlQuery,
-        bindValues: [id, encodedInsertValue, ...setBindValues],
+        bindValues: [id, encodedInsertValue, ...setBindValues] as SqlBindParams,
         writeTables: new Set([name]),
       }
     }

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -3,7 +3,7 @@ import type { Option, Types } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../adapter-types.ts'
-import { type BindValues, type SqlBindValue, sql } from '../../../util.ts'
+import { type SqlBindValue, sql } from '../../../util.ts'
 import type { EventDef, Materializer } from '../../EventDef/mod.ts'
 import { defineEvent, defineMaterializer } from '../../EventDef/mod.ts'
 import { SqliteDsl } from './db-schema/mod.ts'
@@ -296,7 +296,9 @@ export const deriveEventAndMaterializer = ({
     } else {
       const valueColJsonSchema = Schema.parseJson(Schema.partial(valueSchema))
 
-      const encodedInsertValue: string = Schema.encodeSyncDebug(valueColJsonSchema)(mergeDefaultValues(defaultValue, value))
+      const encodedInsertValue: string = Schema.encodeSyncDebug(valueColJsonSchema)(
+        mergeDefaultValues(defaultValue, value),
+      )
 
       let jsonSetSql = 'value'
       const setBindValues: SqlBindValue[] = []

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -3,7 +3,7 @@ import type { Option, Types } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../adapter-types.ts'
-import { type SqlBindParams, sql } from '../../../util.ts'
+import { type BindValues, sql } from '../../../util.ts'
 import type { EventDef, Materializer } from '../../EventDef/mod.ts'
 import { defineEvent, defineMaterializer } from '../../EventDef/mod.ts'
 import { SqliteDsl } from './db-schema/mod.ts'
@@ -290,7 +290,7 @@ export const deriveEventAndMaterializer = ({
 
       return {
         sql: `INSERT INTO '${name}' (id, value) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET value = ?`,
-        bindValues: [id, encodedInsertValue, encodedUpdateValue] as SqlBindParams,
+        bindValues: [id, encodedInsertValue, encodedUpdateValue] as BindValues,
         writeTables: new Set([name]),
       }
     } else {
@@ -328,7 +328,7 @@ export const deriveEventAndMaterializer = ({
 
       return {
         sql: sqlQuery,
-        bindValues: [id, encodedInsertValue, ...setBindValues] as SqlBindParams,
+        bindValues: [id, encodedInsertValue, ...setBindValues] as BindValues,
         writeTables: new Set([name]),
       }
     }

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -2,7 +2,7 @@ import type { GetValForKey, SingleOrReadonlyArray } from '@livestore/utils'
 import { type Option, Predicate, type Schema } from '@livestore/utils/effect'
 
 import type { SessionIdSymbol } from '../../../../adapter-types.ts'
-import type { SqlBindParams } from '../../../../util.ts'
+import type { BindValues } from '../../../../util.ts'
 import type { ClientDocumentTableDef, ClientDocumentTableDefSymbol } from '../client-document-def.ts'
 import type { SqliteDsl } from '../db-schema/mod.ts'
 import type { TableDefBase } from '../table-def.ts'
@@ -122,7 +122,7 @@ export type QueryBuilder<
   readonly [QueryBuilderTypeId]: QueryBuilderTypeId
   readonly [QueryBuilderAstSymbol]: QueryBuilderAst
   readonly ResultType: TResult
-  readonly asSql: () => { query: string; bindValues: SqlBindParams; usedTables: Set<string> }
+  readonly asSql: () => { query: string; bindValues: BindValues; usedTables: Set<string> }
   readonly toString: () => string
 } & Omit<QueryBuilder.ApiFull<TResult, TTableDef, TWithout>, TWithout>
 

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -2,7 +2,7 @@ import type { GetValForKey, SingleOrReadonlyArray } from '@livestore/utils'
 import { type Option, Predicate, type Schema } from '@livestore/utils/effect'
 
 import type { SessionIdSymbol } from '../../../../adapter-types.ts'
-import type { SqlValue } from '../../../../util.ts'
+import type { SqlBindParams } from '../../../../util.ts'
 import type { ClientDocumentTableDef, ClientDocumentTableDefSymbol } from '../client-document-def.ts'
 import type { SqliteDsl } from '../db-schema/mod.ts'
 import type { TableDefBase } from '../table-def.ts'
@@ -122,7 +122,7 @@ export type QueryBuilder<
   readonly [QueryBuilderTypeId]: QueryBuilderTypeId
   readonly [QueryBuilderAstSymbol]: QueryBuilderAst
   readonly ResultType: TResult
-  readonly asSql: () => { query: string; bindValues: SqlValue[]; usedTables: Set<string> }
+  readonly asSql: () => { query: string; bindValues: SqlBindParams; usedTables: Set<string> }
   readonly toString: () => string
 } & Omit<QueryBuilder.ApiFull<TResult, TTableDef, TWithout>, TWithout>
 

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -2,7 +2,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { Schema, SchemaAST } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../../adapter-types.ts'
-import type { SqlBindParams, SqlBindValue, SqlValue } from '../../../../util.ts'
+import type { BindValues, SqlBindValue, SqlValue } from '../../../../util.ts'
 import type { State } from '../../../mod.ts'
 import type { QueryBuilderAst } from './api.ts'
 
@@ -173,7 +173,7 @@ const toSqlBindValue = (value: unknown): SqlBindValue => {
 
 export const astToSql = (
   ast: QueryBuilderAst,
-): { query: string; bindValues: SqlBindParams; usedTables: Set<string> } => {
+): { query: string; bindValues: BindValues; usedTables: Set<string> } => {
   const bindValues: SqlBindValue[] = []
   const usedTables = new Set<string>([ast.tableDef.sqliteDef.name])
 

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -171,9 +171,7 @@ const toSqlBindValue = (value: unknown): SqlBindValue => {
   )
 }
 
-export const astToSql = (
-  ast: QueryBuilderAst,
-): { query: string; bindValues: BindValues; usedTables: Set<string> } => {
+export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: BindValues; usedTables: Set<string> } => {
   const bindValues: SqlBindValue[] = []
   const usedTables = new Set<string>([ast.tableDef.sqliteDef.name])
 

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -3,6 +3,7 @@ import { Schema, SchemaAST } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../../adapter-types.ts'
 import type { BindValues, SqlBindValue, SqlValue } from '../../../../util.ts'
+import { SqlBindValueSchema } from '../../../../util.ts'
 import type { State } from '../../../mod.ts'
 import type { QueryBuilderAst } from './api.ts'
 
@@ -129,12 +130,14 @@ const formatWhereClause = (
           return op === 'IN' ? '0=1' : '1=1'
         }
 
-        const encodedValues = value.map((v) => toSqlBindValue(Schema.encodeSync(colDef.schema)(v)))
+        const encodedValues = value.map((v) =>
+          Schema.encodeSync(SqlBindValueSchema)(Schema.encodeSync(colDef.schema)(v)),
+        )
         bindValues.push(...encodedValues)
         const placeholders = encodedValues.map(() => '?').join(', ')
         return `${quotedCol} ${op} (${placeholders})`
       } else {
-        const encodedValue = toSqlBindValue(Schema.encodeSync(colDef.schema)(value))
+        const encodedValue = Schema.encodeSync(SqlBindValueSchema)(Schema.encodeSync(colDef.schema)(value))
         bindValues.push(encodedValue)
         return `${quotedCol} ${op} ?`
       }
@@ -147,28 +150,6 @@ const formatWhereClause = (
 const formatReturningClause = (returning?: string[]): string => {
   if (!returning || returning.length === 0) return ''
   return ` RETURNING ${returning.map(quoteIdentifier).join(', ')}`
-}
-
-/**
- * Validates that a value is a valid SQL bind value.
- * Throws early if an unsupported type is encountered (e.g., boolean, object).
- */
-const toSqlBindValue = (value: unknown): SqlBindValue => {
-  if (value === null) return value
-  if (typeof value === 'string') return value
-  if (typeof value === 'number') return value
-  if (value instanceof Uint8Array) return value as Uint8Array<ArrayBuffer>
-  if (typeof value === 'boolean') {
-    // SQLite stores booleans as 0/1
-    return value ? 1 : 0
-  }
-  if (typeof value === 'symbol') {
-    // Allow SessionIdSymbol to pass through
-    return value as SqlBindValue
-  }
-  throw new Error(
-    `Invalid SQL bind value: expected string, number, Uint8Array, null, or boolean, got ${typeof value}: ${String(value)}`,
-  )
 }
 
 export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: BindValues; usedTables: Set<string> } => {
@@ -184,7 +165,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Bin
 
     // Ensure bind values are added in the same order as columns
     columns.forEach((col) => {
-      bindValues.push(toSqlBindValue(encodedValues[col]))
+      bindValues.push(Schema.encodeSync(SqlBindValueSchema)(encodedValues[col]))
     })
 
     let insertVerb = 'INSERT'
@@ -227,7 +208,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Bin
               if (colDef === undefined) {
                 throw new Error(`Column ${col} not found`)
               }
-              const encodedValue = toSqlBindValue(Schema.encodeSync(colDef.schema)(value))
+              const encodedValue = Schema.encodeSync(SqlBindValueSchema)(Schema.encodeSync(colDef.schema)(value))
               bindValues.push(encodedValue)
             }
           })
@@ -263,7 +244,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Bin
 
     // Ensure bind values are added in the same order as columns
     setColumns.forEach((col) => {
-      bindValues.push(toSqlBindValue(encodedValues[col]))
+      bindValues.push(Schema.encodeSync(SqlBindValueSchema)(encodedValues[col]))
     })
 
     let query = `UPDATE '${ast.tableDef.sqliteDef.name}' SET ${setColumns
@@ -313,7 +294,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Bin
 
     return {
       query: `SELECT * FROM '${ast.tableDef.sqliteDef.name}' WHERE ${quoteIdentifier('id')} = ?`,
-      bindValues: [toSqlBindValue(encodedId)],
+      bindValues: [Schema.encodeSync(SqlBindValueSchema)(encodedId)],
       usedTables,
     }
   }

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -2,7 +2,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { Schema, SchemaAST } from '@livestore/utils/effect'
 
 import { SessionIdSymbol } from '../../../../adapter-types.ts'
-import type { SqlValue } from '../../../../util.ts'
+import type { SqlBindParams, SqlBindValue, SqlValue } from '../../../../util.ts'
 import type { State } from '../../../mod.ts'
 import type { QueryBuilderAst } from './api.ts'
 
@@ -75,7 +75,7 @@ const quoteIdentifier = (identifier: string): string => `"${identifier.replace(/
 const formatWhereClause = (
   whereConditions: ReadonlyArray<QueryBuilderAst.Where>,
   tableDef: State.SQLite.TableDefBase,
-  bindValues: SqlValue[],
+  bindValues: SqlBindValue[],
 ): string => {
   if (whereConditions.length === 0) return ''
 
@@ -129,13 +129,13 @@ const formatWhereClause = (
           return op === 'IN' ? '0=1' : '1=1'
         }
 
-        const encodedValues = value.map((v) => Schema.encodeSync(colDef.schema)(v)) as SqlValue[]
+        const encodedValues = value.map((v) => toSqlBindValue(Schema.encodeSync(colDef.schema)(v)))
         bindValues.push(...encodedValues)
         const placeholders = encodedValues.map(() => '?').join(', ')
         return `${quotedCol} ${op} (${placeholders})`
       } else {
-        const encodedValue = Schema.encodeSync(colDef.schema)(value)
-        bindValues.push(encodedValue as SqlValue)
+        const encodedValue = toSqlBindValue(Schema.encodeSync(colDef.schema)(value))
+        bindValues.push(encodedValue)
         return `${quotedCol} ${op} ?`
       }
     })
@@ -149,8 +149,32 @@ const formatReturningClause = (returning?: string[]): string => {
   return ` RETURNING ${returning.map(quoteIdentifier).join(', ')}`
 }
 
-export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: SqlValue[]; usedTables: Set<string> } => {
-  const bindValues: SqlValue[] = []
+/**
+ * Validates that a value is a valid SQL bind value.
+ * Throws early if an unsupported type is encountered (e.g., boolean, object).
+ */
+const toSqlBindValue = (value: unknown): SqlBindValue => {
+  if (value === null) return value
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return value
+  if (value instanceof Uint8Array) return value as Uint8Array<ArrayBuffer>
+  if (typeof value === 'boolean') {
+    // SQLite stores booleans as 0/1
+    return value ? 1 : 0
+  }
+  if (typeof value === 'symbol') {
+    // Allow SessionIdSymbol to pass through
+    return value as SqlBindValue
+  }
+  throw new Error(
+    `Invalid SQL bind value: expected string, number, Uint8Array, null, or boolean, got ${typeof value}: ${String(value)}`,
+  )
+}
+
+export const astToSql = (
+  ast: QueryBuilderAst,
+): { query: string; bindValues: SqlBindParams; usedTables: Set<string> } => {
+  const bindValues: SqlBindValue[] = []
   const usedTables = new Set<string>([ast.tableDef.sqliteDef.name])
 
   // INSERT query
@@ -162,7 +186,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
 
     // Ensure bind values are added in the same order as columns
     columns.forEach((col) => {
-      bindValues.push(encodedValues[col] as SqlValue)
+      bindValues.push(toSqlBindValue(encodedValues[col]))
     })
 
     let insertVerb = 'INSERT'
@@ -205,8 +229,8 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
               if (colDef === undefined) {
                 throw new Error(`Column ${col} not found`)
               }
-              const encodedValue = Schema.encodeSync(colDef.schema)(value)
-              bindValues.push(encodedValue as SqlValue)
+              const encodedValue = toSqlBindValue(Schema.encodeSync(colDef.schema)(value))
+              bindValues.push(encodedValue)
             }
           })
 
@@ -241,7 +265,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
 
     // Ensure bind values are added in the same order as columns
     setColumns.forEach((col) => {
-      bindValues.push(encodedValues[col] as SqlValue)
+      bindValues.push(toSqlBindValue(encodedValues[col]))
     })
 
     let query = `UPDATE '${ast.tableDef.sqliteDef.name}' SET ${setColumns
@@ -291,7 +315,7 @@ export const astToSql = (ast: QueryBuilderAst): { query: string; bindValues: Sql
 
     return {
       query: `SELECT * FROM '${ast.tableDef.sqliteDef.name}' WHERE ${quoteIdentifier('id')} = ?`,
-      bindValues: [encodedId as SqlValue],
+      bindValues: [toSqlBindValue(encodedId)],
       usedTables,
     }
   }

--- a/packages/@livestore/common/src/sql-queries/sql-queries.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-queries.ts
@@ -2,7 +2,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { pipe, ReadonlyArray, Schema, TreeFormatter } from '@livestore/utils/effect'
 
 import type { SqliteDsl } from '../schema/state/sqlite/db-schema/mod.ts'
-import { type SqlQueryBindParams, sql } from '../util.ts'
+import { type SqlBindParams, sql } from '../util.ts'
 import { objectEntries } from './misc.ts'
 import * as ClientTypes from './types.ts'
 
@@ -16,7 +16,7 @@ export const findManyRows = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   where: ClientTypes.WhereValuesForColumns<TColumns>
   limit?: number
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const whereSql = buildWhereSql({ where })
   const whereModifier = whereSql === '' ? '' : `WHERE ${whereSql}`
   const limitModifier = limit ? `LIMIT ${limit}` : ''
@@ -34,7 +34,7 @@ export const countRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   columns: TColumns
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const whereSql = buildWhereSql({ where })
   const whereModifier = whereSql === '' ? '' : `WHERE ${whereSql}`
 
@@ -53,7 +53,7 @@ export const insertRow = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   values: ClientTypes.DecodedValuesForColumns<TColumns>
   options?: { orReplace: boolean }
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const stmt = insertRowPrepared({
     tableName,
     columns,
@@ -87,7 +87,7 @@ export const insertRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   columns: TColumns
   valuesArray: ClientTypes.DecodedValuesForColumns<TColumns>[]
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const keysStr = Object.keys(valuesArray[0]!).join(', ')
 
   // NOTE consider batching for large arrays (https://sqlite.org/forum/info/f832398c19d30a4a)
@@ -122,7 +122,7 @@ export const insertOrIgnoreRow = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   values: ClientTypes.DecodedValuesForColumns<TColumns>
   returnRow: boolean
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const values = filterUndefinedFields(values_)
   const keysStr = Object.keys(values).join(', ')
   const valuesStr = Object.keys(values)
@@ -145,7 +145,7 @@ export const updateRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   updateValues: Partial<ClientTypes.DecodedValuesForColumnsAll<TColumns>>
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const updateValues = filterUndefinedFields(updateValues_)
 
   // TODO return an Option instead of `select 1` if there are no update values
@@ -176,7 +176,7 @@ export const deleteRows = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   tableName: string
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const bindValues = {
     ...makeBindValues({ columns, values: where, variablePrefix: 'where_', skipNil: true }),
   }
@@ -200,7 +200,7 @@ export const upsertRow = <TColumns extends SqliteDsl.Columns>({
   updateValues: Partial<ClientTypes.DecodedValuesForColumnsAll<TColumns>>
   // TODO where VALUES are actually not used here. Maybe adjust API?
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlQueryBindParams] => {
+}): [string, SqlBindParams] => {
   const createValues = filterUndefinedFields(createValues_)
   const updateValues = filterUndefinedFields(updateValues_)
 

--- a/packages/@livestore/common/src/sql-queries/sql-queries.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-queries.ts
@@ -2,13 +2,9 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { pipe, ReadonlyArray, Schema, TreeFormatter } from '@livestore/utils/effect'
 
 import type { SqliteDsl } from '../schema/state/sqlite/db-schema/mod.ts'
-import { sql } from '../util.ts'
+import { type SqlQueryBindParams, sql } from '../util.ts'
 import { objectEntries } from './misc.ts'
 import * as ClientTypes from './types.ts'
-
-export type BindValues = {
-  readonly [columnName: string]: any
-}
 
 export const findManyRows = <TColumns extends SqliteDsl.Columns>({
   columns,
@@ -20,7 +16,7 @@ export const findManyRows = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   where: ClientTypes.WhereValuesForColumns<TColumns>
   limit?: number
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const whereSql = buildWhereSql({ where })
   const whereModifier = whereSql === '' ? '' : `WHERE ${whereSql}`
   const limitModifier = limit ? `LIMIT ${limit}` : ''
@@ -38,7 +34,7 @@ export const countRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   columns: TColumns
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const whereSql = buildWhereSql({ where })
   const whereModifier = whereSql === '' ? '' : `WHERE ${whereSql}`
 
@@ -57,7 +53,7 @@ export const insertRow = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   values: ClientTypes.DecodedValuesForColumns<TColumns>
   options?: { orReplace: boolean }
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const stmt = insertRowPrepared({
     tableName,
     columns,
@@ -91,7 +87,7 @@ export const insertRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   columns: TColumns
   valuesArray: ClientTypes.DecodedValuesForColumns<TColumns>[]
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const keysStr = Object.keys(valuesArray[0]!).join(', ')
 
   // NOTE consider batching for large arrays (https://sqlite.org/forum/info/f832398c19d30a4a)
@@ -126,7 +122,7 @@ export const insertOrIgnoreRow = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   values: ClientTypes.DecodedValuesForColumns<TColumns>
   returnRow: boolean
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const values = filterUndefinedFields(values_)
   const keysStr = Object.keys(values).join(', ')
   const valuesStr = Object.keys(values)
@@ -149,7 +145,7 @@ export const updateRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   updateValues: Partial<ClientTypes.DecodedValuesForColumnsAll<TColumns>>
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const updateValues = filterUndefinedFields(updateValues_)
 
   // TODO return an Option instead of `select 1` if there are no update values
@@ -180,7 +176,7 @@ export const deleteRows = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   tableName: string
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const bindValues = {
     ...makeBindValues({ columns, values: where, variablePrefix: 'where_', skipNil: true }),
   }
@@ -204,7 +200,7 @@ export const upsertRow = <TColumns extends SqliteDsl.Columns>({
   updateValues: Partial<ClientTypes.DecodedValuesForColumnsAll<TColumns>>
   // TODO where VALUES are actually not used here. Maybe adjust API?
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, BindValues] => {
+}): [string, SqlQueryBindParams] => {
   const createValues = filterUndefinedFields(createValues_)
   const updateValues = filterUndefinedFields(updateValues_)
 

--- a/packages/@livestore/common/src/sql-queries/sql-queries.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-queries.ts
@@ -2,7 +2,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { pipe, ReadonlyArray, Schema, TreeFormatter } from '@livestore/utils/effect'
 
 import type { SqliteDsl } from '../schema/state/sqlite/db-schema/mod.ts'
-import { type SqlBindParams, sql } from '../util.ts'
+import { type BindValues, sql } from '../util.ts'
 import { objectEntries } from './misc.ts'
 import * as ClientTypes from './types.ts'
 
@@ -16,7 +16,7 @@ export const findManyRows = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   where: ClientTypes.WhereValuesForColumns<TColumns>
   limit?: number
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const whereSql = buildWhereSql({ where })
   const whereModifier = whereSql === '' ? '' : `WHERE ${whereSql}`
   const limitModifier = limit ? `LIMIT ${limit}` : ''
@@ -34,7 +34,7 @@ export const countRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   columns: TColumns
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const whereSql = buildWhereSql({ where })
   const whereModifier = whereSql === '' ? '' : `WHERE ${whereSql}`
 
@@ -53,7 +53,7 @@ export const insertRow = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   values: ClientTypes.DecodedValuesForColumns<TColumns>
   options?: { orReplace: boolean }
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const stmt = insertRowPrepared({
     tableName,
     columns,
@@ -87,7 +87,7 @@ export const insertRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   columns: TColumns
   valuesArray: ClientTypes.DecodedValuesForColumns<TColumns>[]
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const keysStr = Object.keys(valuesArray[0]!).join(', ')
 
   // NOTE consider batching for large arrays (https://sqlite.org/forum/info/f832398c19d30a4a)
@@ -122,7 +122,7 @@ export const insertOrIgnoreRow = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   values: ClientTypes.DecodedValuesForColumns<TColumns>
   returnRow: boolean
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const values = filterUndefinedFields(values_)
   const keysStr = Object.keys(values).join(', ')
   const valuesStr = Object.keys(values)
@@ -145,7 +145,7 @@ export const updateRows = <TColumns extends SqliteDsl.Columns>({
   tableName: string
   updateValues: Partial<ClientTypes.DecodedValuesForColumnsAll<TColumns>>
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const updateValues = filterUndefinedFields(updateValues_)
 
   // TODO return an Option instead of `select 1` if there are no update values
@@ -176,7 +176,7 @@ export const deleteRows = <TColumns extends SqliteDsl.Columns>({
   columns: TColumns
   tableName: string
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const bindValues = {
     ...makeBindValues({ columns, values: where, variablePrefix: 'where_', skipNil: true }),
   }
@@ -200,7 +200,7 @@ export const upsertRow = <TColumns extends SqliteDsl.Columns>({
   updateValues: Partial<ClientTypes.DecodedValuesForColumnsAll<TColumns>>
   // TODO where VALUES are actually not used here. Maybe adjust API?
   where: ClientTypes.WhereValuesForColumns<TColumns>
-}): [string, SqlBindParams] => {
+}): [string, BindValues] => {
   const createValues = filterUndefinedFields(createValues_)
   const updateValues = filterUndefinedFields(updateValues_)
 

--- a/packages/@livestore/common/src/sql-queries/sql-query-builder.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-query-builder.ts
@@ -1,10 +1,10 @@
 import { omitUndefineds } from '@livestore/utils'
 import type { SqliteDsl } from '../schema/state/sqlite/db-schema/mod.ts'
-import type { SqlQueryBindParams } from '../util.ts'
+import type { SqlBindParams } from '../util.ts'
 import * as SqlQueries from './sql-queries.ts'
 import type * as ClientTypes from './types.ts'
 
-export type SqlQuery = [stmt: string, bindValues: SqlQueryBindParams, tableName: string]
+export type SqlQuery = [stmt: string, bindValues: SqlBindParams, tableName: string]
 
 export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: TSchema) => {
   const findManyRows = <TTableName extends keyof TSchema & string>({
@@ -15,7 +15,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
     limit?: number
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.findManyRows({ columns, tableName, where, ...omitUndefineds({ limit }) })
     return [stmt, bindValues, tableName]
@@ -27,7 +27,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.countRows({ columns, tableName, where })
     return [stmt, bindValues, tableName]
@@ -41,7 +41,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     values: ClientTypes.DecodedValuesForTable<TSchema, TTableName>
     options?: { orReplace: boolean }
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertRow({ columns, tableName, values, options })
     return [stmt, bindValues, tableName]
@@ -53,7 +53,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     valuesArray: ClientTypes.DecodedValuesForTable<TSchema, TTableName>[]
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertRows({ columns, tableName, valuesArray })
     return [stmt, bindValues, tableName]
@@ -67,7 +67,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     values: ClientTypes.DecodedValuesForTable<TSchema, TTableName>
     returnRow?: boolean
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertOrIgnoreRow({ columns, tableName, values, returnRow })
     return [stmt, bindValues, tableName]
@@ -81,7 +81,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     updateValues: Partial<ClientTypes.DecodedValuesForTableAll<TSchema, TTableName>>
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.updateRows({ columns, tableName, updateValues, where })
     return [stmt, bindValues, tableName]
@@ -93,7 +93,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.deleteRows({ columns, tableName, where })
     return [stmt, bindValues, tableName]
@@ -110,7 +110,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     updateValues: Partial<ClientTypes.DecodedValuesForTableAll<TSchema, TTableName>>
     // TODO where VALUES are actually not used here. Maybe adjust API?
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlQueryBindParams, TTableName] => {
+  }): [string, SqlBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.upsertRow({
       columns,

--- a/packages/@livestore/common/src/sql-queries/sql-query-builder.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-query-builder.ts
@@ -1,10 +1,10 @@
 import { omitUndefineds } from '@livestore/utils'
 import type { SqliteDsl } from '../schema/state/sqlite/db-schema/mod.ts'
-import type { SqlBindParams } from '../util.ts'
+import type { BindValues } from '../util.ts'
 import * as SqlQueries from './sql-queries.ts'
 import type * as ClientTypes from './types.ts'
 
-export type SqlQuery = [stmt: string, bindValues: SqlBindParams, tableName: string]
+export type SqlQuery = [stmt: string, bindValues: BindValues, tableName: string]
 
 export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: TSchema) => {
   const findManyRows = <TTableName extends keyof TSchema & string>({
@@ -15,7 +15,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
     limit?: number
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.findManyRows({ columns, tableName, where, ...omitUndefineds({ limit }) })
     return [stmt, bindValues, tableName]
@@ -27,7 +27,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.countRows({ columns, tableName, where })
     return [stmt, bindValues, tableName]
@@ -41,7 +41,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     values: ClientTypes.DecodedValuesForTable<TSchema, TTableName>
     options?: { orReplace: boolean }
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertRow({ columns, tableName, values, options })
     return [stmt, bindValues, tableName]
@@ -53,7 +53,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     valuesArray: ClientTypes.DecodedValuesForTable<TSchema, TTableName>[]
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertRows({ columns, tableName, valuesArray })
     return [stmt, bindValues, tableName]
@@ -67,7 +67,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     values: ClientTypes.DecodedValuesForTable<TSchema, TTableName>
     returnRow?: boolean
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertOrIgnoreRow({ columns, tableName, values, returnRow })
     return [stmt, bindValues, tableName]
@@ -81,7 +81,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     updateValues: Partial<ClientTypes.DecodedValuesForTableAll<TSchema, TTableName>>
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.updateRows({ columns, tableName, updateValues, where })
     return [stmt, bindValues, tableName]
@@ -93,7 +93,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.deleteRows({ columns, tableName, where })
     return [stmt, bindValues, tableName]
@@ -110,7 +110,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     updateValues: Partial<ClientTypes.DecodedValuesForTableAll<TSchema, TTableName>>
     // TODO where VALUES are actually not used here. Maybe adjust API?
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, SqlBindParams, TTableName] => {
+  }): [string, BindValues, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.upsertRow({
       columns,

--- a/packages/@livestore/common/src/sql-queries/sql-query-builder.ts
+++ b/packages/@livestore/common/src/sql-queries/sql-query-builder.ts
@@ -1,10 +1,10 @@
 import { omitUndefineds } from '@livestore/utils'
 import type { SqliteDsl } from '../schema/state/sqlite/db-schema/mod.ts'
-import type { BindValues } from './sql-queries.ts'
+import type { SqlQueryBindParams } from '../util.ts'
 import * as SqlQueries from './sql-queries.ts'
 import type * as ClientTypes from './types.ts'
 
-export type SqlQuery = [stmt: string, bindValues: BindValues, tableName: string]
+export type SqlQuery = [stmt: string, bindValues: SqlQueryBindParams, tableName: string]
 
 export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: TSchema) => {
   const findManyRows = <TTableName extends keyof TSchema & string>({
@@ -15,7 +15,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
     limit?: number
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.findManyRows({ columns, tableName, where, ...omitUndefineds({ limit }) })
     return [stmt, bindValues, tableName]
@@ -27,7 +27,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.countRows({ columns, tableName, where })
     return [stmt, bindValues, tableName]
@@ -41,7 +41,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     values: ClientTypes.DecodedValuesForTable<TSchema, TTableName>
     options?: { orReplace: boolean }
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertRow({ columns, tableName, values, options })
     return [stmt, bindValues, tableName]
@@ -53,7 +53,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     valuesArray: ClientTypes.DecodedValuesForTable<TSchema, TTableName>[]
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertRows({ columns, tableName, valuesArray })
     return [stmt, bindValues, tableName]
@@ -67,7 +67,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     values: ClientTypes.DecodedValuesForTable<TSchema, TTableName>
     returnRow?: boolean
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.insertOrIgnoreRow({ columns, tableName, values, returnRow })
     return [stmt, bindValues, tableName]
@@ -81,7 +81,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     tableName: TTableName
     updateValues: Partial<ClientTypes.DecodedValuesForTableAll<TSchema, TTableName>>
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.updateRows({ columns, tableName, updateValues, where })
     return [stmt, bindValues, tableName]
@@ -93,7 +93,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
   }: {
     tableName: TTableName
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.deleteRows({ columns, tableName, where })
     return [stmt, bindValues, tableName]
@@ -110,7 +110,7 @@ export const makeSqlQueryBuilder = <TSchema extends SqliteDsl.DbSchema>(schema: 
     updateValues: Partial<ClientTypes.DecodedValuesForTableAll<TSchema, TTableName>>
     // TODO where VALUES are actually not used here. Maybe adjust API?
     where: ClientTypes.WhereValuesForTable<TSchema, TTableName>
-  }): [string, BindValues, TTableName] => {
+  }): [string, SqlQueryBindParams, TTableName] => {
     const columns = schema[tableName]!.columns
     const [stmt, bindValues] = SqlQueries.upsertRow({
       columns,

--- a/packages/@livestore/common/src/sqlite-db-helper.ts
+++ b/packages/@livestore/common/src/sqlite-db-helper.ts
@@ -2,7 +2,7 @@ import { Schema } from '@livestore/utils/effect'
 
 import { type SqliteDb, SqliteError } from './adapter-types.ts'
 import { getResultSchema, isQueryBuilder } from './schema/state/sqlite/query-builder/mod.ts'
-import type { PreparedBindValues } from './util.ts'
+import { type PreparedBindValues, prepareBindValues } from './util.ts'
 
 export const makeExecute = (
   execute: (
@@ -16,7 +16,7 @@ export const makeExecute = (
 
     if (isQueryBuilder(queryStrOrQueryBuilder)) {
       const { query, bindValues } = queryStrOrQueryBuilder.asSql()
-      return execute(query, bindValues as unknown as PreparedBindValues, bindValuesOrOptions)
+      return execute(query, prepareBindValues(bindValues, query), bindValuesOrOptions)
     } else {
       return execute(queryStrOrQueryBuilder, bindValuesOrOptions, maybeOptions)
     }
@@ -32,7 +32,7 @@ export const makeSelect = <T>(
     if (isQueryBuilder(queryStrOrQueryBuilder)) {
       const { query, bindValues } = queryStrOrQueryBuilder.asSql()
       const resultSchema = getResultSchema(queryStrOrQueryBuilder)
-      const results = select(query, bindValues as unknown as PreparedBindValues)
+      const results = select(query, prepareBindValues(bindValues, query))
       return Schema.decodeSync(resultSchema)(results)
     } else {
       return select(queryStrOrQueryBuilder, maybeBindValues)

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -20,18 +20,12 @@ export type SqlBindValue = SqlValue | SessionIdSymbol
 export type ParamsObject = Record<string, SqlBindValue>
 
 /**
- * Parameters supplied to LiveStore's user-facing query APIs.
+ * Parameters supplied to LiveStore's query APIs.
  *
- * Uses strict `SqlBindValue` typing to catch invalid bind values at compile time.
  * Accepts both SQLite primitives and the `SessionIdSymbol` sentinel.
  *
  * These are normalized immediately before execution using `prepareBindValues()`
  * into `PreparedBindValues` (driver-ready).
- *
- * Both positional (array) and named (record) parameter styles are supported:
- * - Positional: `[value1, value2]` for `?` placeholders
- * - Named: `{ name: value }` for `$name` placeholders
- *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
  */
 export type BindValues = ReadonlyArray<SqlBindValue> | Readonly<ParamsObject>
 

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -3,11 +3,21 @@
 import type { Brand } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
+import type { SessionIdSymbol } from './adapter-types.ts'
+
 /** A primitive value that can be stored in SQLite. */
 export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
 
+/**
+ * A value that can be used in SQL bind parameters.
+ *
+ * This includes all SQLite-compatible primitives (`SqlValue`) plus the `SessionIdSymbol`
+ * sentinel, which is replaced with the actual session ID string before execution.
+ */
+export type SqlBindValue = SqlValue | SessionIdSymbol
+
 /** Record of column names to SQL-compatible values. */
-export type ParamsObject = Record<string, SqlValue>
+export type ParamsObject = Record<string, SqlBindValue>
 
 /**
  * Generic bind parameters shape for SQL queries.
@@ -20,26 +30,27 @@ export type ParamsObject = Record<string, SqlValue>
 export type BindParams<T> = ReadonlyArray<T> | Readonly<Record<string, T>>
 
 /**
- * Parameters supplied to LiveStore's user-facing query APIs (raw SQL).
+ * Parameters supplied to LiveStore's user-facing query APIs.
  *
- * Uses strict `SqlValue` typing to catch invalid bind values at compile time.
+ * Uses strict `SqlBindValue` typing to catch invalid bind values at compile time.
+ * Accepts both SQLite primitives and the `SessionIdSymbol` sentinel.
+ *
  * These are normalized immediately before execution using `prepareBindValues()`
  * into `PreparedBindValues` (driver-ready).
  */
-export type SqlBindParams = BindParams<SqlValue>
+export type SqlBindParams = BindParams<SqlBindValue>
 
 /**
- * Bind params produced by SQL helpers/materializers.
+ * Bind params produced by internal SQL helpers and materializers.
  *
- * Uses loose `unknown` typing because internal helpers may produce values
- * that still need encoding/coercion before execution.
+ * Uses loose `unknown` typing because `Schema.encode*` returns `unknown` and
+ * internal helpers may produce values that still need coercion.
  *
- * Before execution, these must be normalized into `PreparedBindValues`
- * via `prepareQueryBindValues()`.
+ * Before execution, these are normalized via `prepareQueryBindValues()` which
+ * delegates to `prepareBindValues()`. The loose typing here allows flexibility
+ * while the strict `SqlBindParams` protects user-facing APIs.
  *
- * @deprecated Prefer using `SqlBindParams` where possible. This type exists
- * for internal flexibility but may be removed in a future version once all
- * internal producers are tightened to return `SqlValue`.
+ * @see SqlBindParams for the strict user-facing equivalent
  */
 export type SqlQueryBindParams = BindParams<unknown>
 

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -3,10 +3,42 @@
 import type { Brand } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
-export type ParamsObject = Record<string, SqlValue>
+/** A primitive value that can be stored in SQLite. */
 export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
 
-export type Bindable = ReadonlyArray<SqlValue> | ParamsObject
+/** Record of column names to SQL-compatible values. */
+export type ParamsObject = Record<string, SqlValue>
+
+/**
+ * Parameters supplied to LiveStore's user-facing query APIs (raw SQL).
+ *
+ * Shapes:
+ * - Positional parameters for `?` placeholders: `readonly SqlValue[]`
+ * - Named parameters for `$name` placeholders: `{ name: SqlValue }`
+ *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
+ *
+ * These are normalized immediately before execution using `prepareBindValues()`
+ * into `PreparedBindValues` (driver-ready).
+ */
+export type SqlBindParams = ReadonlyArray<SqlValue> | ParamsObject
+
+/**
+ * Bind params produced by SQL helpers/materializers.
+ *
+ * This layer is intentionally LOOSER than `SqlBindParams` because:
+ * - materializers sometimes return positional arrays
+ * - helper-generated objects may contain values that still need encoding/coercion
+ *
+ * Before execution, these must be normalized into `PreparedBindValues`.
+ *
+ * NOTE: If you later want to enforce strictness, `prepareQueryBindValues()` is the
+ * recommended chokepoint for validation/coercion.
+ */
+export type SqlQueryBindParams =
+  | ReadonlyArray<unknown>
+  | {
+      readonly [param: string]: unknown
+    }
 
 export const SqlValueSchema = Schema.Union(
   Schema.String,
@@ -15,12 +47,22 @@ export const SqlValueSchema = Schema.Union(
   Schema.Null,
 )
 
+/**
+ * Driver-ready bind parameters sent to `PreparedStatement.execute/select`.
+ *
+ * - Positional arrays are passed through as-is.
+ * - Named-parameter objects are normalized to include `$`-prefixed keys (e.g. `$userId`)
+ *   and may have unused keys removed (some SQLite implementations reject unused named params).
+ *
+ * Values should be produced via `prepareBindValues(...)` or `prepareQueryBindValues(...)`
+ * immediately before execution.
+ */
 export const PreparedBindValues = Schema.Union(
   Schema.Array(SqlValueSchema),
   Schema.Record({ key: Schema.String, value: SqlValueSchema }),
 ).pipe(Schema.brand('PreparedBindValues'))
 
-export type PreparedBindValues = Brand.Branded<Bindable, 'PreparedBindValues'>
+export type PreparedBindValues = Brand.Branded<SqlBindParams, 'PreparedBindValues'>
 
 /**
  * This is a tag function for tagged literals.
@@ -39,14 +81,15 @@ export const sql = (template: TemplateStringsArray, ...args: unknown[]): string 
 }
 
 /**
- * Prepare bind values to send to SQLite
- * Add $ to the beginning of keys; which we use as our interpolation syntax
- * We also strip out any params that aren't used in the statement,
- * because rusqlite doesn't allow unused named params
+ * Prepare API-layer bind values for SQLite execution.
+ *
+ * Add `$` prefix to named parameter keys. We also strip out any params that aren't
+ * used in the statement, because rusqlite doesn't allow unused named params.
+ *
  * TODO: Search for unused params via proper parsing, not string search
  * TODO: Also make sure that the SQLite binding limit of 1000 is respected
  */
-export const prepareBindValues = (values: Bindable, statement: string): PreparedBindValues => {
+export const prepareBindValues = (values: SqlBindParams, statement: string): PreparedBindValues => {
   if (Array.isArray(values)) return values as any as PreparedBindValues
 
   const result: ParamsObject = {}
@@ -57,4 +100,16 @@ export const prepareBindValues = (values: Bindable, statement: string): Prepared
   }
 
   return result as PreparedBindValues
+}
+
+/**
+ * Normalizes *loose* bind params (from SQL helpers/materializers) for driver execution.
+ *
+ * This currently normalizes keys (adds `$`) and filters unused keys, but does not
+ * guarantee values are valid `SqlValue`s.
+ *
+ * If you want stricter enforcement, add runtime checks/coercion here.
+ */
+export const prepareQueryBindValues = (values: SqlQueryBindParams, statement: string): PreparedBindValues => {
+  return prepareBindValues(values as SqlBindParams, statement)
 }

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -40,20 +40,6 @@ export type BindParams<T> = ReadonlyArray<T> | Readonly<Record<string, T>>
  */
 export type SqlBindParams = BindParams<SqlBindValue>
 
-/**
- * Bind params produced by internal SQL helpers and materializers.
- *
- * Uses loose `unknown` typing because `Schema.encode*` returns `unknown` and
- * internal helpers may produce values that still need coercion.
- *
- * Before execution, these are normalized via `prepareQueryBindValues()` which
- * delegates to `prepareBindValues()`. The loose typing here allows flexibility
- * while the strict `SqlBindParams` protects user-facing APIs.
- *
- * @see SqlBindParams for the strict user-facing equivalent
- */
-export type SqlQueryBindParams = BindParams<unknown>
-
 export const SqlValueSchema = Schema.Union(
   Schema.String,
   Schema.Number,
@@ -68,7 +54,7 @@ export const SqlValueSchema = Schema.Union(
  * - Named-parameter objects are normalized to include `$`-prefixed keys (e.g. `$userId`)
  *   and may have unused keys removed (some SQLite implementations reject unused named params).
  *
- * Values should be produced via `prepareBindValues(...)` or `prepareQueryBindValues(...)`
+ * Values should be produced via `prepareBindValues(...)`
  * immediately before execution.
  */
 export const PreparedBindValues = Schema.Union(
@@ -114,16 +100,4 @@ export const prepareBindValues = (values: SqlBindParams, statement: string): Pre
   }
 
   return result as PreparedBindValues
-}
-
-/**
- * Normalizes *loose* bind params (from SQL helpers/materializers) for driver execution.
- *
- * This currently normalizes keys (adds `$`) and filters unused keys, but does not
- * guarantee values are valid `SqlValue`s.
- *
- * If you want stricter enforcement, add runtime checks/coercion here.
- */
-export const prepareQueryBindValues = (values: SqlQueryBindParams, statement: string): PreparedBindValues => {
-  return prepareBindValues(values as SqlBindParams, statement)
 }

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -33,7 +33,7 @@ export type ParamsObject = Record<string, SqlBindValue>
  * - Named: `{ name: value }` for `$name` placeholders
  *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
  */
-export type SqlBindParams = ReadonlyArray<SqlBindValue> | Readonly<ParamsObject>
+export type BindValues = ReadonlyArray<SqlBindValue> | Readonly<ParamsObject>
 
 export const SqlValueSchema = Schema.Union(
   Schema.String,
@@ -57,7 +57,7 @@ export const PreparedBindValues = Schema.Union(
   Schema.Record({ key: Schema.String, value: SqlValueSchema }),
 ).pipe(Schema.brand('PreparedBindValues'))
 
-export type PreparedBindValues = Brand.Branded<SqlBindParams, 'PreparedBindValues'>
+export type PreparedBindValues = Brand.Branded<BindValues, 'PreparedBindValues'>
 
 /**
  * This is a tag function for tagged literals.
@@ -84,7 +84,7 @@ export const sql = (template: TemplateStringsArray, ...args: unknown[]): string 
  * TODO: Search for unused params via proper parsing, not string search
  * TODO: Also make sure that the SQLite binding limit of 1000 is respected
  */
-export const prepareBindValues = (values: SqlBindParams, statement: string): PreparedBindValues => {
+export const prepareBindValues = (values: BindValues, statement: string): PreparedBindValues => {
   if (Array.isArray(values)) return values as any as PreparedBindValues
 
   const result: ParamsObject = {}

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -20,16 +20,6 @@ export type SqlBindValue = SqlValue | SessionIdSymbol
 export type ParamsObject = Record<string, SqlBindValue>
 
 /**
- * Generic bind parameters shape for SQL queries.
- *
- * Both positional (array) and named (record) parameter styles are supported:
- * - Positional: `[value1, value2]` for `?` placeholders
- * - Named: `{ name: value }` for `$name` placeholders
- *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
- */
-export type BindParams<T> = ReadonlyArray<T> | Readonly<Record<string, T>>
-
-/**
  * Parameters supplied to LiveStore's user-facing query APIs.
  *
  * Uses strict `SqlBindValue` typing to catch invalid bind values at compile time.
@@ -37,8 +27,13 @@ export type BindParams<T> = ReadonlyArray<T> | Readonly<Record<string, T>>
  *
  * These are normalized immediately before execution using `prepareBindValues()`
  * into `PreparedBindValues` (driver-ready).
+ *
+ * Both positional (array) and named (record) parameter styles are supported:
+ * - Positional: `[value1, value2]` for `?` placeholders
+ * - Named: `{ name: value }` for `$name` placeholders
+ *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
  */
-export type SqlBindParams = BindParams<SqlBindValue>
+export type SqlBindParams = ReadonlyArray<SqlBindValue> | Readonly<ParamsObject>
 
 export const SqlValueSchema = Schema.Union(
   Schema.String,

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -2,8 +2,8 @@
 
 import type { Brand } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
-
-import type { SessionIdSymbol } from './adapter-types.ts'
+import type { SessionIdSymbol as SessionIdSymbolType } from './adapter-types.ts'
+import { SessionIdSymbol } from './adapter-types.ts'
 
 /** A primitive value that can be stored in SQLite. */
 export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
@@ -14,7 +14,7 @@ export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
  * This includes all SQLite-compatible primitives (`SqlValue`) plus the `SessionIdSymbol`
  * sentinel, which is replaced with the actual session ID string before execution.
  */
-export type SqlBindValue = SqlValue | SessionIdSymbol
+export type SqlBindValue = SqlValue | SessionIdSymbolType
 
 /** Record of column names to SQL-compatible values. */
 export type ParamsObject = Record<string, SqlBindValue>
@@ -35,6 +35,12 @@ export const SqlValueSchema = Schema.Union(
   Schema.Uint8Array as any as Schema.Schema<Uint8Array<ArrayBuffer>>,
   Schema.Null,
 )
+
+/**
+ * Schema for SQL bind values, which includes SQLite primitives plus the
+ * `SessionIdSymbol` sentinel (replaced with actual session ID before execution).
+ */
+export const SqlBindValueSchema = Schema.Union(SqlValueSchema, Schema.UniqueSymbolFromSelf(SessionIdSymbol))
 
 /**
  * Driver-ready bind parameters sent to `PreparedStatement.execute/select`.

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -10,35 +10,38 @@ export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
 export type ParamsObject = Record<string, SqlValue>
 
 /**
+ * Generic bind parameters shape for SQL queries.
+ *
+ * Both positional (array) and named (record) parameter styles are supported:
+ * - Positional: `[value1, value2]` for `?` placeholders
+ * - Named: `{ name: value }` for `$name` placeholders
+ *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
+ */
+export type BindParams<T> = ReadonlyArray<T> | Readonly<Record<string, T>>
+
+/**
  * Parameters supplied to LiveStore's user-facing query APIs (raw SQL).
  *
- * Shapes:
- * - Positional parameters for `?` placeholders: `readonly SqlValue[]`
- * - Named parameters for `$name` placeholders: `{ name: SqlValue }`
- *   (keys are provided WITHOUT the leading `$`; `prepareBindValues()` adds it)
- *
+ * Uses strict `SqlValue` typing to catch invalid bind values at compile time.
  * These are normalized immediately before execution using `prepareBindValues()`
  * into `PreparedBindValues` (driver-ready).
  */
-export type SqlBindParams = ReadonlyArray<SqlValue> | ParamsObject
+export type SqlBindParams = BindParams<SqlValue>
 
 /**
  * Bind params produced by SQL helpers/materializers.
  *
- * This layer is intentionally LOOSER than `SqlBindParams` because:
- * - materializers sometimes return positional arrays
- * - helper-generated objects may contain values that still need encoding/coercion
+ * Uses loose `unknown` typing because internal helpers may produce values
+ * that still need encoding/coercion before execution.
  *
- * Before execution, these must be normalized into `PreparedBindValues`.
+ * Before execution, these must be normalized into `PreparedBindValues`
+ * via `prepareQueryBindValues()`.
  *
- * NOTE: If you later want to enforce strictness, `prepareQueryBindValues()` is the
- * recommended chokepoint for validation/coercion.
+ * @deprecated Prefer using `SqlBindParams` where possible. This type exists
+ * for internal flexibility but may be removed in a future version once all
+ * internal producers are tightened to return `SqlValue`.
  */
-export type SqlQueryBindParams =
-  | ReadonlyArray<unknown>
-  | {
-      readonly [param: string]: unknown
-    }
+export type SqlQueryBindParams = BindParams<unknown>
 
 export const SqlValueSchema = Schema.Union(
   Schema.String,

--- a/packages/@livestore/livestore/src/QueryCache.ts
+++ b/packages/@livestore/livestore/src/QueryCache.ts
@@ -1,4 +1,4 @@
-import type { Bindable } from '@livestore/common'
+import type { SqlBindParams } from '@livestore/common'
 import { BoundMap, BoundSet, SessionIdSymbol } from '@livestore/common'
 
 const SymbolsBase = Symbol('base')
@@ -20,7 +20,7 @@ export default class QueryCache {
   #entries = new BoundMap<CacheKey, any>(cacheSize)
   #dependencies = new Map<TableName, BoundSet<CacheKey>>()
 
-  getKey = (sql: string, bindValues?: Bindable): CacheKey => {
+  getKey = (sql: string, bindValues?: SqlBindParams): CacheKey => {
     if (bindValues == null) {
       return sql as CacheKey
     }

--- a/packages/@livestore/livestore/src/QueryCache.ts
+++ b/packages/@livestore/livestore/src/QueryCache.ts
@@ -1,4 +1,4 @@
-import type { SqlBindParams } from '@livestore/common'
+import type { BindValues } from '@livestore/common'
 import { BoundMap, BoundSet, SessionIdSymbol } from '@livestore/common'
 
 const SymbolsBase = Symbol('base')
@@ -20,7 +20,7 @@ export default class QueryCache {
   #entries = new BoundMap<CacheKey, any>(cacheSize)
   #dependencies = new Map<TableName, BoundSet<CacheKey>>()
 
-  getKey = (sql: string, bindValues?: SqlBindParams): CacheKey => {
+  getKey = (sql: string, bindValues?: BindValues): CacheKey => {
     if (bindValues == null) {
       return sql as CacheKey
     }

--- a/packages/@livestore/livestore/src/SqliteDbWrapper.ts
+++ b/packages/@livestore/livestore/src/SqliteDbWrapper.ts
@@ -7,6 +7,7 @@ import {
   type MutableDebugInfo,
   type PreparedBindValues,
   type PreparedStatement,
+  prepareBindValues,
   type SqliteDb,
   type SqliteDbChangeset,
   SqliteDbHelper,
@@ -146,7 +147,7 @@ export class SqliteDbWrapper implements SqliteDb {
     const stmt = this.tablesUsedStmt
     const tablesUsed = new Set<string>()
     try {
-      const results = stmt.select<{ tbl_name: string }>([query] as unknown as PreparedBindValues)
+      const results = stmt.select<{ tbl_name: string }>(prepareBindValues([query], stmt.sql))
 
       for (const row of results) {
         tablesUsed.add(row.tbl_name)

--- a/packages/@livestore/livestore/src/live-queries/client-document-get-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/client-document-get-query.ts
@@ -1,5 +1,4 @@
-import type { PreparedBindValues } from '@livestore/common'
-import { SessionIdSymbol } from '@livestore/common'
+import { prepareBindValues, SessionIdSymbol } from '@livestore/common'
 import { State } from '@livestore/common/schema'
 import { shouldNeverHappen } from '@livestore/utils'
 import type * as otel from '@opentelemetry/api'
@@ -33,12 +32,11 @@ export const makeExecBeforeFirstRun =
     const otelContext = otelContext_ ?? store[StoreInternalsSymbol].otel.queriesSpanContext
 
     const idVal = id === SessionIdSymbol ? store.sessionId : id!
+    const query = `SELECT 1 FROM '${table.sqliteDef.name}' WHERE id = ?`
     const rowExists =
-      store[StoreInternalsSymbol].sqliteDbWrapper.cachedSelect(
-        `SELECT 1 FROM '${table.sqliteDef.name}' WHERE id = ?`,
-        [idVal] as any as PreparedBindValues,
-        { otelContext },
-      ).length === 1
+      store[StoreInternalsSymbol].sqliteDbWrapper.cachedSelect(query, prepareBindValues([idVal], query), {
+        otelContext,
+      }).length === 1
 
     if (rowExists) return
 

--- a/packages/@livestore/livestore/src/live-queries/db-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.ts
@@ -1,4 +1,4 @@
-import type { Bindable, QueryBuilder } from '@livestore/common'
+import type { QueryBuilder, SqlBindParams } from '@livestore/common'
 import {
   getDurationMsFromSpan,
   getResultSchema,
@@ -25,7 +25,7 @@ import { makeExecBeforeFirstRun, rowQueryLabel } from './client-document-get-que
 export type QueryInputRaw<TDecoded, TEncoded> = {
   query: string
   schema: Schema.Schema<TDecoded, TEncoded>
-  bindValues?: Bindable
+  bindValues?: SqlBindParams
   /**
    * Can be provided explicitly to slightly speed up initial query performance
    *
@@ -142,7 +142,7 @@ export const queryDb: {
   return def
 }
 
-const bindValuesToDepKey = (bindValues: Bindable | undefined): DepKey => {
+const bindValuesToDepKey = (bindValues: SqlBindParams | undefined): DepKey => {
   if (bindValues === undefined) {
     return []
   }

--- a/packages/@livestore/livestore/src/live-queries/db-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.ts
@@ -1,4 +1,4 @@
-import type { QueryBuilder, SqlBindParams } from '@livestore/common'
+import type { BindValues, QueryBuilder } from '@livestore/common'
 import {
   getDurationMsFromSpan,
   getResultSchema,
@@ -25,7 +25,7 @@ import { makeExecBeforeFirstRun, rowQueryLabel } from './client-document-get-que
 export type QueryInputRaw<TDecoded, TEncoded> = {
   query: string
   schema: Schema.Schema<TDecoded, TEncoded>
-  bindValues?: SqlBindParams
+  bindValues?: BindValues
   /**
    * Can be provided explicitly to slightly speed up initial query performance
    *
@@ -142,7 +142,7 @@ export const queryDb: {
   return def
 }
 
-const bindValuesToDepKey = (bindValues: SqlBindParams | undefined): DepKey => {
+const bindValuesToDepKey = (bindValues: BindValues | undefined): DepKey => {
   if (bindValues === undefined) {
     return []
   }

--- a/packages/@livestore/livestore/src/mod.ts
+++ b/packages/@livestore/livestore/src/mod.ts
@@ -1,6 +1,5 @@
 export type { Adapter, ClientSession, PreparedStatement } from '@livestore/common'
 export {
-  type Bindable,
   type BootStatus,
   type DebugInfo,
   IntentionalShutdownCause,
@@ -13,6 +12,7 @@ export {
   type QueryBuilderAst,
   type RowQuery,
   SessionIdSymbol,
+  type SqlBindParams,
   type SqliteDb,
   StoreInterrupted,
   type SyncState,

--- a/packages/@livestore/livestore/src/mod.ts
+++ b/packages/@livestore/livestore/src/mod.ts
@@ -1,5 +1,6 @@
 export type { Adapter, ClientSession, PreparedStatement } from '@livestore/common'
 export {
+  type BindValues,
   type BootStatus,
   type DebugInfo,
   IntentionalShutdownCause,
@@ -12,7 +13,6 @@ export {
   type QueryBuilderAst,
   type RowQuery,
   SessionIdSymbol,
-  type BindValues,
   type SqliteDb,
   StoreInterrupted,
   type SyncState,

--- a/packages/@livestore/livestore/src/mod.ts
+++ b/packages/@livestore/livestore/src/mod.ts
@@ -12,7 +12,7 @@ export {
   type QueryBuilderAst,
   type RowQuery,
   SessionIdSymbol,
-  type SqlBindParams,
+  type BindValues,
   type SqliteDb,
   StoreInterrupted,
   type SyncState,

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -1,5 +1,4 @@
 import {
-  type Bindable,
   type ClientSession,
   Devtools,
   getExecStatementsFromMaterializer,
@@ -15,6 +14,7 @@ import {
   prepareBindValues,
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
+  type SqlBindParams,
   type StorageMode,
   UnknownError,
 } from '@livestore/common'
@@ -605,7 +605,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * ```
    */
   query = <TResult>(
-    query: Queryable<TResult> | { query: string; bindValues: Bindable; schema?: Schema.Schema<TResult> },
+    query: Queryable<TResult> | { query: string; bindValues: SqlBindParams; schema?: Schema.Schema<TResult> },
     options?: { otelContext?: otel.Context; debugRefreshReason?: RefreshReason },
   ): TResult => {
     this.checkShutdown('query')

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -10,7 +10,6 @@ import {
   MaterializeError,
   MaterializerHashMismatchError,
   makeClientSessionSyncProcessor,
-  type PreparedBindValues,
   prepareBindValues,
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
@@ -643,7 +642,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
       const rawRes = this[StoreInternalsSymbol].sqliteDbWrapper.cachedSelect(
         sqlRes.query,
-        sqlRes.bindValues as any as PreparedBindValues,
+        prepareBindValues(sqlRes.bindValues, sqlRes.query),
         {
           ...omitUndefineds({ otelContext: options?.otelContext }),
           queriedTables: new Set([query[QueryBuilderAstSymbol].tableDef.sqliteDef.name]),

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -13,7 +13,7 @@ import {
   prepareBindValues,
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
-  type SqlBindParams,
+  type BindValues,
   type StorageMode,
   UnknownError,
 } from '@livestore/common'
@@ -604,7 +604,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * ```
    */
   query = <TResult>(
-    query: Queryable<TResult> | { query: string; bindValues: SqlBindParams; schema?: Schema.Schema<TResult> },
+    query: Queryable<TResult> | { query: string; bindValues: BindValues; schema?: Schema.Schema<TResult> },
     options?: { otelContext?: otel.Context; debugRefreshReason?: RefreshReason },
   ): TResult => {
     this.checkShutdown('query')

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -1,4 +1,5 @@
 import {
+  type BindValues,
   type ClientSession,
   Devtools,
   getExecStatementsFromMaterializer,
@@ -13,7 +14,6 @@ import {
   prepareBindValues,
   QueryBuilderAstSymbol,
   replaceSessionIdSymbol,
-  type BindValues,
   type StorageMode,
   UnknownError,
 } from '@livestore/common'

--- a/packages/@livestore/svelte/src/create-store.svelte.ts
+++ b/packages/@livestore/svelte/src/create-store.svelte.ts
@@ -1,4 +1,5 @@
 import {
+  type BindValues,
   type CreateStoreOptionsPromise,
   createStorePromise,
   isLiveQueryDef,
@@ -6,7 +7,6 @@ import {
   type Queryable,
   type RefreshReason,
   type Schema,
-  type BindValues,
   type Store,
 } from '@livestore/livestore'
 import { omitUndefineds } from '@livestore/utils'

--- a/packages/@livestore/svelte/src/create-store.svelte.ts
+++ b/packages/@livestore/svelte/src/create-store.svelte.ts
@@ -1,5 +1,4 @@
 import {
-  type Bindable,
   type CreateStoreOptionsPromise,
   createStorePromise,
   isLiveQueryDef,
@@ -7,6 +6,7 @@ import {
   type Queryable,
   type RefreshReason,
   type Schema,
+  type SqlBindParams,
   type Store,
 } from '@livestore/livestore'
 import { omitUndefineds } from '@livestore/utils'
@@ -61,7 +61,7 @@ export const createStore = async <TSchema extends LiveStoreSchema>(
 
   // monkey-patch `store.query` to add some ✨ svelte magic ✨
   store.query = <TResult>(
-    queryDef: Queryable<TResult> | { query: string; bindValues: Bindable; schema?: Schema.Schema<TResult> },
+    queryDef: Queryable<TResult> | { query: string; bindValues: SqlBindParams; schema?: Schema.Schema<TResult> },
     options?: { otelContext?: otel.Context; debugRefreshReason?: RefreshReason },
   ): TResult => {
     // TODO support other query types

--- a/packages/@livestore/svelte/src/create-store.svelte.ts
+++ b/packages/@livestore/svelte/src/create-store.svelte.ts
@@ -6,7 +6,7 @@ import {
   type Queryable,
   type RefreshReason,
   type Schema,
-  type SqlBindParams,
+  type BindValues,
   type Store,
 } from '@livestore/livestore'
 import { omitUndefineds } from '@livestore/utils'
@@ -61,7 +61,7 @@ export const createStore = async <TSchema extends LiveStoreSchema>(
 
   // monkey-patch `store.query` to add some ✨ svelte magic ✨
   store.query = <TResult>(
-    queryDef: Queryable<TResult> | { query: string; bindValues: SqlBindParams; schema?: Schema.Schema<TResult> },
+    queryDef: Queryable<TResult> | { query: string; bindValues: BindValues; schema?: Schema.Schema<TResult> },
     options?: { otelContext?: otel.Context; debugRefreshReason?: RefreshReason },
   ): TResult => {
     // TODO support other query types


### PR DESCRIPTION
## Problem

SQL bind values were represented inconsistently across the codebase (multiple “bind value” types, mixed import sources, and frequent `as any as PreparedBindValues` casts). This made it difficult to reason about whether the `bindValues` used in the codebase actually needed different types.


```ts
//packages/@livestore/common/src/util.ts
export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
export type ParamsObject = Record<string, SqlValue>
export type Bindable = ReadonlyArray<SqlValue> | ParamsObject

//packages/@livestore/common/src/sql-queries/sql-queries.ts
export type BindValues = {
  readonly [columnName: string]: any
}
```

## Solution

This PR unifies bind value types and standardizes normalization at the execution boundary:

- Introduces canonical bind-value types in `@livestore/common/src/util.ts`:
  - `SqlValue` (SQLite primitives)
  - `SqlBindValue` (`SqlValue` + `SessionIdSymbol` sentinel)
  - `BindValues` (positional array or named object)
  - `SqlBindValueSchema` for schema validation/tooling
- Updates QueryBuilder to return `BindValues` from `.asSql()` and updates AST→SQL encoding to validate bind values via `SqlBindValueSchema`.
- Ensures QueryBuilder execution/select paths normalize bind values via `prepareBindValues(...)` (instead of relying on unsafe casts or call-site conventions).
- Propagates the unified `BindValues` type through LiveStore (`Store.query`, live queries), adapter-web SQL helpers, CLI MCP runtime/tool definitions, and the Svelte wrapper.

**Trade-offs / alternatives considered**
- Alternative: keep separate bind types per package/feature area (QueryBuilder vs sql-queries vs adapters) and add adapters between them. This was rejected in favor of a single shared contract to reduce friction and eliminate repeated conversion logic.
- `prepareBindValues` still uses simple string containment to detect used named params (existing behavior); this PR keeps that approach and focuses on unifying types and call sites first.

### Before / After

**Before: multiple bind types + unsafe casts**
```ts
// ad-hoc bind shapes across the codebase
type Bindable = ReadonlyArray<SqlValue> | Record<string, SqlValue>

// QueryBuilder execution often forced into PreparedBindValues
const { query, bindValues } = qb.asSql()
db.select(query, bindValues as any as PreparedBindValues)
```

**After: single `BindValues` type + normalization at the DB boundary**
```ts
// @livestore/common/src/util.ts
export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
export type SqlBindValue = SqlValue | typeof SessionIdSymbol
export type BindValues = ReadonlyArray<SqlBindValue> | Readonly<Record<string, SqlBindValue>>

export const prepareBindValues = (values: BindValues, statement: string): PreparedBindValues => { /* ... */ }

// sqlite-db-helper.ts
const { query, bindValues } = qb.asSql()
db.select(query, prepareBindValues(bindValues, query))
```