### PR TITLE
Fix broken "state of the project" link in changelog (dev)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 > NOTE: LiveStore is still in beta and releases can include breaking changes.
 > See
-> [state of the project](https://docs.livestore.dev/evaluating/state-of-the-project/)
+> [state of the project](https://docs.livestore.dev/misc/state-of-the-project/)
 > for more info. LiveStore is following a semver-like release strategy where
 > breaking changes are released in minor versions before the 1.0 release.
 


### PR DESCRIPTION
## Summary

- Fix broken link in `CHANGELOG.md`: `/evaluating/state-of-the-project/` → `/misc/state-of-the-project/`

On `dev`, the state-of-the-project page lives under `docs/src/content/docs/misc/`, so the link should point to `/misc/state-of-the-project/`.

Companion to #1009 which fixes the same link on `main` (where the page lives under `evaluation/`).

## Test plan

- [ ] Verify the link path matches the file at `docs/src/content/docs/misc/state-of-the-project.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)