### PR TITLE
Fix perf-test CI hangs by restoring OPFS handle pool semantics

### DIFF
--- a/packages/@livestore/sqlite-wasm/src/browser/opfs/AccessHandlePoolVFS.ts
+++ b/packages/@livestore/sqlite-wasm/src/browser/opfs/AccessHandlePoolVFS.ts
@@ -527,7 +527,7 @@ export class AccessHandlePoolVFS extends FacadeVFS {
       yield* Opfs.Opfs.syncWrite(accessHandle, digest, { at: HEADER_OFFSET_DIGEST })
       yield* Opfs.Opfs.syncFlush(accessHandle)
 
-      if (path !== undefined) {
+      if (path !== '') {
         this.#mapPathToAccessHandle.set(path, accessHandle)
         this.#availableAccessHandles.delete(accessHandle)
       } else {

--- a/tests/perf/tests/suites/latency.test.ts
+++ b/tests/perf/tests/suites/latency.test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 
 import { test } from '../fixtures.ts'
-import { repeatSuite } from '../utils.ts'
+import { assertPerfAppReady, repeatSuite } from '../utils.ts'
 
 const REPETITIONS_PER_TEST = 15
 
@@ -14,6 +14,7 @@ repeatSuite(
   () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/')
+      await assertPerfAppReady(page)
     })
 
     test.afterEach(async ({ page }, testInfo) => {

--- a/tests/perf/tests/suites/memory.test.ts
+++ b/tests/perf/tests/suites/memory.test.ts
@@ -1,7 +1,7 @@
 import { type CDPSession, expect } from '@playwright/test'
 
 import { test } from '../fixtures.ts'
-import { repeatSuite } from '../utils.ts'
+import { assertPerfAppReady, repeatSuite } from '../utils.ts'
 
 const REPETITIONS_PER_TEST = 1
 
@@ -25,6 +25,7 @@ repeatSuite(
   () => {
     test.beforeEach(async ({ page }) => {
       await page.goto('/')
+      await assertPerfAppReady(page)
     })
 
     test.afterEach(async ({ page, context }, testInfo) => {

--- a/tests/perf/tests/utils.ts
+++ b/tests/perf/tests/utils.ts
@@ -1,4 +1,4 @@
-import type { TestDetails } from '@playwright/test'
+import type { Page, TestDetails } from '@playwright/test'
 
 import { test } from './fixtures.ts'
 
@@ -28,3 +28,17 @@ export const repeatSuite = (
 }
 
 export const shouldRecordPerfProfile = process.env.PERF_PROFILER === '1'
+
+export const assertPerfAppReady = async (page: Page): Promise<void> => {
+  try {
+    await page.locator('#create1k').waitFor({ state: 'visible', timeout: 8000 })
+  } catch {
+    const bodyText = await page
+      .locator('body')
+      .innerText()
+      .catch(() => '<body unavailable>')
+    throw new Error(
+      `Perf test app did not become ready (expected #create1k). Current body text: ${bodyText.slice(0, 200)}`,
+    )
+  }
+}


### PR DESCRIPTION
## Problem
- The `perf-test` CI job could appear to hang/time out because the perf app never left `Loading...`.
- Root cause was a regression in OPFS VFS path association: empty path (`''`) was treated as associated, draining `availableAccessHandles` and causing `SQLITE_CANTOPEN` during worker boot.

## Solution
- Restore empty-path semantics in OPFS VFS by treating `''` as unassociated:
  - `packages/@livestore/sqlite-wasm/src/browser/opfs/AccessHandlePoolVFS.ts`
- Add a fast readiness guard in perf suites so boot regressions fail quickly with actionable diagnostics instead of consuming full timeout budgets:
  - `tests/perf/tests/utils.ts`
  - `tests/perf/tests/suites/latency.test.ts`
  - `tests/perf/tests/suites/memory.test.ts`

## Validation
- Rebased branch onto `dev`.
- Ran CI-equivalent perf command locally after rebase:
  - `devenv shell -- dt test:perf`
  - Result: `125 passed` in ~7m14s (no timeout behavior).
- Ran focused suites during investigation:
  - Latency focused scenario: `15 passed`
  - Memory focused scenario: `1 passed`

## Trade-offs / Follow-up
- Readiness guard adds a small startup gate (`#create1k` wait up to 8s) in perf suites, but significantly improves failure visibility and prevents long timeout amplification.

---
*Acting on behalf of the user via OpenCode.*