### PR TITLE
Reduce oxlint --lsp subfolder overhead with generated local configs

### DIFF
--- a/.oxlintrc.json.genie.ts
+++ b/.oxlintrc.json.genie.ts
@@ -141,7 +141,7 @@ const phase2Rules = {
   'import/export': 'off',
 } as const
 
-const livestoreOxlintRules = {
+export const livestoreOxlintRules = {
   ...activeRules,
   ...permanentlyDisabledRules,
   ...phase2Rules,
@@ -151,7 +151,7 @@ const livestoreOxlintRules = {
  * LiveStore-specific overrides (without overeng rules).
  * Based on effect-utils overrides but excluding overeng/* rules.
  */
-const livestoreOxlintOverrides = [
+export const livestoreOxlintOverrides = [
   // CommonJS files legitimately use require/module.exports
   {
     files: ['**/*.cjs', '**/*.cts', '**/*.js'],
@@ -228,10 +228,18 @@ const livestoreOxlintOverrides = [
   },
 ] as const
 
+export const livestoreOxlintPlugins = [...baseOxlintPlugins, 'react', 'react-perf'] as const
+export const livestoreOxlintCategories = baseOxlintCategories
+export const livestoreOxlintIgnorePatterns = [
+  ...baseOxlintIgnorePatterns,
+  'tests/integration/node_modules/**',
+  'docs/src/plugins/**',
+] as const
+
 export default oxlintConfig({
-  plugins: [...baseOxlintPlugins, 'react', 'react-perf'],
-  categories: baseOxlintCategories,
+  plugins: livestoreOxlintPlugins,
+  categories: livestoreOxlintCategories,
   rules: livestoreOxlintRules,
   overrides: livestoreOxlintOverrides,
-  ignorePatterns: [...baseOxlintIgnorePatterns, 'tests/integration/node_modules/**', 'docs/src/plugins/**'],
+  ignorePatterns: livestoreOxlintIgnorePatterns,
 })

--- a/docs/src/content/_assets/code/.oxlintrc.json
+++ b/docs/src/content/_assets/code/.oxlintrc.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "plugins": ["import", "typescript", "unicorn", "oxc", "react", "react-perf"],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/.pnpm/**",
+    "**/.pnpm-store/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/out/**",
+    "**/.wrangler/**",
+    "**/.vercel/**",
+    "**/.netlify/**",
+    "**/.astro/**",
+    "**/.nitro/**",
+    "**/.tanstack/**",
+    "**/.direnv/**",
+    "**/tmp/**",
+    "**/playwright-report/**",
+    "**/test-results/**",
+    "**/nix/**",
+    "**/wip/**",
+    "**/.vite/**",
+    "**/patches/**",
+    "**/.cache/**",
+    "**/.turbo/**",
+    "tests/integration/node_modules/**",
+    "docs/src/plugins/**",
+    "node_modules/**",
+    "dist/**",
+    ".cache/**",
+    ".pnpm/**"
+  ],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off",
+    "perf": "warn",
+    "style": "off",
+    "restriction": "off"
+  },
+  "rules": {
+    "import/no-commonjs": "off",
+    "typescript/consistent-type-imports": "warn",
+    "overeng/explicit-boolean-compare": "warn",
+    "unicorn/no-array-callback-reference": "off",
+    "typescript/no-explicit-any": "off",
+    "typescript/no-deprecated": "off",
+    "typescript/consistent-type-definitions": "off",
+    "no-unused-vars": "off",
+    "eqeqeq": "off",
+    "react/react-in-jsx-scope": "off",
+    "func-style": "error",
+    "oxc/no-barrel-file": "off",
+    "import/default": "off",
+    "import/no-cycle": "off",
+    "import/no-dynamic-require": "off",
+    "import/no-unassigned-import": "off",
+    "import/namespace": "off",
+    "import/no-named-as-default": "off",
+    "react-perf/jsx-no-new-function-as-prop": "error",
+    "react-perf/jsx-no-new-object-as-prop": "error",
+    "react-perf/jsx-no-jsx-as-prop": "error",
+    "react-perf/jsx-no-new-array-as-prop": "error",
+    "block-scoped-var": "off",
+    "no-await-in-loop": "off",
+    "no-unused-expressions": "off",
+    "require-yield": "off",
+    "unicorn/require-post-message-target-origin": "off",
+    "unicorn/prefer-add-event-listener": "off",
+    "unicorn/no-empty-file": "off",
+    "typescript/no-unsafe-type-assertion": "warn",
+    "typescript/no-unnecessary-boolean-literal-compare": "off",
+    "typescript/no-unnecessary-type-arguments": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/restrict-template-expressions": "error",
+    "typescript/no-floating-promises": "off",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-template-expression": "error",
+    "typescript/no-meaningless-void-operator": "error",
+    "typescript/unbound-method": "off",
+    "typescript/no-misused-spread": "off",
+    "typescript/no-for-in-array": "off",
+    "no-extraneous-class": "off",
+    "triple-slash-reference": "off",
+    "no-new": "off",
+    "no-empty-pattern": "off",
+    "no-useless-catch": "off",
+    "no-unused-private-class-members": "off",
+    "no-unassigned-vars": "off",
+    "no-unneeded-ternary": "off",
+    "no-unexpected-multiline": "off",
+    "no-extend-native": "off",
+    "oxc/only-used-in-recursion": "off",
+    "oxc/const-comparisons": "off",
+    "oxc/no-map-spread": "off",
+    "oxc/no-accumulating-spread": "off",
+    "constructor-super": "off",
+    "react/jsx-key": "off",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/no-new-array": "off",
+    "import/named": "off",
+    "import/export": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.cjs", "**/*.cts", "**/*.js"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/docs/src/content/_assets/code/**"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/vitest.config.ts", "**/vite.config.ts", "**/playwright.config.ts", "**/*.genie.ts"],
+      "rules": {
+        "func-style": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/**", "**/tests/**"],
+      "rules": {
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "require-yield": "off"
+      }
+    },
+    {
+      "files": ["**/*.d.ts"],
+      "rules": {
+        "typescript/consistent-type-imports": "off"
+      }
+    },
+    {
+      "files": ["**/*.gen.*", "**/.astro/**", "**/routeTree.gen.ts"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "import/no-named-as-default": "off",
+        "import/no-unassigned-import": "off",
+        "oxc/no-barrel-file": "off",
+        "oxc/no-map-spread": "off",
+        "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["packages/@livestore/react/src/useRcResource.ts"],
+      "rules": {
+        "react-hooks/exhaustive-deps": "off"
+      }
+    },
+    {
+      "files": ["**/wa-sqlite/**"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "typescript/await-thenable": "off",
+        "unicorn/no-new-array": "off",
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "overeng/explicit-boolean-compare": "off"
+      }
+    },
+    {
+      "files": ["**/*.svelte"],
+      "rules": {
+        "import/no-unassigned-import": "off"
+      }
+    }
+  ]
+}

--- a/docs/src/content/_assets/code/.oxlintrc.json.genie.ts
+++ b/docs/src/content/_assets/code/.oxlintrc.json.genie.ts
@@ -1,0 +1,19 @@
+import {
+  livestoreOxlintCategories,
+  livestoreOxlintIgnorePatterns,
+  livestoreOxlintOverrides,
+  livestoreOxlintPlugins,
+  livestoreOxlintRules,
+} from '../../../../../.oxlintrc.json.genie.ts'
+import { oxlintConfig } from '../../../../../repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts'
+
+export default oxlintConfig({
+  plugins: livestoreOxlintPlugins,
+  categories: livestoreOxlintCategories,
+  rules: {
+    ...livestoreOxlintRules,
+    'import/no-commonjs': 'off',
+  },
+  overrides: livestoreOxlintOverrides,
+  ignorePatterns: [...livestoreOxlintIgnorePatterns, 'node_modules/**', 'dist/**', '.cache/**', '.pnpm/**'],
+})

--- a/tests/integration/.oxlintrc.json
+++ b/tests/integration/.oxlintrc.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "plugins": ["import", "typescript", "unicorn", "oxc", "react", "react-perf"],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/.pnpm/**",
+    "**/.pnpm-store/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/out/**",
+    "**/.wrangler/**",
+    "**/.vercel/**",
+    "**/.netlify/**",
+    "**/.astro/**",
+    "**/.nitro/**",
+    "**/.tanstack/**",
+    "**/.direnv/**",
+    "**/tmp/**",
+    "**/playwright-report/**",
+    "**/test-results/**",
+    "**/nix/**",
+    "**/wip/**",
+    "**/.vite/**",
+    "**/patches/**",
+    "**/.cache/**",
+    "**/.turbo/**",
+    "tests/integration/node_modules/**",
+    "docs/src/plugins/**",
+    "node_modules/**",
+    "dist/**",
+    ".cache/**",
+    ".pnpm/**"
+  ],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off",
+    "perf": "warn",
+    "style": "off",
+    "restriction": "off"
+  },
+  "rules": {
+    "import/no-commonjs": "error",
+    "typescript/consistent-type-imports": "warn",
+    "overeng/explicit-boolean-compare": "warn",
+    "unicorn/no-array-callback-reference": "off",
+    "typescript/no-explicit-any": "off",
+    "typescript/no-deprecated": "off",
+    "typescript/consistent-type-definitions": "off",
+    "no-unused-vars": "off",
+    "eqeqeq": "off",
+    "react/react-in-jsx-scope": "off",
+    "func-style": "error",
+    "oxc/no-barrel-file": "off",
+    "import/default": "off",
+    "import/no-cycle": "off",
+    "import/no-dynamic-require": "off",
+    "import/no-unassigned-import": "off",
+    "import/namespace": "off",
+    "import/no-named-as-default": "off",
+    "react-perf/jsx-no-new-function-as-prop": "error",
+    "react-perf/jsx-no-new-object-as-prop": "error",
+    "react-perf/jsx-no-jsx-as-prop": "error",
+    "react-perf/jsx-no-new-array-as-prop": "error",
+    "block-scoped-var": "off",
+    "no-await-in-loop": "off",
+    "no-unused-expressions": "off",
+    "require-yield": "off",
+    "unicorn/require-post-message-target-origin": "off",
+    "unicorn/prefer-add-event-listener": "off",
+    "unicorn/no-empty-file": "off",
+    "typescript/no-unsafe-type-assertion": "warn",
+    "typescript/no-unnecessary-boolean-literal-compare": "off",
+    "typescript/no-unnecessary-type-arguments": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/restrict-template-expressions": "error",
+    "typescript/no-floating-promises": "off",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-template-expression": "error",
+    "typescript/no-meaningless-void-operator": "error",
+    "typescript/unbound-method": "off",
+    "typescript/no-misused-spread": "off",
+    "typescript/no-for-in-array": "off",
+    "no-extraneous-class": "off",
+    "triple-slash-reference": "off",
+    "no-new": "off",
+    "no-empty-pattern": "off",
+    "no-useless-catch": "off",
+    "no-unused-private-class-members": "off",
+    "no-unassigned-vars": "off",
+    "no-unneeded-ternary": "off",
+    "no-unexpected-multiline": "off",
+    "no-extend-native": "off",
+    "oxc/only-used-in-recursion": "off",
+    "oxc/const-comparisons": "off",
+    "oxc/no-map-spread": "off",
+    "oxc/no-accumulating-spread": "off",
+    "constructor-super": "off",
+    "react/jsx-key": "off",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/no-new-array": "off",
+    "import/named": "off",
+    "import/export": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.cjs", "**/*.cts", "**/*.js"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/docs/src/content/_assets/code/**"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/vitest.config.ts", "**/vite.config.ts", "**/playwright.config.ts", "**/*.genie.ts"],
+      "rules": {
+        "func-style": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/**", "**/tests/**"],
+      "rules": {
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "require-yield": "off"
+      }
+    },
+    {
+      "files": ["**/*.d.ts"],
+      "rules": {
+        "typescript/consistent-type-imports": "off"
+      }
+    },
+    {
+      "files": ["**/*.gen.*", "**/.astro/**", "**/routeTree.gen.ts"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "import/no-named-as-default": "off",
+        "import/no-unassigned-import": "off",
+        "oxc/no-barrel-file": "off",
+        "oxc/no-map-spread": "off",
+        "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["packages/@livestore/react/src/useRcResource.ts"],
+      "rules": {
+        "react-hooks/exhaustive-deps": "off"
+      }
+    },
+    {
+      "files": ["**/wa-sqlite/**"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "typescript/await-thenable": "off",
+        "unicorn/no-new-array": "off",
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "overeng/explicit-boolean-compare": "off"
+      }
+    },
+    {
+      "files": ["**/*.svelte"],
+      "rules": {
+        "import/no-unassigned-import": "off"
+      }
+    }
+  ]
+}

--- a/tests/integration/.oxlintrc.json.genie.ts
+++ b/tests/integration/.oxlintrc.json.genie.ts
@@ -1,0 +1,16 @@
+import {
+  livestoreOxlintCategories,
+  livestoreOxlintIgnorePatterns,
+  livestoreOxlintOverrides,
+  livestoreOxlintPlugins,
+  livestoreOxlintRules,
+} from '../../.oxlintrc.json.genie.ts'
+import { oxlintConfig } from '../../repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts'
+
+export default oxlintConfig({
+  plugins: livestoreOxlintPlugins,
+  categories: livestoreOxlintCategories,
+  rules: livestoreOxlintRules,
+  overrides: livestoreOxlintOverrides,
+  ignorePatterns: [...livestoreOxlintIgnorePatterns, 'node_modules/**', 'dist/**', '.cache/**', '.pnpm/**'],
+})

--- a/tests/perf-eventlog/.oxlintrc.json
+++ b/tests/perf-eventlog/.oxlintrc.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "plugins": ["import", "typescript", "unicorn", "oxc", "react", "react-perf"],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/.pnpm/**",
+    "**/.pnpm-store/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/out/**",
+    "**/.wrangler/**",
+    "**/.vercel/**",
+    "**/.netlify/**",
+    "**/.astro/**",
+    "**/.nitro/**",
+    "**/.tanstack/**",
+    "**/.direnv/**",
+    "**/tmp/**",
+    "**/playwright-report/**",
+    "**/test-results/**",
+    "**/nix/**",
+    "**/wip/**",
+    "**/.vite/**",
+    "**/patches/**",
+    "**/.cache/**",
+    "**/.turbo/**",
+    "tests/integration/node_modules/**",
+    "docs/src/plugins/**",
+    "node_modules/**",
+    "dist/**",
+    ".cache/**",
+    ".pnpm/**"
+  ],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off",
+    "perf": "warn",
+    "style": "off",
+    "restriction": "off"
+  },
+  "rules": {
+    "import/no-commonjs": "error",
+    "typescript/consistent-type-imports": "warn",
+    "overeng/explicit-boolean-compare": "warn",
+    "unicorn/no-array-callback-reference": "off",
+    "typescript/no-explicit-any": "off",
+    "typescript/no-deprecated": "off",
+    "typescript/consistent-type-definitions": "off",
+    "no-unused-vars": "off",
+    "eqeqeq": "off",
+    "react/react-in-jsx-scope": "off",
+    "func-style": "error",
+    "oxc/no-barrel-file": "off",
+    "import/default": "off",
+    "import/no-cycle": "off",
+    "import/no-dynamic-require": "off",
+    "import/no-unassigned-import": "off",
+    "import/namespace": "off",
+    "import/no-named-as-default": "off",
+    "react-perf/jsx-no-new-function-as-prop": "error",
+    "react-perf/jsx-no-new-object-as-prop": "error",
+    "react-perf/jsx-no-jsx-as-prop": "error",
+    "react-perf/jsx-no-new-array-as-prop": "error",
+    "block-scoped-var": "off",
+    "no-await-in-loop": "off",
+    "no-unused-expressions": "off",
+    "require-yield": "off",
+    "unicorn/require-post-message-target-origin": "off",
+    "unicorn/prefer-add-event-listener": "off",
+    "unicorn/no-empty-file": "off",
+    "typescript/no-unsafe-type-assertion": "warn",
+    "typescript/no-unnecessary-boolean-literal-compare": "off",
+    "typescript/no-unnecessary-type-arguments": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/restrict-template-expressions": "error",
+    "typescript/no-floating-promises": "off",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-template-expression": "error",
+    "typescript/no-meaningless-void-operator": "error",
+    "typescript/unbound-method": "off",
+    "typescript/no-misused-spread": "off",
+    "typescript/no-for-in-array": "off",
+    "no-extraneous-class": "off",
+    "triple-slash-reference": "off",
+    "no-new": "off",
+    "no-empty-pattern": "off",
+    "no-useless-catch": "off",
+    "no-unused-private-class-members": "off",
+    "no-unassigned-vars": "off",
+    "no-unneeded-ternary": "off",
+    "no-unexpected-multiline": "off",
+    "no-extend-native": "off",
+    "oxc/only-used-in-recursion": "off",
+    "oxc/const-comparisons": "off",
+    "oxc/no-map-spread": "off",
+    "oxc/no-accumulating-spread": "off",
+    "constructor-super": "off",
+    "react/jsx-key": "off",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/no-new-array": "off",
+    "import/named": "off",
+    "import/export": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.cjs", "**/*.cts", "**/*.js"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/docs/src/content/_assets/code/**"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/vitest.config.ts", "**/vite.config.ts", "**/playwright.config.ts", "**/*.genie.ts"],
+      "rules": {
+        "func-style": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/**", "**/tests/**"],
+      "rules": {
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "require-yield": "off"
+      }
+    },
+    {
+      "files": ["**/*.d.ts"],
+      "rules": {
+        "typescript/consistent-type-imports": "off"
+      }
+    },
+    {
+      "files": ["**/*.gen.*", "**/.astro/**", "**/routeTree.gen.ts"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "import/no-named-as-default": "off",
+        "import/no-unassigned-import": "off",
+        "oxc/no-barrel-file": "off",
+        "oxc/no-map-spread": "off",
+        "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["packages/@livestore/react/src/useRcResource.ts"],
+      "rules": {
+        "react-hooks/exhaustive-deps": "off"
+      }
+    },
+    {
+      "files": ["**/wa-sqlite/**"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "typescript/await-thenable": "off",
+        "unicorn/no-new-array": "off",
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "overeng/explicit-boolean-compare": "off"
+      }
+    },
+    {
+      "files": ["**/*.svelte"],
+      "rules": {
+        "import/no-unassigned-import": "off"
+      }
+    }
+  ]
+}

