### PR TITLE
Make CI use direct devenv task execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,12 +394,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
           PLAYWRIGHT_SUITE: '${{ matrix.suite }}'
-        run: |
-          if [ -n "$NETLIFY_AUTH_TOKEN" ]; then
-            bunx netlify-cli deploy --no-build --dir=tests/integration/playwright-report --site livestore-ci --filter @local/tests-integration --alias ${{ matrix.suite }}-$(git rev-parse --short HEAD)
-          else
-            echo "Skipping Netlify deploy: NETLIFY_AUTH_TOKEN not set"
-          fi
+        run: 'devenv tasks run ci:playwright:upload-trace --mode before'
   perf-test:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
@@ -608,9 +603,9 @@ jobs:
         run: 'DEVENV_SKIP_SETUP=1 devenv tasks run pnpm:install genie:run ts:build --mode before --verbose'
         shell: bash
       - name: Install examples dependencies
-        run: pnpm install --frozen-lockfile --dir examples
+        run: 'devenv tasks run examples:install --mode before'
       - name: Build examples
-        run: pnpm --dir examples --filter 'livestore-example-*' --workspace-concurrency=1 build
+        run: 'devenv tasks run examples:build --mode before'
       - name: Test examples
         run: 'devenv tasks run examples:test --mode before'
       - name: Deploy examples to Cloudflare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -34,6 +34,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -47,8 +48,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -60,12 +61,12 @@ jobs:
             devenv version
           fi
         shell: bash
-      - run: 'dt lint:full megarepo:check'
+      - run: 'devenv tasks run lint:full megarepo:check --mode before'
   type-check:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -74,6 +75,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -87,8 +89,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -100,12 +102,12 @@ jobs:
             devenv version
           fi
         shell: bash
-      - run: 'dt ts:build'
+      - run: 'devenv tasks run ts:build --mode before'
   test-unit:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -114,6 +116,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -127,8 +130,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -143,12 +146,12 @@ jobs:
       - name: Preflight workspace bootstrap
         run: 'DEVENV_SKIP_SETUP=1 devenv tasks run pnpm:install genie:run ts:build --mode before --verbose'
         shell: bash
-      - run: 'dt test:unit'
+      - run: 'devenv tasks run test:unit --mode before'
   test-integration-node-sync:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -157,6 +160,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -170,8 +174,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -195,7 +199,7 @@ jobs:
           echo "VITE_OTEL_EXPORTER_OTLP_ENDPOINT=" >> $GITHUB_ENV
       - name: Run node-sync integration tests
         run: |
-          if dt test:integration:node-sync; then
+          if devenv tasks run test:integration:node-sync --mode before; then
             exit 0
           else
             echo "::warning::Node-sync integration tests failed (flaky; see https://github.com/livestorejs/livestore/issues/624 for details)"
@@ -239,7 +243,7 @@ jobs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -248,6 +252,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -261,8 +266,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -304,14 +309,14 @@ jobs:
       - name: 'Run sync-provider tests for ${{ matrix.provider }}'
         run: |
           if [[ "${{ matrix.provider }}" == cf-* ]]; then
-            if dt "test:integration:sync-provider:${{ matrix.provider }}"; then
+            if devenv tasks run test:integration:sync-provider:${{ matrix.provider }} --mode before; then
               exit 0
             else
               echo "::warning::Cloudflare sync-provider tests for ${{ matrix.provider }} failed (flaky; see https://github.com/livestorejs/livestore/issues/625 and upstream https://github.com/cloudflare/workers-sdk/issues/11122)"
               exit 0
             fi
           else
-            dt "test:integration:sync-provider:${{ matrix.provider }}"
+            devenv tasks run test:integration:sync-provider:${{ matrix.provider }} --mode before
           fi
   test-integration-playwright:
     strategy:
@@ -320,7 +325,7 @@ jobs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -329,6 +334,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -342,8 +348,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -373,9 +379,9 @@ jobs:
           PLAYWRIGHT_SUITE: '${{ matrix.suite }}'
         run: |
           if [ "${{ matrix.suite }}" = "devtools" ]; then
