### PR TITLE
perf(build): speed up TypeScript builds by separating emit from type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup-env
-      - run: mono ts --no-emit
+      - run: mono ts
 
   test-unit:
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,21 @@ jobs:
         uses: ./.github/actions/setup-env
       - run: mono lint
 
+  type-check:
+    runs-on:
+      - namespace-profile-linux-x86-64
+      - namespace-features:github.run-id=${{ github.run_id }}
+    env:
+      LIVESTORE_BRANCH_PROTECTION_REQUIRED: "true"
+    defaults:
+      run:
+        shell: devenv shell bash -- -e {0}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+      - run: mono ts --no-emit
+
   test-unit:
     runs-on:
       - namespace-profile-linux-x86-64

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 direnv exec . mono lint --fix
+direnv exec . mono ts --no-emit
 
 # Check if docs files have changed
 if git diff --cached --name-only | grep -q "^docs/"; then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 direnv exec . mono lint --fix
-direnv exec . mono ts --no-emit
+direnv exec . mono ts
 
 # Check if docs files have changed
 if git diff --cached --name-only | grep -q "^docs/"; then

--- a/scripts/src/mono.ts
+++ b/scripts/src/mono.ts
@@ -18,22 +18,27 @@ const tsCommand = Cli.Command.make(
       Cli.Options.withDefault(false),
       Cli.Options.withDescription('Clean build artifacts before compilation'),
     ),
+    noCheck: Cli.Options.boolean('no-check').pipe(
+      Cli.Options.withDefault(false),
+      Cli.Options.withDescription('Disable full type checking (only critical parse and emit errors will be reported)'),
+    ),
+    noEmit: Cli.Options.boolean('no-emit').pipe(
+      Cli.Options.withDefault(false),
+      Cli.Options.withDescription('Type check only without emitting files'),
+    ),
   },
-  Effect.fn(function* ({ watch, clean }) {
+  Effect.fn(function* ({ watch, clean, noCheck, noEmit }) {
     if (clean) {
-      yield* cmd(
-        'find {examples,packages,tests,docs} -path "*node_modules*" -prune -o \\( -name "dist" -type d -a -not -path "*/wa-sqlite/dist" -o -name "*.tsbuildinfo" \\) -exec rm -rf {} +',
-        { shell: true },
-      ).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+      yield* cmd('tsc --build tsconfig.dev.json --clean').pipe(Effect.provide(LivestoreWorkspace.toCwd()))
     }
 
-    if (watch) {
-      yield* cmd('tsc --build tsconfig.dev.json --watch').pipe(Effect.provide(LivestoreWorkspace.toCwd()))
-    } else {
-      yield* cmd('tsc --build tsconfig.dev.json').pipe(Effect.provide(LivestoreWorkspace.toCwd()))
-      // TODO bring back when implemented https://github.com/livestorejs/livestore/issues/477
-      // yield* cmd('tsc --build tsconfig.examples.json', { cwd })
-    }
+    const flags = ['--build', 'tsconfig.dev.json', noCheck && '--noCheck', noEmit && '--noEmit', watch && '--watch']
+      .filter(Boolean)
+      .join(' ')
+
+    yield* cmd(`tsc ${flags}`).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+    // TODO bring back when implemented https://github.com/livestorejs/livestore/issues/477
+    // yield* cmd('tsc --build tsconfig.examples.json', { cwd })
   }),
 )
 

--- a/scripts/src/mono.ts
+++ b/scripts/src/mono.ts
@@ -28,9 +28,7 @@ const tsCommand = Cli.Command.make(
       yield* cmd('tsc --build tsconfig.dev.json --clean').pipe(Effect.provide(LivestoreWorkspace.toCwd()))
     }
 
-    const flags = ['--build', 'tsconfig.dev.json', noCheck && '--noCheck', watch && '--watch']
-      .filter(Boolean)
-      .join(' ')
+    const flags = ['--build', 'tsconfig.dev.json', noCheck && '--noCheck', watch && '--watch'].filter(Boolean).join(' ')
 
     yield* cmd(`tsc ${flags}`).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
     // TODO bring back when implemented https://github.com/livestorejs/livestore/issues/477

--- a/scripts/src/mono.ts
+++ b/scripts/src/mono.ts
@@ -22,17 +22,13 @@ const tsCommand = Cli.Command.make(
       Cli.Options.withDefault(false),
       Cli.Options.withDescription('Disable full type checking (only critical parse and emit errors will be reported)'),
     ),
-    noEmit: Cli.Options.boolean('no-emit').pipe(
-      Cli.Options.withDefault(false),
-      Cli.Options.withDescription('Type check only without emitting files'),
-    ),
   },
