### PR TITLE
Add confirmation prompt to snapshot release command

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -143,7 +143,7 @@ steps:
     commands:
       - direnv allow .
       - direnv exec . bash -lc 'set -euo pipefail; echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc'
-      - direnv exec . mono release snapshot --git-sha="${BUILDKITE_COMMIT}"
+      - direnv exec . mono release snapshot --git-sha="${BUILDKITE_COMMIT}" --yes
 
   - label: 'examples:build+test'
     commands:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,7 @@ jobs:
             devenv version
           fi
         shell: bash
-      - run: 'mono release snapshot --git-sha=${{ github.sha }}'
+      - run: 'mono release snapshot --git-sha=${{ github.sha }} --yes'
   build-and-deploy-examples-src:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -319,7 +319,7 @@ fi`,
         'test-integration-playwright',
       ],
       defaults: devenvShellDefaults,
-      steps: [...livestoreSetupSteps, { run: `mono release snapshot --git-sha=${GITHUB_SHA}` }],
+      steps: [...livestoreSetupSteps, { run: `mono release snapshot --git-sha=${GITHUB_SHA} --yes` }],
     },
 
     'build-and-deploy-examples-src': {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,6 +499,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Comprehensive dependency update script (#516)
 - Add GitHub issue templates to improve issue quality (#602)
 - Reworked the documentation tooling so maintainers continuously publish token-efficient, TypeScript-backed snippets that stay reliable for coding agents (#715)
+- **Snapshot release confirmation prompt:** The `mono release snapshot` command now prompts for confirmation before publishing. Pass `--yes` to skip the prompt in scripts and CI. The prompt is also auto-skipped when `CI` is set (#1049).
 
 #### wa-sqlite Integration
 

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -99,6 +99,10 @@ export const releaseSnapshotCommand = Cli.Command.make(
   {
     gitShaOption: Cli.Options.text('git-sha').pipe(Cli.Options.optional),
     dryRun: Cli.Options.boolean('dry-run').pipe(Cli.Options.withDefault(false)),
+    yes: Cli.Options.boolean('yes').pipe(
+      Cli.Options.withDefault(false),
+      Cli.Options.withDescription('Skip interactive confirmation prompt'),
+    ),
     cwd: Cli.Options.text('cwd').pipe(
       Cli.Options.withDefault(
         process.env.WORKSPACE_ROOT ?? shouldNeverHappen(`WORKSPACE_ROOT is not set. Make sure to run 'direnv allow'`),
@@ -107,7 +111,7 @@ export const releaseSnapshotCommand = Cli.Command.make(
     versionOption: Cli.Options.text('version').pipe(Cli.Options.optional),
     tscBin: Cli.Options.text('tsc-bin').pipe(Cli.Options.optional),
   },
-  Effect.fn(function* ({ gitShaOption, dryRun, cwd, versionOption, tscBin: tscBinOption }) {
+  Effect.fn(function* ({ gitShaOption, dryRun, yes, cwd, versionOption, tscBin: tscBinOption }) {
     const gitSha =
       gitShaOption._tag === 'Some'
         ? gitShaOption.value
@@ -115,6 +119,20 @@ export const releaseSnapshotCommand = Cli.Command.make(
 
     const snapshotVersion = versionOption._tag === 'Some' ? versionOption.value : `0.0.0-snapshot-${gitSha}`
     const snapshotPackages = yield* listSnapshotPackages(cwd)
+
+    /** Confirm before proceeding unless --yes is passed or CI is detected. */
+    const isCI = process.env.CI === 'true' || process.env.CI === '1'
+    const skipConfirmation = yes || isCI
+    if (skipConfirmation === false) {
+      yield* Effect.log(
+        `About to publish ${snapshotPackages.length} package(s) as ${snapshotVersion}${dryRun ? ' (dry-run)' : ''}`,
+      )
+      const confirmed = yield* Cli.Prompt.confirm({ message: 'Proceed with snapshot release?' })
+      if (confirmed === false) {
+        yield* Effect.log('Snapshot release aborted by user')
+        return
+      }
+    }
 
     /**
      * Regenerate all genie-managed files with snapshot version (writable for pnpm publish).
@@ -136,7 +154,6 @@ export const releaseSnapshotCommand = Cli.Command.make(
      * pnpm publish resolves workspace:* → concrete versions automatically,
      * then delegates to the system npm binary for OIDC trusted publishing.
      */
-    const isCI = process.env.CI === 'true' || process.env.CI === '1'
     for (const pkg of snapshotPackages) {
       const pkgDir = `${cwd}/packages/${pkg}`
       const cwdLayer = CurrentWorkingDirectory.fromPath(pkgDir)


### PR DESCRIPTION
## Problem

The `mono release snapshot` command publishes packages without any confirmation step, which could lead to accidental releases. There's no safety mechanism to prevent unintended snapshot publications.

## Solution

Added an interactive confirmation prompt to the snapshot release command that:
- Displays the number of packages and version being released before proceeding
- Prompts the user to confirm before publishing
- Automatically skips the prompt when `--yes` flag is passed (for CI/scripting)
- Automatically skips the prompt when `CI` environment variable is set to `'true'` or `'1'` (for CI environments)
- Allows users to abort the release by declining the prompt

Updated CI configurations (Buildkite and GitHub Actions) to pass `--yes` flag since they run in non-interactive environments.

## Validation

The change is straightforward and defensive:
- Adds a new optional CLI flag with sensible defaults
- Preserves existing behavior in CI environments (auto-skip via `CI` env var detection)
- Requires explicit `--yes` flag in scripts that need non-interactive mode
- Existing CI pipelines updated to pass `--yes` to maintain current behavior

No new tests needed as this is a UX enhancement with conditional logic based on environment variables and CLI flags.

## Related issues

- #1049