-            dt test:integration:devtools || echo "::warning::Script failed but continuing"
+            devenv tasks run test:integration:devtools --mode before || echo "::warning::Script failed but continuing"
           else
-            dt "test:integration:${{ matrix.suite }}"
+            devenv tasks run test:integration:${{ matrix.suite }} --mode before
           fi
       - uses: actions/upload-artifact@v4
         if: '${{ !cancelled() }}'
@@ -398,7 +404,7 @@ jobs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -410,6 +416,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -423,8 +430,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -450,7 +457,7 @@ jobs:
           # Disable in Vite (otherwise CORS issues)
           echo "VITE_OTEL_EXPORTER_OTLP_ENDPOINT=" >> $GITHUB_ENV
       - name: Run performance tests
-        run: 'dt test:perf'
+        run: 'devenv tasks run test:perf --mode before'
         env:
           COMMIT_SHA: '${{ github.event.pull_request.head.sha || github.sha }}'
           GRAFANA_ENDPOINT: 'https://livestore.grafana.net'
@@ -465,6 +472,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -478,8 +486,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -508,7 +516,7 @@ jobs:
         working-directory: packages/@livestore/wa-sqlite
         run: 'nix run .#build'
       - name: Run wa-sqlite tests
-        run: 'devenv shell dt test:integration:wa-sqlite'
+        run: 'devenv tasks run test:integration:wa-sqlite --mode before'
         env:
           COMMIT_SHA: '${{ github.event.pull_request.head.sha || github.sha }}'
           GRAFANA_ENDPOINT: 'https://livestore.grafana.net'
@@ -519,7 +527,7 @@ jobs:
     needs: [test-unit, test-integration-node-sync, test-integration-sync-provider, test-integration-playwright]
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -528,6 +536,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -541,8 +550,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -554,12 +563,12 @@ jobs:
             devenv version
           fi
         shell: bash
-      - run: 'mono release snapshot --git-sha=${{ github.sha }} --yes'
+      - run: 'devenv shell -- mono release snapshot --git-sha=${{ github.sha }} --yes'
   build-and-deploy-examples-src:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -568,6 +577,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -581,8 +591,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -602,10 +612,10 @@ jobs:
       - name: Build examples
         run: pnpm --dir examples --filter 'livestore-example-*' --workspace-concurrency=1 build
       - name: Test examples
-        run: 'dt examples:test'
+        run: 'devenv tasks run examples:test --mode before'
       - name: Deploy examples to Cloudflare
         if: github.event.pull_request.head.repo.fork != true
-        run: 'dt examples:deploy'
+        run: 'devenv tasks run examples:deploy --mode before'
         env:
           CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}'
           CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}'
@@ -613,7 +623,7 @@ jobs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:
       run:
-        shell: devenv shell bash -- -e {0}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -622,6 +632,7 @@ jobs:
           extra-conf: |
             extra-substituters = https://devenv.cachix.org
             extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: Enable Cachix cache
@@ -635,8 +646,8 @@ jobs:
       - name: Sync megarepo dependencies
         run: mr sync --frozen
         shell: bash
-      - name: Install devenv
-        run: 'nix profile install github:cachix/devenv/$(jq -r ".nodes.devenv.locked.rev" devenv.lock)'
+      - name: Install devenv if needed
+        run: 'command -v devenv > /dev/null || nix profile install "github:cachix/devenv/$(jq -r .nodes.devenv.locked.rev devenv.lock)"'
         shell: bash
       - name: Validate Nix store
         run: |
@@ -655,12 +666,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p tmp/ci-docs
-          timeout --signal=TERM --kill-after=2m 20m mono docs snippets build 2>&1 | tee tmp/ci-docs/01-snippets.log
+          timeout --signal=TERM --kill-after=2m 20m devenv shell -- mono docs snippets build 2>&1 | tee tmp/ci-docs/01-snippets.log
       - name: Build docs diagrams
         run: |
           set -euo pipefail
           mkdir -p tmp/ci-docs
-          timeout --signal=TERM --kill-after=2m 20m mono docs diagrams build 2>&1 | tee tmp/ci-docs/02-diagrams.log
+          timeout --signal=TERM --kill-after=2m 20m devenv shell -- mono docs diagrams build 2>&1 | tee tmp/ci-docs/02-diagrams.log
       - name: Build Astro docs bundle
         run: |
           set -euo pipefail
