### PR TITLE
Fix all Effect LSP diagnostics (150 → 0)

### DIFF
--- a/packages/@livestore/adapter-node/src/client-session/adapter.ts
+++ b/packages/@livestore/adapter-node/src/client-session/adapter.ts
@@ -465,7 +465,7 @@ const makeWorkerLeaderThread = ({
   Effect.gen(function* () {
     const nodeWorker = new WT.Worker(workerUrl, {
       execArgv: process.env.DEBUG_WORKER ? ['--inspect --enable-source-maps'] : ['--enable-source-maps'],
-      argv: [Schema.encodeSync(WorkerSchema.WorkerArgv)({ storeId, clientId, sessionId, extraArgs: workerExtraArgs })],
+      argv: [yield* Schema.encode(WorkerSchema.WorkerArgv)({ storeId, clientId, sessionId, extraArgs: workerExtraArgs }).pipe(Effect.orDie)],
     })
     const nodeWorkerLayer = yield* Layer.build(PlatformNode.NodeWorker.layer(() => nodeWorker))
 

--- a/packages/@livestore/adapter-node/src/make-leader-worker.ts
+++ b/packages/@livestore/adapter-node/src/make-leader-worker.ts
@@ -111,58 +111,52 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
         UnknownError.mapToUnknownError,
         Effect.withSpan('@livestore/adapter-node:worker:ExportEventlog'),
       ),
-    GetLeaderHead: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetLeaderHead')),
-    GetLeaderSyncState: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return yield* workerCtx.syncProcessor.syncState
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetLeaderSyncState')),
+    GetLeaderHead: Effect.fn('@livestore/adapter-node:worker:GetLeaderHead')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
+    }, UnknownError.mapToUnknownError),
+    GetLeaderSyncState: Effect.fn('@livestore/adapter-node:worker:GetLeaderSyncState')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      return yield* workerCtx.syncProcessor.syncState
+    }, UnknownError.mapToUnknownError),
     SyncStateStream: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return workerCtx.syncProcessor.syncState.changes
       }).pipe(Stream.unwrapScoped),
-    GetNetworkStatus: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return yield* workerCtx.networkStatus
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetNetworkStatus')),
+    GetNetworkStatus: Effect.fn('@livestore/adapter-node:worker:GetNetworkStatus')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      return yield* workerCtx.networkStatus
+    }, UnknownError.mapToUnknownError),
     NetworkStatusStream: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return workerCtx.networkStatus.changes
       }).pipe(Stream.unwrapScoped),
-    GetRecreateSnapshot: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        // const result = yield* Deferred.await(workerCtx.initialSetupDeferred)
-        // NOTE we can only return the cached snapshot once as it's transferred (i.e. disposed), so we need to set it to undefined
-        // const cachedSnapshot =
-        //   result._tag === 'Recreate' ? yield* Ref.getAndSet(result.snapshotRef, undefined) : undefined
-        // return cachedSnapshot ?? workerCtx.db.export()
-        const snapshot = workerCtx.dbState.export()
-        return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:GetRecreateSnapshot')),
-    Shutdown: () =>
-      // @effect-diagnostics-next-line unnecessaryEffectGen:off
-      Effect.gen(function* () {
-        // const { db, dbEventlog } = yield* LeaderThreadCtx
-        yield* Effect.logDebug('[@livestore/adapter-node:worker] Shutdown')
+    GetRecreateSnapshot: Effect.fn('@livestore/adapter-node:worker:GetRecreateSnapshot')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      // const result = yield* Deferred.await(workerCtx.initialSetupDeferred)
+      // NOTE we can only return the cached snapshot once as it's transferred (i.e. disposed), so we need to set it to undefined
+      // const cachedSnapshot =
+      //   result._tag === 'Recreate' ? yield* Ref.getAndSet(result.snapshotRef, undefined) : undefined
+      // return cachedSnapshot ?? workerCtx.db.export()
+      const snapshot = workerCtx.dbState.export()
+      return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
+    }, UnknownError.mapToUnknownError),
+    Shutdown: Effect.fn('@livestore/adapter-node:worker:Shutdown')(function* () {
+      // const { db, dbEventlog } = yield* LeaderThreadCtx
+      yield* Effect.logDebug('[@livestore/adapter-node:worker] Shutdown')
 
-        // if (devtools.enabled) {
-        //   yield* FiberSet.clear(devtools.connections)
-        // }
-        // db.close()
-        // dbEventlog.close()
+      // if (devtools.enabled) {
+      //   yield* FiberSet.clear(devtools.connections)
+      // }
+      // db.close()
+      // dbEventlog.close()
 
-        // Buy some time for Otel to flush
-        // TODO find a cleaner way to do this
-        // yield* Effect.sleep(1000)
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-node:worker:Shutdown')),
+      // Buy some time for Otel to flush
+      // TODO find a cleaner way to do this
+      // yield* Effect.sleep(1000)
+    }, UnknownError.mapToUnknownError),
     ExtraDevtoolsMessage: ({ message }) =>
       Effect.andThen(LeaderThreadCtx, (_) => _.extraIncomingMessagesQueue.offer(message)).pipe(
         UnknownError.mapToUnknownError,

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
@@ -7,7 +7,7 @@ import { Effect, Stream } from '@livestore/utils/effect'
 import { WebChannelBrowser } from '@livestore/utils/effect/browser'
 import * as Webmesh from '@livestore/webmesh'
 
-export const logDevtoolsUrl = ({
+export const logDevtoolsUrl = Effect.fn('@livestore/adapter-web:client-session:devtools:logDevtoolsUrl')(function* ({
   schema,
   storeId,
   clientId,
@@ -17,37 +17,36 @@ export const logDevtoolsUrl = ({
   storeId: string
   clientId: string
   sessionId: string
-}) =>
-  Effect.gen(function* () {
-    if (isDevEnv()) {
-      const devtoolsPath = globalThis.LIVESTORE_DEVTOOLS_PATH ?? `/_livestore`
-      const devtoolsBaseUrl = `${location.origin}${devtoolsPath}`
+}) {
+  if (isDevEnv()) {
+    const devtoolsPath = globalThis.LIVESTORE_DEVTOOLS_PATH ?? `/_livestore`
+    const devtoolsBaseUrl = `${location.origin}${devtoolsPath}`
 
-      // Check whether devtools are available and then log the URL
-      const response = yield* Effect.promise(() => fetch(devtoolsBaseUrl))
-      if (response.ok) {
-        const text = yield* Effect.promise(() => response.text())
-        if (text.includes('<meta name="livestore-devtools" content="true" />')) {
-          const url = `${devtoolsBaseUrl}/web/${storeId}/${clientId}/${sessionId}/${schema.devtools.alias}`
-          yield* Effect.log(`[@livestore/adapter-web] Devtools ready on ${url}`)
-        }
+    // Check whether devtools are available and then log the URL
+    const response = yield* Effect.promise(() => fetch(devtoolsBaseUrl))
+    if (response.ok) {
+      const text = yield* Effect.promise(() => response.text())
+      if (text.includes('<meta name="livestore-devtools" content="true" />')) {
+        const url = `${devtoolsBaseUrl}/web/${storeId}/${clientId}/${sessionId}/${schema.devtools.alias}`
+        yield* Effect.log(`[@livestore/adapter-web] Devtools ready on ${url}`)
+      }
 
-        // Check for DevTools Chrome extension presence via iframe container the extension injects
-        const hasExt = document.querySelector('[id^="livestore-devtools-iframe-"]') !== null
-        if (!hasExt) {
-          const g = globalThis as { __livestoreDevtoolsChromeNoticeShown?: boolean }
-          if (g.__livestoreDevtoolsChromeNoticeShown !== true) {
-            g.__livestoreDevtoolsChromeNoticeShown = true
+      // Check for DevTools Chrome extension presence via iframe container the extension injects
+      const hasExt = document.querySelector('[id^="livestore-devtools-iframe-"]') !== null
+      if (!hasExt) {
+        const g = globalThis as { __livestoreDevtoolsChromeNoticeShown?: boolean }
+        if (g.__livestoreDevtoolsChromeNoticeShown !== true) {
+          g.__livestoreDevtoolsChromeNoticeShown = true
 
-            const urlToLog = `https://github.com/livestorejs/livestore/releases/download/v${liveStoreVersion}/livestore-devtools-chrome-${liveStoreVersion}.zip`
-            yield* Effect.log(
-              `[@livestore/adapter-web] LiveStore DevTools Chrome extension not detected. Install v${liveStoreVersion}: ${urlToLog}`,
-            )
-          }
+          const urlToLog = `https://github.com/livestorejs/livestore/releases/download/v${liveStoreVersion}/livestore-devtools-chrome-${liveStoreVersion}.zip`
+          yield* Effect.log(
+            `[@livestore/adapter-web] LiveStore DevTools Chrome extension not detected. Install v${liveStoreVersion}: ${urlToLog}`,
+          )
         }
       }
     }
-  }).pipe(Effect.withSpan('@livestore/adapter-web:client-session:devtools:logDevtoolsUrl'))
+  }
+})
 
 export const connectWebmeshNodeClientSession = Effect.fn(function* ({
   webmeshNode,

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -49,8 +49,8 @@ if (isDevEnv()) {
     opfs: Opfs.debugUtils,
     blobUrl: (buffer: Uint8Array<ArrayBuffer>) =>
       URL.createObjectURL(new Blob([buffer], { type: 'application/octet-stream' })),
-    runSync: (effect: Effect.Effect<any, any, never>) => Effect.runSync(effect),
-    runFork: (effect: Effect.Effect<any, any, never>) => Effect.runFork(effect),
+    runSync: <A, E>(effect: Effect.Effect<A, E>) => Effect.runSync(effect),
+    runFork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runFork(effect),
   }
 }
 
@@ -200,19 +200,18 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
         Effect.annotateSpans({ debugInstanceId }),
         Layer.unwrapScoped,
       ),
-    GetRecreateSnapshot: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
+    GetRecreateSnapshot: Effect.fn('@livestore/adapter-web:worker:GetRecreateSnapshot')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
 
-        // NOTE we can only return the cached snapshot once as it's transferred (i.e. disposed), so we need to set it to undefined
-        // const cachedSnapshot =
-        //   result._tag === 'Recreate' ? yield* Ref.getAndSet(result.snapshotRef, undefined) : undefined
+      // NOTE we can only return the cached snapshot once as it's transferred (i.e. disposed), so we need to set it to undefined
+      // const cachedSnapshot =
+      //   result._tag === 'Recreate' ? yield* Ref.getAndSet(result.snapshotRef, undefined) : undefined
 
-        // return cachedSnapshot ?? workerCtx.db.export()
+      // return cachedSnapshot ?? workerCtx.db.export()
 
-        const snapshot = workerCtx.dbState.export()
-        return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-web:worker:GetRecreateSnapshot')),
+      const snapshot = workerCtx.dbState.export()
+      return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
+    }, UnknownError.mapToUnknownError),
     PullStream: ({ cursor }) =>
       Effect.gen(function* () {
         const { syncProcessor } = yield* LeaderThreadCtx // <- syncState comes from here
@@ -256,39 +255,35 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
       ),
     BootStatusStream: () =>
       Effect.andThen(LeaderThreadCtx, (_) => Stream.fromQueue(_.bootStatusQueue)).pipe(Stream.unwrap),
-    GetLeaderHead: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-web:worker:GetLeaderHead')),
-    GetLeaderSyncState: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return yield* workerCtx.syncProcessor.syncState
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-web:worker:GetLeaderSyncState')),
+    GetLeaderHead: Effect.fn('@livestore/adapter-web:worker:GetLeaderHead')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
+    }, UnknownError.mapToUnknownError),
+    GetLeaderSyncState: Effect.fn('@livestore/adapter-web:worker:GetLeaderSyncState')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      return yield* workerCtx.syncProcessor.syncState
+    }, UnknownError.mapToUnknownError),
     SyncStateStream: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return workerCtx.syncProcessor.syncState.changes
       }).pipe(Stream.unwrapScoped),
-    GetNetworkStatus: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return yield* workerCtx.networkStatus
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-web:worker:GetNetworkStatus')),
+    GetNetworkStatus: Effect.fn('@livestore/adapter-web:worker:GetNetworkStatus')(function* () {
+      const workerCtx = yield* LeaderThreadCtx
+      return yield* workerCtx.networkStatus
+    }, UnknownError.mapToUnknownError),
     NetworkStatusStream: () =>
       Effect.gen(function* () {
         const workerCtx = yield* LeaderThreadCtx
         return workerCtx.networkStatus.changes
       }).pipe(Stream.unwrapScoped),
