### PR TITLE
feat: add auto-review workflow for assistant PRs

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,0 +1,21 @@
+# Generated file - DO NOT EDIT
+# Source: auto-review.yml.genie.ts
+
+name: Auto-request review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.pull_request.user.login == 'schickling-assistant' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review from schickling
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        run: 'gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-reviewer schickling'

--- a/.github/workflows/auto-review.yml.genie.ts
+++ b/.github/workflows/auto-review.yml.genie.ts
@@ -1,0 +1,3 @@
+import { autoReviewWorkflow } from '../../repos/effect-utils/genie/auto-review.ts'
+
+export default autoReviewWorkflow()


### PR DESCRIPTION
## Summary
- Adds auto-review GitHub Actions workflow that requests review from `schickling` when `schickling-assistant` opens a non-draft PR
- Uses genie helper from effect-utils (requires overengineeringstudio/effect-utils#227 merged first for `genie --check` to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)