### PR TITLE
ci: remove DEVENV_TUI workaround and bump devenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ env:
   CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}'
   FORCE_SETUP: '1'
   CI: 'true'
-  DEVENV_TUI: 'false'
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -105,8 +105,6 @@ export default githubWorkflow({
     CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}',
     FORCE_SETUP: '1',
     CI: 'true',
-    /** TODO: Drop once devenv auto-disables TUI in CI (https://github.com/cachix/devenv/issues/2504) */
-    DEVENV_TUI: 'false',
   },
 
   jobs: {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1771003747,
-        "narHash": "sha256-s/tUVZE6e5Se1Q2K79SYx2dk7MvExKxnocPmEX9ZQKE=",
+        "lastModified": 1771510130,
+        "narHash": "sha256-Kd/dmNOYLEBwkjT+96DFMt0Ft80ZOYRb6ZSunSXsnUE=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "1af847069ed72448b2ba328d9b45f28eb89d11a9",
+        "rev": "0bcb90a82f1df250943c189545ea614a4dbeaf63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- remove DEVENV_TUI=false from CI workflow env and generator source
- remove resolved TODO referencing cachix/devenv issue 2504
- bump devenv.lock to latest revision with upstream CI TUI behavior fix