### PR TITLE
chore(beads): remove beads:ensure shell entry wiring

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -249,8 +249,6 @@ in
     pass_filenames = false;
   };
 
-  # Wire beads:ensure directly to shell entry
-  tasks."devenv:enterShell".after = lib.mkAfter [ "beads:ensure" ];
   enterShell = ''
     sp="$(git rev-parse --show-superproject-working-tree 2>/dev/null)";
     export WORKSPACE_ROOT="$PWD"


### PR DESCRIPTION
## Summary

- Remove `beads:ensure` from `devenv:enterShell` dependencies in `devenv.nix`
- Beads v0.57+ self-manages `dolt sql-server` per project (deterministic port from FNV hash of BEADS_DIR)
- Follow-up to overengineeringstudio/effect-utils#293 which removed `beads:ensure` from the shared devenv module

🤖 Generated with [Claude Code](https://claude.com/claude-code)