### PR TITLE
docs: annotate megarepo members as primary/input

### DIFF
--- a/megarepo.json.genie.ts
+++ b/megarepo.json.genie.ts
@@ -3,10 +3,10 @@ import { megarepoJson } from './repos/effect-utils/packages/@overeng/genie/src/r
 /** Megarepo config for livestore */
 export default megarepoJson({
   members: {
-    /** Primary member — build dependency that receives PRs during alignment. */
+    /** Primary member */
     'effect-utils': 'overengineeringstudio/effect-utils',
 
-    /** Secondary members — consumed via lock files but never modified during alignment. */
+    /** Secondary members */
     'overeng-beads-public': 'overengineeringstudio/overeng-beads-public',
     /** Reference only — not a build dependency */
     effect: 'effect-ts/effect',

--- a/megarepo.json.genie.ts
+++ b/megarepo.json.genie.ts
@@ -8,6 +8,7 @@ export default megarepoJson({
 
     /** Input members — consumed via lock files but never modified during alignment. */
     'overeng-beads-public': 'overengineeringstudio/overeng-beads-public',
+    /** Reference only — not a build dependency */
     effect: 'effect-ts/effect',
   },
 })

--- a/megarepo.json.genie.ts
+++ b/megarepo.json.genie.ts
@@ -6,7 +6,7 @@ export default megarepoJson({
     /** Primary member — build dependency that receives PRs during alignment. */
     'effect-utils': 'overengineeringstudio/effect-utils',
 
-    /** Input members — consumed via lock files but never modified during alignment. */
+    /** Secondary members — consumed via lock files but never modified during alignment. */
     'overeng-beads-public': 'overengineeringstudio/overeng-beads-public',
     /** Reference only — not a build dependency */
     effect: 'effect-ts/effect',

--- a/megarepo.json.genie.ts
+++ b/megarepo.json.genie.ts
@@ -3,9 +3,11 @@ import { megarepoJson } from './repos/effect-utils/packages/@overeng/genie/src/r
 /** Megarepo config for livestore */
 export default megarepoJson({
   members: {
+    /** Primary member — build dependency that receives PRs during alignment. */
     'effect-utils': 'overengineeringstudio/effect-utils',
+
+    /** Input members — consumed via lock files but never modified during alignment. */
     'overeng-beads-public': 'overengineeringstudio/overeng-beads-public',
-    /** Reference only — not a build dependency */
     effect: 'effect-ts/effect',
   },
 })


### PR DESCRIPTION
## Summary
- Add jsdoc comments classifying megarepo members as "Primary member" (receives alignment PRs) or "Input member" (consumed via lock files, never modified during alignment)

---
_This PR was created on behalf of @schickling by an AI assistant._