--- a/tests/perf-eventlog/.oxlintrc.json.genie.ts
+++ b/tests/perf-eventlog/.oxlintrc.json.genie.ts
@@ -1,0 +1,16 @@
+import {
+  livestoreOxlintCategories,
+  livestoreOxlintIgnorePatterns,
+  livestoreOxlintOverrides,
+  livestoreOxlintPlugins,
+  livestoreOxlintRules,
+} from '../../.oxlintrc.json.genie.ts'
+import { oxlintConfig } from '../../repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts'
+
+export default oxlintConfig({
+  plugins: livestoreOxlintPlugins,
+  categories: livestoreOxlintCategories,
+  rules: livestoreOxlintRules,
+  overrides: livestoreOxlintOverrides,
+  ignorePatterns: [...livestoreOxlintIgnorePatterns, 'node_modules/**', 'dist/**', '.cache/**', '.pnpm/**'],
+})

--- a/tests/perf/.oxlintrc.json
+++ b/tests/perf/.oxlintrc.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "plugins": ["import", "typescript", "unicorn", "oxc", "react", "react-perf"],
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/.pnpm/**",
+    "**/.pnpm-store/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/out/**",
+    "**/.wrangler/**",
+    "**/.vercel/**",
+    "**/.netlify/**",
+    "**/.astro/**",
+    "**/.nitro/**",
+    "**/.tanstack/**",
+    "**/.direnv/**",
+    "**/tmp/**",
+    "**/playwright-report/**",
+    "**/test-results/**",
+    "**/nix/**",
+    "**/wip/**",
+    "**/.vite/**",
+    "**/patches/**",
+    "**/.cache/**",
+    "**/.turbo/**",
+    "tests/integration/node_modules/**",
+    "docs/src/plugins/**",
+    "node_modules/**",
+    "dist/**",
+    ".cache/**",
+    ".pnpm/**"
+  ],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off",
+    "perf": "warn",
+    "style": "off",
+    "restriction": "off"
+  },
+  "rules": {
+    "import/no-commonjs": "error",
+    "typescript/consistent-type-imports": "warn",
+    "overeng/explicit-boolean-compare": "warn",
+    "unicorn/no-array-callback-reference": "off",
+    "typescript/no-explicit-any": "off",
+    "typescript/no-deprecated": "off",
+    "typescript/consistent-type-definitions": "off",
+    "no-unused-vars": "off",
+    "eqeqeq": "off",
+    "react/react-in-jsx-scope": "off",
+    "func-style": "error",
+    "oxc/no-barrel-file": "off",
+    "import/default": "off",
+    "import/no-cycle": "off",
+    "import/no-dynamic-require": "off",
+    "import/no-unassigned-import": "off",
+    "import/namespace": "off",
+    "import/no-named-as-default": "off",
+    "react-perf/jsx-no-new-function-as-prop": "error",
+    "react-perf/jsx-no-new-object-as-prop": "error",
+    "react-perf/jsx-no-jsx-as-prop": "error",
+    "react-perf/jsx-no-new-array-as-prop": "error",
+    "block-scoped-var": "off",
+    "no-await-in-loop": "off",
+    "no-unused-expressions": "off",
+    "require-yield": "off",
+    "unicorn/require-post-message-target-origin": "off",
+    "unicorn/prefer-add-event-listener": "off",
+    "unicorn/no-empty-file": "off",
+    "typescript/no-unsafe-type-assertion": "warn",
+    "typescript/no-unnecessary-boolean-literal-compare": "off",
+    "typescript/no-unnecessary-type-arguments": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/restrict-template-expressions": "error",
+    "typescript/no-floating-promises": "off",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-template-expression": "error",
+    "typescript/no-meaningless-void-operator": "error",
+    "typescript/unbound-method": "off",
+    "typescript/no-misused-spread": "off",
+    "typescript/no-for-in-array": "off",
+    "no-extraneous-class": "off",
+    "triple-slash-reference": "off",
+    "no-new": "off",
+    "no-empty-pattern": "off",
+    "no-useless-catch": "off",
+    "no-unused-private-class-members": "off",
+    "no-unassigned-vars": "off",
+    "no-unneeded-ternary": "off",
+    "no-unexpected-multiline": "off",
+    "no-extend-native": "off",
+    "oxc/only-used-in-recursion": "off",
+    "oxc/const-comparisons": "off",
+    "oxc/no-map-spread": "off",
+    "oxc/no-accumulating-spread": "off",
+    "constructor-super": "off",
+    "react/jsx-key": "off",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/no-new-array": "off",
+    "import/named": "off",
+    "import/export": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.cjs", "**/*.cts", "**/*.js"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/docs/src/content/_assets/code/**"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/vitest.config.ts", "**/vite.config.ts", "**/playwright.config.ts", "**/*.genie.ts"],
+      "rules": {
+        "func-style": "off"
+      }
+    },
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/__tests__/**", "**/tests/**"],
+      "rules": {
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "require-yield": "off"
+      }
+    },
+    {
+      "files": ["**/*.d.ts"],
+      "rules": {
+        "typescript/consistent-type-imports": "off"
+      }
+    },
+    {
+      "files": ["**/*.gen.*", "**/.astro/**", "**/routeTree.gen.ts"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "import/no-named-as-default": "off",
+        "import/no-unassigned-import": "off",
+        "oxc/no-barrel-file": "off",
+        "oxc/no-map-spread": "off",
+        "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["packages/@livestore/react/src/useRcResource.ts"],
+      "rules": {
+        "react-hooks/exhaustive-deps": "off"
+      }
+    },
+    {
+      "files": ["**/wa-sqlite/**"],
+      "rules": {
+        "func-style": "off",
+        "import/no-commonjs": "off",
+        "typescript/await-thenable": "off",
+        "unicorn/no-new-array": "off",
+        "unicorn/no-array-sort": "off",
+        "unicorn/consistent-function-scoping": "off",
+        "overeng/explicit-boolean-compare": "off"
+      }
+    },
+    {
+      "files": ["**/*.svelte"],
+      "rules": {
+        "import/no-unassigned-import": "off"
+      }
+    }
+  ]
+}

