### PR TITLE
refactor(ci): use shared validateNixStoreStep

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771164813,
-        "narHash": "sha256-JOROieCfp0jW4NUkjeGsDj2rSjbDa9EzcIav6ioKUEc=",
+        "lastModified": 1771173487,
+        "narHash": "sha256-DV2zbE9zmXRQ5VlrwXWpF8yt1TMc0cH/Hz1suu2oKpA=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "8fdf2846c032f7f13cfaab7268678f4647ecaab3",
+        "rev": "73cb08ab2bc6afe80e35f8ca646c8103d937c74e",
         "type": "github"
       },
       "original": {
@@ -158,11 +158,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1770128701,
-        "narHash": "sha256-f5rmon6rU5k+VRhPxrfpTSc/7kkN8J6tkJJNiOYfJl8=",
+        "lastModified": 1771164813,
+        "narHash": "sha256-JOROieCfp0jW4NUkjeGsDj2rSjbDa9EzcIav6ioKUEc=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "9c27bfee47fd8fb3a0c8ec953ad98c22d52be6f4",
+        "rev": "8fdf2846c032f7f13cfaab7268678f4647ecaab3",
         "type": "github"
       },
       "original": {

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -484,6 +484,7 @@ import {
   installMegarepoStep,
   syncMegarepoStep,
   installDevenvFromLockStep,
+  validateNixStoreStep,
   checkoutStep,
 } from '../repos/effect-utils/genie/ci-workflow.ts'
 
@@ -510,21 +511,7 @@ export const livestoreSetupStepsAfterCheckout = [
   installMegarepoStep,
   syncMegarepoStep(),
   installDevenvFromLockStep,
-  {
-    name: 'Validate Nix store',
-    // Namespace runners may have stale/invalid paths in their bundled nix store cache.
-    // A cheap `devenv version` probe catches corruption before real work starts;
-    // the expensive `--verify --repair` only runs when actually needed.
-    // See https://github.com/namespacelabs/nscloud-setup/issues/8
-    run: `if devenv version > /dev/null 2>&1; then
-  echo "Nix store OK"
-else
-  echo "::warning::Nix store validation failed, running repair..."
-  nix-store --verify --repair 2>&1 | tail -20
-  devenv version
-fi`,
-    shell: 'bash',
-  },
+  validateNixStoreStep,
 ] as const
 
 /**

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "8fdf2846c032f7f13cfaab7268678f4647ecaab3",
+      "commit": "73cb08ab2bc6afe80e35f8ca646c8103d937c74e",
       "pinned": false,
-      "lockedAt": "2026-02-15T19:33:33.000Z"
+      "lockedAt": "2026-02-15T16:45:00.000Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",


### PR DESCRIPTION
## Summary
- Replace inline Nix store validation with the shared `validateNixStoreStep` atom from effect-utils
- Follow-up to #1033 which adopted shared CI blocks

## Test plan
- [ ] CI passes