-  Effect.fn(function* ({ watch, clean, noCheck, noEmit }) {
+  Effect.fn(function* ({ watch, clean, noCheck }) {
     if (clean) {
       yield* cmd('tsc --build tsconfig.dev.json --clean').pipe(Effect.provide(LivestoreWorkspace.toCwd()))
     }
 
-    const flags = ['--build', 'tsconfig.dev.json', noCheck && '--noCheck', noEmit && '--noEmit', watch && '--watch']
+    const flags = ['--build', 'tsconfig.dev.json', noCheck && '--noCheck', watch && '--watch']
       .filter(Boolean)
       .join(' ')
 

--- a/scripts/standalone/setup.ts
+++ b/scripts/standalone/setup.ts
@@ -39,9 +39,9 @@ if (lastGitHash !== currentGitHash) {
     console.log(`Parent (${parentDir}) is a git repo, skipping node dependencies installation`)
   }
 
-  // Run an initial TS build
-  console.log('Running initial TS build...')
-  await $`mono ts`
+  // Run an initial TS build (skip type checking for speed; IDE and pre-commit handle type errors)
+  console.log('Running initial TS build (no type check)...')
+  await $`mono ts --no-check`
 
   // Update the last git hash
   await $`echo ${currentGitHash} > ${lastGitHashFile}`


### PR DESCRIPTION
## Problem

The `mono ts` command runs full TypeScript type checking during builds, which takes ~36 seconds (MacBook M2 Pro) on a clean build. This is one component of the devenv setup time.

Analysis using `tsc --extendedDiagnostics` showed that **type checking accounts for 71% of the TypeScript build time** (25.87s out of 36.48s).

## Solution

Separate declaration emit from type checking by leveraging TypeScript 5.5+'s `--noCheck` flag:

1. **Add `--no-check` flag to `mono ts`** - Passes `--noCheck` to tsc, disabling full type checking while still emitting declarations. Only critical parse and emit errors are reported.

2. **Update setup.ts** - Use `mono ts --no-check` for faster initial builds since:
   - IDE provides real-time type feedback during development
   - Pre-commit hook catches type errors before commits
   - CI has dedicated type-check job

3. **Add type checking to pre-commit hook** - Runs `mono ts` to catch type errors before they're committed.

4. **Add `type-check` CI job** - Dedicated job for type validation that runs in parallel with other checks.

5. **Use `tsc --build --clean`** - Replace find-based cleaning with tsc's native `--clean` flag for more precise artifact removal.

## Performance Impact

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| `mono ts --no-check` (emit only) | 36.48s | **14.13s** | **61% faster** |

Note: The default `mono ts` behavior is unchanged (full type checking + emit). The speed improvement applies when using `--no-check` (used by setup.ts).

## Trade-offs

- The devenv setup script now skips type checking during initial builds
- Developers rely on IDE for immediate type feedback after setup
- Type safety is enforced at pre-commit and CI

## Validation

- [x] Tested `mono ts --no-check` produces correct declarations
- [x] Tested `mono ts --clean` removes build artifacts correctly
- [x] CI pipeline passes with new `type-check` job