### PR TITLE
Fix example-create CI by using PR head SHA ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1544,7 +1544,7 @@ jobs:
           DEPS=$(jq -r '[(.dependencies // {}), (.devDependencies // {}) | to_entries[] | select(.key | startswith("@livestore/")) | .key] | .[]' ${{ env.APP_PATH }}/package.json | while read dep; do dir="packages/@livestore/${dep#@livestore/}"; [ -d "$dir" ] && echo "$dep"; done | tr '\n' ' ')
           echo "WORKSPACE_DEPS=$DEPS" >> $GITHUB_ENV
       - name: Copy example app
-        run: 'pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --ref ${{ github.ref }} ${{ runner.temp }}/${{ env.APP_PATH }}'
+        run: 'pnpm dlx @livestore/cli@${{ env.SNAPSHOT_VERSION }} create --example ${{ matrix.app }} --ref ${{ github.event.pull_request.head.sha || github.sha }} ${{ runner.temp }}/${{ env.APP_PATH }}'
       - name: Use snapshot version of workspace dependencies
         working-directory: '${{ runner.temp }}/${{ env.APP_PATH }}'
         run: |

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -415,16 +415,11 @@ echo "WORKSPACE_DEPS=$DEPS" >> $GITHUB_ENV`,
         },
         {
           /**
-           * - We use `github.ref` instead of `github.sha` because, when a workflow is triggered by a pull request,
-           *   `github.sha` refers to a temporary commit SHA that can become inaccessible in some contexts.
-           * - We use `github.ref` instead of `github.ref_name` because GitHub's public API requires full refs.
-           *   `github.ref_name` produces shortened refs like `123/merge` for PRs, which the API doesn't recognize.
-           *   `github.ref` provides the full ref (e.g., `refs/pull/123/merge`) that the API understands.
-           *
-           * See https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/
+           * Use PR head SHA for pull_request events. `refs/pull/<id>/merge` can be missing when
+           * merge commits are unavailable, which makes GitHub contents API calls fail.
            */
           name: 'Copy example app',
-          run: `pnpm dlx @livestore/cli@\${{ env.SNAPSHOT_VERSION }} create --example \${{ matrix.app }} --ref ${GITHUB_REF} \${{ runner.temp }}/\${{ env.APP_PATH }}`,
+          run: `pnpm dlx @livestore/cli@\${{ env.SNAPSHOT_VERSION }} create --example \${{ matrix.app }} --ref ${PR_HEAD_SHA} \${{ runner.temp }}/\${{ env.APP_PATH }}`,
         },
         {
           name: 'Use snapshot version of workspace dependencies',


### PR DESCRIPTION
## Problem

build-example-create passed github.ref to @livestore/cli create --ref. For pull request runs this is typically refs/pull/<id>/merge, and that ref can be unavailable, causing GitHub API 404s and failing all example-create matrix jobs.

## Solution

Use ${{ github.event.pull_request.head.sha || github.sha }} for the --ref argument in build-example-create.

- Updated .github/workflows/ci.yml.genie.ts
- Regenerated .github/workflows/ci.yml with genie --writeable

Trade-off: PR jobs now fetch examples from the PR head commit instead of the synthetic merge ref.

## Validation

- genie --writeable (pass)
- bun --eval "import './.github/workflows/ci.yml.genie.ts'" (pass)
- dt ts:check (blocked locally by OTEL shell-capture config: extraDashboards is not supported in OTEL_MODE=system)

## Related issues

- None

---
Acting on behalf of @schickling.
