### PR TITLE
Close oep-1n3.2 by re-enabling React lint signal with scoped legacy exceptions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -46,6 +46,7 @@
     "typescript/consistent-type-definitions": "off",
     "no-unused-vars": "off",
     "eqeqeq": "off",
+    "react/react-in-jsx-scope": "off",
     "func-style": "error",
     "oxc/no-barrel-file": "off",
     "import/default": "off",
@@ -54,9 +55,6 @@
     "import/no-unassigned-import": "off",
     "import/namespace": "off",
     "import/no-named-as-default": "off",
-    "react/react-in-jsx-scope": "off",
-    "react/style-prop-object": "off",
-    "react-hooks/exhaustive-deps": "off",
     "react-perf/jsx-no-new-function-as-prop": "off",
     "react-perf/jsx-no-new-object-as-prop": "off",
     "react-perf/jsx-no-jsx-as-prop": "off",
@@ -146,6 +144,12 @@
         "oxc/no-barrel-file": "off",
         "oxc/no-map-spread": "off",
         "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["packages/@livestore/react/src/useRcResource.ts"],
+      "rules": {
+        "react-hooks/exhaustive-deps": "off"
       }
     },
     {

--- a/.oxlintrc.json.genie.ts
+++ b/.oxlintrc.json.genie.ts
@@ -41,6 +41,8 @@ const permanentlyDisabledRules = {
   'no-unused-vars': 'off',
   // Not enforced in livestore
   eqeqeq: 'off',
+  // Legacy rule; React 17+ automatic JSX runtime doesn't require React in scope
+  'react/react-in-jsx-scope': 'off',
 } as const
 
 // ── TODO(oep-1n3): Phase 2 — re-enable after codebase-wide fixes ───────────
@@ -62,13 +64,6 @@ const phase2Rules = {
   'import/namespace': 'off',
   // TODO(oep-1n3.5): 2 violations — named-as-default false positives
   'import/no-named-as-default': 'off',
-
-  // TODO(oep-1n3.2): 1028 violations — not needed with modern JSX transform (React 17+)
-  'react/react-in-jsx-scope': 'off',
-  // TODO(oep-1n3.2): 2 violations — style prop object type checking
-  'react/style-prop-object': 'off',
-  // TODO(oep-1n3.2): 4 violations — needs React-specific context for Effect patterns
-  'react-hooks/exhaustive-deps': 'off',
 
   // TODO(oep-1n3.3): 276 violations — inline functions as JSX props
   'react-perf/jsx-no-new-function-as-prop': 'off',
@@ -210,6 +205,12 @@ const livestoreOxlintOverrides = [
       'oxc/no-map-spread': 'off',
       'unicorn/consistent-function-scoping': 'off',
     },
+  },
+
+  // Deliberate resource lifecycle semantics in useRcResource rely on key-only invalidation
+  {
+    files: ['packages/@livestore/react/src/useRcResource.ts'],
+    rules: { 'react-hooks/exhaustive-deps': 'off' },
   },
 
   // wa-sqlite is a fork with its own style

--- a/examples/cf-chat/src/components.tsx
+++ b/examples/cf-chat/src/components.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react'
-
 import type { SyncState } from '@livestore/livestore'
+import React, { useState } from 'react'
 
 import { useReactionPickerClickOutside } from './hooks.ts'
 import { useAppStore } from './livestore/store.ts'
@@ -197,13 +196,12 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
     return el.scrollTop + el.clientHeight >= el.scrollHeight - threshold
   }, [])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Need to trigger on new messages only
   React.useEffect(() => {
     const shouldScroll = isAtBottom()
     if (shouldScroll) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
     }
-  }, [messages.length])
+  }, [isAtBottom, messages.length, messagesEndRef])
 
   const isSameDay = (a: Date, b: Date) =>
     a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()

--- a/examples/expo-linearlite/src/context/navigation-history.tsx
+++ b/examples/expo-linearlite/src/context/navigation-history.tsx
@@ -47,7 +47,7 @@ export const NavigationHistoryTracker = () => {
     setTimeout(() => {
       router.push(path as any)
     }, 100)
-  }, [constructPathWithParams, globalParams, navigationHistory, pathname, router.push]) // Empty dependency array ensures this only runs once on mount
+  }, [constructPathWithParams, globalParams, navigationHistory, pathname, router])
 
   return null
 }

--- a/examples/expo-todomvc-sync-cf/src/Root.tsx
+++ b/examples/expo-todomvc-sync-cf/src/Root.tsx
@@ -1,9 +1,8 @@
+import { StoreRegistry } from '@livestore/livestore'
+import { StoreRegistryProvider } from '@livestore/react'
 import { StatusBar } from 'expo-status-bar'
 import { Suspense, useState } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
-
-import { StoreRegistry } from '@livestore/livestore'
-import { StoreRegistryProvider } from '@livestore/react'
 
 import { Filters } from './components/Filters.tsx'
 import { ListTodos } from './components/ListTodos.tsx'
@@ -20,7 +19,7 @@ export const Root = () => {
           <InnerApp />
         </StoreRegistryProvider>
       </Suspense>
-      <StatusBar style="auto" />
+      <StatusBar />
     </View>
   )
 }


### PR DESCRIPTION
## Problem
`oep-1n3.2` left key React lint rules disabled globally, which reduced signal for dependency correctness in app/example code and left legacy JSX-scope handling mixed into phase-2 temporary toggles.

## Solution
- Move `react/react-in-jsx-scope` to permanently disabled rules in `.oxlintrc.json.genie.ts` / `.oxlintrc.json` (React 17+ automatic JSX runtime).
- Re-enable `react-hooks/exhaustive-deps` and `react/style-prop-object` globally by removing their temporary phase-2 disable entries.
- Keep a single scoped override for `packages/@livestore/react/src/useRcResource.ts` to preserve deliberate key-only invalidation semantics until we do a dedicated library-level redesign.
- Fix resulting app/example violations:
  - `examples/cf-chat/src/components.tsx`
  - `examples/expo-linearlite/src/context/navigation-history.tsx`
  - `examples/expo-todomvc-sync-cf/src/Root.tsx`

## Validation
- `devenv shell -- dt lint:full`
- `oxlint --config ./.oxlintrc.json --react-plugin --allow all --deny react/style-prop-object --deny react-hooks/exhaustive-deps -f json .` (0 diagnostics)

## Trade-offs / Follow-ups
- We intentionally keep a file-scoped `react-hooks/exhaustive-deps` override for `useRcResource` to avoid changing library behavior in this PR.
- Follow-up: redesign or annotate `useRcResource` semantics so this scoped override can be removed.