### PR TITLE
Enhancement: Event log O(1) lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,8 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 #### Core Runtime & Storage
 
+- **Event log lookup optimization:** Improved event log lookup performance for large unsynced logs, speeding startup time ([#1011](https://github.com/livestorejs/livestore/pull/1011)).
+
 - **Unknown event handling:** Schemas now ship an `unknownEventHandling` configuration so older clients can warn, ignore, fail, or forward telemetry when they see future events while keeping the eventlog intact ([#353](https://github.com/livestorejs/livestore/issues/353)).
 
 - **Schema-first tables:** LiveStore now accepts Effect schema definitions as SQLite table inputs, keeping type information and stored schema in the same place. For example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,7 +310,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 #### Core Runtime & Storage
 
-- **Event log lookup optimization:** Improved event log lookup performance for large unsynced logs, speeding startup time ([#1011](https://github.com/livestorejs/livestore/pull/1011)).
+- **Event log lookup optimization:** Improved event log lookup performance for large unsynced logs, speeding startup time ([#1012](https://github.com/livestorejs/livestore/pull/1012)).
 
 - **Unknown event handling:** Schemas now ship an `unknownEventHandling` configuration so older clients can warn, ignore, fail, or forward telemetry when they see future events while keeping the eventlog intact ([#353](https://github.com/livestorejs/livestore/issues/353)).
 

--- a/packages/@livestore/common/src/leader-thread/eventlog.ts
+++ b/packages/@livestore/common/src/leader-thread/eventlog.ts
@@ -58,13 +58,14 @@ export const getEventsSince = ({
     sessionChangesetMetaTable.where('seqNumGlobal', '>=', since.global),
   )
 
+  // Create a Map for O(1) lookup instead of O(n) find
+  const sessionChangesetMap = new Map(
+    sessionChangesetRowsDecoded.map((row) => [`${row.seqNumGlobal}:${row.seqNumClient}`, row]),
+  )
+
   return pendingEvents
     .map((eventlogEvent) => {
-      const sessionChangeset = sessionChangesetRowsDecoded.find(
-        (readModelEvent) =>
-          readModelEvent.seqNumGlobal === eventlogEvent.seqNumGlobal &&
-          readModelEvent.seqNumClient === eventlogEvent.seqNumClient,
-      )
+      const sessionChangeset = sessionChangesetMap.get(`${eventlogEvent.seqNumGlobal}:${eventlogEvent.seqNumClient}`)
       return LiveStoreEvent.Client.EncodedWithMeta.make({
         name: eventlogEvent.name,
         args: eventlogEvent.argsJson,


### PR DESCRIPTION
Improved event log lookup in the leader thread to O(1) for faster startup.

## Problem

Initially described in [discord](https://discord.com/channels/1154415661842452532/1154415662874247191/1469453604460036290) but briefly, when there were lots of unsynced local event logs (like 20k), the expo app would start up very late (29 seconds).

## Solution

It turned out that most of the time was spent inside `getEventsSince` method because of nested loops. Using precomputed map for lookup instead of calling `sessionChangesetRowsDecoded.find` inside the `map` loop reduced the duration from `29` seconds to `8` seconds (like 70% faster). Still higher but that's good enough for a simple change. 

The other time consuming part is `LiveStoreEvent.Client.EncodedWithMeta.make` call. I believe it runs validation on each call contributing to slowness. I was able to squeeze it to 4 seconds my replacing `LiveStoreEvent.Client.EncodedWithMeta.make` calls with object construction with manual prototype setter but that becomes very cumbersome and unnecessary I'd say.