--- a/tests/perf/.oxlintrc.json.genie.ts
+++ b/tests/perf/.oxlintrc.json.genie.ts
@@ -1,0 +1,16 @@
+import {
+  livestoreOxlintCategories,
+  livestoreOxlintIgnorePatterns,
+  livestoreOxlintOverrides,
+  livestoreOxlintPlugins,
+  livestoreOxlintRules,
+} from '../../.oxlintrc.json.genie.ts'
+import { oxlintConfig } from '../../repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts'
+
+export default oxlintConfig({
+  plugins: livestoreOxlintPlugins,
+  categories: livestoreOxlintCategories,
+  rules: livestoreOxlintRules,
+  overrides: livestoreOxlintOverrides,
+  ignorePatterns: [...livestoreOxlintIgnorePatterns, 'node_modules/**', 'dist/**', '.cache/**', '.pnpm/**'],
+})


### PR DESCRIPTION
## Problem
`oxlint --lsp` processes started from subfolder CWDs (often via opencode) can miss root ignore patterns, causing avoidable traversal overhead. We need to reduce that overhead without dropping docs snippet lint coverage in `docs/src/content/_assets/code`.

## Solution
- Added self-contained, genie-based local oxlint configs in hot subfolders:
  - `docs/src/content/_assets/code/.oxlintrc.json.genie.ts`
  - `tests/integration/.oxlintrc.json.genie.ts`
  - `tests/perf/.oxlintrc.json.genie.ts`
  - `tests/perf-eventlog/.oxlintrc.json.genie.ts`
