### PR TITLE
refactor: replace raw OTel addEvent calls with Effect.spanEvent

### DIFF
--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -10,7 +10,6 @@ import {
   FiberHandle,
   Layer,
   Option,
-  OtelTracer,
   Queue,
   ReadonlyArray,
   Schedule,
@@ -19,7 +18,6 @@ import {
   Subscribable,
   SubscriptionRef,
 } from '@livestore/utils/effect'
-import type * as otel from '@opentelemetry/api'
 
 import { type MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
 import { IntentionalShutdownCause } from '../errors.ts'
@@ -36,11 +34,6 @@ import { rollback } from './materialize-event.ts'
 import type { ShutdownChannel } from './shutdown-channel.ts'
 import type { InitialBlockingSyncContext, LeaderSyncProcessor } from './types.ts'
 import { LeaderThreadCtx } from './types.ts'
-
-// WORKAROUND: @effect/opentelemetry mis-parses `Span.addEvent(name, attributes)` and treats the attributes object as a
-// time input, causing `TypeError: {} is not iterable` at runtime.
-// Upstream: https://github.com/Effect-TS/effect/pull/5929
-// TODO: simplify back to the 2-arg overload once the upstream fix is released and adopted.
 
 /** Serialize value to JSON string for trace attributes */
 const jsonStringify = Schema.encodeSync(Schema.parseJson())
@@ -182,7 +175,6 @@ export const makeLeaderSyncProcessor = ({
       current: undefined as
         | undefined
         | {
-            otelSpan: otel.Span | undefined
             span: Tracer.Span
             devtoolsLatch: Effect.Latch | undefined
             runtime: Runtime.Runtime<LeaderThreadCtx>
@@ -286,12 +278,10 @@ export const makeLeaderSyncProcessor = ({
     // Starts various background loops
     const boot: LeaderSyncProcessor['boot'] = Effect.gen(function* () {
       const span = yield* Effect.currentSpan.pipe(Effect.orDie)
-      const otelSpan = yield* OtelTracer.currentOtelSpan.pipe(Effect.catchAll(() => Effect.succeed(undefined)))
       const { devtools, shutdownChannel } = yield* LeaderThreadCtx
       const runtime = yield* Effect.runtime<LeaderThreadCtx>()
 
       ctxRef.current = {
-        otelSpan,
         span,
         devtoolsLatch: devtools.enabled === true ? devtools.syncBackendLatch : undefined,
         runtime,
@@ -361,7 +351,6 @@ export const makeLeaderSyncProcessor = ({
         syncBackendPushQueue,
         schema,
         isClientEvent,
-        otelSpan,
         connectedClientSessionPullQueues,
         localPushBatchSize,
         testing: {
@@ -372,7 +361,6 @@ export const makeLeaderSyncProcessor = ({
       const backendPushingFiberHandle = yield* FiberHandle.make<void, never>()
       const backendPushingEffect = backgroundBackendPushing({
         syncBackendPushQueue,
-        otelSpan,
         devtoolsLatch: ctxRef.current?.devtoolsLatch,
         backendPushBatchSize,
       }).pipe(
@@ -399,7 +387,6 @@ export const makeLeaderSyncProcessor = ({
         localPushBackendPullMutex,
         livePull,
         dbState,
-        otelSpan,
         initialBlockingSyncContext,
         devtoolsLatch: ctxRef.current?.devtoolsLatch,
         connectedClientSessionPullQueues,
@@ -471,7 +458,6 @@ const backgroundApplyLocalPushes = ({
   syncBackendPushQueue,
   schema,
   isClientEvent,
-  otelSpan,
   connectedClientSessionPullQueues,
   localPushBatchSize,
   testing,
@@ -482,7 +468,6 @@ const backgroundApplyLocalPushes = ({
   syncBackendPushQueue: BucketQueue.BucketQueue<LiveStoreEvent.Client.EncodedWithMeta>
   schema: LiveStoreSchema
   isClientEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
-  otelSpan: otel.Span | undefined
   connectedClientSessionPullQueues: PullQueueSet
   localPushBatchSize: number
   testing: {
@@ -511,14 +496,10 @@ const backgroundApplyLocalPushes = ({
         )
 
         if (droppedItems.length > 0) {
-          otelSpan?.addEvent(
-            `push:drop-old-generation`,
-            {
-              droppedCount: droppedItems.length,
-              currentRebaseGeneration,
-            },
-            undefined,
-          )
+          yield* Effect.spanEvent(`push:drop-old-generation`, {
+          droppedCount: droppedItems.length,
+          currentRebaseGeneration,
+        })
 
         /**
          * Dropped pushes may still have a deferred awaiting completion.
@@ -550,28 +531,24 @@ const backgroundApplyLocalPushes = ({
         yield* Effect.annotateCurrentSpan({
         'batchSize': newEvents.length,
         ...(TRACE_VERBOSE === true ? { 'newEvents': jsonStringify(newEvents) } : {}),
-      })
+        })
 
-      const mergeResult = yield* SyncState.merge({
-        syncState,
-        payload: { _tag: 'local-push', newEvents },
-        isClientEvent,
-        isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-      })
+        const mergeResult = yield* SyncState.merge({
+          syncState,
+          payload: { _tag: 'local-push', newEvents },
+          isClientEvent,
+          isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+        })
 
         switch (mergeResult._tag) {
           case 'rebase': {
             return yield* Effect.dieDebugger('The leader thread should never have to rebase due to a local push')
           }
           case 'reject': {
-            otelSpan?.addEvent(
-              `push:reject`,
-              {
-                batchSize: newEvents.length,
-                mergeResult: TRACE_VERBOSE === true ? jsonStringify(mergeResult) : undefined,
-              },
-              undefined,
-            )
+            yield* Effect.spanEvent(`push:reject`, {
+              batchSize: newEvents.length,
+              ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+            })
 
             // TODO: how to test this?
             const nextRebaseGeneration = currentRebaseGeneration + 1
@@ -623,14 +600,10 @@ const backgroundApplyLocalPushes = ({
           leaderHead: mergeResult.newSyncState.localHead,
         })
 
-        otelSpan?.addEvent(
-          `push:advance`,
-          {
-            batchSize: newEvents.length,
-            mergeResult: TRACE_VERBOSE === true ? jsonStringify(mergeResult) : undefined,
-          },
-          undefined,
-        )
+        yield* Effect.spanEvent(`push:advance`, {
+          batchSize: newEvents.length,
+        ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+        })
 
         // Don't sync client-local events
         const filteredBatch = mergeResult.newEvents.filter((eventEncoded) => {
@@ -697,7 +670,6 @@ const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds 
 const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcessor:backend-pulling')(function* ({
   isClientEvent,
   restartBackendPushing,
-  otelSpan,
   dbState,
   syncStateSref,
   localPushBackendPullMutex,
@@ -711,7 +683,6 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
   restartBackendPushing: (
     filteredRebasedPending: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
   ) => Effect.Effect<void, never, LeaderThreadCtx | HttpClient.HttpClient>
-  otelSpan: otel.Span | undefined
   syncStateSref: SubscriptionRef.SubscriptionRef<SyncState.SyncState | undefined>
   dbState: SqliteDb
   localPushBackendPullMutex: Effect.Semaphore
@@ -779,16 +750,12 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
         Eventlog.updateBackendHead(dbEventlog, newBackendHead)
 
         if (mergeResult._tag === 'rebase') {
-          otelSpan?.addEvent(
-            `pull:rebase[${mergeResult.newSyncState.localHead.rebaseGeneration}]`,
-            {
-              newEventsCount: newEvents.length,
-              newEvents: TRACE_VERBOSE === true ? jsonStringify(newEvents) : undefined,
-              rollbackCount: mergeResult.rollbackEvents.length,
-              mergeResult: TRACE_VERBOSE === true ? jsonStringify(mergeResult) : undefined,
-            },
-            undefined,
-          )
+          yield* Effect.spanEvent(`pull:rebase[${mergeResult.newSyncState.localHead.rebaseGeneration}]`, {
+          newEventsCount: newEvents.length,
+          ...(TRACE_VERBOSE === true ? { newEvents: jsonStringify(newEvents) } : {}),
+          rollbackCount: mergeResult.rollbackEvents.length,
+          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+          })
 
           const globalRebasedPendingEvents = mergeResult.newSyncState.pending.filter((event) => {
             const eventDef = schema.eventsDefsMap.get(event.name)
@@ -809,14 +776,10 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
             leaderHead: mergeResult.newSyncState.localHead,
           })
         } else {
-          otelSpan?.addEvent(
-            `pull:advance`,
-            {
-              newEventsCount: newEvents.length,
-              mergeResult: TRACE_VERBOSE === true ? jsonStringify(mergeResult) : undefined,
-            },
-            undefined,
-          )
+          yield* Effect.spanEvent(`pull:advance`, {
+            newEventsCount: newEvents.length,
+          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+          })
 
           // Ensure push fiber is active after advance by restarting with current pending (non-client) events
           const globalPendingEvents = mergeResult.newSyncState.pending.filter((event) => {
@@ -871,12 +834,6 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
     // TODO only take from queue while connected
     Stream.tap(({ batch, pageInfo }) =>
       Effect.gen(function* () {
-        // yield* Effect.spanEvent('batch', {
-        //   attributes: {
-        //     batchSize: batch.length,
-        //     batch: TRACE_VERBOSE ? batch : undefined,
-        //   },
-        // })
         // NOTE we only want to take process events when the sync backend is connected
         // (e.g. needed for simulating being offline)
         // TODO remove when there's a better way to handle this in stream above
@@ -907,12 +864,10 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
 
 const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcessor:backend-pushing')(function* ({
   syncBackendPushQueue,
-  otelSpan,
   devtoolsLatch,
   backendPushBatchSize,
 }: {
   syncBackendPushQueue: BucketQueue.BucketQueue<LiveStoreEvent.Client.EncodedWithMeta>
-  otelSpan: otel.Span | undefined
   devtoolsLatch: Effect.Latch | undefined
   backendPushBatchSize: number
 }) {
@@ -930,14 +885,10 @@ const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcesso
       yield* devtoolsLatch.await
     }
 
-    otelSpan?.addEvent(
-      'backend-push',
-      {
-        batchSize: queueItems.length,
-        batch: TRACE_VERBOSE === true ? jsonStringify(queueItems) : undefined,
-      },
-      undefined,
-    )
+    yield* Effect.spanEvent('backend-push', {
+      batchSize: queueItems.length,
+      ...(TRACE_VERBOSE === true ? { batch: jsonStringify(queueItems) } : {}),
+    })
 
     // Push with declarative retry/backoff using Effect schedules
     // - Exponential backoff starting at 1s and doubling (1s, 2s, 4s, 8s, 16s, 30s ...)
@@ -951,19 +902,15 @@ const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcesso
 
       const retries = iteration.recurrence
       if (retries > 0 && pushResult._tag === 'Right') {
-        otelSpan?.addEvent('backend-push-retry-success', { retries, batchSize: queueItems.length }, undefined)
+        yield* Effect.spanEvent('backend-push-retry-success', { retries, batchSize: queueItems.length })
       }
 
       if (pushResult._tag === 'Left') {
-        otelSpan?.addEvent(
-          'backend-push-error',
-          {
-            error: pushResult.left.toString(),
-            retries,
-            batchSize: queueItems.length,
-          },
-          undefined,
-        )
+        yield* Effect.spanEvent('backend-push-error', {
+          error: pushResult.left.toString(),
+          retries,
+          batchSize: queueItems.length,
+        })
         const error = pushResult.left
         if (error._tag === 'InvalidPushError' && error.cause._tag === 'ServerAheadError') {
           // It's a core part of the sync protocol that the sync backend will emit a new pull chunk alongside the ServerAheadError

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -13,7 +13,6 @@ import {
   Stream,
   Subscribable,
 } from '@livestore/utils/effect'
-import type * as otel from '@opentelemetry/api'
 
 import { type ClientSession, type UnknownError } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
@@ -22,11 +21,6 @@ import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import * as SyncState from './syncstate.ts'
-
-// WORKAROUND: @effect/opentelemetry mis-parses `Span.addEvent(name, attributes)` and treats the attributes object as a
-// time input, causing `TypeError: {} is not iterable` at runtime.
-// Upstream: https://github.com/Effect-TS/effect/pull/5929
-// TODO: simplify back to the 2-arg overload once the upstream fix is released and adopted.
 
 /** Serialize value to JSON string for trace attributes */
 const jsonStringify = Schema.encodeSync(Schema.parseJson())
@@ -53,7 +47,6 @@ export const makeClientSessionSyncProcessor = ({
   materializeEvent,
   rollback,
   refreshTables,
-  span,
   params,
   confirmUnsavedChanges,
 }: {
@@ -76,7 +69,6 @@ export const makeClientSessionSyncProcessor = ({
   >
   rollback: (changeset: Uint8Array<ArrayBuffer>) => void
   refreshTables: (tables: Set<string>) => void
-  span: otel.Span
   params: {
     leaderPushBatchSize: number
     simulation?: ClientSessionSyncProcessorSimulationParams
@@ -252,17 +244,13 @@ export const makeClientSessionSyncProcessor = ({
           syncStateRef.current = mergeResult.newSyncState
 
           if (mergeResult._tag === 'rebase') {
-            span.addEvent(
-              'merge:pull:rebase',
-              {
-                payloadTag: payload._tag,
-                payload: TRACE_VERBOSE === true ? jsonStringify(payload) : undefined,
-                newEventsCount: mergeResult.newEvents.length,
-                rollbackCount: mergeResult.rollbackEvents.length,
-                res: TRACE_VERBOSE === true ? jsonStringify(mergeResult) : undefined,
-              },
-              undefined,
-            )
+            yield* Effect.spanEvent('merge:pull:rebase', {
+              payloadTag: payload._tag,
+              ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
+              newEventsCount: mergeResult.newEvents.length,
+              rollbackCount: mergeResult.rollbackEvents.length,
+              ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
+            })
 
             debugInfo.rebaseCount++
 
@@ -301,16 +289,12 @@ export const makeClientSessionSyncProcessor = ({
 
             yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
           } else {
-            span.addEvent(
-              'merge:pull:advance',
-              {
-                payloadTag: payload._tag,
-                payload: TRACE_VERBOSE === true ? jsonStringify(payload) : undefined,
-                newEventsCount: mergeResult.newEvents.length,
-                res: TRACE_VERBOSE === true ? jsonStringify(mergeResult) : undefined,
-              },
-              undefined,
-            )
+            yield* Effect.spanEvent('merge:pull:advance', {
+              payloadTag: payload._tag,
+              ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
+              newEventsCount: mergeResult.newEvents.length,
+              ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
+            })
 
             debugInfo.advanceCount++
           }

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -36,9 +36,6 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
       },
     },
     {
-      "_name": "LiveStore:sync",
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {
@@ -123,9 +120,6 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
       },
     },
     {
-      "_name": "LiveStore:sync",
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {
@@ -208,9 +202,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
         "span.label": "⚠︎ Interrupted",
         "status.interrupted": true,
       },
-    },
-    {
-      "_name": "LiveStore:sync",
     },
     {
       "_name": "LiveStore:commits",
@@ -343,9 +334,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       },
     },
     {
-      "_name": "LiveStore:sync",
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {
@@ -474,9 +462,6 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
         "span.label": "⚠︎ Interrupted",
         "status.interrupted": true,
       },
-    },
-    {
-      "_name": "LiveStore:sync",
     },
     {
       "_name": "LiveStore:commits",
@@ -614,9 +599,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
         "span.label": "⚠︎ Interrupted",
         "status.interrupted": true,
       },
-    },
-    {
-      "_name": "LiveStore:sync",
     },
     {
       "_name": "LiveStore:commits",
@@ -807,9 +789,6 @@ exports[`otel > otel 3`] = `
         "span.label": "⚠︎ Interrupted",
         "status.interrupted": true,
       },
-    },
-    {
-      "_name": "LiveStore:sync",
     },
     {
       "_name": "LiveStore:commits",
@@ -1104,9 +1083,6 @@ exports[`otel > with thunks 7`] = `
       },
     },
     {
-      "_name": "LiveStore:sync",
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {
@@ -1231,9 +1207,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
         "span.label": "⚠︎ Interrupted",
         "status.interrupted": true,
       },
-    },
-    {
-      "_name": "LiveStore:sync",
     },
     {
       "_name": "LiveStore:commits",

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -207,8 +207,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
     const reactivityGraph = makeReactivityGraph()
 
-    const syncSpan = otelOptions.tracer.startSpan('LiveStore:sync', {}, otelOptions.rootSpanContext)
-
     const syncProcessor = makeClientSessionSyncProcessor({
       schema,
       clientSession,
@@ -314,7 +312,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         }
         reactivityGraph.setRefs(tablesToUpdate)
       },
-      span: syncSpan,
       params: {
         ...omitUndefineds({
           leaderPushBatchSize: params.leaderPushBatchSize,
@@ -385,7 +382,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
           }
 
           // End the otel spans
-          syncSpan.end()
           commitsSpan.end()
           queriesSpan.end()
         }),

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -43,9 +43,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "LiveStore:sync",
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {
@@ -304,9 +301,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "span.label": "⚠︎ Interrupted",
         "status.interrupted": true,
       },
-    },
-    {
-      "_name": "LiveStore:sync",
     },
     {
       "_name": "LiveStore:commits",

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -36,9 +36,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "LiveStore:sync",
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {

--- a/packages/@livestore/utils/src/effect/Effect.test.ts
+++ b/packages/@livestore/utils/src/effect/Effect.test.ts
@@ -1,0 +1,101 @@
+import { it, describe, expect } from '@effect/vitest'
+import { Effect, Tracer } from 'effect'
+
+import { spanEvent } from './Effect.ts'
+
+type RecordedEvent = { name: string; attributes?: Record<string, unknown> }
+
+/**
+ * Creates a test tracer that captures span events for assertion,
+ * using only the public `Tracer` API (no internal NativeSpan access).
+ * Each span records its own events, retrievable by span name.
+ */
+const makeTestTracer = () => {
+  const spanEvents = new Map<string, Array<RecordedEvent>>()
+
+  const tracer = Tracer.make({
+    span(name, parent, context, links, startTime, kind) {
+      const events: Array<RecordedEvent> = []
+      spanEvents.set(name, events)
+      const attributes = new Map<string, unknown>()
+      return {
+        _tag: 'Span' as const,
+        name,
+        spanId: `test-${name}`,
+        traceId: 'test-trace',
+        parent,
+        context,
+        status: { _tag: 'Started' as const, startTime },
+        attributes,
+        links: [...links],
+        sampled: true,
+        kind,
+        end() {},
+        attribute(key: string, value: unknown) {
+          attributes.set(key, value)
+        },
+        event(eventName: string, _startTime: bigint, attrs?: Record<string, unknown>) {
+          events.push({ name: eventName, attributes: attrs })
+        },
+        addLinks() {},
+      }
+    },
+    context(f) {
+      return f()
+    },
+  })
+
+  return {
+    tracer,
+    getEvents: (spanName: string): Array<RecordedEvent> => spanEvents.get(spanName) ?? [],
+  }
+}
+
+describe('spanEvent', () => {
+  it.effect('should emit a span event with the given message', () => {
+    const { tracer, getEvents } = makeTestTracer()
+    return Effect.gen(function* () {
+      yield* spanEvent('test-event')
+      const events = getEvents('test-span')
+      expect(events).toHaveLength(1)
+      expect(events[0]!.name).toBe('test-event')
+    }).pipe(Effect.withSpan('test-span'), Effect.withTracer(tracer))
+  })
+
+  it.effect('should emit a span event with attributes', () => {
+    const { tracer, getEvents } = makeTestTracer()
+    return Effect.gen(function* () {
+      yield* spanEvent('event-with-attrs', { key1: 'value1', key2: 42 })
+      const events = getEvents('test-span')
+      expect(events).toHaveLength(1)
+      expect(events[0]!.name).toBe('event-with-attrs')
+      expect(events[0]!.attributes).toMatchObject({ key1: 'value1', key2: 42 })
+    }).pipe(Effect.withSpan('test-span'), Effect.withTracer(tracer))
+  })
+
+  it.effect('should emit to the nearest enclosing span', () => {
+    const { tracer, getEvents } = makeTestTracer()
+    return Effect.gen(function* () {
+      yield* spanEvent('outer-event')
+
+      yield* Effect.gen(function* () {
+        yield* spanEvent('inner-event')
+      }).pipe(Effect.withSpan('inner-span'))
+
+      const outerEvents = getEvents('outer-span')
+      const innerEvents = getEvents('inner-span')
+
+      expect(outerEvents).toHaveLength(1)
+      expect(outerEvents[0]!.name).toBe('outer-event')
+
+      expect(innerEvents).toHaveLength(1)
+      expect(innerEvents[0]!.name).toBe('inner-event')
+    }).pipe(Effect.withSpan('outer-span'), Effect.withTracer(tracer))
+  })
+
+  it.effect('should be a no-op when no span is in context', () =>
+    Effect.gen(function* () {
+      yield* spanEvent('orphan-event')
+    }),
+  )
+})

--- a/packages/@livestore/utils/src/effect/Effect.ts
+++ b/packages/@livestore/utils/src/effect/Effect.ts
@@ -6,9 +6,6 @@ import {
   Duration,
   Effect,
   Fiber,
-  FiberRef,
-  HashSet,
-  Logger,
   pipe,
   Scope,
   type Stream,
@@ -22,6 +19,7 @@ import { isDevEnv, isPromise, objectToString } from '../mod.ts'
 import { UnknownError } from './Error.ts'
 
 export * from 'effect/Effect'
+export { spanEvent } from './spanEvent.ts'
 
 // export const log = <A>(message: A, ...rest: any[]): Effect.Effect<void> =>
 //   Effect.sync(() => {
@@ -177,11 +175,6 @@ export const eventListener = <TEvent = unknown>(
 
     yield* Effect.addFinalizer(() => Effect.sync(() => target.removeEventListener(type, handlerFn)))
   })
-
-export const spanEvent = (message: any, attributes?: Record<string, any>) =>
-  Effect.locallyWith(Effect.log(message).pipe(Effect.annotateLogs(attributes ?? {})), FiberRef.currentLoggers, () =>
-    HashSet.make(Logger.tracerLogger),
-  )
 
 export const logWarnIfTakesLongerThan =
   ({ label, duration }: { label: string; duration: Duration.DurationInput }) =>

--- a/packages/@livestore/utils/src/effect/spanEvent.test.ts
+++ b/packages/@livestore/utils/src/effect/spanEvent.test.ts
@@ -1,9 +1,9 @@
 import { it, describe, expect } from '@effect/vitest'
 import { Effect, Tracer } from 'effect'
 
-import { spanEvent } from './Effect.ts'
+import { spanEvent } from './spanEvent.ts'
 
-type RecordedEvent = { name: string; attributes?: Record<string, unknown> }
+type RecordedEvent = { name: string; attributes: Record<string, unknown> | undefined }
 
 /**
  * Creates a test tracer that captures span events for assertion,
@@ -78,9 +78,7 @@ describe('spanEvent', () => {
     return Effect.gen(function* () {
       yield* spanEvent('outer-event')
 
-      yield* Effect.gen(function* () {
-        yield* spanEvent('inner-event')
-      }).pipe(Effect.withSpan('inner-span'))
+      yield* spanEvent('inner-event').pipe(Effect.withSpan('inner-span'))
 
       const outerEvents = getEvents('outer-span')
       const innerEvents = getEvents('inner-span')
@@ -93,9 +91,5 @@ describe('spanEvent', () => {
     }).pipe(Effect.withSpan('outer-span'), Effect.withTracer(tracer))
   })
 
-  it.effect('should be a no-op when no span is in context', () =>
-    Effect.gen(function* () {
-      yield* spanEvent('orphan-event')
-    }),
-  )
+  it.effect('should be a no-op when no span is in context', () => spanEvent('orphan-event'))
 })

--- a/packages/@livestore/utils/src/effect/spanEvent.ts
+++ b/packages/@livestore/utils/src/effect/spanEvent.ts
@@ -1,5 +1,14 @@
 import { Effect, FiberRef, HashSet, Logger } from 'effect'
 
+/**
+ * Emits a span event on the current Effect span via the tracer logger.
+ *
+ * @remarks
+ *
+ * Unlike raw `otelSpan.addEvent`, this doesn't require manual span threading —
+ * it automatically targets the nearest enclosing `Effect.withSpan`. If no span
+ * is in context, the call is a no-op.
+ */
 export const spanEvent = (message: any, attributes?: Record<string, unknown>) =>
   Effect.locallyWith(Effect.log(message).pipe(Effect.annotateLogs(attributes ?? {})), FiberRef.currentLoggers, () =>
     HashSet.make(Logger.tracerLogger),

--- a/packages/@livestore/utils/src/effect/spanEvent.ts
+++ b/packages/@livestore/utils/src/effect/spanEvent.ts
@@ -1,0 +1,6 @@
+import { Effect, FiberRef, HashSet, Logger } from 'effect'
+
+export const spanEvent = (message: any, attributes?: Record<string, unknown>) =>
+  Effect.locallyWith(Effect.log(message).pipe(Effect.annotateLogs(attributes ?? {})), FiberRef.currentLoggers, () =>
+    HashSet.make(Logger.tracerLogger),
+  )

--- a/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
@@ -4,7 +4,6 @@ import {
   Deferred,
   Effect,
   Exit,
-  OtelTracer,
   Predicate,
   Queue,
   Schema,
@@ -15,11 +14,6 @@ import {
 
 import { type ChannelName, type MeshNodeName, type MessageQueueItem, packetAsOtelAttributes } from '../common.ts'
 import * as MeshSchema from '../mesh-schema.ts'
-
-// WORKAROUND: @effect/opentelemetry mis-parses `Span.addEvent(name, attributes)` and treats the attributes object as a
-// time input, causing `TypeError: {} is not iterable` at runtime.
-// Upstream: https://github.com/Effect-TS/effect/pull/5929
-// TODO: simplify back to the 2-arg overload once the upstream fix is released and adopted.
 
 export interface MakeDirectChannelArgs {
   nodeName: MeshNodeName
@@ -94,11 +88,6 @@ export const makeDirectChannelInternal = ({
 
     const deferred = yield* makeDeferredResult()
 
-    const span = yield* OtelTracer.currentOtelSpan.pipe(Effect.catchAll(() => Effect.succeed(undefined)))
-    // const span = {
-    //   addEvent: (...msg: any[]) => console.log(`${nodeName}→${channelName}→${target}[${channelVersion}]`, ...msg),
-    // }
-
     const schema = {
       send: Schema.Union(schema_.send, MeshSchema.DirectChannelPing, MeshSchema.DirectChannelPong),
       listen: Schema.Union(schema_.listen, MeshSchema.DirectChannelPing, MeshSchema.DirectChannelPong),
@@ -112,16 +101,12 @@ export const makeDirectChannelInternal = ({
       Effect.gen(function* () {
         const channelState = channelStateRef.current
 
-        span?.addEvent(
-          `process:${packet._tag}`,
-          {
-            channelState: channelState._tag,
-            packetId: packet.id,
-            packetReqId: packet.reqId,
-            packetChannelVersion: Predicate.hasProperty('channelVersion')(packet) === true ? packet.channelVersion : undefined,
-          },
-          undefined,
-        )
+        yield* Effect.spanEvent(`process:${packet._tag}`, {
+          channelState: channelState._tag,
+          packetId: packet.id,
+          packetReqId: packet.reqId,
+          ...(Predicate.hasProperty('channelVersion')(packet) === true ? { packetChannelVersion: packet.channelVersion } : {}),
+        })
 
         // const reqIdStr =
         //   Predicate.hasProperty('reqId')(packet) && packet.reqId !== undefined ? ` for ${packet.reqId}` : ''
@@ -139,7 +124,7 @@ export const makeDirectChannelInternal = ({
         // If the other side has a higher version, we need to close this channel and
         // recreate it with the new version
         if (packet.channelVersion > channelVersion) {
-          span?.addEvent(`incoming packet has higher version (${packet.channelVersion}), closing channel`)
+          yield* Effect.spanEvent(`incoming packet has higher version (${packet.channelVersion}), closing channel`)
           yield* Scope.close(scope, Exit.succeed('higher-version-expected'))
           // TODO include expected version in the error so the channel gets recreated with the new version
           return 'close'
@@ -158,7 +143,7 @@ export const makeDirectChannelInternal = ({
             remainingHops: packet.hops,
             reqId: undefined,
           })
-          span?.addEvent(
+          yield* Effect.spanEvent(
             `incoming packet has lower version (${packet.channelVersion}), sending request to reconnect (${newPacket.id})`,
           )
 
@@ -173,7 +158,7 @@ export const makeDirectChannelInternal = ({
           } else {
             // In case the instance of the source has changed, we need to close the channel
             // and reconnect with a new channel
-            span?.addEvent(`force-new-channel`)
+            yield* Effect.spanEvent(`force-new-channel`)
             yield* Scope.close(scope, Exit.succeed('force-new-channel'))
             return 'close'
           }
@@ -200,7 +185,7 @@ export const makeDirectChannelInternal = ({
                 remainingHops: packet.hops,
                 reqId: packet.id,
               })
-              span?.addEvent(`Re-sending new request (${newRequestPacket.id}) for incoming request (${packet.id})`)
+              yield* Effect.spanEvent(`Re-sending new request (${newRequestPacket.id}) for incoming request (${packet.id})`)
 
               yield* sendPacket(newRequestPacket)
             }
@@ -208,7 +193,7 @@ export const makeDirectChannelInternal = ({
             const isWinner = nodeName > target
 
             if (isWinner === true) {
-              span?.addEvent(`winner side: creating direct channel and sending response`)
+              yield* Effect.spanEvent(`winner side: creating direct channel and sending response`)
               const mc = new MessageChannel()
 
               // We're using a direct channel with acks here to make sure messages are not lost
@@ -236,8 +221,6 @@ export const makeDirectChannelInternal = ({
 
               channelStateRef.current = { _tag: 'winner:ResponseSent', channel, otherSourceId: packet.sourceId }
 
-              // span?.addEvent(`winner side: waiting for ping`)
-
               // Now we wait for the other side to respond via the channel
               yield* channel.listen.pipe(
                 Stream.flatten(),
@@ -246,16 +229,14 @@ export const makeDirectChannelInternal = ({
                 Stream.runDrain,
               )
 
-              // span?.addEvent(`winner side: sending pong`)
-
               yield* channel.send(MeshSchema.DirectChannelPong.make({}))
 
-              span?.addEvent(`winner side: established`)
+              yield* Effect.spanEvent(`winner side: established`)
               channelStateRef.current = { _tag: 'Established', otherSourceId: packet.sourceId }
 
               yield* Deferred.succeed(deferred, channel)
             } else {
-              span?.addEvent(`loser side: waiting for response`)
+              yield* Effect.spanEvent(`loser side: waiting for response`)
               // Wait for `DirectChannelResponseSuccess` packet
               channelStateRef.current = { _tag: 'loser:WaitingForResponse', otherSourceId: packet.sourceId }
             }
@@ -284,8 +265,6 @@ export const makeDirectChannelInternal = ({
               Effect.fork,
             )
 
-            // span?.addEvent(`loser side: sending ping`)
-
             // There seems to be some scenario where the initial ping message is lost.
             // As a workaround until we find the root cause, we're retrying the ping a few times.
             // TODO write a test that reproduces this issue and fix the root cause ()
@@ -294,11 +273,9 @@ export const makeDirectChannelInternal = ({
               .send(MeshSchema.DirectChannelPing.make({}))
               .pipe(Effect.timeout(10), Effect.retry({ times: 2 }))
 
-            // span?.addEvent(`loser side: waiting for pong`)
-
             yield* waitForPongFiber
 
-            span?.addEvent(`loser side: established`)
+            yield* Effect.spanEvent(`loser side: established`)
             channelStateRef.current = { _tag: 'Established', otherSourceId: channelState.otherSourceId }
 
             yield* Deferred.succeed(deferred, channel)
@@ -354,7 +331,7 @@ export const makeDirectChannelInternal = ({
       }
 
       yield* sendPacket(packet)
-      span?.addEvent(`initial edge request sent (${packet.id})`)
+      yield* Effect.spanEvent(`initial edge request sent (${packet.id})`)
     })
 
     yield* edgeRequest

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -18,7 +18,7 @@ import { EventFactory } from '@livestore/common/testing'
 import type { ShutdownDeferred, Store } from '@livestore/livestore'
 import { createStore, makeShutdownDeferred, StoreInternalsSymbol } from '@livestore/livestore'
 import type { MakeNodeSqliteDb } from '@livestore/sqlite-wasm/node'
-import { makeNoopSpan, omitUndefineds } from '@livestore/utils'
+import { omitUndefineds } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 import type { OtelTracer } from '@livestore/utils/effect'
 import {
@@ -344,7 +344,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     Effect.gen(function* () {
       const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
       const runtime = yield* Effect.runtime<Scope.Scope>()
-      const span = makeNoopSpan()
+
       const baseHead = EventSequenceNumber.Client.Composite.make({ global: 10, client: 0, rebaseGeneration: 4 })
       const recordedEvents: LiveStoreEvent.Client.EncodedWithMeta[] = []
 
@@ -399,7 +399,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
           ),
         rollback: () => undefined,
         refreshTables: () => undefined,
-        span,
+
         params: { leaderPushBatchSize: 10 },
         confirmUnsavedChanges: false,
       })
@@ -494,7 +494,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const materializedEvents: LiveStoreEvent.Client.EncodedWithMeta[] = []
       const materialized = yield* Deferred.make<void>()
       const runtime = yield* Effect.runtime<Scope.Scope>()
-      const span = makeNoopSpan()
+
       const lockStatus = yield* SubscriptionRef.make<'has-lock' | 'no-lock'>('has-lock')
 
       const networkStatus = Subscribable.make<SyncBackend.NetworkStatus, never, never>({
@@ -564,7 +564,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         materializeEvent,
         rollback: () => undefined,
         refreshTables: () => undefined,
-        span,
+
         params: { leaderPushBatchSize: 10 },
         confirmUnsavedChanges: false,
       })
@@ -585,8 +585,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
           yield* Deferred.await(materialized)
         }),
       )
-
-      span.end()
 
       expect(materializedEvents).toHaveLength(1)
       expect(materializedEvents[0]?.name).toEqual('unknown_event_test')


### PR DESCRIPTION
## Problem

Several files manually thread an `otelSpan` / `span` parameter through functions and call `span?.addEvent(name, attrs, undefined)` for observability. This pattern:

- Requires explicit parameter threading through multiple levels of functions
- Uses the raw OpenTelemetry API instead of the Effect-native `Effect.spanEvent` utility
- Needs a 3-arg workaround for `@effect/opentelemetry` mis-parsing the 2-arg overload

## Solution

Replace all raw `span?.addEvent` / `span.addEvent` calls with `yield* Effect.spanEvent(name, attrs)`, which automatically emits span events on the current Effect span via the tracer logger — no manual span threading needed. Extract `spanEvent` into its own module with TSDoc and tests using a custom `Tracer`.

### Changes

- **`LeaderSyncProcessor.ts`** — replaced 10 `addEvent` call sites, removed `otelSpan` parameter from `backgroundApplyLocalPushes`, `backgroundBackendPulling`, and `backgroundBackendPushing` signatures and call sites, removed `OtelTracer.currentOtelSpan` lookup in `boot`, removed `otelSpan` field from `ctxRef`, removed `import type * as otel` and `OtelTracer` imports
- **`ClientSessionSyncProcessor.ts`** — replaced 2 `addEvent` call sites, removed `span: otel.Span` parameter, removed `import type * as otel`
- **`direct-channel-internal.ts`** — replaced 13 `span?.addEvent` call sites, removed `OtelTracer.currentOtelSpan` capture, cleaned up stale commented-out span events
- **`store.ts`** — removed `syncSpan` creation, passing, and ending (no longer needed)
- **`spanEvent.ts`** — extracted `spanEvent` into its own module with TSDoc
- **`spanEvent.test.ts`** — added 4 tests using a custom `Tracer` (public API only, no internal `NativeSpan` access)
- **Test/snapshot updates** — removed `span` parameter from `ClientSessionSyncProcessor.test.ts`, updated otel snapshots to reflect removed `LiveStore:sync` span

All files also had the `@effect/opentelemetry` workaround comment removed. `TRACE_VERBOSE` conditional attributes now use spread (`...(TRACE_VERBOSE === true ? { key: value } : {})`) instead of `value: TRACE_VERBOSE ? x : undefined` to avoid sending `undefined` attribute values.

Note: `store.ts`'s `commitsSpan?.addEvent('commit')` was intentionally left unchanged since `commitsSpan` is a long-lived container span for all commits — `Effect.spanEvent` would emit to the wrong span there.

Closes #1092

## Test plan

- [x] `vitest run packages/@livestore/utils/src/effect/spanEvent.test.ts` — 4 tests pass
- [x] `dt ts:check` passes
- [x] `dt lint:full:fix` passes
- [x] `vitest run packages/@livestore/common/` passes