### PR TITLE
Re-enable func-style by migrating declarations to expressions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -46,7 +46,7 @@
     "typescript/consistent-type-definitions": "off",
     "no-unused-vars": "off",
     "eqeqeq": "off",
-    "func-style": "off",
+    "func-style": "error",
     "oxc/no-barrel-file": "off",
     "import/default": "off",
     "import/no-cycle": "off",

--- a/.oxlintrc.json.genie.ts
+++ b/.oxlintrc.json.genie.ts
@@ -46,8 +46,7 @@ const permanentlyDisabledRules = {
 // ── TODO(oep-1n3): Phase 2 — re-enable after codebase-wide fixes ───────────
 
 const phase2Rules = {
-  // TODO(oep-1n3.1): 93 violations — migrate function declarations to arrow expressions
-  'func-style': 'off',
+  'func-style': 'error',
   // TODO(oep-1n3.6): 18 violations — eliminate barrel files in favor of mod.ts
   'oxc/no-barrel-file': 'off',
 

--- a/docs/src/components/LlmsShort.astro
+++ b/docs/src/components/LlmsShort.astro
@@ -59,10 +59,10 @@ type TProcessedItem<T extends { _tag: string }> =
  * Groups consecutive link items together into batches, preserving order.
  * This ensures all links at the same level are rendered in a single <ul>.
  */
-function processItems<T extends { _tag: string }>(
+const processItems = <T extends { _tag: string }>(
   items: readonly T[],
   getEntry: (item: T) => TLlmsEntry | undefined,
-): TProcessedItem<T>[] {
+): TProcessedItem<T>[] => {
   const result: TProcessedItem<T>[] = []
   let currentBatch: TLlmsEntry[] = []
 

--- a/docs/src/content/_assets/code/tsconfig.json
+++ b/docs/src/content/_assets/code/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/docs/src/pages/api/docs-slugs.json.ts
+++ b/docs/src/pages/api/docs-slugs.json.ts
@@ -21,7 +21,7 @@ const toSlug = (id: string, slug: string | undefined): string => {
     .replace(/\/index$/i, '')
 }
 
-export async function GET() {
+export const GET = async () => {
   if (!import.meta.env.DEV) {
     return new Response('Not found', { status: 404 })
   }

--- a/docs/src/pages/api/search.ts
+++ b/docs/src/pages/api/search.ts
@@ -27,7 +27,7 @@ export interface SearchResult {
   url: string
 }
 
-function filePathToHref(filePath: string): string {
+const filePathToHref = (filePath: string): string => {
   // Extract the path after /src/content/docs/
   const match = filePath.match(/\/src\/content\/docs\/(.+)$/)
   if (!match || !match[1]) return '/'
@@ -37,7 +37,7 @@ function filePathToHref(filePath: string): string {
   return `/${href}`
 }
 
-function extractHeadingTitle(text: string): string {
+const extractHeadingTitle = (text: string): string => {
   const trimmedText = text.trim()
 
   if (!trimmedText.startsWith('#')) {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/examples/expo-linearlite/src/assets/Icons/convert-to-base64.js
+++ b/examples/expo-linearlite/src/assets/Icons/convert-to-base64.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs')
 const path = require('node:path')
 
-function imageToBase64(filePath) {
+const imageToBase64 = (filePath) => {
   const image = fs.readFileSync(filePath)
   return Buffer.from(image).toString('base64')
 }

--- a/examples/tutorial-starter/src/App.tsx
+++ b/examples/tutorial-starter/src/App.tsx
@@ -5,7 +5,7 @@ interface Todo {
   text: string
 }
 
-function App() {
+const App = () => {
   const [todos, setTodos] = useState<Todo[]>([])
   const [input, setInput] = useState('')
 

--- a/examples/web-email-client/src/stores/thread/commands.ts
+++ b/examples/web-email-client/src/stores/thread/commands.ts
@@ -3,13 +3,13 @@ import { queryDb, type Store } from '@livestore/livestore'
 import { type schema as mailboxSchema, mailboxTables } from '../mailbox/schema.ts'
 import { threadEvents, type schema as threadSchema, threadTables } from './schema.ts'
 
-export function applyUserLabelToThread(
+export const applyUserLabelToThread = (
   threadStore: Store<typeof threadSchema>,
   params: {
     threadId: string
     labelId: string
   },
-): void {
+): void => {
   try {
     threadStore.commit(
       threadEvents.threadLabelApplied({
@@ -23,13 +23,13 @@ export function applyUserLabelToThread(
   }
 }
 
-export function removeUserLabelFromThread(
+export const removeUserLabelFromThread = (
   threadStore: Store<typeof threadSchema>,
   params: {
     threadId: string
     labelId: string
   },
-): void {
+): void => {
   try {
     threadStore.commit(
       threadEvents.threadLabelRemoved({
@@ -43,13 +43,13 @@ export function removeUserLabelFromThread(
   }
 }
 
-export function archiveThread(
+export const archiveThread = (
   threadStore: Store<typeof threadSchema>,
   mailboxStore: Store<typeof mailboxSchema>,
   params: {
     threadId: string
   },
-): void {
+): void => {
   // Query necessary data
   const systemLabels = mailboxStore.query(queryDb(mailboxTables.labels.where({ type: 'system' })))
   const threadLabels = threadStore.query(queryDb(threadTables.threadLabels.where({})))
@@ -82,13 +82,13 @@ export function archiveThread(
   }
 }
 
-export function trashThread(
+export const trashThread = (
   threadStore: Store<typeof threadSchema>,
   mailboxStore: Store<typeof mailboxSchema>,
   params: {
     threadId: string
   },
-): void {
+): void => {
   // Query necessary data
   const systemLabels = mailboxStore.query(queryDb(mailboxTables.labels.where({ type: 'system' })))
   const threadLabels = threadStore.query(queryDb(threadTables.threadLabels.where({})))

--- a/examples/web-linearlite/src/livestore/seed.ts
+++ b/examples/web-linearlite/src/livestore/seed.ts
@@ -1,6 +1,5 @@
-import { generateKeyBetween } from 'fractional-indexing'
-
 import type { Store } from '@livestore/livestore'
+import { generateKeyBetween } from 'fractional-indexing'
 
 import { priorityOptions } from '../data/priority-options.ts'
 import { statusOptions } from '../data/status-options.ts'
@@ -22,7 +21,7 @@ export const seed = (store: Store, count: number) => {
   }
 }
 
-function* createIssues(
+const createIssues = function* (
   numTasks: number,
   highestId?: number,
   highestKanbanOrder?: string,

--- a/examples/web-linearlite/src/routes/$storeId/issue.tsx
+++ b/examples/web-linearlite/src/routes/$storeId/issue.tsx
@@ -1,6 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router'
-
 import { shouldNeverHappen } from '@livestore/utils'
+import { createFileRoute } from '@tanstack/react-router'
 
 import { Issue } from '../../components/layout/issue/index.tsx'
 
@@ -8,7 +7,7 @@ export const Route = createFileRoute('/$storeId/issue')({
   component: IssueRoute,
 })
 
-function IssueRoute() {
+const IssueRoute = () => {
   const search = Route.useSearch() as Record<string, unknown>
   const issueIdValue = search.issueId
 

--- a/examples/web-linearlite/src/routes/__root.tsx
+++ b/examples/web-linearlite/src/routes/__root.tsx
@@ -1,9 +1,9 @@
 import '../app/init-theme.ts'
-import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
-import React, { type ReactNode, Suspense } from 'react'
 
 import type { StoreRegistry } from '@livestore/livestore'
 import { StoreRegistryProvider } from '@livestore/react'
+import { createRootRouteWithContext, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
+import React, { type ReactNode, Suspense } from 'react'
 
 import { MenuContext, NewIssueModalContext } from '../app/contexts.ts'
 import stylesheetUrl from '../app/style.css?url'
@@ -47,7 +47,7 @@ const RootComponent = () => {
   )
 }
 
-function Loading() {
+const Loading = () => {
   return (
     <div
       className="fixed inset-0 bg-white dark:bg-neutral-900 flex flex-col items-center justify-center gap-4 text-sm"

--- a/examples/web-multi-store/src/components/ErrorFallback.tsx
+++ b/examples/web-multi-store/src/components/ErrorFallback.tsx
@@ -1,4 +1,4 @@
-export function ErrorFallback({ error, resetErrorBoundary }: { error: Error; resetErrorBoundary: () => void }) {
+export const ErrorFallback = ({ error, resetErrorBoundary }: { error: Error; resetErrorBoundary: () => void }) => {
   return (
     <div className="error">
       <h3>Something went wrong:</h3>

--- a/examples/web-multi-store/src/components/IssueView.tsx
+++ b/examples/web-multi-store/src/components/IssueView.tsx
@@ -1,14 +1,13 @@
-import { ErrorFallback } from '@/components/ErrorFallback.tsx'
-import { issueStoreOptions } from '@/stores/issue/index.ts'
-import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-
 import { queryDb } from '@livestore/livestore'
 import { useStore } from '@livestore/react'
+import { Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
+import { issueStoreOptions } from '@/stores/issue/index.ts'
 
 import { issueEvents, issueTables } from '../stores/issue/schema.ts'
 
-export function IssueView({ issueId }: { issueId: string }) {
+export const IssueView = ({ issueId }: { issueId: string }) => {
   const issueStore = useStore(issueStoreOptions(issueId)) // Will suspend component if the store is not yet loaded
   const [issue] = issueStore.useQuery(queryDb(issueTables.issue.select().limit(1)))
 

--- a/examples/web-multi-store/src/components/WorkspaceView.tsx
+++ b/examples/web-multi-store/src/components/WorkspaceView.tsx
@@ -1,16 +1,15 @@
+import { queryDb } from '@livestore/livestore'
+import { useStore, useStoreRegistry } from '@livestore/react'
+import { Suspense, useState } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 import { ErrorFallback } from '@/components/ErrorFallback.tsx'
 import { issueStoreOptions } from '@/stores/issue/index.ts'
 import { workspaceStoreOptions } from '@/stores/workspace/index.ts'
-import { Suspense, useState } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
-
-import { queryDb } from '@livestore/livestore'
-import { useStore, useStoreRegistry } from '@livestore/react'
 
 import { workspaceEvents, workspaceTables } from '../stores/workspace/schema.ts'
 import { IssueView } from './IssueView.tsx'
 
-export function WorkspaceView() {
+export const WorkspaceView = () => {
   const workspaceStore = useStore(workspaceStoreOptions)
 
   const [workspace] = workspaceStore.useQuery(queryDb(workspaceTables.workspaces.select().limit(1)))

--- a/examples/web-multi-store/src/routes/__root.tsx
+++ b/examples/web-multi-store/src/routes/__root.tsx
@@ -1,8 +1,7 @@
-import stylesheetUrl from '@/styles.css?url'
+import type { StoreRegistry } from '@livestore/livestore'
 import { createRootRouteWithContext, HeadContent, Link, Outlet, Scripts } from '@tanstack/react-router'
 import type { ReactNode } from 'react'
-
-import type { StoreRegistry } from '@livestore/livestore'
+import stylesheetUrl from '@/styles.css?url'
 
 type RouterContext = {
   storeRegistry: StoreRegistry
@@ -31,7 +30,7 @@ const tabs = [
   { to: '/recursive', label: 'Recursive' },
 ] as const
 
-function RootComponent() {
+const RootComponent = () => {
   return (
     <RootDocument>
       <main>
@@ -56,7 +55,7 @@ function RootComponent() {
   )
 }
 
-function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
+const RootDocument = ({ children }: Readonly<{ children: ReactNode }>) => {
   return (
     <html lang="en">
       <head>

--- a/examples/web-multi-store/src/routes/chained.tsx
+++ b/examples/web-multi-store/src/routes/chained.tsx
@@ -1,16 +1,15 @@
-import { ErrorFallback } from '@/components/ErrorFallback.tsx'
-import { WorkspaceView } from '@/components/WorkspaceView.tsx'
+import { StoreRegistryProvider } from '@livestore/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { StoreRegistryProvider } from '@livestore/react'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
+import { WorkspaceView } from '@/components/WorkspaceView.tsx'
 
 export const Route = createFileRoute('/chained')({
   component: ChainedDemoRoute,
 })
 
-function ChainedDemoRoute() {
+const ChainedDemoRoute = () => {
   const { storeRegistry } = Route.useRouteContext()
 
   return (

--- a/examples/web-multi-store/src/routes/independent.tsx
+++ b/examples/web-multi-store/src/routes/independent.tsx
@@ -1,17 +1,16 @@
-import { ErrorFallback } from '@/components/ErrorFallback.tsx'
-import { IssueView } from '@/components/IssueView.tsx'
-import { WorkspaceView } from '@/components/WorkspaceView.tsx'
+import { StoreRegistryProvider } from '@livestore/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { StoreRegistryProvider } from '@livestore/react'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
+import { IssueView } from '@/components/IssueView.tsx'
+import { WorkspaceView } from '@/components/WorkspaceView.tsx'
 
 export const Route = createFileRoute('/independent')({
   component: IndependentDemoRoute,
 })
 
-function IndependentDemoRoute() {
+const IndependentDemoRoute = () => {
   const { storeRegistry } = Route.useRouteContext()
 
   return (

--- a/examples/web-multi-store/src/routes/index.tsx
+++ b/examples/web-multi-store/src/routes/index.tsx
@@ -1,12 +1,11 @@
-import { ErrorFallback } from '@/components/ErrorFallback.tsx'
-import { workspaceStoreOptions } from '@/stores/workspace/index.ts'
-import { workspaceEvents, workspaceTables } from '@/stores/workspace/schema.ts'
+import { queryDb } from '@livestore/livestore'
+import { StoreRegistryProvider, useStore } from '@livestore/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { queryDb } from '@livestore/livestore'
-import { StoreRegistryProvider, useStore } from '@livestore/react'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
+import { workspaceStoreOptions } from '@/stores/workspace/index.ts'
+import { workspaceEvents, workspaceTables } from '@/stores/workspace/schema.ts'
 
 export const Route = createFileRoute('/')({
   loader: ({ context }) => {
@@ -15,7 +14,7 @@ export const Route = createFileRoute('/')({
   component: SingleRoute,
 })
 
-function SingleRoute() {
+const SingleRoute = () => {
   const { storeRegistry } = Route.useRouteContext()
 
   return (
@@ -35,7 +34,7 @@ function SingleRoute() {
   )
 }
 
-function Workspace() {
+const Workspace = () => {
   const workspaceStore = useStore(workspaceStoreOptions)
   const [workspace] = workspaceStore.useQuery(queryDb(workspaceTables.workspaces.select().limit(1)))
   const issues = workspaceStore.useQuery(

--- a/examples/web-multi-store/src/routes/multi-instance.tsx
+++ b/examples/web-multi-store/src/routes/multi-instance.tsx
@@ -1,10 +1,9 @@
-import { ErrorFallback } from '@/components/ErrorFallback.tsx'
-import { IssueView } from '@/components/IssueView.tsx'
+import { StoreRegistryProvider } from '@livestore/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { StoreRegistryProvider } from '@livestore/react'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
+import { IssueView } from '@/components/IssueView.tsx'
 
 const issueIds = ['issue-1', 'issue-2', 'issue-3'] as const
 
@@ -19,7 +18,7 @@ export const Route = createFileRoute('/multi-instance')({
   component: MultiInstanceRoute,
 })
 
-function MultiInstanceRoute() {
+const MultiInstanceRoute = () => {
   const { storeRegistry } = Route.useRouteContext()
 
   return (

--- a/examples/web-multi-store/src/routes/recursive.tsx
+++ b/examples/web-multi-store/src/routes/recursive.tsx
@@ -1,10 +1,9 @@
-import { ErrorFallback } from '@/components/ErrorFallback.tsx'
-import { IssueView } from '@/components/IssueView.tsx'
+import { StoreRegistryProvider } from '@livestore/react'
 import { createFileRoute } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-
-import { StoreRegistryProvider } from '@livestore/react'
+import { ErrorFallback } from '@/components/ErrorFallback.tsx'
+import { IssueView } from '@/components/IssueView.tsx'
 
 export const Route = createFileRoute('/recursive')({
   ssr: false,
@@ -18,7 +17,7 @@ export const Route = createFileRoute('/recursive')({
   component: RecursiveRoute,
 })
 
-function RecursiveRoute() {
+const RecursiveRoute = () => {
   const { storeRegistry } = Route.useRouteContext()
 
   return (

--- a/examples/web-todomvc-custom-elements/src/main.ts
+++ b/examples/web-todomvc-custom-elements/src/main.ts
@@ -214,7 +214,7 @@ class TodoList extends HTMLElement {
 
 customElements.define('todo-list', TodoList)
 
-export function parseTemplate(source: string) {
+export const parseTemplate = (source: string) => {
   const el = document.createElement('template')
   el.innerHTML = source
 

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "348b660b3730b0c5ad86a398a51c8c6ed0172060",
+      "commit": "34025f2a839177ac1fe2caf6e9987f6c87a42be0",
       "pinned": false,
-      "lockedAt": "2026-02-13T21:37:00.229Z"
+      "lockedAt": "2026-02-15T09:18:58.905Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
       "ref": "main",
-      "commit": "6b910598ccbe27ac98ded98c9cdd98c16cae36e7",
+      "commit": "5846cf4e9f9c38644adb6f1fa4cd3728537b7c06",
       "pinned": false,
-      "lockedAt": "2026-02-12T12:47:38.672Z"
+      "lockedAt": "2026-02-15T09:18:58.905Z"
     }
   }
 }

--- a/packages/@livestore/adapter-cloudflare/tsconfig.json
+++ b/packages/@livestore/adapter-cloudflare/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/adapter-expo/tsconfig.json
+++ b/packages/@livestore/adapter-expo/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/adapter-node/tsconfig.json
+++ b/packages/@livestore/adapter-node/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/adapter-web/tsconfig.json
+++ b/packages/@livestore/adapter-web/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/cli/tsconfig.json
+++ b/packages/@livestore/cli/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/common-cf/tsconfig.json
+++ b/packages/@livestore/common-cf/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
@@ -277,19 +277,19 @@ const emptyAst = (tableDef: TableDefBase): QueryBuilderAst.SelectQuery => ({
 
 // Helper functions
 
-function assertSelectQueryBuilderAst(ast: QueryBuilderAst): asserts ast is QueryBuilderAst.SelectQuery {
+const assertSelectQueryBuilderAst: (ast: QueryBuilderAst) => asserts ast is QueryBuilderAst.SelectQuery = (ast) => {
   if (ast._tag !== 'SelectQuery') {
     return shouldNeverHappen(`Expected SelectQuery but got ${ast._tag}`)
   }
 }
 
-function assertInsertQueryBuilderAst(ast: QueryBuilderAst): asserts ast is QueryBuilderAst.InsertQuery {
+const assertInsertQueryBuilderAst: (ast: QueryBuilderAst) => asserts ast is QueryBuilderAst.InsertQuery = (ast) => {
   if (ast._tag !== 'InsertQuery') {
     return shouldNeverHappen(`Expected InsertQuery but got ${ast._tag}`)
   }
 }
 
-function assertWriteQueryBuilderAst(ast: QueryBuilderAst): asserts ast is QueryBuilderAst.WriteQuery {
+const assertWriteQueryBuilderAst: (ast: QueryBuilderAst) => asserts ast is QueryBuilderAst.WriteQuery = (ast) => {
   if (ast._tag !== 'InsertQuery' && ast._tag !== 'UpdateQuery' && ast._tag !== 'DeleteQuery') {
     return shouldNeverHappen(`Expected WriteQuery but got ${ast._tag}`)
   }

--- a/packages/@livestore/common/src/sync/next/compact-events.ts
+++ b/packages/@livestore/common/src/sync/next/compact-events.ts
@@ -64,7 +64,7 @@ export const compactEvents = (inputDag: HistoryDag): { dag: HistoryDag; compacte
   return { dag, compactedEventCount }
 }
 
-function* makeSubDagsForEvent(inputDag: HistoryDag, eventNumStr: string): Generator<HistoryDag> {
+const makeSubDagsForEvent = function* (inputDag: HistoryDag, eventNumStr: string): Generator<HistoryDag> {
   /** Map from eventNumStr to array of eventNumStrs that are dependencies */
   let nextIterationEls: Map<string, string[]> = new Map([[eventNumStr, []]])
   let previousDag: HistoryDag | undefined

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -519,20 +519,20 @@ const expectEventArraysEqual = (
   })
 }
 
-function expectAdvance(
+const expectAdvance: (
   result: typeof SyncState.MergeResult.Type,
-): asserts result is typeof SyncState.MergeResultAdvance.Type {
+) => asserts result is typeof SyncState.MergeResultAdvance.Type = (result) => {
   expect(result._tag).toBe('advance')
 }
 
-function expectRebase(
+const expectRebase: (
   result: typeof SyncState.MergeResult.Type,
-): asserts result is typeof SyncState.MergeResultRebase.Type {
+) => asserts result is typeof SyncState.MergeResultRebase.Type = (result) => {
   expect(result._tag, `Expected rebase, got ${result}`).toBe('rebase')
 }
 
-function expectReject(
+const expectReject: (
   result: typeof SyncState.MergeResult.Type,
-): asserts result is typeof SyncState.MergeResultReject.Type {
+) => asserts result is typeof SyncState.MergeResultReject.Type = (result) => {
   expect(result._tag).toBe('reject')
 }

--- a/packages/@livestore/common/tsconfig.json
+++ b/packages/@livestore/common/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/devtools-expo/tsconfig.json
+++ b/packages/@livestore/devtools-expo/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/devtools-web-common/tsconfig.json
+++ b/packages/@livestore/devtools-web-common/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/effect-playwright/tsconfig.json
+++ b/packages/@livestore/effect-playwright/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/framework-toolkit/tsconfig.json
+++ b/packages/@livestore/framework-toolkit/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/graphql/tsconfig.json
+++ b/packages/@livestore/graphql/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -18,8 +18,8 @@ import {
 } from '@livestore/utils/effect'
 
 import { type CreateStoreOptions, createStore } from './create-store.ts'
-import type { OtelOptions } from './store-types.ts'
 import type { Store } from './store.ts'
+import type { OtelOptions } from './store-types.ts'
 
 /**
  * Default time to keep unused stores in cache.
@@ -406,12 +406,10 @@ export class StoreRegistry {
  * });
  * ```
  */
-export function storeOptions<
+export const storeOptions = <
   TSchema extends LiveStoreSchema,
   TContext = {},
   TSyncPayloadSchema extends Schema.Schema<any> = typeof Schema.JsonValue,
 >(
   options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
-): RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema> {
-  return options
-}
+): RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema> => options

--- a/packages/@livestore/livestore/tsconfig.json
+++ b/packages/@livestore/livestore/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/react/tsconfig.json
+++ b/packages/@livestore/react/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/solid/src/useStore.client.test.tsx
+++ b/packages/@livestore/solid/src/useStore.client.test.tsx
@@ -1,7 +1,3 @@
-import * as SolidTesting from '@solidjs/testing-library'
-import * as Solid from 'solid-js'
-import { describe, expect, it } from 'vitest'
-
 import { makeInMemoryAdapter } from '@livestore/adapter-web'
 import {
   queryDb,
@@ -12,14 +8,17 @@ import {
   storeOptions,
 } from '@livestore/livestore'
 import { Schema } from '@livestore/utils/effect'
+import * as SolidTesting from '@solidjs/testing-library'
+import * as Solid from 'solid-js'
+import { describe, expect, it } from 'vitest'
 
 import { events, schema, tables } from './__tests__/fixture.tsx'
 import { StoreRegistryProvider } from './StoreRegistryContext.tsx'
 import { useStore } from './useStore.ts'
 
-function createSuspenseCount(id: string) {
+const createSuspenseCount = (id: string) => {
   let count = 0
-  function Comp(props: Solid.ParentProps) {
+  const Comp = (props: Solid.ParentProps) => {
     return (
       <Solid.Suspense
         fallback={

--- a/packages/@livestore/solid/src/utils.ts
+++ b/packages/@livestore/solid/src/utils.ts
@@ -2,7 +2,7 @@ import type { Accessor } from 'solid-js'
 
 export type AccessorMaybe<T> = Accessor<T> | T
 
-export function resolve<T>(value: AccessorMaybe<T>): T {
+export const resolve = <T>(value: AccessorMaybe<T>): T => {
   if (typeof value === 'function') {
     return (value as Accessor<T>)()
   }

--- a/packages/@livestore/solid/src/whenever.ts
+++ b/packages/@livestore/solid/src/whenever.ts
@@ -61,9 +61,9 @@ export const when: {
  * @returns A function that can be called to conditionally execute based on the truthiness of all accessor values,
  *          returning their results as an array or undefined if any are not truthy.
  */
-export function every<TAccessors extends Array<AccessorMaybe<any>>>(
+export const every = <TAccessors extends Array<AccessorMaybe<any>>>(
   ...accessors: TAccessors
-): () => InferNonNullableTuple<TAccessors> | undefined {
+): (() => InferNonNullableTuple<TAccessors> | undefined) => {
   return () => {
     const values = new Array(accessors.length) as InferNonNullableTuple<TAccessors>
     for (let i = 0; i < accessors.length; i++) {

--- a/packages/@livestore/solid/tsconfig.json
+++ b/packages/@livestore/solid/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/sqlite-wasm/src/FacadeVFS.ts
+++ b/packages/@livestore/sqlite-wasm/src/FacadeVFS.ts
@@ -506,6 +506,4 @@ export class FacadeVFS extends VFS.Base {
 }
 // Emscripten "legalizes" 64-bit integer arguments by passing them as
 // two 32-bit signed integers.
-function delegalize(lo32, hi32) {
-  return hi32 * 0x1_00_00_00_00 + lo32 + (lo32 < 0 ? 2 ** 32 : 0)
-}
+const delegalize = (lo32, hi32) => hi32 * 0x1_00_00_00_00 + lo32 + (lo32 < 0 ? 2 ** 32 : 0)

--- a/packages/@livestore/sqlite-wasm/src/browser/mod.ts
+++ b/packages/@livestore/sqlite-wasm/src/browser/mod.ts
@@ -62,7 +62,7 @@ type MakeOpfsWebDatabase = MakeSqliteDb<
   Opfs.Opfs | Scope.Scope
 >
 
-export function sqliteDbFactory({ sqlite3 }: { sqlite3: SQLiteAPI }) {
+export const sqliteDbFactory = ({ sqlite3 }: { sqlite3: SQLiteAPI }) => {
   function makeDb(input: WebDatabaseInputInMemory): ReturnType<MakeInMemoryWebDatabase>
   function makeDb(input: WebDatabaseInputOpfs): ReturnType<MakeOpfsWebDatabase>
   function makeDb(

--- a/packages/@livestore/sqlite-wasm/src/cf/test/sql/cloudflare-sql-vfs-core.test.ts
+++ b/packages/@livestore/sqlite-wasm/src/cf/test/sql/cloudflare-sql-vfs-core.test.ts
@@ -1,9 +1,8 @@
 /// <reference types="vitest/globals" />
 
-import { beforeEach, describe, expect, it } from 'vitest'
-
 import type { CfTypes } from '@livestore/common-cf'
 import * as VFS from '@livestore/wa-sqlite/src/VFS.js'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { CloudflareSqlVFS } from '../../mod.ts'
 
@@ -134,9 +133,9 @@ describe('CloudflareSqlVFS - Core Functionality', () => {
       Statement: {} as any,
     } as CfTypes.SqlStorage
 
-    function createMockCursor<T extends Record<string, CfTypes.SqlStorageValue>>(
+    const createMockCursor = <T extends Record<string, CfTypes.SqlStorageValue>>(
       data: T[],
-    ): CfTypes.SqlStorageCursor<T> {
+    ): CfTypes.SqlStorageCursor<T> => {
       let index = 0
 
       return {

--- a/packages/@livestore/sqlite-wasm/tsconfig.json
+++ b/packages/@livestore/sqlite-wasm/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/svelte/tsconfig.json
+++ b/packages/@livestore/svelte/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/svelte/tsconfig.tests.json
+++ b/packages/@livestore/svelte/tsconfig.tests.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/sync-cf/tsconfig.json
+++ b/packages/@livestore/sync-cf/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/sync-electric/tsconfig.json
+++ b/packages/@livestore/sync-electric/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/sync-s2/tsconfig.json
+++ b/packages/@livestore/sync-s2/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/utils-dev/tsconfig.json
+++ b/packages/@livestore/utils-dev/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/utils/src/effect/Debug.ts
+++ b/packages/@livestore/utils/src/effect/Debug.ts
@@ -35,7 +35,7 @@ export type MutableSpanGraphInfo = {
 
 const graphByTraceId = new Map<string, MutableSpanGraphInfo>()
 
-function ensureSpan(traceId: string, spanId: string): [MutableSpanGraph, number] {
+const ensureSpan = (traceId: string, spanId: string): [MutableSpanGraph, number] => {
   let info = graphByTraceId.get(traceId)
   if (info === undefined) {
     info = {
@@ -56,16 +56,16 @@ function ensureSpan(traceId: string, spanId: string): [MutableSpanGraph, number]
   return [info.graph, nodeId]
 }
 
-function sortSpan(
+const sortSpan = (
   prev: Tracer.AnySpan,
   next: Tracer.AnySpan,
-): [info: Tracer.AnySpan, isUpgrade: boolean, timingUpdated: boolean] {
+): [info: Tracer.AnySpan, isUpgrade: boolean, timingUpdated: boolean] => {
   if (prev._tag === 'ExternalSpan' && next._tag === 'Span') return [next, true, true]
   if (prev._tag === 'Span' && next._tag === 'Span' && next.status._tag === 'Ended') return [next, false, true]
   return [prev, false, false]
 }
 
-function addNode(span: Tracer.AnySpan) {
+const addNode = (span: Tracer.AnySpan) => {
   const [mutableGraph, nodeId] = ensureSpan(span.traceId, span.spanId)
   Graph.updateNode(mutableGraph, nodeId, (previousInfo) => {
     const [latestInfo, upgraded] = sortSpan(previousInfo.span, span)
@@ -78,14 +78,14 @@ function addNode(span: Tracer.AnySpan) {
   return nodeId
 }
 
-function addEvent(traceId: string, spanId: string, event: SpanEvent) {
+const addEvent = (traceId: string, spanId: string, event: SpanEvent) => {
   const [mutableGraph, nodeId] = ensureSpan(traceId, spanId)
   Graph.updateNode(mutableGraph, nodeId, (previousInfo) => {
     return { ...previousInfo, events: [...previousInfo.events, event] }
   })
   return nodeId
 }
-function addNodeExit(traceId: string, spanId: string, exit: Exit.Exit<any, any>) {
+const addNodeExit = (traceId: string, spanId: string, exit: Exit.Exit<any, any>) => {
   const [mutableGraph, nodeId] = ensureSpan(traceId, spanId)
   Graph.updateNode(mutableGraph, nodeId, (previousInfo) => {
     const isInterruptedOnly = exit._tag === 'Failure' && Cause.isInterruptedOnly(exit.cause)
@@ -97,11 +97,11 @@ function addNodeExit(traceId: string, spanId: string, exit: Exit.Exit<any, any>)
   return nodeId
 }
 
-function createPropertyInterceptor<T extends object, K extends keyof T>(
+const createPropertyInterceptor = <T extends object, K extends keyof T>(
   obj: T,
   property: K,
   interceptor: (value: T[K]) => void,
-): void {
+): void => {
   const descriptor = Object.getOwnPropertyDescriptor(obj, property)
 
   const previousSetter = descriptor?.set
@@ -151,7 +151,7 @@ type GlobalWithFiberCurrent = {
 }
 
 const patchedTracer = new WeakSet<Tracer.Tracer>()
-function ensureTracerPatched(currentTracer: Tracer.Tracer) {
+const ensureTracerPatched = (currentTracer: Tracer.Tracer) => {
   if (patchedTracer.has(currentTracer)) {
     return
   }
@@ -202,7 +202,7 @@ const knownScopes = new Map<
   { id: number; allocationFiber: Fiber.RuntimeFiber<any, any> | undefined; allocationSpan: Tracer.AnySpan | undefined }
 >()
 let lastScopeId = 0
-function ensureScopePatched(scope: ScopeImpl, allocationFiber: Fiber.RuntimeFiber<any, any> | undefined) {
+const ensureScopePatched = (scope: ScopeImpl, allocationFiber: Fiber.RuntimeFiber<any, any> | undefined) => {
   if (scope.state._tag === 'Closed') return
   if (knownScopes.has(scope)) return
   const id = lastScopeId++
@@ -231,7 +231,7 @@ const cleanupScopes = () => {
 }
 
 const knownFibers = new Set<Fiber.RuntimeFiber<any, any>>()
-function ensureFiberPatched(fiber: Fiber.RuntimeFiber<any, any>) {
+const ensureFiberPatched = (fiber: Fiber.RuntimeFiber<any, any>) => {
   // patch tracer
   ensureTracerPatched(fiber.currentTracer)
   // patch scope
@@ -250,7 +250,7 @@ let patchScopeClose = false
 let onFiberResumed: undefined | ((fiber: Fiber.RuntimeFiber<any, any>) => void)
 let onFiberSuspended: undefined | ((fiber: Fiber.RuntimeFiber<any, any>) => void)
 let onFiberCompleted: undefined | ((fiber: Fiber.RuntimeFiber<any, any>, exit: Exit.Exit<any, any>) => void)
-export function attachSlowDebugInstrumentation(options: {
+export const attachSlowDebugInstrumentation = (options: {
   /** If set to true, the scope prototype will be patched to attach a span to visualize pending scope closing */
   readonly patchScopeClose?: boolean
   /** An optional callback that will be called when any fiber resumes performing a run loop */
@@ -259,7 +259,7 @@ export function attachSlowDebugInstrumentation(options: {
   readonly onFiberSuspended?: (fiber: Fiber.RuntimeFiber<any, any>) => void
   /** An optional callback that will be called when any fiber completes with a exit */
   readonly onFiberCompleted?: (fiber: Fiber.RuntimeFiber<any, any>, exit: Exit.Exit<any, any>) => void
-}) {
+}): void => {
   const _globalThis = globalThis as any as GlobalWithFiberCurrent
   if (_globalThis['effect/DevtoolsHook']) {
     return console.error(
@@ -292,7 +292,7 @@ export function attachSlowDebugInstrumentation(options: {
   }
 }
 
-function formatDuration(startTime: bigint, endTime: bigint | undefined): string {
+const formatDuration = (startTime: bigint, endTime: bigint | undefined): string => {
   if (endTime === undefined) return '[running]'
   const durationMs = Number(endTime - startTime) / 1000000 // Convert nanoseconds to milliseconds
   if (durationMs < 1000) return `${durationMs.toFixed(0)}ms`
@@ -300,12 +300,12 @@ function formatDuration(startTime: bigint, endTime: bigint | undefined): string 
   return `${(durationMs / 60000).toFixed(2)}m`
 }
 
-function getSpanName(span: Tracer.AnySpan): string {
+const getSpanName = (span: Tracer.AnySpan): string => {
   if (span._tag === 'ExternalSpan') return `[external] ${span.spanId}`
   return span.name
 }
 
-function getSpanStatus(info: GraphNodeInfo): string {
+const getSpanStatus = (info: GraphNodeInfo): string => {
   if (info.span._tag === 'ExternalSpan') return '?'
   if (info.exitTag === 'Success') return '✓'
   if (info.exitTag === 'Failure') return '✗'
@@ -313,16 +313,16 @@ function getSpanStatus(info: GraphNodeInfo): string {
   return '⋮'
 }
 
-function getSpanDuration(span: Tracer.AnySpan): string {
+const getSpanDuration = (span: Tracer.AnySpan): string => {
   if (span._tag === 'ExternalSpan') return ''
   const endTime = span.status._tag === 'Ended' ? span.status.endTime : undefined
   return formatDuration(span.status.startTime, endTime)
 }
 
-function filterGraphKeepAncestors<N, E>(
+const filterGraphKeepAncestors = <N, E>(
   graph: Graph.Graph<N, E>,
   predicate: (nodeData: N, nodeId: number) => boolean,
-): Graph.Graph<N, E> {
+): Graph.Graph<N, E> => {
   // Find all root nodes (nodes with no incoming edges)
   const rootNodes = Array.from(Graph.indices(Graph.externals(graph, { direction: 'incoming' })))
   const shouldInclude = new Set<number>()
@@ -351,7 +351,7 @@ function filterGraphKeepAncestors<N, E>(
   })
 }
 
-function renderSpanNode(graph: Graph.Graph<GraphNodeInfo, void, 'directed'>, nodeId: number): string[] {
+const renderSpanNode = (graph: Graph.Graph<GraphNodeInfo, void, 'directed'>, nodeId: number): string[] => {
   const node = Graph.getNode(graph, nodeId)
   if (Option.isNone(node)) return []
   const info = node.value
@@ -371,11 +371,11 @@ function renderSpanNode(graph: Graph.Graph<GraphNodeInfo, void, 'directed'>, nod
   return [` ${status} ${name}${durationStr}${runningOnFibers}`]
 }
 
-function renderTree<N, E, T extends Graph.Kind>(
+const renderTree = <N, E, T extends Graph.Kind>(
   graph: Graph.Graph<N, E, T>,
   nodeIds: Array<number>,
   renderNode: (graph: Graph.Graph<N, E, T>, nodeId: number) => string[],
-): string[] {
+): string[] => {
   let lines: string[] = []
   for (let childIndex = 0; childIndex < nodeIds.length; childIndex++) {
     const isLastChild = childIndex === nodeIds.length - 1

--- a/packages/@livestore/utils/src/mod.ts
+++ b/packages/@livestore/utils/src/mod.ts
@@ -173,7 +173,7 @@ export const isReadonlyArray = <I, T>(value: ReadonlyArray<I> | T): value is Rea
  * union have been accounted for.
  */
 
-export function casesHandled(unexpectedCase: never): never {
+export const casesHandled = (unexpectedCase: never): never => {
   // oxlint-disable-next-line eslint(no-debugger) -- intentional breakpoint for unhandled cases
   debugger
   throw new Error(`A case was not handled for value: ${truncate(objectToString(unexpectedCase), 1000)}`)

--- a/packages/@livestore/utils/tsconfig.json
+++ b/packages/@livestore/utils/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/wa-sqlite/tsconfig.json
+++ b/packages/@livestore/wa-sqlite/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@livestore/webmesh/tsconfig.json
+++ b/packages/@livestore/webmesh/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@local/astro-tldraw/tsconfig.json
+++ b/packages/@local/astro-tldraw/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@local/astro-twoslash-code/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/packages/@local/shared/tsconfig.json
+++ b/packages/@local/shared/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/tests/package-common/tsconfig.json
+++ b/tests/package-common/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/tests/perf-eventlog/test-app/tsconfig.json
+++ b/tests/perf-eventlog/test-app/tsconfig.json
@@ -32,7 +32,7 @@
           "reportSuggestionsAsWarningsInTsc": true,
           "pipeableMinArgCount": 2,
           "diagnosticSeverity": {
-            "missedPipeableOpportunity": "suggestion",
+            "missedPipeableOpportunity": "warning",
             "schemaUnionOfLiterals": "warning",
             "anyUnknownInErrorContext": "warning",
             "preferSchemaOverJson": "warning"

--- a/tests/perf-eventlog/tsconfig.json
+++ b/tests/perf-eventlog/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/tests/perf/tsconfig.json
+++ b/tests/perf/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/tests/sync-provider/tsconfig.json
+++ b/tests/sync-provider/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"

--- a/tests/wa-sqlite/tsconfig.json
+++ b/tests/wa-sqlite/tsconfig.json
@@ -31,7 +31,7 @@
         "reportSuggestionsAsWarningsInTsc": true,
         "pipeableMinArgCount": 2,
         "diagnosticSeverity": {
-          "missedPipeableOpportunity": "suggestion",
+          "missedPipeableOpportunity": "warning",
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"


### PR DESCRIPTION
## Problem
- `func-style` was still disabled in the phase-1 oxlint configuration (`oep-1n3.1`), which let declaration-style function usage continue drifting across packages/docs/examples.

## Solution
- Converted remaining `func-style` violations to function expressions/arrow forms across affected package, docs, and examples files.
- Re-enabled `func-style` in generated lint config source (`.oxlintrc.json.genie.ts`) and regenerated `.oxlintrc.json`.
- Kept regenerated tsconfig/lock artifacts in sync from `setup:opt:genie-run` (including Effect diagnostic severity churn) to avoid config skew.
- Fixed follow-on type/assertion narrowing regressions by adding explicit assertion function variable type annotations where required.

## Validation
- `oxlint --deny func-style .`
- `devenv shell dt lint:full`
- `devenv shell dt ts:check`
- `devenv shell env CI=1 vitest run packages/@livestore/common/src/sync/syncstate.test.ts packages/@livestore/solid/src/useStore.client.test.tsx packages/@livestore/sqlite-wasm/src/cf/test/sql/cloudflare-sql-vfs-core.test.ts`

## Trade-offs / Notes
- This PR intentionally includes generated `tsconfig.json` and `megarepo.lock` updates from `setup:opt:genie-run` alongside the `func-style` migration.