@@ -677,7 +688,7 @@ jobs:
             kill "$HEARTBEAT_PID" 2>/dev/null || true
           }
           trap cleanup EXIT
-          timeout --signal=TERM --kill-after=2m 20m mono docs build --api-docs --skip-deps 2>&1 | tee tmp/ci-docs/03-astro-build.log
+          timeout --signal=TERM --kill-after=2m 20m devenv shell -- mono docs build --api-docs --skip-deps 2>&1 | tee tmp/ci-docs/03-astro-build.log
       - name: Collect docs build diagnostics on failure
         if: '${{ failure() }}'
         run: |
@@ -695,7 +706,7 @@ jobs:
           retention-days: 14
       - name: Deploy docs
         if: "${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true) }}"
-        run: 'dt docs:deploy'
+        run: 'devenv tasks run docs:deploy --mode before'
         env:
           NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
   build-example-create:
@@ -722,8 +733,6 @@ jobs:
           echo "WORKSPACE_DEPS=$DEPS" >> $GITHUB_ENV
       - name: Copy example app
         run: 'pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --ref ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}'
-      - name: Increase pnpm fetch retries
-        run: pnpm config set fetchRetries 3
       - name: Use snapshot version of workspace dependencies
         working-directory: '${{ runner.temp }}/${{ env.APP_PATH }}'
         run: |

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -1,11 +1,12 @@
 import { playwrightSuites, syncProviderMatrix } from '../../genie/ci.ts'
 import {
-  devenvShellDefaults,
+  bashShellDefaults,
   githubWorkflow,
   livestoreSetupSteps,
   livestoreSetupStepsAfterCheckout,
   namespaceRunner,
   otelSetupStep,
+  runDevenvTasksBefore,
 } from '../../genie/repo.ts'
 
 // =============================================================================
@@ -36,11 +37,11 @@ const namespaceRunnerConfig = {
   'runs-on': namespaceRunner(GITHUB_RUN_ID),
 }
 
-/** Standard CI job configuration (namespace runner + devenv shell) */
+/** Standard CI job configuration (namespace runner + bash shell) */
 const standardCIJob = (config: { env?: Record<string, string>; steps: unknown[] }) => ({
   ...namespaceRunnerConfig,
   env: config.env,
-  defaults: devenvShellDefaults,
+  defaults: bashShellDefaults,
   steps: config.steps,
 })
 
