### PR TITLE
fix(ci): wait for npm registry propagation before build-example-create

### DIFF
--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -481,13 +481,6 @@ echo "WORKSPACE_DEPS=$DEPS" >> $GITHUB_ENV`,
           run: `pnpm dlx @livestore/cli@\${{ env.SNAPSHOT_VERSION }} create --example \${{ matrix.app }} --ref ${GITHUB_REF} \${{ runner.temp }}/\${{ env.APP_PATH }}`,
         },
         {
-          // Sometimes the snapshot version is not available immediately after publishing
-          // due to network propagation delays. We increase the fetch retries to mitigate this.
-          // See https://pnpm.io/settings#fetchretries
-          name: 'Increase pnpm fetch retries',
-          run: 'pnpm config set fetchRetries 3',
-        },
-        {
           name: 'Use snapshot version of workspace dependencies',
           'working-directory': '${{ runner.temp }}/${{ env.APP_PATH }}',
           run: `pnpm add $(

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "73cb08ab2bc6afe80e35f8ca646c8103d937c74e",
+      "commit": "cd7b0dc3a1747888c85290e255de53b227faeccb",
       "pinned": false,
-      "lockedAt": "2026-02-15T16:45:00.000Z"
+      "lockedAt": "2026-02-17T09:26:12.085Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
@@ -18,9 +18,9 @@
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "12b1f1eadf649e30dec581b7351ba3abb12f8004",
+      "commit": "4f2107548fa64c21a8643b7b0efcd556cd16d4b9",
       "pinned": false,
-      "lockedAt": "2026-02-16T11:44:30.831Z"
+      "lockedAt": "2026-02-17T09:26:12.085Z"
     }
   }
 }

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -1,6 +1,6 @@
 import { shouldNeverHappen } from '@livestore/utils'
 import { CurrentWorkingDirectory, cmd, cmdText } from '@livestore/utils-dev/node'
-import { Effect, FileSystem, Schema } from '@livestore/utils/effect'
+import { Effect, FileSystem, Schedule, Schema } from '@livestore/utils/effect'
 import { Cli } from '@livestore/utils/node'
 
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../shared/misc.ts'
@@ -158,6 +158,23 @@ export const releaseSnapshotCommand = Cli.Command.make(
         shell: true,
       }).pipe(Effect.provide(cwdLayer))
       yield* Effect.log(`Published ${pkg}@${snapshotVersion}`)
+    }
+
+    /**
+     * Verify all published packages are installable from the registry.
+     * npm publish returns 200 before the package is globally available due to
+     * CouchDB replication + Fastly CDN cache propagation (up to ~5 minutes).
+     * See https://github.com/livestorejs/livestore/issues/1039
+     */
+    if (dryRun === false) {
+      yield* Effect.log('Verifying snapshot packages are available on the registry...')
+      for (const pkg of snapshotPackages) {
+        yield* cmd(`npm view ${pkg}@${snapshotVersion} version`, { stdout: 'pipe', stderr: 'pipe' }).pipe(
+          Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
+          Effect.retry(Schedule.spaced('5 seconds').pipe(Schedule.intersect(Schedule.recurs(60)))),
+        )
+        yield* Effect.log(`Verified ${pkg}@${snapshotVersion}`)
+      }
     }
 
     /** Restore original dev versions (read-only) and verify files are in sync */


### PR DESCRIPTION
## Problem

The `build-example-create` CI job flakes when the npm registry hasn't yet propagated the freshly published snapshot version, failing with `ERR_PNPM_NO_MATCHING_VERSION`. This happens because `npm publish` returns 200 before the package is globally available on the registry (due to CouchDB replication + Fastly CDN cache propagation, up to ~5 minutes).

## Solution

Added a post-publish verification loop in the snapshot release command that polls `npm view` until all packages are confirmed installable. The key insight: the publish job should guarantee its postcondition—that packages are not just *published* but *installable*. This is the correct abstraction boundary, and any future consumer jobs benefit automatically.

Removed the ineffective `fetchRetries 3` workaround from the consumer job. pnpm's `fetchRetries` handles network-level errors, not HTTP 404s from the registry saying "version doesn't exist."

## Validation

The verification step uses `npm view` with retry schedule `Schedule.spaced('5 seconds').pipe(Schedule.intersect(Schedule.recurs(60)))` (5-second intervals, up to 60 retries = ~5 min timeout). Skipped in dry-run mode. Fixes #1039.

## Related issues

- #1039