### PR TITLE
fix(devenv): update beads task refs for Dolt-native backend

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -79,7 +79,7 @@ let
 in
 {
   imports = [
-    # Beads integration: daemon, sync task, commit correlation hook
+    # Beads integration
     (taskModules.beads {
       beadsPrefix = "oep";
       beadsRepoName = "overeng-beads-public";
@@ -249,8 +249,7 @@ in
     pass_filenames = false;
   };
 
-  # Wire beads:daemon:ensure directly to shell entry
-  tasks."devenv:enterShell".after = lib.mkAfter [ "beads:daemon:ensure" ];
+  tasks."devenv:enterShell".after = lib.mkAfter [ "beads:ensure" ];
   enterShell = ''
     sp="$(git rev-parse --show-superproject-working-tree 2>/dev/null)";
     export WORKSPACE_ROOT="$PWD"


### PR DESCRIPTION
## Summary
- `beads:daemon:ensure` → `beads:ensure` (daemon removed in beads v0.51+)
- Remove outdated comment referencing daemon/sync

## Context
Part of beads v0.55.4 upgrade across all repos. The beads devenv module now uses Dolt as its sole database backend — the daemon and SQLite-based sync layer were removed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)