### PR TITLE
Fix broken "state of the project" link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-> NOTE: LiveStore is still in beta and releases can include breaking changes. See [state of the project](https://docs.livestore.dev/evaluating/state-of-the-project/) for more info.
+> NOTE: LiveStore is still in beta and releases can include breaking changes. See [state of the project](https://docs.livestore.dev/evaluation/state-of-the-project/) for more info.
 > LiveStore is following a semver-like release strategy where breaking changes are released in minor versions before the 1.0 release.
 
 ## 0.3.0


### PR DESCRIPTION
## Summary

- Fix broken link in `CHANGELOG.md`: `/evaluating/state-of-the-project/` → `/evaluation/state-of-the-project/`

This is the same fix as #1008 (targeting `dev`) but for `main`, which is what the deployed docs at https://docs.livestore.dev/changelog/ are built from.

## Test plan

- [ ] Verify https://docs.livestore.dev/evaluation/state-of-the-project/ loads correctly (it does)
- [ ] Verify the changelog no longer links to a 404 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)