### PR TITLE
Fix broken "state of the project" links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > NOTE: LiveStore is still in beta and releases can include breaking changes.
 > See
-> [state of the project](https://docs.livestore.dev/evaluating/state-of-the-project/)
+> [state of the project](https://docs.livestore.dev/evaluation/state-of-the-project/)
 > for more info. LiveStore is following a semver-like release strategy where
 > breaking changes are released in minor versions before the 1.0 release.
 

--- a/docs/src/content/docs/overview/when-livestore.md
+++ b/docs/src/content/docs/overview/when-livestore.md
@@ -11,7 +11,7 @@ Choosing a data layer for a local-first app is a big decision and should be cons
 - you want to use SQLite for your queries
 - you like [event sourcing](/understanding-livestore/event-sourcing) to model data changes
 - you are working on a new app as LiveStore doesn't yet provide a way to [re-use an existing database](/misc/faq#existing-database)
-- the current [state of the project](/misc/state-of-the-project) aligns with your own timeline and requirements
+- the current [state of the project](/evaluation/state-of-the-project) aligns with your own timeline and requirements
 
 ## Evaluation exercise
 


### PR DESCRIPTION
## Summary

- Fix broken link in `CHANGELOG.md`: `/evaluating/state-of-the-project/` → `/evaluation/state-of-the-project/`
- Fix broken link in `docs/src/content/docs/overview/when-livestore.md`: `/misc/state-of-the-project` → `/evaluation/state-of-the-project`

The `evaluating/` path was renamed to `evaluation/` at some point but these links were not updated, resulting in 404s on the deployed docs.

## Test plan

- [ ] Verify https://docs.livestore.dev/evaluation/state-of-the-project/ loads correctly (it does)
- [ ] Verify the changelog renders the correct link after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)