-    Shutdown: () =>
-      Effect.gen(function* () {
-        yield* Effect.logDebug('[@livestore/adapter-web:worker] Shutdown')
+    Shutdown: Effect.fn('@livestore/adapter-web:worker:Shutdown')(function* () {
+      yield* Effect.logDebug('[@livestore/adapter-web:worker] Shutdown')
 
-        // Buy some time for Otel to flush
-        // TODO find a cleaner way to do this
-        yield* Effect.sleep(300)
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('@livestore/adapter-web:worker:Shutdown')),
+      // Buy some time for Otel to flush
+      // TODO find a cleaner way to do this
+      yield* Effect.sleep(300)
+    }, UnknownError.mapToUnknownError),
     ExtraDevtoolsMessage: ({ message }) =>
       Effect.andThen(LeaderThreadCtx, (_) => _.extraIncomingMessagesQueue.offer(message)).pipe(
         UnknownError.mapToUnknownError,

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -43,11 +43,12 @@ if (isDevEnv()) {
   globalThis.__debugLiveStoreUtils = {
     blobUrl: (buffer: Uint8Array<ArrayBuffer>) =>
       URL.createObjectURL(new Blob([buffer], { type: 'application/octet-stream' })),
-    runSync: (effect: Effect.Effect<any, any, never>) => Effect.runSync(effect),
-    runFork: (effect: Effect.Effect<any, any, never>) => Effect.runFork(effect),
+    runSync: <A, E>(effect: Effect.Effect<A, E>) => Effect.runSync(effect),
+    runFork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runFork(effect),
   }
 }
 
+// @effect-diagnostics-next-line anyUnknownInErrorContext:off
 const makeWorkerRunner = Effect.gen(function* () {
   const leaderWorkerContextSubRef = yield* SubscriptionRef.make<
     | {
@@ -71,7 +72,12 @@ const makeWorkerRunner = Effect.gen(function* () {
     // Forward the request to the active worker and normalize platform errors into UnknownError.
     waitForWorker.pipe(
       // Effect.logBefore(`forwardRequest: ${req._tag}`),
-      Effect.andThen((worker) => worker.executeEffect(req) as Effect.Effect<unknown, unknown, unknown>),
+      Effect.andThen((worker) =>
+        worker.executeEffect(req) as unknown as Effect.Effect<
+          Schema.WithResult.Success<TReq>,
+          WorkerError.WorkerError | ParseResult.ParseError | Schema.WithResult.Failure<TReq>
+        >,
+      ),
       // Effect.tap((_) => Effect.log(`forwardRequest: ${req._tag}`, _)),
       // Effect.tapError((cause) => Effect.logError(`forwardRequest err: ${req._tag}`, cause)),
       Effect.interruptible,
@@ -104,7 +110,10 @@ const makeWorkerRunner = Effect.gen(function* () {
     Effect.gen(function* () {
       yield* Effect.logDebug(`forwardRequestStream: ${req._tag}`)
       const { worker, scope } = yield* SubscriptionRef.waitUntil(leaderWorkerContextSubRef, isNotUndefined)
-      const stream = worker.execute(req) as Stream.Stream<unknown, unknown, unknown>
+      const stream = worker.execute(req) as unknown as Stream.Stream<
+        Schema.WithResult.Success<TReq>,
+        WorkerError.WorkerError | ParseResult.ParseError | Schema.WithResult.Failure<TReq>
+      >
 
       // It seems the request stream is not automatically interrupted when the scope shuts down
       // so we need to manually interrupt it when the scope shuts down
@@ -168,6 +177,7 @@ const makeWorkerRunner = Effect.gen(function* () {
   const invariantsRef = yield* Ref.make<Invariants | undefined>(undefined)
   const sameInvariants = Schema.equivalence(InvariantsSchema)
 
+  // @effect-diagnostics-next-line anyUnknownInErrorContext:off
   return WorkerRunner.layerSerialized(WorkerSchema.SharedWorkerRequest, {
     // Whenever the client session leader changes (and thus creates a new leader thread), the new client session leader
     // sends a new MessagePort to the shared worker which proxies messages to the new leader thread.
@@ -267,6 +277,7 @@ export const makeWorker = (options?: LogConfig.WithLoggerOptions): void => {
     WebmeshWorker.CacheService.layer({ nodeName: DevtoolsWeb.makeNodeName.sharedWorker({ storeId }) }),
   )
 
+  // @effect-diagnostics-next-line anyUnknownInErrorContext:off
   makeWorkerRunner.pipe(
     Layer.provide(BrowserWorkerRunner.layer),
     // WorkerRunner.launch,
@@ -277,7 +288,8 @@ export const makeWorker = (options?: LogConfig.WithLoggerOptions): void => {
     Effect.provide(runtimeLayer),
     LS_DEV ? TaskTracing.withAsyncTaggingTracing((name) => (console as any).createTask(name)) : identity,
     // TODO remove type-cast (currently needed to silence a tsc bug)
-    (_) => _ as any as Effect.Effect<void, any>,
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off
+    (_) => _ as any as Effect.Effect<void, never>,
     LogConfig.withLoggerConfig(options, { threadName: self.name }),
     Effect.runFork,
   )

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -48,7 +48,7 @@ if (isDevEnv()) {
   }
 }
 
-// @effect-diagnostics-next-line anyUnknownInErrorContext:off
+// @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `SerializedRunner.Handlers` uses `any` in the R channel, propagating as `unknown` in `HandlersContext`
 const makeWorkerRunner = Effect.gen(function* () {
   const leaderWorkerContextSubRef = yield* SubscriptionRef.make<
     | {
@@ -177,7 +177,7 @@ const makeWorkerRunner = Effect.gen(function* () {
   const invariantsRef = yield* Ref.make<Invariants | undefined>(undefined)
   const sameInvariants = Schema.equivalence(InvariantsSchema)
 
-  // @effect-diagnostics-next-line anyUnknownInErrorContext:off
+  // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `SerializedRunner.Handlers` uses `any` in the R channel
   return WorkerRunner.layerSerialized(WorkerSchema.SharedWorkerRequest, {
     // Whenever the client session leader changes (and thus creates a new leader thread), the new client session leader
     // sends a new MessagePort to the shared worker which proxies messages to the new leader thread.
@@ -277,7 +277,7 @@ export const makeWorker = (options?: LogConfig.WithLoggerOptions): void => {
     WebmeshWorker.CacheService.layer({ nodeName: DevtoolsWeb.makeNodeName.sharedWorker({ storeId }) }),
   )
 
-  // @effect-diagnostics-next-line anyUnknownInErrorContext:off
+  // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- propagated from `makeWorkerRunner`
   makeWorkerRunner.pipe(
     Layer.provide(BrowserWorkerRunner.layer),
     // WorkerRunner.launch,
@@ -288,7 +288,7 @@ export const makeWorker = (options?: LogConfig.WithLoggerOptions): void => {
     Effect.provide(runtimeLayer),
     LS_DEV ? TaskTracing.withAsyncTaggingTracing((name) => (console as any).createTask(name)) : identity,
     // TODO remove type-cast (currently needed to silence a tsc bug)
-    // @effect-diagnostics-next-line anyUnknownInErrorContext:off
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- TSC bug workaround; the cast uses `any` as an intermediate
     (_) => _ as any as Effect.Effect<void, never>,
     LogConfig.withLoggerConfig(options, { threadName: self.name }),
     Effect.runFork,

--- a/packages/@livestore/cli/src/__tests__/fixtures/mock-config.ts
+++ b/packages/@livestore/cli/src/__tests__/fixtures/mock-config.ts
@@ -8,6 +8,11 @@ import { Effect, FileSystem, type Mailbox, Schema } from '@livestore/utils/effec
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+class DynamicImportError extends Schema.TaggedError<DynamicImportError>()('DynamicImportError', {
+  cause: Schema.Defect,
+  path: Schema.String,
+}) {}
+
 // Use package-local temp directory for test config files to ensure proper module resolution
 const tmpDir = path.join(__dirname, '.tmp-test-configs')
 
@@ -84,7 +89,7 @@ export const useMockConfig = Effect.acquireRelease(
 
     const mod = (yield* Effect.tryPromise({
       try: () => import(pathToFileURL(tempPath).href),
-      catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+      catch: (cause) => new DynamicImportError({ cause, path: tempPath }),
     })) as {
       mockBackend: MockSyncBackend
       connectionEvents: Mailbox.Mailbox<'connect' | 'disconnect'>

--- a/packages/@livestore/cli/src/commands/import-export.ts
+++ b/packages/@livestore/cli/src/commands/import-export.ts
@@ -1,10 +1,13 @@
 import path from 'node:path'
 
 import type { UnknownError } from '@livestore/common'
-import { Console, Effect, FileSystem, type HttpClient, type Scope } from '@livestore/utils/effect'
+import { Console, Effect, FileSystem, type HttpClient, Schema, type Scope } from '@livestore/utils/effect'
 import { Cli } from '@livestore/utils/node'
 
 import * as SyncOps from '../sync-operations.ts'
+
+const jsonStringifyPretty = Schema.encodeSync(Schema.parseJson({ space: 2 }))
+const jsonParse = Schema.decodeUnknownSync(Schema.parseJson())
 
 const LARGE_EVENT_WARNING_THRESHOLD = 100_000
 
@@ -42,8 +45,7 @@ const exportEvents = ({
     const fs = yield* FileSystem.FileSystem
     const absOutputPath = path.isAbsolute(outputPath) ? outputPath : path.resolve(process.cwd(), outputPath)
 
-    // @effect-diagnostics-next-line preferSchemaOverJson:off
-    yield* fs.writeFileString(absOutputPath, JSON.stringify(result.data, null, 2)).pipe(
+    yield* fs.writeFileString(absOutputPath, jsonStringifyPretty(result.data)).pipe(
       Effect.mapError(
         (cause) =>
           new SyncOps.ExportError({
@@ -111,8 +113,7 @@ const importEvents = ({
     )
 
     const parsedContent = yield* Effect.try({
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      try: () => JSON.parse(fileContent),
+      try: () => jsonParse(fileContent),
       catch: (error) =>
         new SyncOps.ImportError({
           cause: new Error(`Failed to parse JSON: ${error instanceof Error ? error.message : String(error)}`),

--- a/packages/@livestore/cli/src/commands/import-export.ts
+++ b/packages/@livestore/cli/src/commands/import-export.ts
@@ -42,6 +42,7 @@ const exportEvents = ({
     const fs = yield* FileSystem.FileSystem
     const absOutputPath = path.isAbsolute(outputPath) ? outputPath : path.resolve(process.cwd(), outputPath)
 
+    // @effect-diagnostics-next-line preferSchemaOverJson:off
     yield* fs.writeFileString(absOutputPath, JSON.stringify(result.data, null, 2)).pipe(
       Effect.mapError(
         (cause) =>
@@ -110,6 +111,7 @@ const importEvents = ({
     )
 
     const parsedContent = yield* Effect.try({
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       try: () => JSON.parse(fileContent),
       catch: (error) =>
         new SyncOps.ImportError({

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -73,8 +73,7 @@ const fetchExamples = (ref: string) =>
 
     const responseText = yield* response.text
 
-    // @effect-diagnostics-next-line preferSchemaOverJson:off
-    const examples = yield* Schema.decodeUnknown(GitHubContentsResponseSchema)(JSON.parse(responseText)).pipe(
+    const examples = yield* Schema.decodeUnknown(Schema.parseJson(GitHubContentsResponseSchema))(responseText).pipe(
       Effect.catchAll(
         (error) =>
           new NetworkError({

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -73,6 +73,7 @@ const fetchExamples = (ref: string) =>
 
     const responseText = yield* response.text
 
+    // @effect-diagnostics-next-line preferSchemaOverJson:off
     const examples = yield* Schema.decodeUnknown(GitHubContentsResponseSchema)(JSON.parse(responseText)).pipe(
       Effect.catchAll(
         (error) =>

--- a/packages/@livestore/cli/src/mcp-runtime/runtime.ts
+++ b/packages/@livestore/cli/src/mcp-runtime/runtime.ts
@@ -102,31 +102,34 @@ export const status = Effect.gen(function* () {
   }
 }).pipe(Effect.withSpan('mcp-runtime:status'))
 
-export const query = ({ sql, bindValues }: { sql: string; bindValues?: readonly any[] | Record<string, unknown> }) =>
-  Effect.gen(function* () {
-    const opt = yield* getStore
-    if (opt._tag === 'None') {
-      return yield* Effect.dieMessage('LiveStore not connected. Call livestore_instance_connect first.')
-    }
-    const s = opt.value
+export const query = Effect.fn('mcp-runtime:query')(function* ({
+  sql,
+  bindValues,
+}: { sql: string; bindValues?: readonly any[] | Record<string, unknown> }) {
+  const opt = yield* getStore
+  if (opt._tag === 'None') {
+    return yield* Effect.dieMessage('LiveStore not connected. Call livestore_instance_connect first.')
+  }
+  const s = opt.value
 
-    const rows = s.query({ query: sql, bindValues: (bindValues as any) ?? [] }) as Array<Record<string, unknown>>
-    const jsonRows = rows.map((r) => Object.fromEntries(Object.entries(r).map(([k, v]) => [k, v as Schema.JsonValue])))
-    return { rows: jsonRows, rowCount: jsonRows.length }
-  }).pipe(Effect.withSpan('mcp-runtime:query'))
+  const rows = s.query({ query: sql, bindValues: (bindValues as any) ?? [] }) as Array<Record<string, unknown>>
+  const jsonRows = rows.map((r) => Object.fromEntries(Object.entries(r).map(([k, v]) => [k, v as Schema.JsonValue])))
+  return { rows: jsonRows, rowCount: jsonRows.length }
+})
 
-export const commit = ({ events }: { events: ReadonlyArray<{ name: string; args: Schema.JsonValue }> }) =>
-  Effect.gen(function* () {
-    const opt = yield* getStore
-    if (opt._tag === 'None') {
-      return yield* Effect.dieMessage('LiveStore not connected. Call livestore_instance_connect first.')
-    }
-    const s = opt.value
-    const InputEventSchema = LiveStoreEvent.Input.makeSchema(s.schema) as Schema.Schema<any>
-    const decoded = events.map((e) => Schema.decodeSync(InputEventSchema)(e))
-    s.commit(...decoded)
-    return { committed: decoded.length }
-  }).pipe(Effect.withSpan('mcp-runtime:commit'))
+export const commit = Effect.fn('mcp-runtime:commit')(function* ({
+  events,
+}: { events: ReadonlyArray<{ name: string; args: Schema.JsonValue }> }) {
+  const opt = yield* getStore
+  if (opt._tag === 'None') {
+    return yield* Effect.dieMessage('LiveStore not connected. Call livestore_instance_connect first.')
+  }
+  const s = opt.value
+  const InputEventSchema = LiveStoreEvent.Input.makeSchema(s.schema) as Schema.Schema<any>
+  const decoded = events.map((e) => Schema.decodeSync(InputEventSchema)(e))
+  s.commit(...decoded)
+  return { committed: decoded.length }
+})
 
 export const disconnect = Effect.promise(async () => {
   if (store) {

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -87,6 +87,7 @@ export const toDurableObjectHandler =
 
         // For streaming RPCs with only one request, return ReadableStream directly
         if (isStream && requests.length === 1) {
+          // @effect-diagnostics-next-line anyUnknownInErrorContext:off
           return yield* createStreamingResponse(rpc, entry, request, parser, options.layer)
         }
 
@@ -101,6 +102,7 @@ export const toDurableObjectHandler =
 
           let value: any
           if (Effect.isEffect(handlerResult)) {
+            // @effect-diagnostics-next-line anyUnknownInErrorContext:off
             value = yield* handlerResult
           } else {
             value = handlerResult
@@ -157,7 +159,7 @@ export const toDurableObjectHandler =
     }).pipe(Effect.provide(options.layer), Effect.scoped, Effect.orDie)
 
 /** Out-of-band RPC stream response emission back to the caller DO */
-export const emitStreamResponse = ({
+export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(function* ({
   callerContext,
   env,
   requestId,
@@ -167,22 +169,21 @@ export const emitStreamResponse = ({
   callerContext: { bindingName: string; durableObjectId: string }
   requestId: string
   values: NonEmptyArray<any>
-}) =>
-  Effect.gen(function* () {
-    const clientDoNamespace = env[callerContext.bindingName] as
-      | CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>
-      | undefined
+}) {
+  const clientDoNamespace = env[callerContext.bindingName] as
+    | CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback>
+    | undefined
 
-    if (clientDoNamespace === undefined) {
-      throw new Error(`Client DO namespace not found: ${callerContext.bindingName}`)
-    }
+  if (clientDoNamespace === undefined) {
+    throw new Error(`Client DO namespace not found: ${callerContext.bindingName}`)
+  }
 
-    const clientDo = clientDoNamespace.get(clientDoNamespace.idFromString(callerContext.durableObjectId))
+  const clientDo = clientDoNamespace.get(clientDoNamespace.idFromString(callerContext.durableObjectId))
 
-    const res: RpcMessage.ResponseChunkEncoded = { _tag: 'Chunk', requestId, values }
+  const res: RpcMessage.ResponseChunkEncoded = { _tag: 'Chunk', requestId, values }
 
-    yield* Effect.tryPromise(() => clientDo.syncUpdateRpc(res))
-  }).pipe(Effect.withSpan('do-rpc/emitStreamResponse'))
+  yield* Effect.tryPromise(() => clientDo.syncUpdateRpc(res))
+})
 
 /**
  * Creates a ReadableStream response for streaming RPCs.
@@ -207,6 +208,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
     let stream: Stream.Stream<any, any, never>
     if (Effect.isEffect(handlerResult)) {
       // If handler returns Effect<Stream>, we need to run it to get the stream
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       stream = yield* handlerResult
     } else {
       // Direct stream

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -87,7 +87,6 @@ export const toDurableObjectHandler =
 
         // For streaming RPCs with only one request, return ReadableStream directly
         if (isStream && requests.length === 1) {
-          // @effect-diagnostics-next-line anyUnknownInErrorContext:off
           return yield* createStreamingResponse(rpc, entry, request, parser, options.layer)
         }
 
@@ -102,7 +101,7 @@ export const toDurableObjectHandler =
 
           let value: any
           if (Effect.isEffect(handlerResult)) {
-            // @effect-diagnostics-next-line anyUnknownInErrorContext:off
+            // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Rpc.Handler.handler` returns `Effect<any, any>` due to dynamic dispatch
             value = yield* handlerResult
           } else {
             value = handlerResult
@@ -195,7 +194,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
   request: any,
   parser: ReturnType<typeof RpcSerialization.msgPack.unsafeMake>,
   layer: Layer.Layer<Rpc.ToHandler<Rpcs> | Rpc.Middleware<Rpcs>, LE>,
-): Effect.Effect<CfTypes.ReadableStream, any, Scope.Scope> =>
+): Effect.Effect<CfTypes.ReadableStream, never, Scope.Scope> =>
   Effect.gen(function* () {
     // Execute the handler to get the stream
     const handlerResult = entry.handler(request.payload, {
@@ -205,15 +204,10 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
       }),
     })
 
-    let stream: Stream.Stream<any, any, never>
-    if (Effect.isEffect(handlerResult)) {
-      // If handler returns Effect<Stream>, we need to run it to get the stream
-      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
-      stream = yield* handlerResult
-    } else {
-      // Direct stream
-      stream = handlerResult
-    }
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Rpc.Handler.handler` returns `Effect<any, any>` due to dynamic dispatch; orDie converts the error to a defect handled by the downstream catchAllCause
+    const stream: Stream.Stream<any, any, never> = Effect.isEffect(handlerResult)
+      ? yield* Effect.orDie(handlerResult)
+      : handlerResult
 
     // Get the stream schemas for proper chunk-level encoding
     const streamSchemas = RpcSchema.getStreamSchemas((rpc as any).successSchema.ast)

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -16,6 +16,7 @@ import {
   Queue,
   ReadonlyArray,
   Schedule,
+  Schema,
   Stream,
   Subscribable,
   SubscriptionRef,
@@ -46,6 +47,9 @@ import { LeaderThreadCtx } from './types.ts'
 // time input, causing `TypeError: {} is not iterable` at runtime.
 // Upstream: https://github.com/Effect-TS/effect/pull/5929
 // TODO: simplify back to the 2-arg overload once the upstream fix is released and adopted.
+
+/** Serialize value to JSON string for trace attributes */
+const jsonStringify = Schema.encodeSync(Schema.parseJson())
 
 type LocalPushQueueItem = [
   event: LiveStoreEvent.Client.EncodedWithMeta,
@@ -546,8 +550,7 @@ const backgroundApplyLocalPushes = ({
             `push:unknown-error`,
             {
               batchSize: newEvents.length,
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
+              newEvents: TRACE_VERBOSE ? jsonStringify(newEvents) : undefined,
             },
             undefined,
           )
@@ -561,8 +564,7 @@ const backgroundApplyLocalPushes = ({
             `push:reject`,
             {
               batchSize: newEvents.length,
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
+              mergeResult: TRACE_VERBOSE ? jsonStringify(mergeResult) : undefined,
             },
             undefined,
           )
@@ -624,8 +626,7 @@ const backgroundApplyLocalPushes = ({
         `push:advance`,
         {
           batchSize: newEvents.length,
-          // @effect-diagnostics-next-line preferSchemaOverJson:off
-          mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
+          mergeResult: TRACE_VERBOSE ? jsonStringify(mergeResult) : undefined,
         },
         undefined,
       )
@@ -757,8 +758,7 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
             `pull:unknown-error`,
             {
               newEventsCount: newEvents.length,
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
+              newEvents: TRACE_VERBOSE ? jsonStringify(newEvents) : undefined,
             },
             undefined,
           )
@@ -774,11 +774,9 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
             `pull:rebase[${mergeResult.newSyncState.localHead.rebaseGeneration}]`,
             {
               newEventsCount: newEvents.length,
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
+              newEvents: TRACE_VERBOSE ? jsonStringify(newEvents) : undefined,
               rollbackCount: mergeResult.rollbackEvents.length,
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
+              mergeResult: TRACE_VERBOSE ? jsonStringify(mergeResult) : undefined,
             },
             undefined,
           )
@@ -806,8 +804,7 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
             `pull:advance`,
             {
               newEventsCount: newEvents.length,
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
+              mergeResult: TRACE_VERBOSE ? jsonStringify(mergeResult) : undefined,
             },
             undefined,
           )
@@ -923,8 +920,7 @@ const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcesso
       'backend-push',
       {
         batchSize: queueItems.length,
-        // @effect-diagnostics-next-line preferSchemaOverJson:off
-        batch: TRACE_VERBOSE ? JSON.stringify(queueItems) : undefined,
+        batch: TRACE_VERBOSE ? jsonStringify(queueItems) : undefined,
       },
       undefined,
     )

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -546,6 +546,7 @@ const backgroundApplyLocalPushes = ({
             `push:unknown-error`,
             {
               batchSize: newEvents.length,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
             },
             undefined,
@@ -560,6 +561,7 @@ const backgroundApplyLocalPushes = ({
             `push:reject`,
             {
               batchSize: newEvents.length,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
             },
             undefined,
@@ -622,6 +624,7 @@ const backgroundApplyLocalPushes = ({
         `push:advance`,
         {
           batchSize: newEvents.length,
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
           mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
         },
         undefined,
@@ -691,7 +694,7 @@ const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds 
     Effect.tapCauseLogPretty,
   )
 
-const backgroundBackendPulling = ({
+const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcessor:backend-pulling')(function* ({
   isClientEvent,
   restartBackendPushing,
   otelSpan,
@@ -717,8 +720,7 @@ const backgroundBackendPulling = ({
   initialBlockingSyncContext: InitialBlockingSyncContext
   connectedClientSessionPullQueues: PullQueueSet
   advancePushHead: (eventNum: EventSequenceNumber.Client.Composite) => void
-}) =>
-  Effect.gen(function* () {
+}) {
     const { syncBackend, dbState: db, dbEventlog, schema } = yield* LeaderThreadCtx
 
     if (syncBackend === undefined) return
@@ -755,6 +757,7 @@ const backgroundBackendPulling = ({
             `pull:unknown-error`,
             {
               newEventsCount: newEvents.length,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
             },
             undefined,
@@ -771,8 +774,10 @@ const backgroundBackendPulling = ({
             `pull:rebase[${mergeResult.newSyncState.localHead.rebaseGeneration}]`,
             {
               newEventsCount: newEvents.length,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               newEvents: TRACE_VERBOSE ? JSON.stringify(newEvents) : undefined,
               rollbackCount: mergeResult.rollbackEvents.length,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
             },
             undefined,
@@ -801,6 +806,7 @@ const backgroundBackendPulling = ({
             `pull:advance`,
             {
               newEventsCount: newEvents.length,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               mergeResult: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
             },
             undefined,
@@ -886,9 +892,9 @@ const backgroundBackendPulling = ({
 
     // Should only ever happen when livePull is false
     yield* Effect.logDebug('backend-pulling finished', { livePull })
-  }).pipe(Effect.withSpan('@livestore/common:LeaderSyncProcessor:backend-pulling'))
+  })
 
-const backgroundBackendPushing = ({
+const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcessor:backend-pushing')(function* ({
   syncBackendPushQueue,
   otelSpan,
   devtoolsLatch,
@@ -898,84 +904,84 @@ const backgroundBackendPushing = ({
   otelSpan: otel.Span | undefined
   devtoolsLatch: Effect.Latch | undefined
   backendPushBatchSize: number
-}) =>
-  Effect.gen(function* () {
-    const { syncBackend } = yield* LeaderThreadCtx
-    if (syncBackend === undefined) return
+}) {
+  const { syncBackend } = yield* LeaderThreadCtx
+  if (syncBackend === undefined) return
 
-    while (true) {
-      yield* SubscriptionRef.waitUntil(syncBackend.isConnected, (isConnected) => isConnected === true)
+  while (true) {
+    yield* SubscriptionRef.waitUntil(syncBackend.isConnected, (isConnected) => isConnected === true)
 
-      const queueItems = yield* BucketQueue.takeBetween(syncBackendPushQueue, 1, backendPushBatchSize)
+    const queueItems = yield* BucketQueue.takeBetween(syncBackendPushQueue, 1, backendPushBatchSize)
 
-      yield* SubscriptionRef.waitUntil(syncBackend.isConnected, (isConnected) => isConnected === true)
+    yield* SubscriptionRef.waitUntil(syncBackend.isConnected, (isConnected) => isConnected === true)
 
-      if (devtoolsLatch !== undefined) {
-        yield* devtoolsLatch.await
-      }
+    if (devtoolsLatch !== undefined) {
+      yield* devtoolsLatch.await
+    }
 
-      otelSpan?.addEvent(
-        'backend-push',
-        {
-          batchSize: queueItems.length,
-          batch: TRACE_VERBOSE ? JSON.stringify(queueItems) : undefined,
-        },
-        undefined,
+    otelSpan?.addEvent(
+      'backend-push',
+      {
+        batchSize: queueItems.length,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        batch: TRACE_VERBOSE ? JSON.stringify(queueItems) : undefined,
+      },
+      undefined,
+    )
+
+    // Push with declarative retry/backoff using Effect schedules
+    // - Exponential backoff starting at 1s and doubling (1s, 2s, 4s, 8s, 16s, 30s ...)
+    // - Delay clamped at 30s (continues retrying at 30s)
+    // - Resets automatically after successful push
+    // TODO(metrics): expose counters/gauges for retry attempts and queue health via devtools/metrics
+
+    // Only retry for transient UnknownError cases
+    const isRetryable = (err: InvalidPushError | IsOfflineError) =>
+      err._tag === 'InvalidPushError' && err.cause._tag === 'LiveStore.UnknownError'
+
+    // Input: InvalidPushError | IsOfflineError, Output: Duration
+    const retrySchedule: Schedule.Schedule<Duration.DurationInput, InvalidPushError | IsOfflineError> =
+      Schedule.exponential(Duration.seconds(1)).pipe(
+        Schedule.andThenEither(Schedule.spaced(Duration.seconds(30))), // clamp at 30 second intervals
+        Schedule.compose(Schedule.elapsed),
+        Schedule.whileInput(isRetryable),
       )
 
-      // Push with declarative retry/backoff using Effect schedules
-      // - Exponential backoff starting at 1s and doubling (1s, 2s, 4s, 8s, 16s, 30s ...)
-      // - Delay clamped at 30s (continues retrying at 30s)
-      // - Resets automatically after successful push
-      // TODO(metrics): expose counters/gauges for retry attempts and queue health via devtools/metrics
+    yield* Effect.gen(function* () {
+      const iteration = yield* Schedule.CurrentIterationMetadata
 
-      // Only retry for transient UnknownError cases
-      const isRetryable = (err: InvalidPushError | IsOfflineError) =>
-        err._tag === 'InvalidPushError' && err.cause._tag === 'LiveStore.UnknownError'
+      const pushResult = yield* syncBackend.push(queueItems.map((_) => _.toGlobal())).pipe(Effect.either)
 
-      // Input: InvalidPushError | IsOfflineError, Output: Duration
-      const retrySchedule: Schedule.Schedule<Duration.DurationInput, InvalidPushError | IsOfflineError> =
-        Schedule.exponential(Duration.seconds(1)).pipe(
-          Schedule.andThenEither(Schedule.spaced(Duration.seconds(30))), // clamp at 30 second intervals
-          Schedule.compose(Schedule.elapsed),
-          Schedule.whileInput(isRetryable),
+      const retries = iteration.recurrence
+      if (retries > 0 && pushResult._tag === 'Right') {
+        otelSpan?.addEvent('backend-push-retry-success', { retries, batchSize: queueItems.length }, undefined)
+      }
+
+      if (pushResult._tag === 'Left') {
+        otelSpan?.addEvent(
+          'backend-push-error',
+          {
+            error: pushResult.left.toString(),
+            retries,
+            batchSize: queueItems.length,
+          },
+          undefined,
         )
-
-      yield* Effect.gen(function* () {
-        const iteration = yield* Schedule.CurrentIterationMetadata
-
-        const pushResult = yield* syncBackend.push(queueItems.map((_) => _.toGlobal())).pipe(Effect.either)
-
-        const retries = iteration.recurrence
-        if (retries > 0 && pushResult._tag === 'Right') {
-          otelSpan?.addEvent('backend-push-retry-success', { retries, batchSize: queueItems.length }, undefined)
+        const error = pushResult.left
+        if (
+          error._tag === 'IsOfflineError' ||
+          (error._tag === 'InvalidPushError' && error.cause._tag === 'ServerAheadError')
+        ) {
+          // It's a core part of the sync protocol that the sync backend will emit a new pull chunk alongside the ServerAheadError
+          yield* Effect.logDebug('handled backend-push-error (waiting for interupt caused by pull)', { error })
+          return yield* Effect.never
         }
 
-        if (pushResult._tag === 'Left') {
-          otelSpan?.addEvent(
-            'backend-push-error',
-            {
-              error: pushResult.left.toString(),
-              retries,
-              batchSize: queueItems.length,
-            },
-            undefined,
-          )
-          const error = pushResult.left
-          if (
-            error._tag === 'IsOfflineError' ||
-            (error._tag === 'InvalidPushError' && error.cause._tag === 'ServerAheadError')
-          ) {
-            // It's a core part of the sync protocol that the sync backend will emit a new pull chunk alongside the ServerAheadError
-            yield* Effect.logDebug('handled backend-push-error (waiting for interupt caused by pull)', { error })
-            return yield* Effect.never
-          }
-
-          return yield* error
-        }
-      }).pipe(Effect.retry(retrySchedule))
-    }
-  }).pipe(Effect.interruptible, Effect.withSpan('@livestore/common:LeaderSyncProcessor:backend-pushing'))
+        return yield* error
+      }
+    }).pipe(Effect.retry(retrySchedule))
+  }
+}, Effect.interruptible)
 
 const trimChangesetRows = (db: SqliteDb, newHead: EventSequenceNumber.Client.Composite) => {
   // Since we're using the session changeset rows to query for the current head,
@@ -1145,18 +1151,18 @@ const validatePushBatch = (
  * Handles a BackendIdMismatchError based on the configured behavior.
  * This occurs when the sync backend has been reset and has a new identity.
  */
-const handleBackendIdMismatch = ({
-  cause,
-  onBackendIdMismatch,
-  shutdownChannel,
-}: {
-  cause: Cause.Cause<
-    UnknownError | IntentionalShutdownCause | IsOfflineError | InvalidPushError | InvalidPullError | MaterializeError
-  >
-  onBackendIdMismatch: 'reset' | 'shutdown' | 'ignore'
-  shutdownChannel: ShutdownChannel
-}) =>
-  Effect.gen(function* () {
+const handleBackendIdMismatch = Effect.fn('@livestore/common:LeaderSyncProcessor:handleBackendIdMismatch')(
+  function* ({
+    cause,
+    onBackendIdMismatch,
+    shutdownChannel,
+  }: {
+    cause: Cause.Cause<
+      UnknownError | IntentionalShutdownCause | IsOfflineError | InvalidPushError | InvalidPullError | MaterializeError
+    >
+    onBackendIdMismatch: 'reset' | 'shutdown' | 'ignore'
+    shutdownChannel: ShutdownChannel
+  }) {
     const { dbEventlog, dbState } = yield* LeaderThreadCtx
 
     if (onBackendIdMismatch === 'reset') {
@@ -1193,7 +1199,8 @@ const handleBackendIdMismatch = ({
         Cause.pretty(cause),
       )
     }
-  }).pipe(Effect.withSpan('@livestore/common:LeaderSyncProcessor:handleBackendIdMismatch'))
+  },
+)
 
 /**
  * Clears local databases (eventlog and state) so the client can start fresh on next boot.

--- a/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
+++ b/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
@@ -18,81 +18,82 @@ const isDevtoolsViteNotInstalledError = (
   typeof error === 'object' && error !== null && '_tag' in error && error._tag === 'DevtoolsViteNotInstalledError'
 
 // TODO bind scope to the webchannel lifetime
-export const bootDevtools = (options: DevtoolsOptions) =>
-  Effect.gen(function* () {
-    if (options.enabled === false) {
-      return
-    }
+export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:boot')(function* (
+  options: DevtoolsOptions,
+) {
+  if (options.enabled === false) {
+    return
+  }
 
-    const { syncProcessor, extraIncomingMessagesQueue, clientId, storeId } = yield* LeaderThreadCtx
+  const { syncProcessor, extraIncomingMessagesQueue, clientId, storeId } = yield* LeaderThreadCtx
 
-    yield* listenToDevtools({
-      incomingMessages: Stream.fromQueue(extraIncomingMessagesQueue),
-      sendMessage: () => Effect.void,
-    }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
+  yield* listenToDevtools({
+    incomingMessages: Stream.fromQueue(extraIncomingMessagesQueue),
+    sendMessage: () => Effect.void,
+  }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
 
-    const bootResult = yield* options.boot.pipe(
-      Effect.map(Option.some),
-      Effect.catchIf(isDevtoolsViteNotInstalledError, (error) =>
-        Effect.logWarning(`[@livestore/devtools] ${error.message} Devtools will be disabled.`).pipe(
-          Effect.as(Option.none()),
-        ),
+  const bootResult = yield* options.boot.pipe(
+    Effect.map(Option.some),
+    Effect.catchIf(isDevtoolsViteNotInstalledError, (error) =>
+      Effect.logWarning(`[@livestore/devtools] ${error.message} Devtools will be disabled.`).pipe(
+        Effect.as(Option.none()),
       ),
-      Effect.catchAllCause((cause) =>
-        Effect.logWarning(
-          `[@livestore/devtools] Failed to start devtools server. Devtools will be disabled.`,
-          cause,
-        ).pipe(Effect.as(Option.none())),
-      ),
-    )
+    ),
+    Effect.catchAllCause((cause) =>
+      Effect.logWarning(
+        `[@livestore/devtools] Failed to start devtools server. Devtools will be disabled.`,
+        cause,
+      ).pipe(Effect.as(Option.none())),
+    ),
+  )
 
-    if (Option.isNone(bootResult)) {
-      return
-    }
+  if (Option.isNone(bootResult)) {
+    return
+  }
 
-    const { node, persistenceInfo, mode } = bootResult.value
+  const { node, persistenceInfo, mode } = bootResult.value
 
-    yield* node.listenForChannel.pipe(
-      Stream.filter(
-        (res) =>
-          Devtools.isChannelName.devtoolsClientLeader(res.channelName, { storeId, clientId }) && res.mode === mode,
-      ),
-      Stream.tap(({ channelName, source }) =>
-        Effect.gen(function* () {
-          const channel = yield* node.makeChannel({
-            target: source,
-            channelName,
-            schema: { listen: Devtools.Leader.MessageToApp, send: Devtools.Leader.MessageFromApp },
-            mode,
-          })
+  yield* node.listenForChannel.pipe(
+    Stream.filter(
+      (res) =>
+        Devtools.isChannelName.devtoolsClientLeader(res.channelName, { storeId, clientId }) && res.mode === mode,
+    ),
+    Stream.tap(({ channelName, source }) =>
+      Effect.gen(function* () {
+        const channel = yield* node.makeChannel({
+          target: source,
+          channelName,
+          schema: { listen: Devtools.Leader.MessageToApp, send: Devtools.Leader.MessageFromApp },
+          mode,
+        })
 
-          const sendMessage: SendMessageToDevtools = (message) =>
-            channel
-              .send(message)
-              .pipe(
-                Effect.withSpan('@livestore/common:leader-thread:devtools:sendToDevtools'),
-                Effect.interruptible,
-                Effect.ignoreLogged,
-              )
+        const sendMessage: SendMessageToDevtools = (message) =>
+          channel
+            .send(message)
+            .pipe(
+              Effect.withSpan('@livestore/common:leader-thread:devtools:sendToDevtools'),
+              Effect.interruptible,
+              Effect.ignoreLogged,
+            )
 
-          const syncState = yield* syncProcessor.syncState
+        const syncState = yield* syncProcessor.syncState
 
-          yield* syncProcessor.pull({ cursor: syncState.localHead }).pipe(
-            Stream.tap(({ payload }) => sendMessage(Devtools.Leader.SyncPull.make({ payload, liveStoreVersion }))),
-            Stream.runDrain,
-            Effect.forkScoped,
-          )
+        yield* syncProcessor.pull({ cursor: syncState.localHead }).pipe(
+          Stream.tap(({ payload }) => sendMessage(Devtools.Leader.SyncPull.make({ payload, liveStoreVersion }))),
+          Stream.runDrain,
+          Effect.forkScoped,
+        )
 
-          yield* listenToDevtools({
-            incomingMessages: channel.listen.pipe(Stream.flatten(), Stream.orDie),
-            sendMessage,
-            persistenceInfo,
-          })
-        }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped),
-      ),
-      Stream.runDrain,
-    )
-  }).pipe(Effect.withSpan('@livestore/common:leader-thread:devtools:boot'))
+        yield* listenToDevtools({
+          incomingMessages: channel.listen.pipe(Stream.flatten(), Stream.orDie),
+          sendMessage,
+          persistenceInfo,
+        })
+      }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped),
+    ),
+    Stream.runDrain,
+  )
+})
 
 const listenToDevtools = ({
   incomingMessages,

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -8,6 +8,9 @@ import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } fr
 import type { PreparedBindValues } from './util.ts'
 import { sql } from './util.ts'
 
+/** Parse JSON string to unknown value */
+const jsonParse = Schema.decodeUnknownSync(Schema.parseJson())
+
 export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerializeFromEventlog')(function* ({
   dbEventlog,
   // TODO re-use this db when bringing back the boot in-memory db implementation
@@ -31,8 +34,7 @@ export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerial
     const processEvent = Effect.fn(`@livestore/common:rematerializeFromEventlog:processEvent`)(function* (
       row: SystemTables.EventlogMetaRow,
     ) {
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      const args = JSON.parse(row.argsJson)
+      const args = jsonParse(row.argsJson)
       const eventEncoded = LiveStoreEvent.Client.EncodedWithMeta.make({
         name: row.name,
         args,

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -8,7 +8,7 @@ import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } fr
 import type { PreparedBindValues } from './util.ts'
 import { sql } from './util.ts'
 
-export const rematerializeFromEventlog = ({
+export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerializeFromEventlog')(function* ({
   dbEventlog,
   // TODO re-use this db when bringing back the boot in-memory db implementation
   // db,
@@ -21,69 +21,70 @@ export const rematerializeFromEventlog = ({
   schema: LiveStoreSchema
   onProgress: (_: { done: number; total: number }) => Effect.Effect<void>
   materializeEvent: MaterializeEvent
-}) =>
-  Effect.gen(function* () {
+}) {
     const eventsCount = dbEventlog.select<{ count: number }>(
       `SELECT COUNT(*) AS count FROM ${SystemTables.EVENTLOG_META_TABLE}`,
     )[0]!.count
 
     const hashEventDef = memoizeByRef((event: EventDef.AnyWithoutFn) => Schema.hash(event.schema))
 
-    const processEvent = (row: SystemTables.EventlogMetaRow) =>
-      Effect.gen(function* () {
-        const args = JSON.parse(row.argsJson)
-        const eventEncoded = LiveStoreEvent.Client.EncodedWithMeta.make({
-          name: row.name,
-          args,
-          seqNum: {
-            global: row.seqNumGlobal,
-            client: row.seqNumClient,
-            rebaseGeneration: row.seqNumRebaseGeneration,
-          },
-          parentSeqNum: {
-            global: row.parentSeqNumGlobal,
-            client: row.parentSeqNumClient,
-            rebaseGeneration: row.parentSeqNumRebaseGeneration,
-          },
-          clientId: row.clientId,
-          sessionId: row.sessionId,
-        })
+    const processEvent = Effect.fn(`@livestore/common:rematerializeFromEventlog:processEvent`)(function* (
+      row: SystemTables.EventlogMetaRow,
+    ) {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const args = JSON.parse(row.argsJson)
+      const eventEncoded = LiveStoreEvent.Client.EncodedWithMeta.make({
+        name: row.name,
+        args,
+        seqNum: {
+          global: row.seqNumGlobal,
+          client: row.seqNumClient,
+          rebaseGeneration: row.seqNumRebaseGeneration,
+        },
+        parentSeqNum: {
+          global: row.parentSeqNumGlobal,
+          client: row.parentSeqNumClient,
+          rebaseGeneration: row.parentSeqNumRebaseGeneration,
+        },
+        clientId: row.clientId,
+        sessionId: row.sessionId,
+      })
 
-        const resolution = yield* resolveEventDef(schema, {
-          operation: '@livestore/common:rematerializeFromEventlog:processEvent',
-          event: eventEncoded,
-        }).pipe(UnknownError.mapToUnknownError)
+      const resolution = yield* resolveEventDef(schema, {
+        operation: '@livestore/common:rematerializeFromEventlog:processEvent',
+        event: eventEncoded,
+      }).pipe(UnknownError.mapToUnknownError)
 
-        if (resolution._tag === 'unknown') {
-          // Old snapshots can contain newer events. Skip until the runtime has
-          // been updated; the event stays in the log for future replays.
-          return
-        }
+      if (resolution._tag === 'unknown') {
+        // Old snapshots can contain newer events. Skip until the runtime has
+        // been updated; the event stays in the log for future replays.
+        return
+      }
 
-        const { eventDef } = resolution
+      const { eventDef } = resolution
 
-        if (hashEventDef(eventDef) !== row.schemaHash) {
-          yield* Effect.logWarning(
-            `Schema hash mismatch for event definition ${row.name}. Trying to materialize event anyway.`,
-          )
-        }
+      if (hashEventDef(eventDef) !== row.schemaHash) {
+        yield* Effect.logWarning(
+          `Schema hash mismatch for event definition ${row.name}. Trying to materialize event anyway.`,
+        )
+      }
 
-        // Checking whether the schema has changed in an incompatible way
-        yield* Schema.decodeUnknown(eventDef.schema)(args).pipe(
-          Effect.mapError((cause) =>
-            UnknownError.make({
-              cause,
-              note: `\
+      // Checking whether the schema has changed in an incompatible way
+      yield* Schema.decodeUnknown(eventDef.schema)(args).pipe(
+        Effect.mapError((cause) =>
+          UnknownError.make({
+            cause,
+            note: `\
 There was an error during rematerializing from the eventlog while decoding
 the persisted event args for event definition "${row.name}".
 This likely means the schema has changed in an incompatible way.
 `,
-            }),
-          ),
-        )
+          }),
+        ),
+      )
 
-        yield* materializeEvent(eventEncoded, { skipEventlog: true })
-      }).pipe(Effect.withSpan(`@livestore/common:rematerializeFromEventlog:processEvent`))
+      yield* materializeEvent(eventEncoded, { skipEventlog: true })
+    })
 
     const CHUNK_SIZE = 100
 
@@ -129,7 +130,4 @@ LIMIT ${CHUNK_SIZE}
       ),
       Stream.runDrain,
     )
-  }).pipe(
-    Effect.withPerformanceMeasure('@livestore/common:rematerializeFromEventlog'),
-    Effect.withSpan('@livestore/common:rematerializeFromEventlog'),
-  )
+}, Effect.withPerformanceMeasure('@livestore/common:rematerializeFromEventlog'))

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -149,6 +149,7 @@ export const makeClientSessionSyncProcessor = ({
         acc[event.name] = (acc[event.name] ?? 0) + 1
         return acc
       }, {}),
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       ...(TRACE_VERBOSE && { mergeResult: JSON.stringify(mergeResult) }),
     })
 
@@ -255,9 +256,11 @@ export const makeClientSessionSyncProcessor = ({
               'merge:pull:rebase',
               {
                 payloadTag: payload._tag,
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
                 payload: TRACE_VERBOSE ? JSON.stringify(payload) : undefined,
                 newEventsCount: mergeResult.newEvents.length,
                 rollbackCount: mergeResult.rollbackEvents.length,
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
                 res: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
               },
               undefined,
@@ -304,8 +307,10 @@ export const makeClientSessionSyncProcessor = ({
               'merge:pull:advance',
               {
                 payloadTag: payload._tag,
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
                 payload: TRACE_VERBOSE ? JSON.stringify(payload) : undefined,
                 newEventsCount: mergeResult.newEvents.length,
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
                 res: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
               },
               undefined,

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -28,6 +28,9 @@ import * as SyncState from './syncstate.ts'
 // Upstream: https://github.com/Effect-TS/effect/pull/5929
 // TODO: simplify back to the 2-arg overload once the upstream fix is released and adopted.
 
+/** Serialize value to JSON string for trace attributes */
+const jsonStringify = Schema.encodeSync(Schema.parseJson())
+
 /**
  * Rebase behaviour:
  * - We continously pull events from the leader and apply them to the local store.
@@ -149,8 +152,7 @@ export const makeClientSessionSyncProcessor = ({
         acc[event.name] = (acc[event.name] ?? 0) + 1
         return acc
       }, {}),
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      ...(TRACE_VERBOSE && { mergeResult: JSON.stringify(mergeResult) }),
+      ...(TRACE_VERBOSE && { mergeResult: jsonStringify(mergeResult) }),
     })
 
     if (mergeResult._tag === 'unknown-error') {
@@ -256,12 +258,10 @@ export const makeClientSessionSyncProcessor = ({
               'merge:pull:rebase',
               {
                 payloadTag: payload._tag,
-                // @effect-diagnostics-next-line preferSchemaOverJson:off
-                payload: TRACE_VERBOSE ? JSON.stringify(payload) : undefined,
+                payload: TRACE_VERBOSE ? jsonStringify(payload) : undefined,
                 newEventsCount: mergeResult.newEvents.length,
                 rollbackCount: mergeResult.rollbackEvents.length,
-                // @effect-diagnostics-next-line preferSchemaOverJson:off
-                res: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
+                res: TRACE_VERBOSE ? jsonStringify(mergeResult) : undefined,
               },
               undefined,
             )
@@ -307,11 +307,9 @@ export const makeClientSessionSyncProcessor = ({
               'merge:pull:advance',
               {
                 payloadTag: payload._tag,
-                // @effect-diagnostics-next-line preferSchemaOverJson:off
-                payload: TRACE_VERBOSE ? JSON.stringify(payload) : undefined,
+                payload: TRACE_VERBOSE ? jsonStringify(payload) : undefined,
                 newEventsCount: mergeResult.newEvents.length,
-                // @effect-diagnostics-next-line preferSchemaOverJson:off
-                res: TRACE_VERBOSE ? JSON.stringify(mergeResult) : undefined,
+                res: TRACE_VERBOSE ? jsonStringify(mergeResult) : undefined,
               },
               undefined,
             )

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -277,10 +277,10 @@ export class StoreRegistry {
       if (cached) return cached as Promise<Store<TSchema, TContext>>
 
       // Create and cache the promise
-      const fiber = defect.value.fiber
+      const fiber = defect.value.fiber as Fiber.RuntimeFiber<Store<TSchema, TContext>>
       const promise = Fiber.join(fiber)
         .pipe(Runtime.runPromise(this.#runtime))
-        .finally(() => this.#loadingPromises.delete(storeId)) as Promise<Store<TSchema, TContext>>
+        .finally(() => this.#loadingPromises.delete(storeId))
 
       this.#loadingPromises.set(storeId, promise)
       return promise

--- a/packages/@livestore/livestore/src/store/devtools.ts
+++ b/packages/@livestore/livestore/src/store/devtools.ts
@@ -23,7 +23,7 @@ const requestNextTick: (cb: () => void) => number =
 const cancelTick: (id: number) => void =
   globalThis.cancelAnimationFrame === undefined ? (id: number) => clearTimeout(id) : globalThis.cancelAnimationFrame
 
-export const connectDevtoolsToStore = ({
+export const connectDevtoolsToStore = Effect.fn('LSD.devtools.connectStoreToDevtools')(function* ({
   storeDevtoolsChannel,
   store,
 }: {
@@ -32,8 +32,7 @@ export const connectDevtoolsToStore = ({
     Devtools.ClientSession.MessageFromApp
   >
   store: Store
-}) =>
-  Effect.gen(function* () {
+}) {
     const reactivityGraphSubcriptions: SubMap = new Map()
     const liveQueriesSubscriptions: SubMap = new Map()
     const debugInfoHistorySubscriptions: SubMap = new Map()
@@ -347,4 +346,4 @@ export const connectDevtoolsToStore = ({
       Stream.runDrain,
       Effect.withSpan('LSD.devtools.onMessage'),
     )
-  }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('LSD.devtools.connectStoreToDevtools'))
+}, UnknownError.mapToUnknownError)

--- a/packages/@livestore/livestore/src/utils/dev.ts
+++ b/packages/@livestore/livestore/src/utils/dev.ts
@@ -33,8 +33,8 @@ export const downloadURL = (data: string, fileName: string) => {
 export const exposeDebugUtils = () => {
   globalThis.__debugLiveStoreUtils = {
     downloadBlob,
-    runSync: (effect: Effect.Effect<any, any, never>) => Effect.runSync(effect),
-    runFork: (effect: Effect.Effect<any, any, never>) => Effect.runFork(effect),
+    runSync: <A, E>(effect: Effect.Effect<A, E>) => Effect.runSync(effect),
+    runFork: <A, E>(effect: Effect.Effect<A, E>) => Effect.runFork(effect),
     dumpDb: (db: SqliteDb) => {
       const tables = db.select<{ name: string }>(`SELECT name FROM sqlite_master WHERE type='table'`)
       for (const table of tables) {

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -141,7 +141,7 @@ export const makePush =
 
             // NOTE we're also sending the pullRes chunk to the pushing ws client as confirmation
             for (const conn of connectedClients) {
-              const attachment = Schema.decodeSync(WebSocketAttachmentSchema)(conn.deserializeAttachment())
+              const attachment = yield* Schema.decode(WebSocketAttachmentSchema)(conn.deserializeAttachment())
 
               // We're doing something a bit "advanced" here as we're directly emitting Effect RPC-compatible
               // response messsages on the Effect RPC-managed websocket connection to the WS client.
@@ -152,6 +152,7 @@ export const makePush =
                   requestId,
                   values: [encoded],
                 }
+                // @effect-diagnostics-next-line preferSchemaOverJson:off
                 conn.send(JSON.stringify(res))
               }
             }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -21,6 +21,7 @@ import {
 import { DoCtx } from './layer.ts'
 
 const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
+const jsonStringify = Schema.encodeSync(Schema.parseJson())
 type PullBatchItem = SyncMessage.PullResponse['batch'][number]
 
 export const makePush =
@@ -152,8 +153,7 @@ export const makePush =
                   requestId,
                   values: [encoded],
                 }
-                // @effect-diagnostics-next-line preferSchemaOverJson:off
-                conn.send(JSON.stringify(res))
+                conn.send(jsonStringify(res))
               }
             }
           }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/sync-storage.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/sync-storage.ts
@@ -121,6 +121,7 @@ export const makeStorage = (
             return Option.none()
           }
 
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
           const encodedSize = textEncoder.encode(JSON.stringify(rawEvents)).byteLength
 
           if (encodedSize > D1_TARGET_RESPONSE_BYTES && state.limit > D1_MIN_PAGE_SIZE) {

--- a/packages/@livestore/sync-cf/src/cf-worker/do/sync-storage.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/sync-storage.ts
@@ -52,6 +52,7 @@ export const makeStorage = (
   const D1_MIN_PAGE_SIZE = 1
 
   const decodeEventlogRows = Schema.decodeUnknownSync(Schema.Array(eventlogTable.rowSchema))
+  const jsonStringify = Schema.encodeSync(Schema.parseJson())
   const textEncoder = new TextEncoder()
 
   const decreaseLimit = (limit: number) => Math.max(D1_MIN_PAGE_SIZE, Math.floor(limit / 2))
@@ -121,8 +122,7 @@ export const makeStorage = (
             return Option.none()
           }
 
-          // @effect-diagnostics-next-line preferSchemaOverJson:off
-          const encodedSize = textEncoder.encode(JSON.stringify(rawEvents)).byteLength
+          const encodedSize = textEncoder.encode(jsonStringify(rawEvents)).byteLength
 
           if (encodedSize > D1_TARGET_RESPONSE_BYTES && state.limit > D1_MIN_PAGE_SIZE) {
             const nextLimit = decreaseLimit(state.limit)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
@@ -8,7 +8,7 @@ import { DoCtx } from '../layer.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
 
-export const createHttpRpcHandler = ({
+export const createHttpRpcHandler = Effect.fn('createHttpRpcHandler')(function* ({
   request,
   responseHeaders,
   forwardedHeaders,
@@ -16,24 +16,23 @@ export const createHttpRpcHandler = ({
   request: CfTypes.Request
   responseHeaders?: Record<string, string>
   forwardedHeaders?: Record<string, string>
-}) =>
-  Effect.gen(function* () {
-    const handlerLayer = createHttpRpcLayer(forwardedHeaders)
-    const httpApp = RpcServer.toHttpApp(SyncHttpRpc).pipe(Effect.provide(handlerLayer))
-    const webHandler = yield* httpApp.pipe(Effect.map(HttpApp.toWebHandler))
+}) {
+  const handlerLayer = createHttpRpcLayer(forwardedHeaders)
+  const httpApp = RpcServer.toHttpApp(SyncHttpRpc).pipe(Effect.provide(handlerLayer))
+  const webHandler = yield* httpApp.pipe(Effect.map(HttpApp.toWebHandler))
 
-    const response = yield* Effect.promise(
-      () => webHandler(request as TODO as Request) as TODO as Promise<CfTypes.Response>,
-    ).pipe(Effect.timeout(10000))
+  const response = yield* Effect.promise(
+    () => webHandler(request as TODO as Request) as TODO as Promise<CfTypes.Response>,
+  ).pipe(Effect.timeout(10000))
 
-    if (responseHeaders !== undefined) {
-      for (const [key, value] of Object.entries(responseHeaders)) {
-        response.headers.set(key, value)
-      }
+  if (responseHeaders !== undefined) {
+    for (const [key, value] of Object.entries(responseHeaders)) {
+      response.headers.set(key, value)
     }
+  }
 
-    return response
-  }).pipe(Effect.withSpan('createHttpRpcHandler'))
+  return response
+})
 
 const createHttpRpcLayer = (forwardedHeaders: Record<string, string> | undefined) => {
   const headers = headersRecordToMap(forwardedHeaders)

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -100,8 +100,8 @@ export const makeDoRpcSync =
           Stream.withSpan('rpc-sync-client:pull'),
         )
 
-      const push: SyncBackend.SyncBackend<{ createdAt: string }>['push'] = (batch) =>
-        Effect.gen(function* () {
+      const push: SyncBackend.SyncBackend<{ createdAt: string }>['push'] = Effect.fn('rpc-sync-client:push')(
+        function* (batch) {
           if (batch.length === 0) {
             return
           }
@@ -124,12 +124,11 @@ export const makeDoRpcSync =
             const chunkArray = Chunk.toReadonlyArray(chunk)
             yield* rpcClient.SyncDoRpc.Push({ batch: chunkArray, storeId, backendId })
           }
-        }).pipe(
-          Effect.mapError((cause) =>
-            cause._tag === 'InvalidPushError' ? cause : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
-          ),
-          Effect.withSpan('rpc-sync-client:push'),
-        )
+        },
+        Effect.mapError((cause) =>
+          cause._tag === 'InvalidPushError' ? cause : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
+        ),
+      )
 
       const ping: SyncBackend.SyncBackend<{ createdAt: string }>['ping'] = rpcClient.SyncDoRpc.Ping({
         storeId,

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -175,8 +175,8 @@ export const makeHttpSync =
 
       const pushSemaphore = yield* Effect.makeSemaphore(1)
 
-      const push: SyncBackend.SyncBackend<SyncMetadata>['push'] = (batch) =>
-        Effect.gen(function* () {
+      const push: SyncBackend.SyncBackend<SyncMetadata>['push'] = Effect.fn('http-sync-client:push')(
+        function* (batch) {
           if (batch.length === 0) {
             return
           }
@@ -200,13 +200,12 @@ export const makeHttpSync =
             const chunkArray = Chunk.toReadonlyArray(chunk)
             yield* rpcClient.SyncHttpRpc.Push({ storeId, payload, batch: chunkArray, backendId })
           }
-        }).pipe(
-          pushSemaphore.withPermits(1),
-          Effect.mapError((cause) =>
-            cause._tag === 'InvalidPushError' ? cause : new InvalidPushError({ cause: new UnknownError({ cause }) }),
-          ),
-          Effect.withSpan('http-sync-client:push'),
-        )
+        },
+        pushSemaphore.withPermits(1),
+        Effect.mapError((cause) =>
+          cause._tag === 'InvalidPushError' ? cause : new InvalidPushError({ cause: new UnknownError({ cause }) }),
+        ),
+      )
 
       return SyncBackend.of({
         connect,

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -153,41 +153,40 @@ export const makeWsSync =
             Stream.withSpan('pull'),
           ),
 
-        push: (batch) =>
-          Effect.gen(function* () {
-            if (batch.length === 0) return
+        push: Effect.fn('push')(function* (batch) {
+          if (batch.length === 0) return
 
-            const encodePayload = (batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>) => ({
+          const encodePayload = (batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>) => ({
+            storeId,
+            payload,
+            batch,
+            backendId: backendIdHelper.get(),
+          })
+
+          const chunksChunk = yield* Chunk.fromIterable(batch).pipe(
+            splitChunkBySize({
+              maxItems: MAX_PUSH_EVENTS_PER_REQUEST,
+              maxBytes: MAX_WS_MESSAGE_BYTES,
+              encode: encodePayload,
+            }),
+            Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
+          )
+
+          for (const sub of chunksChunk) {
+            yield* rpcClient.SyncWsRpc.Push({
               storeId,
               payload,
-              batch,
+              batch: Chunk.toReadonlyArray(sub),
               backendId: backendIdHelper.get(),
-            })
-
-            const chunksChunk = yield* Chunk.fromIterable(batch).pipe(
-              splitChunkBySize({
-                maxItems: MAX_PUSH_EVENTS_PER_REQUEST,
-                maxBytes: MAX_WS_MESSAGE_BYTES,
-                encode: encodePayload,
-              }),
-              Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
+            }).pipe(
+              Effect.mapError((cause) =>
+                cause._tag === 'InvalidPushError'
+                  ? cause
+                  : new InvalidPushError({ cause: new UnknownError({ cause }) }),
+              ),
             )
-
-            for (const sub of chunksChunk) {
-              yield* rpcClient.SyncWsRpc.Push({
-                storeId,
-                payload,
-                batch: Chunk.toReadonlyArray(sub),
-                backendId: backendIdHelper.get(),
-              }).pipe(
-                Effect.mapError((cause) =>
-                  cause._tag === 'InvalidPushError'
-                    ? cause
-                    : new InvalidPushError({ cause: new UnknownError({ cause }) }),
-                ),
-              )
-            }
-          }).pipe(Effect.withSpan('push')),
+          }
+        }),
         ping,
         metadata: {
           name: '@livestore/cf-sync',

--- a/packages/@livestore/sync-electric/src/index.ts
+++ b/packages/@livestore/sync-electric/src/index.ts
@@ -368,22 +368,21 @@ export const makeSyncBackend =
           )
         },
 
-        push: (batch) =>
-          Effect.gen(function* () {
-            const resp = yield* HttpClientRequest.schemaBodyJson(ApiSchema.PushPayload)(
-              HttpClientRequest.post(pushEndpoint),
-              ApiSchema.PushPayload.make({ storeId, batch }),
-            ).pipe(
-              Effect.andThen(httpClient.pipe(HttpClient.filterStatusOk).execute),
-              Effect.andThen(HttpClientResponse.schemaBodyJson(Schema.Struct({ success: Schema.Boolean }))),
-              Effect.scoped,
-              Effect.mapError((cause) => InvalidPushError.make({ cause: UnknownError.make({ cause }) })),
-            )
+        push: Effect.fn('electric-provider:push')(function* (batch) {
+          const resp = yield* HttpClientRequest.schemaBodyJson(ApiSchema.PushPayload)(
+            HttpClientRequest.post(pushEndpoint),
+            ApiSchema.PushPayload.make({ storeId, batch }),
+          ).pipe(
+            Effect.andThen(httpClient.pipe(HttpClient.filterStatusOk).execute),
+            Effect.andThen(HttpClientResponse.schemaBodyJson(Schema.Struct({ success: Schema.Boolean }))),
+            Effect.scoped,
+            Effect.mapError((cause) => InvalidPushError.make({ cause: UnknownError.make({ cause }) })),
+          )
 
-            if (!resp.success) {
-              return yield* InvalidPushError.make({ cause: new UnknownError({ cause: new Error('Push failed') }) })
-            }
-          }).pipe(Effect.withSpan('electric-provider:push')),
+          if (!resp.success) {
+            return yield* InvalidPushError.make({ cause: new UnknownError({ cause: new Error('Push failed') }) })
+          }
+        }),
         ping,
         isConnected,
         metadata: {

--- a/packages/@livestore/sync-s2/src/http-client-generated.ts
+++ b/packages/@livestore/sync-s2/src/http-client-generated.ts
@@ -697,6 +697,7 @@ export const make = (
   return {
     httpClient,
     listAccessTokens: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/access-tokens`).pipe(
         HttpClientRequest.setUrlParams({
           prefix: options?.prefix as any,
@@ -713,6 +714,7 @@ export const make = (
         ),
       ),
     issueAccessToken: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.post(`/access-tokens`).pipe(
         HttpClientRequest.bodyUnsafeJson(options),
         withResponse(
@@ -726,6 +728,7 @@ export const make = (
         ),
       ),
     revokeAccessToken: (id) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.del(`/access-tokens/${id}`).pipe(
         withResponse(
           HttpClientResponse.matchStatus({
@@ -737,6 +740,7 @@ export const make = (
         ),
       ),
     listBasins: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/basins`).pipe(
         HttpClientRequest.setUrlParams({
           prefix: options?.prefix as any,
@@ -753,6 +757,7 @@ export const make = (
         ),
       ),
     createBasin: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.post(`/basins`).pipe(
         HttpClientRequest.bodyUnsafeJson(options),
         withResponse(
@@ -768,6 +773,7 @@ export const make = (
         ),
       ),
     getBasinConfig: (basin) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/basins/${basin}`).pipe(
         withResponse(
           HttpClientResponse.matchStatus({
@@ -780,6 +786,7 @@ export const make = (
         ),
       ),
     createOrReconfigureBasin: (basin, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.put(`/basins/${basin}`).pipe(
         HttpClientRequest.setHeaders({ 's2-request-token': options.params?.['s2-request-token'] ?? undefined }),
         HttpClientRequest.bodyUnsafeJson(options.payload),
@@ -794,6 +801,7 @@ export const make = (
         ),
       ),
     deleteBasin: (basin) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.del(`/basins/${basin}`).pipe(
         withResponse(
           HttpClientResponse.matchStatus({
@@ -807,6 +815,7 @@ export const make = (
         ),
       ),
     reconfigureBasin: (basin, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.patch(`/basins/${basin}`).pipe(
         HttpClientRequest.bodyUnsafeJson(options),
         withResponse(
@@ -820,6 +829,7 @@ export const make = (
         ),
       ),
     accountMetrics: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/metrics`).pipe(
         HttpClientRequest.setUrlParams({
           set: options?.set as any,
@@ -837,6 +847,7 @@ export const make = (
         ),
       ),
     basinMetrics: (basin, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/metrics/${basin}`).pipe(
         HttpClientRequest.setUrlParams({
           set: options?.set as any,
@@ -854,6 +865,7 @@ export const make = (
         ),
       ),
     streamMetrics: (basin, stream, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/metrics/${basin}/${stream}`).pipe(
         HttpClientRequest.setUrlParams({
           set: options?.set as any,
@@ -871,6 +883,7 @@ export const make = (
         ),
       ),
     listStreams: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/streams`).pipe(
         HttpClientRequest.setUrlParams({
           prefix: options?.prefix as any,
@@ -888,6 +901,7 @@ export const make = (
         ),
       ),
     createStream: (options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.post(`/streams`).pipe(
         HttpClientRequest.bodyUnsafeJson(options),
         withResponse(
@@ -902,6 +916,7 @@ export const make = (
         ),
       ),
     getStreamConfig: (stream) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/streams/${stream}`).pipe(
         withResponse(
           HttpClientResponse.matchStatus({
@@ -915,6 +930,7 @@ export const make = (
         ),
       ),
     createOrReconfigureStream: (stream, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.put(`/streams/${stream}`).pipe(
         HttpClientRequest.setHeaders({ 's2-request-token': options.params?.['s2-request-token'] ?? undefined }),
         HttpClientRequest.bodyUnsafeJson(options.payload),
@@ -931,6 +947,7 @@ export const make = (
         ),
       ),
     deleteStream: (stream) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.del(`/streams/${stream}`).pipe(
         withResponse(
           HttpClientResponse.matchStatus({
@@ -943,6 +960,7 @@ export const make = (
         ),
       ),
     reconfigureStream: (stream, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.patch(`/streams/${stream}`).pipe(
         HttpClientRequest.bodyUnsafeJson(options),
         withResponse(
@@ -957,6 +975,7 @@ export const make = (
         ),
       ),
     read: (stream, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/streams/${stream}/records`).pipe(
         HttpClientRequest.setUrlParams({
           seq_num: options?.seq_num as any,
@@ -982,6 +1001,7 @@ export const make = (
         ),
       ),
     append: (stream, options) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.post(`/streams/${stream}/records`).pipe(
         HttpClientRequest.setHeaders({ 's2-format': options.params?.['s2-format'] ?? undefined }),
         HttpClientRequest.bodyUnsafeJson(options.payload),
@@ -999,6 +1019,7 @@ export const make = (
         ),
       ),
     checkTail: (stream) =>
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       HttpClientRequest.get(`/streams/${stream}/records/tail`).pipe(
         withResponse(
           HttpClientResponse.matchStatus({

--- a/packages/@livestore/utils-dev/src/node/DockerComposeService/DockerComposeService.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerComposeService/DockerComposeService.ts
@@ -127,54 +127,52 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
         Effect.scoped,
       )
 
-      const start = (options: StartOptions = {}) =>
-        Effect.gen(function* () {
-          const { detached = true, healthCheck } = options
+      const start = Effect.fn('startDockerCompose')(function* (options: StartOptions = {}) {
+        const { detached = true, healthCheck } = options
 
-          // Build start command
-          const startArgs = ['docker', 'compose', ...baseComposeArgs, 'up']
-          if (detached) startArgs.push('-d')
-          if (serviceName) startArgs.push(serviceName)
+        // Build start command
+        const startArgs = ['docker', 'compose', ...baseComposeArgs, 'up']
+        if (detached) startArgs.push('-d')
+        if (serviceName) startArgs.push(serviceName)
 
-          const command = yield* Command.make(startArgs[0]!, ...startArgs.slice(1)).pipe(
-            Command.workingDirectory(cwd),
-            Command.env(options.env ?? {}),
-            Command.stderr('inherit'),
-            Command.stdout('inherit'),
-            Command.start,
-            Effect.catchAll((cause) =>
-              Effect.fail(
-                new DockerComposeError({
-                  cause,
-                  note: `Failed to start Docker Compose services in ${cwd}`,
-                }),
-              ),
-            ),
-            Effect.provide(commandExecutorContext),
-          )
+        const command = yield* Command.make(startArgs[0]!, ...startArgs.slice(1)).pipe(
+          Command.workingDirectory(cwd),
+          Command.env(options.env ?? {}),
+          Command.stderr('inherit'),
+          Command.stdout('inherit'),
+          Command.start,
+          Effect.mapError(
+            (cause) =>
+              new DockerComposeError({
+                cause,
+                note: `Failed to start Docker Compose services in ${cwd}`,
+              }),
+          ),
+          Effect.provide(commandExecutorContext),
+        )
 
-          // Wait for command completion
-          yield* command.exitCode.pipe(
-            Effect.flatMap((exitCode) =>
-              exitCode === 0
-                ? Effect.void
-                : Effect.fail(
-                    new DockerComposeError({
-                      cause: new Error(`Docker compose exited with code ${exitCode}`),
-                      note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${JSON.stringify(options.env)}`,
-                    }),
-                  ),
-            ),
-            Effect.provide(commandExecutorContext),
-          )
+        // Wait for command completion
+        yield* command.exitCode.pipe(
+          Effect.flatMap((exitCode) =>
+            exitCode === 0
+              ? Effect.void
+              : Effect.fail(
+                  new DockerComposeError({
+                    cause: new Error(`Docker compose exited with code ${exitCode}`),
+                    note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${JSON.stringify(options.env)}`,
+                  }),
+                ),
+          ),
+          Effect.provide(commandExecutorContext),
+        )
 
-          // Perform health check if requested
-          if (healthCheck) {
-            yield* performHealthCheck(healthCheck).pipe(Effect.provide(commandExecutorContext))
-          }
+        // Perform health check if requested
+        if (healthCheck) {
+          yield* performHealthCheck(healthCheck).pipe(Effect.provide(commandExecutorContext))
+        }
 
-          yield* Effect.log(`Docker Compose services started successfully in ${cwd}`)
-        }).pipe(Effect.withSpan('startDockerCompose'))
+        yield* Effect.log(`Docker Compose services started successfully in ${cwd}`)
+      })
 
       const stop = Effect.gen(function* () {
         yield* Effect.log(`Stopping Docker Compose services in ${cwd}`)
@@ -215,13 +213,12 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
           const command = yield* Command.make(logsArgs[0]!, ...logsArgs.slice(1)).pipe(
             Command.workingDirectory(cwd),
             Command.start,
-            Effect.catchAll((cause) =>
-              Effect.fail(
+            Effect.mapError(
+              (cause) =>
                 new DockerComposeError({
                   cause,
                   note: `Failed to read Docker Compose logs in ${cwd}`,
                 }),
-              ),
             ),
             Effect.provide(commandExecutorContext),
           )
@@ -239,38 +236,37 @@ export class DockerComposeService extends Effect.Service<DockerComposeService>()
           )
         }).pipe(Stream.unwrapScoped)
 
-      const down = (options?: {
+      const down = Effect.fn('downDockerCompose')(function* (options?: {
         readonly env?: Record<string, string>
         readonly volumes?: boolean
         readonly removeOrphans?: boolean
-      }) =>
-        Effect.gen(function* () {
-          yield* Effect.log(`Tearing down Docker Compose services in ${cwd}`)
+      }) {
+        yield* Effect.log(`Tearing down Docker Compose services in ${cwd}`)
 
-          const downArgs = ['docker', 'compose', ...baseComposeArgs, 'down']
-          if (options?.volumes) downArgs.push('-v')
-          if (options?.removeOrphans) downArgs.push('--remove-orphans')
-          if (serviceName) downArgs.push(serviceName)
+        const downArgs = ['docker', 'compose', ...baseComposeArgs, 'down']
+        if (options?.volumes) downArgs.push('-v')
+        if (options?.removeOrphans) downArgs.push('--remove-orphans')
+        if (serviceName) downArgs.push(serviceName)
 
-          yield* Command.make(downArgs[0]!, ...downArgs.slice(1)).pipe(
-            Command.workingDirectory(cwd),
-            Command.env(options?.env ?? {}),
-            Command.exitCode,
-            Effect.flatMap((exitCode: number) =>
-              exitCode === 0
-                ? Effect.void
-                : Effect.fail(
-                    new DockerComposeError({
-                      cause: new Error(`Docker compose down exited with code ${exitCode}`),
-                      note: `Failed to tear down Docker Compose services`,
-                    }),
-                  ),
-            ),
-            Effect.provide(commandExecutorContext),
-          )
+        yield* Command.make(downArgs[0]!, ...downArgs.slice(1)).pipe(
+          Command.workingDirectory(cwd),
+          Command.env(options?.env ?? {}),
+          Command.exitCode,
+          Effect.flatMap((exitCode: number) =>
+            exitCode === 0
+              ? Effect.void
+              : Effect.fail(
+                  new DockerComposeError({
+                    cause: new Error(`Docker compose down exited with code ${exitCode}`),
+                    note: `Failed to tear down Docker Compose services`,
+                  }),
+                ),
+          ),
+          Effect.provide(commandExecutorContext),
+        )
 
-          yield* Effect.log(`Docker Compose services torn down successfully`)
-        }).pipe(Effect.withSpan('downDockerCompose'))
+        yield* Effect.log(`Docker Compose services torn down successfully`)
+      })
 
       // Register cleanup finalizer to ensure containers are removed when scope closes
       yield* Effect.addFinalizer(() =>
@@ -308,13 +304,12 @@ const performHealthCheck = ({
         schedule: Schedule.fixed(interval),
       }),
       Effect.timeout(timeout),
-      Effect.catchAll(() =>
-        Effect.fail(
+      Effect.mapError(
+        () =>
           new DockerComposeError({
             cause: new Error('Health check timeout'),
             note: `Health check failed for ${url} after ${Duration.toMillis(timeout)}ms`,
           }),
-        ),
       ),
     )
 

--- a/packages/@livestore/utils-dev/src/node/mod.ts
+++ b/packages/@livestore/utils-dev/src/node/mod.ts
@@ -158,6 +158,7 @@ export const getTracingBackendUrl = (span: otel.Span) =>
     const grafanaEndpoint = endpoint.value
     const searchParams = new URLSearchParams({
       orgId: '1',
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       left: JSON.stringify({
         datasource: 'tempo',
         queries: [{ query: traceId, queryType: 'traceql', refId: 'A' }],

--- a/packages/@livestore/utils-dev/src/node/mod.ts
+++ b/packages/@livestore/utils-dev/src/node/mod.ts
@@ -9,7 +9,7 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 
 import { IS_BUN, isNonEmptyString } from '@livestore/utils'
 import type { Tracer } from '@livestore/utils/effect'
-import { Config, Effect, FiberRef, Layer, LogLevel, OtelTracer } from '@livestore/utils/effect'
+import { Config, Effect, FiberRef, Layer, LogLevel, OtelTracer, Schema } from '@livestore/utils/effect'
 import { OtelLiveDummy } from '@livestore/utils/node'
 
 export { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http'
@@ -156,14 +156,14 @@ export const getTracingBackendUrl = (span: otel.Span) =>
     // Grafana + Tempo
 
     const grafanaEndpoint = endpoint.value
+    const left = yield* Schema.encode(Schema.parseJson())({
+      datasource: 'tempo',
+      queries: [{ query: traceId, queryType: 'traceql', refId: 'A' }],
+      range: { from: 'now-1h', to: 'now' },
+    }).pipe(Effect.orDie)
     const searchParams = new URLSearchParams({
       orgId: '1',
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      left: JSON.stringify({
-        datasource: 'tempo',
-        queries: [{ query: traceId, queryType: 'traceql', refId: 'A' }],
-        range: { from: 'now-1h', to: 'now' },
-      }),
+      left,
     })
 
     // TODO make dynamic via env var

--- a/packages/@livestore/utils/src/browser/Opfs/debug-utils.ts
+++ b/packages/@livestore/utils/src/browser/Opfs/debug-utils.ts
@@ -7,6 +7,7 @@
 import { Effect, Stream } from 'effect'
 import prettyBytes from 'pretty-bytes'
 
+import type * as WebError from '../WebError.ts'
 import { Opfs } from './Opfs.ts'
 import { getDirectoryHandleByPath, getMetadata, remove } from './utils.ts'
 
@@ -34,10 +35,10 @@ const ROOT_NAME = '/'
 const buildTree = Effect.fn('@livestore/utils:Opfs.buildTree')(function* () {
   const rootHandle = yield* Opfs.getRootDirectoryHandle
 
-  const collectDirectory: (
+  const collectDirectory = (
     handle: FileSystemDirectoryHandle,
     pathSegments: ReadonlyArray<string>,
-  ) => Effect.Effect<OpfsTreeNode, unknown, Opfs> = (handle, pathSegments) =>
+  ): Effect.Effect<OpfsTreeNode, WebError.WebError, Opfs> =>
     Effect.gen(function* () {
       const handlesStream = yield* Opfs.values(handle)
       const handles = yield* handlesStream.pipe(

--- a/packages/@livestore/utils/src/effect/ServiceContext.ts
+++ b/packages/@livestore/utils/src/effect/ServiceContext.ts
@@ -24,13 +24,13 @@ export const make = <TStaticData, Ctx>(
   close: Effect.Effect<void> = Effect.dieMessage('close not implemented'),
 ): ServiceContext<Ctx, TStaticData> => {
   return {
-    provide: (self) => Effect.provide(runtime)(self),
-    runWithErrorLog: <E, A>(self: Effect.Effect<A, E, Ctx>) => runWithErrorLog(Effect.provide(runtime)(self)),
-    runSync: <E, A>(self: Effect.Effect<A, E, Ctx>) => Effect.runSync(Effect.provide(runtime)(self)),
+    provide: (self) => self.pipe(Effect.provide(runtime)),
+    runWithErrorLog: <E, A>(self: Effect.Effect<A, E, Ctx>) => runWithErrorLog(self.pipe(Effect.provide(runtime))),
+    runSync: <E, A>(self: Effect.Effect<A, E, Ctx>) => Effect.runSync(self.pipe(Effect.provide(runtime))),
     runPromiseWithErrorLog: <E, A>(self: Effect.Effect<A, E, Ctx>) =>
-      runPromiseWithErrorLog(Effect.provide(runtime)(self)),
-    runPromiseExit: <E, A>(self: Effect.Effect<A, E, Ctx>) => Effect.runPromiseExit(Effect.provide(runtime)(self)),
-    runPromise: <E, A>(self: Effect.Effect<A, E, Ctx>) => Effect.runPromise(Effect.provide(runtime)(self)),
+      runPromiseWithErrorLog(self.pipe(Effect.provide(runtime))),
+    runPromiseExit: <E, A>(self: Effect.Effect<A, E, Ctx>) => Effect.runPromiseExit(self.pipe(Effect.provide(runtime))),
+    runPromise: <E, A>(self: Effect.Effect<A, E, Ctx>) => Effect.runPromise(self.pipe(Effect.provide(runtime))),
     withRuntime: (fn) => fn(runtime),
     close: close,
     closePromise: () => Effect.runPromise(close),

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
@@ -191,7 +191,7 @@ export const messagePortChannelWithAck: <MsgListen, MsgSend, MsgListenEncoded, M
                 yield* Deferred.succeed(requestAckMap.get(msg.right.reqId)!, void 0)
               } else if (msg.right._tag === 'ChannelRequest') {
                 debugInfo.listenTotal++
-                port.postMessage(Schema.encodeSync(ChannelMessage)({ _tag: 'ChannelRequestAck', reqId: msg.right.id }))
+                port.postMessage(yield* Schema.encode(ChannelMessage)({ _tag: 'ChannelRequestAck', reqId: msg.right.id }))
               }
             }
           }),

--- a/packages/@livestore/utils/src/node/ChildProcessRunner/ChildProcessRunnerTest/serializedWorker.ts
+++ b/packages/@livestore/utils/src/node/ChildProcessRunner/ChildProcessRunnerTest/serializedWorker.ts
@@ -33,19 +33,18 @@ const WorkerLive = Runner.layerSerialized(WorkerMessage, {
   //       return req.name
   //     }),
   //   ),
-  GetSpan: (_) =>
-    Effect.gen(function* () {
-      const span = yield* Effect.currentSpan.pipe(Effect.orDie)
-      return {
+  GetSpan: Effect.fn('GetSpan')(function* (_) {
+    const span = yield* Effect.currentSpan.pipe(Effect.orDie)
+    return {
+      traceId: span.traceId,
+      spanId: span.spanId,
+      name: span.name,
+      parent: Option.map(span.parent, (span) => ({
         traceId: span.traceId,
         spanId: span.spanId,
-        name: span.name,
-        parent: Option.map(span.parent, (span) => ({
-          traceId: span.traceId,
-          spanId: span.spanId,
-        })),
-      }
-    }).pipe(Effect.withSpan('GetSpan')),
+      })),
+    }
+  }),
   RunnerInterrupt: () => Effect.interrupt,
   StartStubbornWorker: ({ blockDuration }) =>
     Effect.gen(function* () {

--- a/packages/@livestore/webmesh/src/websocket-edge.ts
+++ b/packages/@livestore/webmesh/src/websocket-edge.ts
@@ -166,7 +166,7 @@ export const makeWebSocketEdge = ({
         Effect.gen(function* () {
           yield* isConnectedLatch.await
           const payload = yield* Schema.encode(schema.send)(message)
-          yield* sendToSocket(Schema.encodeSync(MessageMsgPack)({ _tag: 'WSEdgePayload', payload, from }))
+          yield* sendToSocket(yield* Schema.encode(MessageMsgPack)({ _tag: 'WSEdgePayload', payload, from }))
         }).pipe(Effect.orDie)
 
       const listen = Stream.fromQueue(listenQueue).pipe(

--- a/packages/@local/astro-tldraw/src/cache.ts
+++ b/packages/@local/astro-tldraw/src/cache.ts
@@ -105,6 +105,7 @@ export const saveManifest = (
         .makeDirectory(path.dirname(manifestPath), { recursive: true })
         .pipe(Effect.mapError((cause) => new FileSystemError({ path: manifestPath, operation: 'mkdir', cause })))
 
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       yield* fs
         .writeFileString(manifestPath, JSON.stringify(manifest, null, 2))
         .pipe(
@@ -159,6 +160,7 @@ export const saveDiagramToCache = (
       }
 
       /* Write to disk */
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       yield* fs
         .writeFileString(fullArtifactPath, JSON.stringify(cachedDiagram, null, 2))
         .pipe(
@@ -200,6 +202,7 @@ export const loadCachedDiagram = (
 
       yield* Effect.annotateCurrentSpan({ entryFile: entry.entryFile, artifactPath: entry.artifactPath })
 
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       return JSON.parse(content) as CachedDiagram
     }),
   )

--- a/packages/@local/astro-tldraw/src/cache.ts
+++ b/packages/@local/astro-tldraw/src/cache.ts
@@ -5,6 +5,9 @@ import { Effect, FileSystem, Schema } from '@livestore/utils/effect'
 
 import type { RenderResult } from './renderer.ts'
 
+const jsonStringifyPretty = Schema.encodeSync(Schema.parseJson({ space: 2 }))
+const jsonParse = Schema.decodeUnknownSync(Schema.parseJson())
+
 const hashString = (value: string): string => crypto.createHash('sha256').update(value).digest('hex')
 
 export class FileSystemError extends Schema.TaggedError<FileSystemError>()('Tldraw.FileSystemError', {
@@ -105,9 +108,8 @@ export const saveManifest = (
         .makeDirectory(path.dirname(manifestPath), { recursive: true })
         .pipe(Effect.mapError((cause) => new FileSystemError({ path: manifestPath, operation: 'mkdir', cause })))
 
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
       yield* fs
-        .writeFileString(manifestPath, JSON.stringify(manifest, null, 2))
+        .writeFileString(manifestPath, jsonStringifyPretty(manifest))
         .pipe(
           Effect.mapError((cause) => new FileSystemError({ path: manifestPath, operation: 'write manifest', cause })),
         )
@@ -160,9 +162,8 @@ export const saveDiagramToCache = (
       }
 
       /* Write to disk */
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
       yield* fs
-        .writeFileString(fullArtifactPath, JSON.stringify(cachedDiagram, null, 2))
+        .writeFileString(fullArtifactPath, jsonStringifyPretty(cachedDiagram))
         .pipe(
           Effect.mapError(
             (cause) => new FileSystemError({ path: fullArtifactPath, operation: 'write diagram', cause }),
@@ -202,8 +203,7 @@ export const loadCachedDiagram = (
 
       yield* Effect.annotateCurrentSpan({ entryFile: entry.entryFile, artifactPath: entry.artifactPath })
 
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      return JSON.parse(content) as CachedDiagram
+      return jsonParse(content) as CachedDiagram
     }),
   )
 

--- a/packages/@local/astro-tldraw/src/vite-plugin.ts
+++ b/packages/@local/astro-tldraw/src/vite-plugin.ts
@@ -144,6 +144,7 @@ export const createTldrawPlugin = (options: TldrawPluginOptions = {}): MinimalVi
             generatedAt: cached.generatedAt,
           }
 
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
           const serializedPayload = JSON.stringify(payload)
 
           return {

--- a/packages/@local/astro-tldraw/src/vite-plugin.ts
+++ b/packages/@local/astro-tldraw/src/vite-plugin.ts
@@ -8,6 +8,8 @@ import { PlatformNode } from '@livestore/utils/node'
 import { getCacheEntry, loadCachedDiagram, loadManifest, resolveCachePaths, type TldrawCachePaths } from './cache.ts'
 import { getSvgDimensions } from './renderer.ts'
 
+const jsonStringify = Schema.encodeSync(Schema.parseJson())
+
 type MinimalVitePlugin = {
   name: string
   enforce?: 'pre' | 'post'
@@ -144,8 +146,7 @@ export const createTldrawPlugin = (options: TldrawPluginOptions = {}): MinimalVi
             generatedAt: cached.generatedAt,
           }
 
-          // @effect-diagnostics-next-line preferSchemaOverJson:off
-          const serializedPayload = JSON.stringify(payload)
+          const serializedPayload = jsonStringify(payload)
 
           return {
             code: createComponentModuleSource(serializedPayload, diagramComponentSpecifier),

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.ts
@@ -113,6 +113,9 @@ import { resolveProjectPaths, type TwoslashProjectPaths } from '../project-paths
 import type { SnippetBundle } from '../vite/snippet-graph.ts'
 import { buildSnippetBundle, __internal as snippetGraphInternal } from '../vite/snippet-graph.ts'
 
+const jsonStringify = Schema.encodeSync(Schema.parseJson())
+const jsonStringifyPretty = Schema.encodeSync(Schema.parseJson({ space: 2 }))
+
 type THastRendererResult = {
   renderedGroupAst: THastElement
   styles: Set<string>
@@ -1486,9 +1489,8 @@ const buildSnippetsInternal = ({ paths, runtimeOptions }: ResolvedBuildOptions) 
           }
         })
 
-        // @effect-diagnostics-next-line preferSchemaOverJson:off
         const bundleHash = hashString(
-          JSON.stringify({
+          jsonStringify({
             files: filesWithHash.map((file) => ({
               filename: file.filename,
               hash: file.hash,
@@ -1569,8 +1571,7 @@ const buildSnippetsInternal = ({ paths, runtimeOptions }: ResolvedBuildOptions) 
           ),
         )
 
-        // @effect-diagnostics-next-line preferSchemaOverJson:off
-        yield* fs.writeFileString(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`).pipe(
+        yield* fs.writeFileString(artifactPath, `${jsonStringifyPretty(artifact)}\n`).pipe(
           Effect.mapError(
             (cause) =>
               new SnippetBuildError({
@@ -1606,18 +1607,15 @@ const buildSnippetsInternal = ({ paths, runtimeOptions }: ResolvedBuildOptions) 
       entries: artifactEntries,
     }
 
-    // @effect-diagnostics-next-line preferSchemaOverJson:off
-    yield* fs
-      .writeFileString(path.join(paths.cacheRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new SnippetBuildError({
-              message: 'Unable to write snippets manifest',
-              cause,
-            }),
-        ),
-      )
+    yield* fs.writeFileString(path.join(paths.cacheRoot, 'manifest.json'), `${jsonStringifyPretty(manifest)}\n`).pipe(
+      Effect.mapError(
+        (cause) =>
+          new SnippetBuildError({
+            message: 'Unable to write snippets manifest',
+            cause,
+          }),
+      ),
+    )
 
     const cacheHits = snippetEntries.length - renderedCount
     yield* Effect.log(`Rendered ${renderedCount} snippet bundles (${cacheHits} cache hits)`)

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.ts
@@ -1486,6 +1486,7 @@ const buildSnippetsInternal = ({ paths, runtimeOptions }: ResolvedBuildOptions) 
           }
         })
 
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
         const bundleHash = hashString(
           JSON.stringify({
             files: filesWithHash.map((file) => ({
@@ -1568,6 +1569,7 @@ const buildSnippetsInternal = ({ paths, runtimeOptions }: ResolvedBuildOptions) 
           ),
         )
 
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
         yield* fs.writeFileString(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`).pipe(
           Effect.mapError(
             (cause) =>
@@ -1604,6 +1606,7 @@ const buildSnippetsInternal = ({ paths, runtimeOptions }: ResolvedBuildOptions) 
       entries: artifactEntries,
     }
 
+    // @effect-diagnostics-next-line preferSchemaOverJson:off
     yield* fs
       .writeFileString(path.join(paths.cacheRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
       .pipe(

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
@@ -35,6 +35,7 @@ const writeInitialProject = (fs: FileSystem.FileSystem, projectRoot: string): Ef
     yield* fs
       .writeFileString(
         tsconfigPath,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
         `${JSON.stringify(
           {
             compilerOptions: {

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { Effect, FileSystem, Queue } from '@livestore/utils/effect'
+import { Effect, FileSystem, Queue, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
 import { type WatchSnippetsRebuildInfo, watchSnippets } from './snippets.ts'
@@ -32,30 +32,21 @@ const writeInitialProject = (fs: FileSystem.FileSystem, projectRoot: string): Ef
 
     yield* fs.writeFileString(snippetPath, 'export const value = 1\n').pipe(Effect.orDie)
     yield* fs.writeFileString(docsPath, createDocsImportSource('../content/_assets/code/example.ts')).pipe(Effect.orDie)
-    yield* fs
-      .writeFileString(
-        tsconfigPath,
-        // @effect-diagnostics-next-line preferSchemaOverJson:off
-        `${JSON.stringify(
-          {
-            compilerOptions: {
-              target: 'ESNext',
-              module: 'ESNext',
-              moduleResolution: 'Bundler',
-              jsx: 'react-jsx',
-              types: ['node'],
-              skipLibCheck: true,
-              allowImportingTsExtensions: true,
-              noEmit: true,
-            },
-            include: ['./**/*'],
-            exclude: ['./node_modules'],
-          },
-          null,
-          2,
-        )}\n`,
-      )
-      .pipe(Effect.orDie)
+    const tsconfigJson = yield* Schema.encode(Schema.parseJson({ space: 2 }))({
+      compilerOptions: {
+        target: 'ESNext',
+        module: 'ESNext',
+        moduleResolution: 'Bundler',
+        jsx: 'react-jsx',
+        types: ['node'],
+        skipLibCheck: true,
+        allowImportingTsExtensions: true,
+        noEmit: true,
+      },
+      include: ['./**/*'],
+      exclude: ['./node_modules'],
+    }).pipe(Effect.orDie)
+    yield* fs.writeFileString(tsconfigPath, `${tsconfigJson}\n`).pipe(Effect.orDie)
   })
 
 describe('watchSnippets', () => {

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -35,6 +35,7 @@ const viteDevServer = ({
     yield* cmd(`./node_modules/.bin/vite --config src/tests/playwright/fixtures/vite.config.ts dev --port ${devPort}`, {
       env: {
         // Relative to vite config
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
         TEST_LIVESTORE_SCHEMA_PATH_JSON: JSON.stringify('./devtools/todomvc/livestore/schema.ts'),
         LSD_DEVTOOLS_LOCAL_PREVIEW: useDevtoolsLocalPreview ? '1' : undefined,
       },

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { UnknownError } from '@livestore/common'
 import { type CmdError, CurrentWorkingDirectory, cmd } from '@livestore/utils-dev/node'
 import type { CommandExecutor, Option, PlatformError } from '@livestore/utils/effect'
-import { Effect, FetchHttpClient, Layer, Logger, LogLevel, OtelTracer } from '@livestore/utils/effect'
+import { Effect, FetchHttpClient, Layer, Logger, LogLevel, OtelTracer, Schema } from '@livestore/utils/effect'
 import { Cli, getFreePort, PlatformNode } from '@livestore/utils/node'
 import { LIVESTORE_DEVTOOLS_CHROME_DIST_PATH } from '@local/shared'
 
@@ -35,8 +35,7 @@ const viteDevServer = ({
     yield* cmd(`./node_modules/.bin/vite --config src/tests/playwright/fixtures/vite.config.ts dev --port ${devPort}`, {
       env: {
         // Relative to vite config
-        // @effect-diagnostics-next-line preferSchemaOverJson:off
-        TEST_LIVESTORE_SCHEMA_PATH_JSON: JSON.stringify('./devtools/todomvc/livestore/schema.ts'),
+        TEST_LIVESTORE_SCHEMA_PATH_JSON: yield* Schema.encode(Schema.parseJson())('./devtools/todomvc/livestore/schema.ts').pipe(Effect.orDie),
         LSD_DEVTOOLS_LOCAL_PREVIEW: useDevtoolsLocalPreview ? '1' : undefined,
       },
     }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)), Effect.forkScoped)

--- a/tests/integration/src/tests/node-sync/client-node-worker.ts
+++ b/tests/integration/src/tests/node-sync/client-node-worker.ts
@@ -108,11 +108,10 @@ const runner = WorkerRunner.layerSerialized(WorkerSchema.Request, {
       const query$ = queryDb(tables.todo.orderBy('id', 'desc'))
       return store.subscribeStream(query$)
     }).pipe(Stream.unwrap, Stream.withSpan('@livestore/adapter-node-sync:test:stream-todos')),
-  OnShutdown: () =>
-    Effect.gen(function* () {
-      const { shutdownDeferred } = yield* WorkerContext
-      yield* shutdownDeferred.pipe(Effect.catchTag('LiveStore.StoreInterrupted', () => Effect.void))
-    }).pipe(Effect.withSpan('@livestore/adapter-node-sync:test:on-shutdown')),
+  OnShutdown: Effect.fn('@livestore/adapter-node-sync:test:on-shutdown')(function* () {
+    const { shutdownDeferred } = yield* WorkerContext
+    yield* shutdownDeferred.pipe(Effect.catchTag('LiveStore.StoreInterrupted', () => Effect.void))
+  }),
 })
 
 const clientId = process.argv[2]!

--- a/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
@@ -127,7 +127,7 @@ const getLiveStoreDevtoolsFrame = (devtools: PW.Page, label: string) =>
   })
 
 const runTest =
-  (eff: Effect.Effect<void, unknown, Playwright.BrowserContext>) =>
+  <E>(eff: Effect.Effect<void, E, Playwright.BrowserContext>) =>
   (
     {}: PW.PlaywrightTestArgs & PW.PlaywrightTestOptions & PW.PlaywrightWorkerArgs & PW.PlaywrightWorkerOptions,
     testInfo: PW.TestInfo,
@@ -139,6 +139,7 @@ const runTest =
     )
 
     return Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       const parentSpanContext = JSON.parse(process.env.SPAN_CONTEXT_JSON ?? '{}') as otel.SpanContext
       const parentSpan = OtelTracer.makeExternalSpan({
         traceId: parentSpanContext.traceId,

--- a/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
@@ -139,8 +139,7 @@ const runTest =
     )
 
     return Effect.gen(function* () {
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      const parentSpanContext = JSON.parse(process.env.SPAN_CONTEXT_JSON ?? '{}') as otel.SpanContext
+      const parentSpanContext = (yield* Schema.decodeUnknown(Schema.parseJson())(process.env.SPAN_CONTEXT_JSON ?? '{}')) as otel.SpanContext
       const parentSpan = OtelTracer.makeExternalSpan({
         traceId: parentSpanContext.traceId,
         spanId: parentSpanContext.spanId,

--- a/tests/integration/src/tests/playwright/devtools/web.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/web.play.ts
@@ -116,7 +116,7 @@ const PWLive = Effect.gen(function* () {
 }).pipe(Layer.unwrapEffect)
 
 const runTest =
-  (eff: Effect.Effect<void, unknown, Playwright.BrowserContext | Scope.Scope>) =>
+  <E>(eff: Effect.Effect<void, E, Playwright.BrowserContext | Scope.Scope>) =>
   (
     {}: PW.PlaywrightTestArgs & PW.PlaywrightTestOptions & PW.PlaywrightWorkerArgs & PW.PlaywrightWorkerOptions,
     testInfo: PW.TestInfo,
@@ -311,17 +311,16 @@ const runTest =
   }
 })
 
-const shutdownTab = (tab: PW.Page) =>
-  Effect.gen(function* () {
-    // yield* Playwright.withPage(() => tab.pause())
-    yield* Effect.sleep(1000)
-    yield* Playwright.withPage(() => tab.evaluate('console.log(window.__debugLiveStore)'))
-    yield* Playwright.withPage(() => tab.evaluate('window.__debugLiveStore.default.shutdown()'), {
-      label: 'shutdown',
-    }).pipe(Effect.timeout(1000))
+const shutdownTab = Effect.fn('shutdown-tab')(function* (tab: PW.Page) {
+  // yield* Playwright.withPage(() => tab.pause())
+  yield* Effect.sleep(1000)
+  yield* Playwright.withPage(() => tab.evaluate('console.log(window.__debugLiveStore)'))
+  yield* Playwright.withPage(() => tab.evaluate('window.__debugLiveStore.default.shutdown()'), {
+    label: 'shutdown',
+  }).pipe(Effect.timeout(1000))
 
-    yield* Playwright.withPage(() => tab.getByText('LiveStore Shutdown').waitFor())
-  }).pipe(Effect.withSpan('shutdown-tab'))
+  yield* Playwright.withPage(() => tab.getByText('LiveStore Shutdown').waitFor())
+})
 
 test(
   'version mismatch overlay',

--- a/tests/integration/src/tests/playwright/shared-test.ts
+++ b/tests/integration/src/tests/playwright/shared-test.ts
@@ -14,7 +14,7 @@ import { Deferred, Duration, Effect, Fiber, Layer, Logger, Schema } from '@lives
 const runAndGetExitTimeoutMs = Duration.minutes(2)
 
 export const runTest =
-  (eff: Effect.Effect<void, unknown, Playwright.BrowserContext>) =>
+  <E>(eff: Effect.Effect<void, E, Playwright.BrowserContext>) =>
   (
     {}: PW.PlaywrightTestArgs & PW.PlaywrightTestOptions & PW.PlaywrightWorkerArgs & PW.PlaywrightWorkerOptions,
     testInfo: PW.TestInfo,

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -218,12 +218,11 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       })
 
       const eventSchema = LiveStoreEvent.Input.makeSchema(schema) as TODO as Schema.Schema<LiveStoreEvent.Input.Encoded>
-      const encode = Schema.encodeSync(eventSchema)
 
       yield* Queue.offer(
         pullQueue,
         LiveStoreEvent.Client.EncodedWithMeta.make({
-          ...encode(events.todoCreated({ id: `id_0`, text: '', completed: false })),
+          ...(yield* Schema.encode(eventSchema)(events.todoCreated({ id: `id_0`, text: '', completed: false }))),
           seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
           parentSeqNum: EventSequenceNumber.Client.ROOT,
           clientId: 'other-client',
@@ -449,11 +448,10 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       })
 
       const eventSchema = LiveStoreEvent.Input.makeSchema(schema)
-      const encode = Schema.encodeSync(eventSchema)
 
       // Create an event that comes from the leader with a specific hash that won't match the client-side materializer's computed hash.
       const eventFromLeader = LiveStoreEvent.Client.EncodedWithMeta.make({
-        ...encode(events.todoCreated({ id: 'test-id', text: 'from-leader', completed: false })),
+        ...(yield* Schema.encode(eventSchema)(events.todoCreated({ id: 'test-id', text: 'from-leader', completed: false }))),
         seqNum: EventSequenceNumber.Client.Composite.make({ global: 0, client: 1 }),
         parentSeqNum: EventSequenceNumber.Client.ROOT,
         clientId: 'this-client',

--- a/tests/package-common/src/state-sqlite.test.ts
+++ b/tests/package-common/src/state-sqlite.test.ts
@@ -48,7 +48,7 @@ Vitest.describe('SQLite State', () => {
         const rawResult = db.select(sql`select * from test`)
         expect(rawResult).toEqual([{ id: 1, json: null }])
 
-        const result = Schema.decodeUnknownSync(testTable.rowSchema.pipe(Schema.Array, Schema.headOrElse()))(rawResult)
+        const result = yield* Schema.decodeUnknown(testTable.rowSchema.pipe(Schema.Array, Schema.headOrElse()))(rawResult)
 
         expect(result).toEqual({ id: 1, json: null })
       }, Effect.provide(PlatformNode.NodeFileSystem.layer)),
@@ -73,7 +73,7 @@ Vitest.describe('SQLite State', () => {
         const rawResult = db.select(sql`select * from test`)
         expect(rawResult).toEqual([{ id: 1, json: '"null"' }])
 
-        const result = Schema.decodeUnknownSync(testTable.rowSchema.pipe(Schema.Array, Schema.headOrElse()))(rawResult)
+        const result = yield* Schema.decodeUnknown(testTable.rowSchema.pipe(Schema.Array, Schema.headOrElse()))(rawResult)
 
         expect(result).toEqual({ id: 1, json: 'null' })
       }, Effect.provide(PlatformNode.NodeFileSystem.layer)),

--- a/tests/sync-provider/src/providers/electric.ts
+++ b/tests/sync-provider/src/providers/electric.ts
@@ -19,6 +19,7 @@ import { nanoid, Schema } from '@livestore/livestore'
 import * as ElectricSync from '@livestore/sync-electric'
 import { type DockerComposeError, DockerComposeService } from '@livestore/utils-dev/node'
 import {
+  type Cause,
   type CommandExecutor,
   Effect,
   HttpClient,
@@ -52,8 +53,8 @@ export const prepare: Effect.Effect<
 export const getProviderSpecific = (provider: SyncProviderImpl['Type']) =>
   provider.providerSpecific as {
     getDbForTesting: (storeId: string) => {
-      migrate: Effect.Effect<void, unknown>
-      disconnect: Effect.Effect<void, unknown>
+      migrate: Effect.Effect<void, Cause.UnknownException>
+      disconnect: Effect.Effect<void, Cause.UnknownException>
       sql: any
       tableName: string
     }

--- a/tests/sync-provider/src/s2-specific.test.ts
+++ b/tests/sync-provider/src/s2-specific.test.ts
@@ -11,6 +11,7 @@ import {
   Logger,
   LogLevel,
   Option,
+  Schema,
   Stream,
 } from '@livestore/utils/effect'
 
@@ -168,8 +169,8 @@ Vitest.describe('S2-specific', { timeout: 60000 }, () => {
         parentSeqNum: EventSequenceNumber.Global.make(1),
       })
 
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      yield* providerSpecific.appendRaw(storeId, [JSON.stringify(ev1), JSON.stringify(ev2)])
+      const jsonEncode = Schema.encode(Schema.parseJson())
+      yield* providerSpecific.appendRaw(storeId, [yield* jsonEncode(ev1), yield* jsonEncode(ev2)])
 
       // Non-live pull should yield the 2 events
       const results = yield* syncBackend.pull(Option.none()).pipe(Stream.runCollectReadonlyArray)

--- a/tests/sync-provider/src/s2-specific.test.ts
+++ b/tests/sync-provider/src/s2-specific.test.ts
@@ -168,6 +168,7 @@ Vitest.describe('S2-specific', { timeout: 60000 }, () => {
         parentSeqNum: EventSequenceNumber.Global.make(1),
       })
 
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       yield* providerSpecific.appendRaw(storeId, [JSON.stringify(ev1), JSON.stringify(ev2)])
 
       // Non-live pull should yield the 2 events

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -665,6 +665,7 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
       expect((originalError.cause as BackendIdMismatchError).received).toBe('received-backend-id-456')
 
       // Simulate what happens during RPC: encode to JSON and decode back
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       const encoded = JSON.parse(JSON.stringify(originalError))
 
       // The encoded form should preserve the structure (this was broken before the fix)

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -665,8 +665,11 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
       expect((originalError.cause as BackendIdMismatchError).received).toBe('received-backend-id-456')
 
       // Simulate what happens during RPC: encode to JSON and decode back
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
-      const encoded = JSON.parse(JSON.stringify(originalError))
+      const str = yield* Schema.encode(Schema.parseJson())(originalError)
+      const encoded = (yield* Schema.decodeUnknown(Schema.parseJson())(str)) as {
+        _tag: string
+        cause: { _tag: string; expected: string; received: string }
+      }
 
       // The encoded form should preserve the structure (this was broken before the fix)
       expect(encoded._tag).toBe('InvalidPullError')


### PR DESCRIPTION
## Summary

- Resolve all 150 Effect Language Service diagnostics reported by `tsc --build tsconfig.dev.json`, bringing the count to zero
- Mix of actual type-safety improvements and justified suppressions for generated/dynamic code

## Changes

**Type-safety improvements:**
- Properly type debug utility generics (`runSync`/`runFork`) instead of `Effect.Effect<any, any>`
- Type OPFS operations with `WebError.WebError` error channel instead of `unknown`
- Type `Fiber.RuntimeFiber` in StoreRegistry with proper generic params
- Make Playwright `runTest` generic over error type instead of using `unknown`
- Replace global `Error` with `DynamicImportError` TaggedError
- Convert `Effect.catchAll(e => Effect.fail(...))` to `Effect.mapError` (3 instances)
- Convert `Schema.encodeSync`/`decodeSync` to async `Schema.encode`/`decode` inside Effect generators (7 instances)
- Convert ~31 functions to `Effect.fn('name')` pattern from manual `Effect.withSpan`
- Convert nested `Effect.provide(runtime)(self)` to pipeable `self.pipe(Effect.provide(runtime))`

**Justified suppressions:**
- Generated `http-client-generated.ts` (21 methods from external openapi-gen fork)
- Dynamic RPC dispatch in `do-rpc/server.ts` (inherently untyped handler dispatch)
- Generic WorkerRunner patterns with `unknown` requirements (type inference limitation)
- `preferSchemaOverJson` for span attributes, serialization, tooling code (34 instances)

## Test plan

- [x] `tsc --build tsconfig.dev.json` — zero warnings/messages/errors
- [x] `dt lint:full` — all checks pass
- [x] Pre-commit hooks pass (`check:quick`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)