### PR TITLE
feat: streamline beads integration via effect-utils shared module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 
 name: ci
 
-run-name: "${{ github.event.pull_request.title || format('Push to {0}', github.ref_name) }} (${{ github.event.pull_request.head.sha || github.sha }})"
+run-name: ${{ github.event.pull_request.title || format('Push to {0}', github.ref_name) }} (${{ github.event.pull_request.head.sha || github.sha }})
 
 permissions:
   id-token: write
@@ -15,9 +15,9 @@ on:
   pull_request: {}
 
 env:
-  GITHUB_BRANCH_NAME: '${{ github.head_ref || github.ref_name }}'
-  S2_ACCESS_TOKEN: '${{ secrets.S2_ACCESS_TOKEN }}'
-  CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  GITHUB_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  S2_ACCESS_TOKEN: ${{ secrets.S2_ACCESS_TOKEN }}
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
 jobs:
   lint:
@@ -35,7 +35,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -66,7 +66,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -97,7 +97,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -128,7 +128,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -146,7 +146,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -210,7 +210,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -228,15 +228,15 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
           echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-prod-us-east-2.grafana.net/otlp" >> $GITHUB_ENV
           # Disable in Vite (otherwise CORS issues)
           echo "VITE_OTEL_EXPORTER_OTLP_ENDPOINT=" >> $GITHUB_ENV
-      - name: 'Run sync-provider tests for ${{ matrix.provider }}'
-        if: "${{ matrix.provider != 's2' || env.S2_ACCESS_TOKEN != '' }}"
+      - name: Run sync-provider tests for ${{ matrix.provider }}
+        if: ${{ matrix.provider != 's2' || env.S2_ACCESS_TOKEN != '' }}
         run: |
           if [[ "${{ matrix.provider }}" == cf-* ]]; then
             if dt "test:integration:sync-provider:${{ matrix.provider }}"; then
@@ -249,7 +249,7 @@ jobs:
             dt "test:integration:sync-provider:${{ matrix.provider }}"
           fi
       - name: Skip S2 sync-provider tests (missing S2_ACCESS_TOKEN)
-        if: "${{ matrix.provider == 's2' && env.S2_ACCESS_TOKEN == '' }}"
+        if: ${{ matrix.provider == 's2' && env.S2_ACCESS_TOKEN == '' }}
         run: 'echo "Skipping S2 sync-provider tests: S2_ACCESS_TOKEN not set"'
   test-integration-playwright:
     strategy:
@@ -269,7 +269,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -287,7 +287,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -296,7 +296,7 @@ jobs:
           echo "VITE_OTEL_EXPORTER_OTLP_ENDPOINT=" >> $GITHUB_ENV
       - name: Run integration tests
         env:
-          PLAYWRIGHT_SUITE: '${{ matrix.suite }}'
+          PLAYWRIGHT_SUITE: ${{ matrix.suite }}
         run: |
           if [ "${{ matrix.suite }}" = "devtools" ]; then
             dt test:integration:devtools || echo "::warning::Script failed but continuing"
@@ -304,16 +304,16 @@ jobs:
             dt "test:integration:${{ matrix.suite }}"
           fi
       - uses: actions/upload-artifact@v4
-        if: '${{ !cancelled() }}'
+        if: ${{ !cancelled() }}
         with:
-          name: 'playwright-report-${{ matrix.suite }}'
+          name: playwright-report-${{ matrix.suite }}
           path: tests/integration/playwright-report/
           retention-days: 30
       - name: Upload trace
-        if: '${{ !cancelled() }}'
+        if: ${{ !cancelled() }}
         env:
-          NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
-          PLAYWRIGHT_SUITE: '${{ matrix.suite }}'
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          PLAYWRIGHT_SUITE: ${{ matrix.suite }}
         run: |
           if [ -n "$NETLIFY_AUTH_TOKEN" ]; then
             bunx netlify-cli deploy --no-build --dir=tests/integration/playwright-report --site livestore-ci --filter @local/tests-integration --alias ${{ matrix.suite }}-$(git rev-parse --short HEAD)
@@ -329,14 +329,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: '${{ github.event.pull_request.head.sha || github.sha }}'
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Install Nix
         uses: cachix/install-nix-action@v31
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -354,7 +354,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -364,7 +364,7 @@ jobs:
       - name: Run performance tests
         run: 'dt test:perf'
         env:
-          COMMIT_SHA: '${{ github.event.pull_request.head.sha || github.sha }}'
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GRAFANA_ENDPOINT: 'https://livestore.grafana.net'
           OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp-gateway-prod-us-east-2.grafana.net/otlp'
   wa-sqlite-test:
@@ -379,7 +379,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -397,7 +397,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -410,7 +410,7 @@ jobs:
       - name: Run wa-sqlite tests
         run: 'devenv shell dt test:integration:wa-sqlite'
         env:
-          COMMIT_SHA: '${{ github.event.pull_request.head.sha || github.sha }}'
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GRAFANA_ENDPOINT: 'https://livestore.grafana.net'
           OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp-gateway-prod-us-east-2.grafana.net/otlp'
   publish-snapshot-version:
@@ -428,7 +428,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -446,8 +446,8 @@ jobs:
       - name: Configure NPM authentication
         run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc'
         env:
-          NPM_TOKEN: '${{ secrets.NPM_TOKEN }}'
-      - run: 'mono release snapshot --git-sha=${{ github.sha }}'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: mono release snapshot --git-sha=${{ github.sha }}
   build-and-deploy-examples-src:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
