### PR TITLE
Remove stale task-based approach section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,34 +41,6 @@ Use the `mono` CLI for common workflows:
 - Keep exported members at the top of the file and move unexported helpers to the bottom.
 - Never add `paths` to `tsconfig.json`. Prefer using `package.json#exports` instead.
 
-## Task-based Approach
-
-### 0. Tasks
-
-- Operate on a task basis. Store all intermediate context in markdown files inside `tasks/{year}/{month}/{branch-name}/{task-id}/` folders.
-- Use semantic task ID slugs.
-
-### 1. Research
-
-- Identify existing patterns in the codebase.
-- Search external resources if relevant.
-- Begin by asking follow-up questions to set the research direction. Avoid trivial questions that you can look up yourself. Already do some preliminary research first to only ask questions that are ambiguous or strategically important.
-- Document findings in the `research.md` file.
-- When working on a bug/problem, create a separate `problem.md` to document the problem with a detailed description of the problem, the expected behavior, and the actual behavior including clear reproduction steps and evidence (e.g. logs, screenshots, CLI output, etc.).
-
-### 2. Planning
-
-- Review `research.md` in `tasks/<task-id>`.
-- Based on the research, create a plan for implementing the user request. Reuse existing patterns, components, and code wherever possible.
-- If needed, ask clarifying questions to the user to better understand the scope of the task.
-- Write a comprehensive plan in `plan.md`. This plan should include all the context required for an engineer to implement the feature.
-
-### 3. Implementation
-
-- Read `plan.md` and create a to-do list with all required items.
-- Execute the plan step by step.
-- Continue as far as possible. If ambiguities remain, note all questions at the end and group them together.
-
 ## Task Management (Beads)
 
 This repo uses [beads](../overeng-beads-public) for task tracking via the megarepo setup.


### PR DESCRIPTION
## Summary
- Removes the "Task-based Approach" section from CLAUDE.md which prescribed a rigid task/research/planning file workflow that is no longer used

## Test plan
- [x] Verify CLAUDE.md reads correctly without the section
- No code changes, documentation only