### PR TITLE
fix(ts): eliminate TS errors under strict type checking

### DIFF
--- a/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
@@ -19,7 +19,7 @@ export const logDevtoolsUrl = Effect.fn('@livestore/adapter-web:client-session:d
   sessionId: string
 }) {
   if (isDevEnv() === true) {
-    const devtoolsPath = LIVESTORE_DEVTOOLS_PATH ?? `/_livestore`
+    const devtoolsPath = (globalThis as unknown as { LIVESTORE_DEVTOOLS_PATH?: string }).LIVESTORE_DEVTOOLS_PATH ?? `/_livestore`
     const devtoolsBaseUrl = `${location.origin}${devtoolsPath}`
 
     // Check whether devtools are available and then log the URL

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
@@ -19,7 +19,7 @@ export const logDevtoolsUrl = Effect.fn('@livestore/adapter-web:client-session:d
   sessionId: string
 }) {
   if (isDevEnv() === true) {
-    const devtoolsPath = globalThis.LIVESTORE_DEVTOOLS_PATH ?? `/_livestore`
+    const devtoolsPath = LIVESTORE_DEVTOOLS_PATH ?? `/_livestore`
     const devtoolsBaseUrl = `${location.origin}${devtoolsPath}`
 
     // Check whether devtools are available and then log the URL

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -31,7 +31,7 @@ export const recreateDb = ({
 }): Effect.Effect<{ migrationsReport: MigrationsReport }, UnknownError | MaterializeError | SqliteError> =>
   Effect.gen(function* () {
     const migrationOptions = schema.state.sqlite.migrations
-    let migrationsReport: MigrationsReport
+    let migrationsReport: MigrationsReport = { migrations: [] }
 
     yield* Effect.addFinalizer(
       Effect.fn('recreateDb:finalizer')(function* (ex) {

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
@@ -359,8 +359,7 @@ export const getResultSchema = (qb: QueryBuilder<any, any, any>): Schema.Schema<
         Schema.headOrElse(),
       )
     }
-    default: {
-      casesHandled(queryAst)
-    }
+    default:
+      return casesHandled(queryAst)
   }
 }

--- a/packages/@livestore/common/src/sync/next/facts.ts
+++ b/packages/@livestore/common/src/sync/next/facts.ts
@@ -199,7 +199,7 @@ export const getFactsGroupForEventArgs = ({
         }
       }
 
-      notYetImplemented(`getFactsGroupForEventArgs: ${prop.toString()} is not yet implemented`)
+      return notYetImplemented(`getFactsGroupForEventArgs: ${prop.toString()} is not yet implemented`)
     },
   })
 

--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -434,9 +434,8 @@ export const merge = ({
       }
     }
 
-    default: {
-      casesHandled(payload)
-    }
+    default:
+      return casesHandled(payload)
   }
 }
 

--- a/packages/@livestore/utils/src/browser/Opfs/Opfs.ts
+++ b/packages/@livestore/utils/src/browser/Opfs/Opfs.ts
@@ -103,9 +103,16 @@ export class Opfs extends Effect.Service<Opfs>()('@livestore/utils/Opfs', {
      *
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle/values | MDN Reference}
      */
-    const values = (directory: FileSystemDirectoryHandle) =>
-      Stream.fromAsyncIterable(directory.values(), (u) =>
-        WebError.parseWebError(u, [WebError.NotAllowedError, WebError.NotFoundError]),
+    const values = (
+      directory: FileSystemDirectoryHandle,
+    ): Stream.Stream<
+      FileSystemHandle,
+      WebError.NotAllowedError | WebError.NotFoundError | WebError.UnknownError,
+      never
+    > =>
+      Stream.fromAsyncIterable(
+        (directory as unknown as { values(): AsyncIterable<FileSystemHandle> }).values(),
+        (u) => WebError.parseWebError(u, [WebError.NotAllowedError, WebError.NotFoundError]),
       )
 
     /**

--- a/packages/@livestore/utils/src/env.ts
+++ b/packages/@livestore/utils/src/env.ts
@@ -26,4 +26,5 @@ export const IS_CI = envTruish(env('CI'))
 
 export const IS_BUN = typeof Bun !== 'undefined'
 
-export const IS_REACT_NATIVE = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
+export const IS_REACT_NATIVE =
+  typeof navigator !== 'undefined' && (navigator as unknown as Record<string, unknown>)['product'] === 'ReactNative'

--- a/packages/@livestore/utils/src/fast-deep-equal.ts
+++ b/packages/@livestore/utils/src/fast-deep-equal.ts
@@ -53,7 +53,7 @@ export const deepEqual = <T>(a: T, b: T): boolean => {
     length = keys.length
     if (length !== Object.keys(b).length) return false
 
-    for (i = length; i-- !== 0; ) if (Object.hasOwn(b, keys[i]) === false) return false
+    for (i = length; i-- !== 0; ) if (Object.prototype.hasOwnProperty.call(b, keys[i]) === false) return false
 
     for (i = length; i-- !== 0; ) {
       const key = keys[i]

--- a/packages/@livestore/webmesh/src/node.ts
+++ b/packages/@livestore/webmesh/src/node.ts
@@ -553,7 +553,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
             schema,
             queue: channelQueue,
             sendPacket,
-            simulation,
+            ...(simulation !== undefined ? { simulation } : {}),
           })
 
           channelMap.set(channelKey, { queue: channelQueue, debugInfo: { channel, target } })


### PR DESCRIPTION
## Summary

Fix TypeScript errors that surface under strict type checking (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, strict DOM lib types).

- **Navigator.product** (TS2339): deprecated property accessed via bracket notation with `unknown` cast
- **Object.hasOwn** (TS2550): replaced with `Object.prototype.hasOwnProperty.call`
- **migrationsReport used before assigned** (TS2454): initialized with default value
- **EOP violation in webmesh** (TS2379): conditional spread for optional `simulation` param
- **FileSystemDirectoryHandle.values()** (TS2339): cast to typed object with explicit return type annotation
- **handle is unknown** (TS18046): resolved by properly typing `Opfs.values` return
- **LIVESTORE_DEVTOOLS_PATH** (TS2304): use typed `globalThis` cast instead of bare global var (ambient.d.ts `declare var` not visible from external tsconfig references)
- **Missing return before never-returning calls** (TS2366/TS7030): `casesHandled()` and `notYetImplemented()` return `never` but need explicit `return` for TS to see the code path as terminated

Refs #1084

## Test plan

- [x] `tsc --build` passes for all affected packages
- [x] No new `@ts-ignore` or `@ts-expect-error` annotations introduced
- [x] Type assertions kept minimal and principled (only for deprecated/missing DOM APIs)
- [x] Verified from overeng megarepo: 0 TS errors when referencing this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)