### PR TITLE
chore: align shared CI lockfiles

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -158,11 +158,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1771164813,
-        "narHash": "sha256-JOROieCfp0jW4NUkjeGsDj2rSjbDa9EzcIav6ioKUEc=",
+        "lastModified": 1771319491,
+        "narHash": "sha256-ikAK5kYuOY5FVVr0IeAV/McbY/tp6oI13gmA47k1h9s=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "8fdf2846c032f7f13cfaab7268678f4647ecaab3",
+        "rev": "cb50755c5f470233c79169601f5dcec3b86a8cc4",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "cd7b0dc3a1747888c85290e255de53b227faeccb",
+      "commit": "cb50755c5f470233c79169601f5dcec3b86a8cc4",
       "pinned": false,
-      "lockedAt": "2026-02-17T09:26:12.085Z"
+      "lockedAt": "2026-02-17T10:02:39.461Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",
       "ref": "main",
       "commit": "8c83a6a12ff023da829da0e2a958a3fb6f47cbc9",
       "pinned": false,
-      "lockedAt": "2026-02-16T11:44:30.831Z"
+      "lockedAt": "2026-02-17T10:02:39.461Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Why
Continue the shared CI alignment follow-up in livestore on top of current `dev`.

## What
- update `devenv.lock` and `megarepo.lock` to align shared CI/effect-utils pins
- preserve current `dev` lock structure (including existing `effect` member) while applying the intended bump

## Notes
- branch created fresh from `origin/dev` to avoid stale historical `schickling/shared-ci-blocks` branch history
- commit used `PRE_COMMIT_ALLOW_NO_CONFIG=1` because this worktree has no `.pre-commit-config.yaml`

---
Acting on behalf of @schickling.