### PR TITLE
chore: fix region folding comments for WebStorm/VS Code compatibility

### DIFF
--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -251,7 +251,7 @@ export const merge = ({
       )
     }
 
-    // #region upstream-advance
+    //#region upstream-advance
     case 'upstream-advance': {
       if (payload.newEvents.length === 0) {
         return validateMergeResult(
@@ -374,7 +374,7 @@ export const merge = ({
         )
       }
     }
-    // #endregion
+    //#endregion upstream-advance
 
     // This is the same as what's running in the sync backend
     case 'local-push': {

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -182,7 +182,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    */
   readonly [StoreInternalsSymbol]: StoreInternals
 
-  // #region constructor
+  //#region constructor
   constructor({
     clientSession,
     schema,
@@ -416,7 +416,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     // Initialize stable network status property from client session
     this.networkStatus = clientSession.leaderThread.networkStatus
   }
-  // #endregion constructor
+  //#endregion constructor
 
   /**
    * Current session identifier for this Store instance.
@@ -710,7 +710,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     }
   }
 
-  // #region commit
+  //#region commit
   /**
    * Commit a list of events to the store which will immediately update the local database
    * and sync the events across other clients (similar to a `git commit`).
@@ -858,7 +858,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
       Runtime.runSync(this[StoreInternalsSymbol].effectContext.runtime),
     )
   }
-  // #endregion commit
+  //#endregion commit
 
   /**
    * Returns an async iterable of events from the eventlog.

--- a/packages/@livestore/webmesh/src/channel/direct-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel.ts
@@ -61,7 +61,7 @@ export const makeDirectChannel = ({
         innerChannelRef: { current: undefined as WebChannel.WebChannel<any, any> | undefined },
       }
 
-      // #region reconnect-loop
+      //#region reconnect-loop
       yield* Effect.gen(function* () {
         const resultDeferred = yield* Deferred.make<{
           channel: WebChannel.WebChannel<any, any>
@@ -193,7 +193,7 @@ export const makeDirectChannel = ({
         Effect.tapCauseLogPretty,
         Effect.forkScoped,
       )
-      // #endregion reconnect-loop
+      //#endregion reconnect-loop
 
       const parentSpan = yield* Effect.currentSpan.pipe(Effect.orDie)
 


### PR DESCRIPTION
## Summary

- Removes the space between `//` and `#region`/`#endregion` in custom folding region comments so they are recognized by WebStorm and VS Code
- Adds missing region name to an `#endregion` in `syncstate.ts`

References:
- [VS Code — Folding](https://code.visualstudio.com/docs/editing/codebasics#_folding)
- [WebStorm — Custom folding regions](https://www.jetbrains.com/help/webstorm/working-with-source-code.html#custom_folding_regions)

## Files changed

- `packages/@livestore/livestore/src/store/store.ts` — 4 comments
- `packages/@livestore/webmesh/src/channel/direct-channel.ts` — 2 comments
- `packages/@livestore/common/src/sync/syncstate.ts` — 2 comments

## Test plan

- [x] Open one of the changed files in WebStorm/VS Code and verify folding regions appear in the gutter