@@ -109,16 +110,16 @@ export default githubWorkflow({
 
   jobs: {
     lint: standardCIJob({
-      steps: [...livestoreSetupSteps, { run: 'dt lint:full megarepo:check' }],
+      steps: [...livestoreSetupSteps, { run: runDevenvTasksBefore('lint:full', 'megarepo:check') }],
     }),
 
     'type-check': standardCIJob({
       // TODO(oep-1n3.9): Switch back to patched tsc once Effect diagnostics backlog is addressed.
-      steps: [...livestoreSetupSteps, { run: 'dt ts:build' }],
+      steps: [...livestoreSetupSteps, { run: runDevenvTasksBefore('ts:build') }],
     }),
 
     'test-unit': standardCIJob({
-      steps: [...livestoreSetupSteps, deterministicPreflightStep, { run: 'dt test:unit' }],
+      steps: [...livestoreSetupSteps, deterministicPreflightStep, { run: runDevenvTasksBefore('test:unit') }],
     }),
 
     // TODO: Remove flaky test wrapper once node-sync flakiness is resolved
@@ -127,7 +128,7 @@ export default githubWorkflow({
       steps: [
         flakyTestStep(
           'Run node-sync integration tests',
-          'dt test:integration:node-sync',
+          runDevenvTasksBefore('test:integration:node-sync'),
           'https://github.com/livestorejs/livestore/issues/624',
           'Node-sync integration tests failed',
         ),
@@ -170,7 +171,7 @@ fi`,
         },
       },
       ...namespaceRunnerConfig,
-      defaults: devenvShellDefaults,
+      defaults: bashShellDefaults,
       steps: [
         ...livestoreSetupSteps,
         deterministicPreflightStep,
@@ -193,14 +194,14 @@ done`,
         {
           name: 'Run sync-provider tests for ${{ matrix.provider }}',
           run: `if [[ "\${{ matrix.provider }}" == cf-* ]]; then
-  if dt "test:integration:sync-provider:\${{ matrix.provider }}"; then
+  if ${runDevenvTasksBefore('test:integration:sync-provider:${{ matrix.provider }}')}; then
     exit 0
   else
     echo "::warning::Cloudflare sync-provider tests for \${{ matrix.provider }} failed (flaky; see https://github.com/livestorejs/livestore/issues/625 and upstream https://github.com/cloudflare/workers-sdk/issues/11122)"
     exit 0
   fi
 else
-  dt "test:integration:sync-provider:\${{ matrix.provider }}"
+  ${runDevenvTasksBefore('test:integration:sync-provider:${{ matrix.provider }}')}
 fi`,
         },
       ],
@@ -213,7 +214,7 @@ fi`,
         },
       },
       ...namespaceRunnerConfig,
-      defaults: devenvShellDefaults,
+      defaults: bashShellDefaults,
       steps: [
         ...livestoreSetupSteps,
         deterministicPreflightStep,
@@ -223,9 +224,9 @@ fi`,
           env: { PLAYWRIGHT_SUITE: '${{ matrix.suite }}' },
           // TODO: fix flaky devtools test
           run: `if [ "\${{ matrix.suite }}" = "devtools" ]; then
-  dt test:integration:devtools || echo "::warning::Script failed but continuing"
+  ${runDevenvTasksBefore('test:integration:devtools')} || echo "::warning::Script failed but continuing"
 else
-  dt "test:integration:\${{ matrix.suite }}"
+  ${runDevenvTasksBefore('test:integration:${{ matrix.suite }}')}
 fi`,
         },
         {
@@ -257,7 +258,7 @@ fi`,
     // Run on namespace runners to align CI environment with the rest of the test matrix.
     'perf-test': {
       ...namespaceRunnerConfig,
-      defaults: devenvShellDefaults,
+      defaults: bashShellDefaults,
       steps: [
         {
           // See https://github.com/orgs/community/discussions/26325
@@ -270,7 +271,7 @@ fi`,
         otelSetupStep,
         {
           name: 'Run performance tests',
-          run: 'dt test:perf',
+          run: runDevenvTasksBefore('test:perf'),
           env: {
             COMMIT_SHA: PR_HEAD_SHA,
             GRAFANA_ENDPOINT: 'https://livestore.grafana.net',
@@ -294,7 +295,7 @@ fi`,
         },
         {
           name: 'Run wa-sqlite tests',
-          run: 'devenv shell dt test:integration:wa-sqlite',
+          run: runDevenvTasksBefore('test:integration:wa-sqlite'),
           env: {
             COMMIT_SHA: PR_HEAD_SHA,
             GRAFANA_ENDPOINT: 'https://livestore.grafana.net',
@@ -318,13 +319,13 @@ fi`,
         'test-integration-sync-provider',
         'test-integration-playwright',
       ],
-      defaults: devenvShellDefaults,
-      steps: [...livestoreSetupSteps, { run: `mono release snapshot --git-sha=${GITHUB_SHA} --yes` }],
+      defaults: bashShellDefaults,
+      steps: [...livestoreSetupSteps, { run: `devenv shell -- mono release snapshot --git-sha=${GITHUB_SHA} --yes` }],
     },
 
     'build-and-deploy-examples-src': {
       ...namespaceRunnerConfig,
-      defaults: devenvShellDefaults,
+      defaults: bashShellDefaults,
       steps: [
         ...livestoreSetupSteps,
         deterministicPreflightStep,
@@ -338,11 +339,11 @@ fi`,
           // Run pnpm from root devenv shell, targeting examples workspace
           run: "pnpm --dir examples --filter 'livestore-example-*' --workspace-concurrency=1 build",
         },
-        { name: 'Test examples', run: 'dt examples:test' },
+        { name: 'Test examples', run: runDevenvTasksBefore('examples:test') },
         {
           name: 'Deploy examples to Cloudflare',
           if: IS_NOT_FORK,
-          run: 'dt examples:deploy',
+          run: runDevenvTasksBefore('examples:deploy'),
           env: {
             CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}',
             CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}',
@@ -363,7 +364,7 @@ fi`,
      */
     'build-deploy-docs': {
       ...namespaceRunnerConfig,
-      defaults: devenvShellDefaults,
+      defaults: bashShellDefaults,
       steps: [
         ...livestoreSetupSteps,
         deterministicPreflightStep,
@@ -375,7 +376,7 @@ fi`,
           name: 'Build docs snippets',
           run: `set -euo pipefail
 mkdir -p tmp/ci-docs
-timeout --signal=TERM --kill-after=2m 20m mono docs snippets build 2>&1 | tee tmp/ci-docs/01-snippets.log`,
+timeout --signal=TERM --kill-after=2m 20m devenv shell -- mono docs snippets build 2>&1 | tee tmp/ci-docs/01-snippets.log`,
         },
         // TODO(oep-bbd): Temporary diagnostics step for docs CI hang triage.
         // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
@@ -383,7 +384,7 @@ timeout --signal=TERM --kill-after=2m 20m mono docs snippets build 2>&1 | tee tm
           name: 'Build docs diagrams',
           run: `set -euo pipefail
 mkdir -p tmp/ci-docs
-timeout --signal=TERM --kill-after=2m 20m mono docs diagrams build 2>&1 | tee tmp/ci-docs/02-diagrams.log`,
+timeout --signal=TERM --kill-after=2m 20m devenv shell -- mono docs diagrams build 2>&1 | tee tmp/ci-docs/02-diagrams.log`,
         },
         // TODO(oep-bbd): Temporary heartbeat/process logging for Astro build visibility.
         // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
@@ -403,7 +404,7 @@ cleanup() {
   kill "$HEARTBEAT_PID" 2>/dev/null || true
 }
 trap cleanup EXIT
-timeout --signal=TERM --kill-after=2m 20m mono docs build --api-docs --skip-deps 2>&1 | tee tmp/ci-docs/03-astro-build.log`,
+timeout --signal=TERM --kill-after=2m 20m devenv shell -- mono docs build --api-docs --skip-deps 2>&1 | tee tmp/ci-docs/03-astro-build.log`,
         },
         // TODO(oep-bbd): Temporary failure-time process dump for docs CI hang triage.
         // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
@@ -431,7 +432,7 @@ pgrep -af 'astro|chromium|chrome_crashpad_handler|node|mono|dt' > tmp/ci-docs/pg
         {
           name: 'Deploy docs',
           if: `\${{ success() && (github.event_name != 'pull_request' || ${IS_NOT_FORK}) }}`,
-          run: 'dt docs:deploy',
+          run: runDevenvTasksBefore('docs:deploy'),
           env: { NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}' },
         },
       ],

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -246,11 +246,7 @@ fi`,
             NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}',
             PLAYWRIGHT_SUITE: '${{ matrix.suite }}',
           },
-          run: `if [ -n "$NETLIFY_AUTH_TOKEN" ]; then
-  bunx netlify-cli deploy --no-build --dir=tests/integration/playwright-report --site livestore-ci --filter @local/tests-integration --alias \${{ matrix.suite }}-$(git rev-parse --short HEAD)
-else
-  echo "Skipping Netlify deploy: NETLIFY_AUTH_TOKEN not set"
-fi`,
+          run: runDevenvTasksBefore('ci:playwright:upload-trace'),
         },
       ],
     },
@@ -331,13 +327,11 @@ fi`,
         deterministicPreflightStep,
         {
           name: 'Install examples dependencies',
-          // Run pnpm from root devenv shell, targeting examples workspace
-          run: 'pnpm install --frozen-lockfile --dir examples',
+          run: runDevenvTasksBefore('examples:install'),
         },
         {
           name: 'Build examples',
-          // Run pnpm from root devenv shell, targeting examples workspace
-          run: "pnpm --dir examples --filter 'livestore-example-*' --workspace-concurrency=1 build",
+          run: runDevenvTasksBefore('examples:build'),
         },
         { name: 'Test examples', run: runDevenvTasksBefore('examples:test') },
         {

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -478,17 +478,18 @@ export { githubWorkflow } from '../repos/effect-utils/packages/@overeng/genie/sr
 
 import {
   namespaceRunner as namespaceRunnerBase,
-  devenvShellDefaults,
+  bashShellDefaults,
   installNixStep,
   cachixStep,
   installMegarepoStep,
+  runDevenvTasksBefore,
   syncMegarepoStep,
   installDevenvFromLockStep,
   validateNixStoreStep,
   checkoutStep,
 } from '../repos/effect-utils/genie/ci-workflow.ts'
 
-export { devenvShellDefaults }
+export { bashShellDefaults, runDevenvTasksBefore }
 
 export const namespaceRunner = (runId: string) =>
   namespaceRunnerBase('namespace-profile-linux-x86-64', runId)

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "cd7b0dc3a1747888c85290e255de53b227faeccb",
+      "ref": "schickling/ci-no-nested-devenv",
+      "commit": "2a99b56d4c534655058db3613b0f2e995ccf4805",
       "pinned": false,
-      "lockedAt": "2026-02-17T15:07:21.787Z"
+      "lockedAt": "2026-02-19T18:38:10.000Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "schickling/ci-no-nested-devenv",
-      "commit": "2a99b56d4c534655058db3613b0f2e995ccf4805",
+      "commit": "c9ceaab0d96192051f5be1eb617355ce65f08ff1",
       "pinned": false,
-      "lockedAt": "2026-02-19T18:38:10.000Z"
+      "lockedAt": "2026-02-19T21:13:07.000Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -51,6 +51,17 @@
       exec = "mono test integration node-sync";
     };
 
+    "ci:playwright:upload-trace" = {
+      description = "Upload Playwright trace to Netlify in CI";
+      exec = ''
+        if [ -n "''${NETLIFY_AUTH_TOKEN:-}" ]; then
+          bunx netlify-cli deploy --no-build --dir=tests/integration/playwright-report --site livestore-ci --filter @local/tests-integration --alias "''${PLAYWRIGHT_SUITE:-unknown}-$(git rev-parse --short HEAD)"
+        else
+          echo "Skipping Netlify deploy: NETLIFY_AUTH_TOKEN not set"
+        fi
+      '';
+    };
+
     # Sync provider tests (individual providers for CI matrix)
     "test:integration:sync-provider" = {
       description = "Run all sync provider tests";
@@ -138,6 +149,16 @@
     "examples:deploy" = {
       description = "Deploy examples to Cloudflare";
       exec = "mono examples deploy";
+    };
+
+    "examples:install" = {
+      description = "Install examples dependencies";
+      exec = "pnpm install --frozen-lockfile --dir examples";
+    };
+
+    "examples:build" = {
+      description = "Build examples";
+      exec = "pnpm --dir examples --filter 'livestore-example-*' --workspace-concurrency=1 build";
     };
 
     # =========================================================================


### PR DESCRIPTION
## Problem
This CI workflow used nested devenv shell execution (`shell: devenv shell bash -- -e {0}`), which can hide failures and make exit-code propagation unreliable.

## Solution
- Switched CI job defaults from nested devenv shell to shared `bashShellDefaults`.
- Replaced direct `dt ...` invocations with shared `runDevenvTasksBefore(...)` where applicable.
- Removed explicit nested `devenv shell dt ...` for wa-sqlite tests.
- Updated generated workflow YAML accordingly.
- Updated `megarepo.lock` to consume the effect-utils branch containing the shared helper updates (including the hard breaking export removal).

## Validation
- `CI=1 devenv tasks run genie:run --mode before`
- `CI=1 devenv tasks run genie:check --mode before`
- Verified no `shell: devenv shell bash -- -e {0}` remains in `.github/workflows/ci.yml`
- `devenv tasks run __ci_nonexistent_task__ --mode before` exits with code `1`

## Dependency
Depends on effect-utils PR #252.

---
Acting on behalf of @schickling.