- Generated corresponding `.oxlintrc.json` files for each folder (no `extends`, no `.eslintignore`).
- Added shared exports in root `.oxlintrc.json.genie.ts` so subfolder configs can compose the same rules/plugins/categories/overrides via genie.
- Kept snippet coverage intact; only generated/vendor artifacts are additionally ignored locally (`node_modules/**`, `dist/**`, `.cache/**`, `.pnpm/**`).
- Preserved docs CJS snippet behavior by disabling `import/no-commonjs` in the docs subfolder config.

## Validation
- Spot checks:
  - `oxlint .` in `tests/integration`: 0 warnings / 0 errors, 75 files, 317ms
  - `oxlint .` in `tests/perf`: 0 warnings / 0 errors, 19 files, 133ms
  - `oxlint .` in `tests/perf-eventlog`: 0 warnings / 0 errors, 19 files, 197ms
- Docs snippet coverage preserved:
  - `oxlint reference/syncing/sync-provider/electricsql/api-proxy.ts` -> 2 errors (still linted)
  - docs folder JSON run: 69 diagnostics across 28 files; includes `reference/syncing/sync-provider/electricsql/api-proxy.ts`
  - `oxlint reference/devtools/metro-config.ts` -> 0 errors (expected docs CJS override)
- Root lint command:
  - `dt lint:check:oxlint` still fails on existing repository baseline violations unrelated to this change.
- `oxlint --lsp` process snapshot during this run:
  - Before: count=0
  - After: count=0

## Residual Risk / Phase 2 Option (not implemented)
If overhead remains high, split linting into:
1. Pass A: root lint excluding `docs/src/content/_assets/code/**`
2. Pass B: snippet-only lint config for that folder with import plugin removed

---
Created by OpenCode on behalf of the user.