@@ -461,7 +461,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -486,8 +486,8 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: 'dt examples:deploy'
         env:
-          CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}'
-          CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
   build-deploy-docs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
@@ -501,7 +501,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Install megarepo CLI
         run: 'nix profile install github:overengineeringstudio/effect-utils#megarepo'
         shell: bash
@@ -519,10 +519,10 @@ jobs:
       - name: Build docs
         run: 'dt docs:build:api'
       - name: Deploy docs
-        if: "${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}"
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
         run: 'dt docs:deploy'
         env:
-          NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
   build-example-create:
     if: github.event.pull_request.head.repo.fork != true
     needs: publish-snapshot-version
@@ -531,8 +531,8 @@ jobs:
         app: [web-todomvc, web-linearlite, expo-linearlite]
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     env:
-      APP_PATH: 'examples/${{ matrix.app }}'
-      SNAPSHOT_VERSION: '0.0.0-snapshot-${{ github.sha }}'
+      APP_PATH: examples/${{ matrix.app }}
+      SNAPSHOT_VERSION: 0.0.0-snapshot-${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -542,24 +542,24 @@ jobs:
           standalone: true
           run_install: true
       - name: Get app's workspace dependencies
-        working-directory: '${{ env.APP_PATH }}'
+        working-directory: ${{ env.APP_PATH }}
         run: |
           echo "WORKSPACE_DEPS=$( \
             pnpm list --only-projects --json | \
             jq -r '.[0].dependencies | keys | join(" ")' \
           )" >> $GITHUB_ENV
       - name: Copy example app
-        run: 'pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --ref ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}'
+        run: pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --ref ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}
       - name: Increase pnpm fetch retries
         run: pnpm config set fetchRetries 3
       - name: Use snapshot version of workspace dependencies
-        working-directory: '${{ runner.temp }}/${{ env.APP_PATH }}'
+        working-directory: ${{ runner.temp }}/${{ env.APP_PATH }}
         run: |
           pnpm add $(
             for dep in $WORKSPACE_DEPS; do
               echo "$dep@${{ env.SNAPSHOT_VERSION }}"
             done
           )
-      - if: "${{ matrix.app != 'expo-linearlite' }}"
-        working-directory: '${{ runner.temp }}/${{ env.APP_PATH }}'
+      - if: ${{ matrix.app != 'expo-linearlite' }}
+        working-directory: ${{ runner.temp }}/${{ env.APP_PATH }}
         run: pnpm build

--- a/devenv.lock
+++ b/devenv.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770458462,
-        "narHash": "sha256-gTSrxPeXl1JFLXmEDb26rs+Qf108MQK+JmF1jS98Vxc=",
+        "lastModified": 1770461281,
+        "narHash": "sha256-yKDVGfRePnqhr3lf5lReZCLAZROw7RmktryeBT9tzDU=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "6a2c2778021e06181d8704e68af7cce0d96d527e",
+        "rev": "a541dfb4b979253a3ae1caad493610d2e8cb3fa0",
         "type": "github"
       },
       "original": {
@@ -149,40 +149,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1770197578,
-        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "overeng-beads-public": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1770412971,
-        "narHash": "sha256-iTRK5Put5VuaC+x8ISmots95gpdfd3FSxcBy3IVPx7E=",
-        "owner": "overengineeringstudio",
-        "repo": "overeng-beads-public",
-        "rev": "39ae4181295b4d6807d0f89178520fbb10c2aa94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "overengineeringstudio",
-        "repo": "overeng-beads-public",
-        "type": "github"
-      }
-    },
     "playwright": {
       "inputs": {
         "nixpkgs": [
@@ -234,7 +200,6 @@
         "effect-utils": "effect-utils",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "overeng-beads-public": "overeng-beads-public",
         "playwright": "playwright"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -57,8 +57,8 @@ let
 in
 {
   imports = [
-    # Beads commit correlation for issue tracking
-    (inputs.overeng-beads-public.devenvModules.beads {
+    # Beads integration: daemon, sync task, commit correlation hook
+    (taskModules.beads {
       beadsPrefix = "oep";
       beadsRepoName = "overeng-beads-public";
     })
@@ -192,6 +192,9 @@ in
     pass_filenames = false;
   };
 
+
+  # Wire beads:daemon:ensure directly to shell entry
+  tasks."devenv:enterShell".after = lib.mkAfter [ "beads:daemon:ensure" ];
   enterShell = ''
     sp="$(git rev-parse --show-superproject-working-tree 2>/dev/null)";
     export WORKSPACE_ROOT="$PWD"

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -16,6 +16,3 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
-  overeng-beads-public:
-    url: github:overengineeringstudio/overeng-beads-public
-    flake: true


### PR DESCRIPTION
## Summary

- Switches beads module import from `overeng-beads-public` flake (`inputs.overeng-beads-public.devenvModules.beads`) to the shared beads task module from effect-utils (`taskModules.beads`)
- Removes the `overeng-beads-public` flake input from `devenv.yaml` (no longer needed as a flake — now a pure data store)
- Adds `beads:daemon:ensure` auto-start on shell entry via `tasks."devenv:enterShell".after`

## Dependencies

- Requires effect-utils PR to be merged first (beads export in `flake.nix` / `taskModules.beads`)
- Stacks on top of #996 (`refactor/genie-igor-ci`)

## Test plan

- [ ] Verify `direnv allow` + shell entry starts beads daemon automatically
- [ ] Verify `dt beads:sync` works correctly
- [ ] Verify commit correlation hook still fires on git commit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>