### PR TITLE
refactor: surface decisional errors directly in SyncBackend interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,8 +637,9 @@ jobs:
           done
         shell: bash
       - name: 'Run sync-provider tests for ${{ matrix.provider }}'
-        run: 'OTEL_STATE_DIR= DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:integration:sync-provider:matrix --mode before'
+        run: "if [ -n \"${NIX_CONFIG:-}\" ]; then NIX_CONFIG_WITH_APPEND=$(printf '%s\\n%s' \"$NIX_CONFIG\" 'restrict-eval = false'); else NIX_CONFIG_WITH_APPEND='restrict-eval = false'; fi; NIX_CONFIG=\"$NIX_CONFIG_WITH_APPEND\" DT_PASSTHROUGH=1 \"${DEVENV_BIN:?DEVENV_BIN not set}\" tasks run test:integration:sync-provider:matrix --mode before"
         env:
+          OTEL_STATE_DIR: ''
           TEST_SYNC_PROVIDER: '${{ matrix.provider }}'
       - name: Upload Nix diagnostics artifact
         if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -20,7 +20,6 @@ const GITHUB_SHA = '${{ github.sha }}'
 const GITHUB_REF = '${{ github.ref }}'
 const PR_HEAD_SHA = '${{ github.event.pull_request.head.sha || github.sha }}'
 const IS_NOT_FORK = 'github.event.pull_request.head.repo.fork != true'
-const devenvBinRef = '"${DEVENV_BIN:?DEVENV_BIN not set}"'
 
 // =============================================================================
 // Job Helpers
@@ -171,8 +170,8 @@ done`,
         },
         {
           name: 'Run sync-provider tests for ${{ matrix.provider }}',
-          run: `OTEL_STATE_DIR= DT_PASSTHROUGH=1 ${devenvBinRef} tasks run test:integration:sync-provider:matrix --mode before`,
-          env: { TEST_SYNC_PROVIDER: '${{ matrix.provider }}' },
+          run: runDevenvTasksBefore('test:integration:sync-provider:matrix'),
+          env: { OTEL_STATE_DIR: '', TEST_SYNC_PROVIDER: '${{ matrix.provider }}' },
         },
         nixDiagnosticsArtifactStep(),
       ],

--- a/docs/src/content/docs/sync-providers/custom.md
+++ b/docs/src/content/docs/sync-providers/custom.md
@@ -13,8 +13,12 @@ Implement the `SyncBackend` interface (running in the client) which describes th
 ```ts
 // Slightly simplified API (see packages/@livestore/common/src/sync/sync.ts for the full API)
 export type SyncBackend = {
-  pull: (cursor: EventSequenceNumber) => Stream<{ batch: LiveStoreEvent[] }, InvalidPullError>
-  push: (batch: LiveStoreEvent[]) => Effect<void, InvalidPushError>
+  pull: (
+    cursor: EventSequenceNumber,
+  ) => Stream<{ batch: LiveStoreEvent[] }, IsOfflineError | BackendIdMismatchError | UnknownError>
+  push: (
+    batch: LiveStoreEvent[],
+  ) => Effect<void, IsOfflineError | BackendIdMismatchError | ServerAheadError | UnknownError>
 }
 
 // my-sync-backend.ts

--- a/docs/src/content/docs/sync-providers/s2.mdx
+++ b/docs/src/content/docs/sync-providers/s2.mdx
@@ -31,18 +31,18 @@ graph LR
     subgraph Browser
         LS[LiveStore Client]
     end
-    
+
     subgraph "Your Server"
         AP[API Proxy<br/>'/api/s2']
     end
-    
+
     subgraph "S2 Cloud"
         S2[S2 Backend<br/>'*.s2.dev']
     end
-    
+
     LS -->|"GET (pull)<br/>POST (push)<br/>HEAD (ping)"| AP
     AP -->|"Authenticated<br/>Requests"| S2
-    
+
     style LS fill:#e1f5fe
     style AP fill:#fff3e0
     style S2 fill:#f3e5f5
@@ -98,7 +98,7 @@ S2 provider supports live pulls over Server-Sent Events (SSE). When `live: true`
 - Parses SSE frames robustly (multi-line `data:` support) and reacts to typed events:
   - `event: batch` → parses `data` as S2 `ReadBatch` and emits items.
   - `event: ping` → ignored; keeps the stream alive.
-  - `event: error` → mapped to `InvalidPullError`.
+  - `event: error` → mapped to `UnknownError`.
 
 ## Implementation notes
 

--- a/packages/@livestore/adapter-node/src/client-session/adapter.ts
+++ b/packages/@livestore/adapter-node/src/client-session/adapter.ts
@@ -11,7 +11,6 @@ import {
   type LockStatus,
   type MakeSqliteDb,
   makeClientSession,
-  type SyncError,
   type SyncOptions,
   UnknownError,
 } from '@livestore/common'
@@ -448,7 +447,7 @@ const makeWorkerLeaderThread = ({
   syncPayloadEncoded,
   testing,
 }: {
-  shutdown: (cause: Exit.Exit<IntentionalShutdownCause, UnknownError | SyncError>) => Effect.Effect<void>
+  shutdown: (cause: Exit.Exit<IntentionalShutdownCause, UnknownError>) => Effect.Effect<void>
   storeId: string
   clientId: string
   sessionId: string

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -13,7 +13,7 @@ import type * as Devtools from './devtools/mod.ts'
 import type { IntentionalShutdownCause, MaterializeError, UnknownError } from './errors.ts'
 import type { LiveStoreSchema } from './schema/mod.ts'
 import type { SqliteDb } from './sqlite-types.ts'
-import type { SyncError } from './sync/index.ts'
+import type { BackendIdMismatchError, SyncError } from './sync/index.ts'
 
 export * as ClientSessionLeaderThreadProxy from './ClientSessionLeaderThreadProxy.ts'
 export * from './defs.ts'
@@ -36,7 +36,7 @@ export interface ClientSession {
   shutdown: (
     cause: Exit.Exit<
       IntentionalShutdownCause,
-      UnknownError | SyncError | MaterializeError
+      UnknownError | SyncError | MaterializeError | BackendIdMismatchError
     >,
   ) => Effect.Effect<void>
   /** A proxy API to communicate with the leader thread */
@@ -165,7 +165,7 @@ export interface AdapterArgs {
   shutdown: (
     exit: Exit.Exit<
       IntentionalShutdownCause,
-      UnknownError | SyncError | MaterializeError
+      UnknownError | SyncError | MaterializeError | BackendIdMismatchError
     >,
   ) => Effect.Effect<void>
   connectDevtoolsToStore: ConnectDevtoolsToStore

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -13,7 +13,7 @@ import type * as Devtools from './devtools/mod.ts'
 import type { IntentionalShutdownCause, MaterializeError, UnknownError } from './errors.ts'
 import type { LiveStoreSchema } from './schema/mod.ts'
 import type { SqliteDb } from './sqlite-types.ts'
-import type { BackendIdMismatchError, SyncError } from './sync/index.ts'
+import type { BackendIdMismatchError } from './sync/index.ts'
 
 export * as ClientSessionLeaderThreadProxy from './ClientSessionLeaderThreadProxy.ts'
 export * from './defs.ts'
@@ -36,7 +36,7 @@ export interface ClientSession {
   shutdown: (
     cause: Exit.Exit<
       IntentionalShutdownCause,
-      UnknownError | SyncError | MaterializeError | BackendIdMismatchError
+      UnknownError | MaterializeError | BackendIdMismatchError
     >,
   ) => Effect.Effect<void>
   /** A proxy API to communicate with the leader thread */
@@ -165,7 +165,7 @@ export interface AdapterArgs {
   shutdown: (
     exit: Exit.Exit<
       IntentionalShutdownCause,
-      UnknownError | SyncError | MaterializeError | BackendIdMismatchError
+      UnknownError | MaterializeError | BackendIdMismatchError
     >,
   ) => Effect.Effect<void>
   connectDevtoolsToStore: ConnectDevtoolsToStore

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -25,7 +25,8 @@ import { makeMaterializerHash } from '../materializer-helper.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '../schema/mod.ts'
 import { EVENTLOG_META_TABLE, SYNC_STATUS_TABLE } from '../schema/state/sqlite/system-tables/eventlog-tables.ts'
-import { type InvalidPullError, type InvalidPushError, type IsOfflineError, type SyncBackend } from '../sync/sync.ts'
+import { type BackendIdMismatchError,
+  type InvalidPullError, type InvalidPushError, type IsOfflineError, type SyncBackend } from '../sync/sync.ts'
 import { isRejectedPushError, LeaderAheadError, NonMonotonicBatchError, StaleRebaseGenerationError } from './RejectedPushError.ts'
 import * as SyncState from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
@@ -304,6 +305,9 @@ export const makeLeaderSyncProcessor = ({
         }
       }
 
+      const handleBackendIdMismatchError = (error: BackendIdMismatchError) =>
+        handleBackendIdMismatch({ error, onBackendIdMismatch, shutdownChannel })
+
       const maybeShutdownOnError = (
         cause: Cause.Cause<
           | UnknownError
@@ -313,21 +317,6 @@ export const makeLeaderSyncProcessor = ({
         >,
       ) =>
         Effect.gen(function* () {
-          // Check if this is a BackendIdMismatchError and handle it specially
-          const isBackendIdMismatch =
-            Cause.isFailType(cause) &&
-            (cause.error._tag === 'InvalidPullError' || cause.error._tag === 'InvalidPushError') &&
-            cause.error.cause._tag === 'BackendIdMismatchError'
-
-          if (isBackendIdMismatch === true) {
-            return yield* handleBackendIdMismatch({
-              cause,
-              onBackendIdMismatch,
-              shutdownChannel,
-            })
-          }
-
-          // Handle other errors with existing logic
           if (onError === 'ignore') {
             if (LS_DEV === true) {
               yield* Effect.logDebug(
@@ -356,7 +345,10 @@ export const makeLeaderSyncProcessor = ({
         testing: {
           delay: testing?.delays?.localPushProcessing,
         },
-      }).pipe(Effect.catchAllCause(maybeShutdownOnError), Effect.forkScoped)
+      }).pipe(
+        Effect.catchAllCause(maybeShutdownOnError),
+        Effect.forkScoped,
+      )
 
       const backendPushingFiberHandle = yield* FiberHandle.make<void, never>()
       const backendPushingEffect = backgroundBackendPushing({
@@ -364,6 +356,7 @@ export const makeLeaderSyncProcessor = ({
         devtoolsLatch: ctxRef.current?.devtoolsLatch,
         backendPushBatchSize,
       }).pipe(
+        Effect.catchTag('BackendIdMismatchError', handleBackendIdMismatchError),
         Effect.catchAllCause(maybeShutdownOnError),
       )
 
@@ -398,6 +391,7 @@ export const makeLeaderSyncProcessor = ({
           // See https://github.com/Effect-TS/effect/issues/6122
           until: (error): error is Exclude<typeof error, IsOfflineError> => error._tag !== 'IsOfflineError',
         }),
+        Effect.catchTag('BackendIdMismatchError', handleBackendIdMismatchError),
         Effect.catchAllCause(maybeShutdownOnError),
         // Needed to avoid `Fiber terminated with an unhandled error` logs which seem to happen because of the `Effect.retry` above.
         // This might be a bug in Effect. Only seems to happen in the browser.
@@ -1104,13 +1098,11 @@ const validatePushBatch = (
  * This occurs when the sync backend has been reset and has a new identity.
  */
 const handleBackendIdMismatch = Effect.fn('@livestore/common:LeaderSyncProcessor:handleBackendIdMismatch')(function* ({
-  cause,
+  error,
   onBackendIdMismatch,
   shutdownChannel,
 }: {
-  cause: Cause.Cause<
-    UnknownError | InvalidPushError | InvalidPullError | MaterializeError
-  >
+  error: BackendIdMismatchError
   onBackendIdMismatch: 'reset' | 'shutdown' | 'ignore'
   shutdownChannel: ShutdownChannel
 }) {
@@ -1119,7 +1111,7 @@ const handleBackendIdMismatch = Effect.fn('@livestore/common:LeaderSyncProcessor
   if (onBackendIdMismatch === 'reset') {
     yield* Effect.logWarning(
       'Sync backend identity changed (backend was reset). Clearing local storage and shutting down.',
-      { cause: Cause.isFailType(cause) === true ? cause.error.cause : cause },
+      error,
     )
 
     // Clear local databases so the client can start fresh on next boot
@@ -1128,26 +1120,25 @@ const handleBackendIdMismatch = Effect.fn('@livestore/common:LeaderSyncProcessor
     // Send shutdown signal with special reason
     yield* shutdownChannel.send(IntentionalShutdownCause.make({ reason: 'backend-id-mismatch' })).pipe(Effect.orDie)
 
-    return yield* Effect.failCause(cause).pipe(Effect.orDie)
+    return yield* Effect.die(error)
   }
 
   if (onBackendIdMismatch === 'shutdown') {
     yield* Effect.logWarning(
       'Sync backend identity changed (backend was reset). Shutting down without clearing local storage.',
-      { cause: Cause.isFailType(cause) === true ? cause.error.cause : cause },
+      error,
     )
 
-    const errorToSend = Cause.isFailType(cause) === true ? cause.error : UnknownError.make({ cause })
-    yield* shutdownChannel.send(errorToSend).pipe(Effect.orDie)
+    yield* shutdownChannel.send(error).pipe(Effect.orDie)
 
-    return yield* Effect.failCause(cause).pipe(Effect.orDie)
+    return yield* Effect.die(error)
   }
 
   // ignore mode
   if (LS_DEV === true) {
     yield* Effect.logDebug(
       'Ignoring BackendIdMismatchError (sync backend was reset but client continues with stale data)',
-      Cause.pretty(cause),
+      error,
     )
   }
 })

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -25,8 +25,7 @@ import { makeMaterializerHash } from '../materializer-helper.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '../schema/mod.ts'
 import { EVENTLOG_META_TABLE, SYNC_STATUS_TABLE } from '../schema/state/sqlite/system-tables/eventlog-tables.ts'
-import { type BackendIdMismatchError,
-  type InvalidPullError, type InvalidPushError, type IsOfflineError, type SyncBackend } from '../sync/sync.ts'
+import type { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, SyncBackend } from '../sync/sync.ts'
 import { isRejectedPushError, LeaderAheadError, NonMonotonicBatchError, StaleRebaseGenerationError } from './RejectedPushError.ts'
 import * as SyncState from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
@@ -906,7 +905,7 @@ const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcesso
           batchSize: queueItems.length,
         })
         const error = pushResult.left
-        if (error._tag === 'InvalidPushError' && error.cause._tag === 'ServerAheadError') {
+        if (error._tag === 'ServerAheadError') {
           // It's a core part of the sync protocol that the sync backend will emit a new pull chunk alongside the ServerAheadError
           yield* Effect.logDebug('handled backend-push-error (waiting for interupt caused by pull)', { error })
           return yield* Effect.never

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -25,7 +25,7 @@ import { makeMaterializerHash } from '../materializer-helper.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '../schema/mod.ts'
 import { EVENTLOG_META_TABLE, SYNC_STATUS_TABLE } from '../schema/state/sqlite/system-tables/eventlog-tables.ts'
-import type { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, SyncBackend } from '../sync/sync.ts'
+import type { BackendIdMismatchError, IsOfflineError, SyncBackend } from '../sync/sync.ts'
 import { isRejectedPushError, LeaderAheadError, NonMonotonicBatchError, StaleRebaseGenerationError } from './RejectedPushError.ts'
 import * as SyncState from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
@@ -310,8 +310,6 @@ export const makeLeaderSyncProcessor = ({
       const maybeShutdownOnError = (
         cause: Cause.Cause<
           | UnknownError
-          | InvalidPushError
-          | InvalidPullError
           | MaterializeError
         >,
       ) =>
@@ -919,10 +917,10 @@ const backgroundBackendPushing = Effect.fn('@livestore/common:LeaderSyncProcesso
         schedule: Schedule.exponential(Duration.seconds(1)).pipe(
           Schedule.modifyDelay((_, delay) => Duration.min(delay, Duration.seconds(30))) // Cap delay at 30s intervals.
         ),
-        while: (error) => error._tag === 'IsOfflineError' || (error._tag === 'InvalidPushError' && error.cause._tag === 'LiveStore.UnknownError'),
+        while: (error) => error._tag === 'IsOfflineError' || error._tag === 'LiveStore.UnknownError',
       }),
       // This is needed to narrow the Error type. Our retry policy runs indefinitely, but Effect.retry does not narrow the Error type.
-      Effect.catchTag("IsOfflineError", Effect.die),
+      Effect.catchIf((error) => error._tag === 'IsOfflineError' || error._tag === 'LiveStore.UnknownError', Effect.die),
     )
   }
 }, Effect.interruptible)

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -24,7 +24,7 @@ import type { MigrationsReport } from '../defs.ts'
 import type * as Devtools from '../devtools/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '../schema/mod.ts'
-import type { InvalidPullError, SyncBackend, SyncOptions } from '../sync/sync.ts'
+import type { SyncBackend, SyncOptions } from '../sync/sync.ts'
 import { SyncState } from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
 import * as Eventlog from './eventlog.ts'
@@ -362,7 +362,7 @@ const bootLeaderThread = ({
   devtoolsOptions: DevtoolsOptions
 }): Effect.Effect<
   LeaderThreadCtx['Type']['initialState'],
-  UnknownError | InvalidPullError | MaterializerHashMismatchError,
+  UnknownError | MaterializerHashMismatchError,
   LeaderThreadCtx | Scope.Scope | HttpClient.HttpClient
 > =>
   Effect.gen(function* () {

--- a/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
+++ b/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
@@ -4,8 +4,6 @@ import { Schema } from '@livestore/utils/effect'
 import {
   BackendIdMismatchError,
   IntentionalShutdownCause,
-  InvalidPullError,
-  InvalidPushError,
   MaterializeError,
   UnknownError,
 } from '../index.ts'
@@ -13,8 +11,6 @@ import {
 export class All extends Schema.Union(
   IntentionalShutdownCause,
   UnknownError,
-  InvalidPushError,
-  InvalidPullError,
   BackendIdMismatchError,
   MaterializeError,
 ) {}

--- a/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
+++ b/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
@@ -2,6 +2,7 @@ import type { WebChannel } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
 import {
+  BackendIdMismatchError,
   IntentionalShutdownCause,
   InvalidPullError,
   InvalidPushError,
@@ -14,6 +15,7 @@ export class All extends Schema.Union(
   UnknownError,
   InvalidPushError,
   InvalidPullError,
+  BackendIdMismatchError,
   MaterializeError,
 ) {}
 

--- a/packages/@livestore/common/src/sync/errors.ts
+++ b/packages/@livestore/common/src/sync/errors.ts
@@ -21,12 +21,12 @@ export class ServerAheadError extends Schema.TaggedError<ServerAheadError>()('Se
 }) {}
 
 export class InvalidPushError extends Schema.TaggedError<InvalidPushError>()('InvalidPushError', {
-  cause: Schema.Union(UnknownError, ServerAheadError),
+  cause: UnknownError,
 }) {}
 
 export class InvalidPullError extends Schema.TaggedError<InvalidPullError>()('InvalidPullError', {
   cause: UnknownError,
 }) {}
 
-export const SyncError = Schema.Union(InvalidPushError, InvalidPullError)
+export const SyncError = Schema.Union(InvalidPushError, InvalidPullError, ServerAheadError)
 export type SyncError = typeof SyncError.Type

--- a/packages/@livestore/common/src/sync/errors.ts
+++ b/packages/@livestore/common/src/sync/errors.ts
@@ -1,6 +1,5 @@
 import { Schema } from '@livestore/utils/effect'
 
-import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber } from '../schema/mod.ts'
 
 export class IsOfflineError extends Schema.TaggedError<IsOfflineError>()('IsOfflineError', {
@@ -19,14 +18,3 @@ export class ServerAheadError extends Schema.TaggedError<ServerAheadError>()('Se
   minimumExpectedNum: EventSequenceNumber.Global.Schema,
   providedNum: EventSequenceNumber.Global.Schema,
 }) {}
-
-export class InvalidPushError extends Schema.TaggedError<InvalidPushError>()('InvalidPushError', {
-  cause: UnknownError,
-}) {}
-
-export class InvalidPullError extends Schema.TaggedError<InvalidPullError>()('InvalidPullError', {
-  cause: UnknownError,
-}) {}
-
-export const SyncError = Schema.Union(InvalidPushError, InvalidPullError, ServerAheadError)
-export type SyncError = typeof SyncError.Type

--- a/packages/@livestore/common/src/sync/errors.ts
+++ b/packages/@livestore/common/src/sync/errors.ts
@@ -21,11 +21,11 @@ export class ServerAheadError extends Schema.TaggedError<ServerAheadError>()('Se
 }) {}
 
 export class InvalidPushError extends Schema.TaggedError<InvalidPushError>()('InvalidPushError', {
-  cause: Schema.Union(UnknownError, ServerAheadError, BackendIdMismatchError),
+  cause: Schema.Union(UnknownError, ServerAheadError),
 }) {}
 
 export class InvalidPullError extends Schema.TaggedError<InvalidPullError>()('InvalidPullError', {
-  cause: Schema.Union(UnknownError, BackendIdMismatchError),
+  cause: UnknownError,
 }) {}
 
 export const SyncError = Schema.Union(InvalidPushError, InvalidPullError)

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -3,7 +3,7 @@ import { Effect, Mailbox, Option, Queue, Ref, Stream, SubscriptionRef } from '@l
 
 import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
-import { type BackendIdMismatchError, InvalidPullError, InvalidPushError, type ServerAheadError } from './errors.ts'
+import { type BackendIdMismatchError, type ServerAheadError } from './errors.ts'
 import * as SyncBackend from './sync-backend.ts'
 import { validatePushPayload } from './validate-push-payload.ts'
 
@@ -13,17 +13,17 @@ export interface MockSyncBackend {
   disconnect: Effect.Effect<void>
   makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
   advance: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
-  /** Fail the next N push calls with an InvalidPushError, ServerAheadError, BackendIdMismatchError, or custom error */
+  /** Fail the next N push calls with an UnknownError, ServerAheadError, BackendIdMismatchError, or custom error */
   failNextPushes: (
     count: number,
     error?: (
       batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-    ) => Effect.Effect<never, InvalidPushError | ServerAheadError | BackendIdMismatchError>,
+    ) => Effect.Effect<never, UnknownError | ServerAheadError | BackendIdMismatchError>,
   ) => Effect.Effect<void>
-  /** Fail the next N pull calls with an InvalidPullError, BackendIdMismatchError, or custom error */
+  /** Fail the next N pull calls with an UnknownError, BackendIdMismatchError, or custom error */
   failNextPulls: (
     count: number,
-    error?: () => Effect.Effect<never, InvalidPullError | BackendIdMismatchError>,
+    error?: () => Effect.Effect<never, UnknownError | BackendIdMismatchError>,
   ) => Effect.Effect<void>
 }
 
@@ -53,9 +53,9 @@ export const makeMockSyncBackend = (
 
     // Failure simulation state
     const failPushRef = yield* Ref.make<
-      FailureState<InvalidPushError | ServerAheadError | BackendIdMismatchError, [ReadonlyArray<LiveStoreEvent.Global.Encoded>]>
+      FailureState<UnknownError | ServerAheadError | BackendIdMismatchError, [ReadonlyArray<LiveStoreEvent.Global.Encoded>]>
     >({ remaining: 0, error: undefined })
-    const failPullRef = yield* Ref.make<FailureState<InvalidPullError | BackendIdMismatchError, []>>({
+    const failPullRef = yield* Ref.make<FailureState<UnknownError | BackendIdMismatchError, []>>({
       remaining: 0,
       error: undefined,
     })
@@ -142,9 +142,7 @@ export const makeMockSyncBackend = (
           Stream.fromEffect(
             checkFailure(
               failPullRef,
-              new InvalidPullError({
-                cause: new UnknownError({ cause: new Error('MockSyncBackend: simulated pull failure') }),
-              }),
+              new UnknownError({ cause: new Error('MockSyncBackend: simulated pull failure') }),
             ),
           ).pipe(
             Stream.flatMap(() => (pullOptions?.live === true ? pullLive : pullNonLive(cursor))),
@@ -157,9 +155,7 @@ export const makeMockSyncBackend = (
 
             yield* checkFailure(
               failPushRef,
-              new InvalidPushError({
-                cause: new UnknownError({ cause: new Error('MockSyncBackend: simulated push failure') }),
-              }),
+              new UnknownError({ cause: new Error('MockSyncBackend: simulated push failure') }),
               batch,
             )
 
@@ -204,12 +200,12 @@ export const makeMockSyncBackend = (
       count: number,
       error?: (
         batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-      ) => Effect.Effect<never, InvalidPushError | ServerAheadError | BackendIdMismatchError>,
+      ) => Effect.Effect<never, UnknownError | ServerAheadError | BackendIdMismatchError>,
     ) => Ref.set(failPushRef, { remaining: count, error })
 
     const failNextPulls = (
       count: number,
-      error?: () => Effect.Effect<never, InvalidPullError | BackendIdMismatchError>,
+      error?: () => Effect.Effect<never, UnknownError | BackendIdMismatchError>,
     ) => Ref.set(failPullRef, { remaining: count, error })
 
     return {

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -3,7 +3,7 @@ import { Effect, Mailbox, Option, Queue, Ref, Stream, SubscriptionRef } from '@l
 
 import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
-import { type BackendIdMismatchError, InvalidPullError, InvalidPushError } from './errors.ts'
+import { type BackendIdMismatchError, InvalidPullError, InvalidPushError, type ServerAheadError } from './errors.ts'
 import * as SyncBackend from './sync-backend.ts'
 import { validatePushPayload } from './validate-push-payload.ts'
 
@@ -13,12 +13,12 @@ export interface MockSyncBackend {
   disconnect: Effect.Effect<void>
   makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
   advance: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
-  /** Fail the next N push calls with an InvalidPushError, BackendIdMismatchError, or custom error */
+  /** Fail the next N push calls with an InvalidPushError, ServerAheadError, BackendIdMismatchError, or custom error */
   failNextPushes: (
     count: number,
     error?: (
       batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-    ) => Effect.Effect<never, InvalidPushError | BackendIdMismatchError>,
+    ) => Effect.Effect<never, InvalidPushError | ServerAheadError | BackendIdMismatchError>,
   ) => Effect.Effect<void>
   /** Fail the next N pull calls with an InvalidPullError, BackendIdMismatchError, or custom error */
   failNextPulls: (
@@ -53,7 +53,7 @@ export const makeMockSyncBackend = (
 
     // Failure simulation state
     const failPushRef = yield* Ref.make<
-      FailureState<InvalidPushError | BackendIdMismatchError, [ReadonlyArray<LiveStoreEvent.Global.Encoded>]>
+      FailureState<InvalidPushError | ServerAheadError | BackendIdMismatchError, [ReadonlyArray<LiveStoreEvent.Global.Encoded>]>
     >({ remaining: 0, error: undefined })
     const failPullRef = yield* Ref.make<FailureState<InvalidPullError | BackendIdMismatchError, []>>({
       remaining: 0,
@@ -204,7 +204,7 @@ export const makeMockSyncBackend = (
       count: number,
       error?: (
         batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-      ) => Effect.Effect<never, InvalidPushError | BackendIdMismatchError>,
+      ) => Effect.Effect<never, InvalidPushError | ServerAheadError | BackendIdMismatchError>,
     ) => Ref.set(failPushRef, { remaining: count, error })
 
     const failNextPulls = (

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -3,7 +3,7 @@ import { Effect, Mailbox, Option, Queue, Ref, Stream, SubscriptionRef } from '@l
 
 import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
-import { InvalidPullError, InvalidPushError } from './errors.ts'
+import { type BackendIdMismatchError, InvalidPullError, InvalidPushError } from './errors.ts'
 import * as SyncBackend from './sync-backend.ts'
 import { validatePushPayload } from './validate-push-payload.ts'
 
@@ -13,13 +13,18 @@ export interface MockSyncBackend {
   disconnect: Effect.Effect<void>
   makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
   advance: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
-  /** Fail the next N push calls with an InvalidPushError (or custom error) */
+  /** Fail the next N push calls with an InvalidPushError, BackendIdMismatchError, or custom error */
   failNextPushes: (
     count: number,
-    error?: (batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>) => Effect.Effect<never, InvalidPushError>,
+    error?: (
+      batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
+    ) => Effect.Effect<never, InvalidPushError | BackendIdMismatchError>,
   ) => Effect.Effect<void>
-  /** Fail the next N pull calls with an InvalidPullError (or custom error) */
-  failNextPulls: (count: number, error?: () => Effect.Effect<never, InvalidPullError>) => Effect.Effect<void>
+  /** Fail the next N pull calls with an InvalidPullError, BackendIdMismatchError, or custom error */
+  failNextPulls: (
+    count: number,
+    error?: () => Effect.Effect<never, InvalidPullError | BackendIdMismatchError>,
+  ) => Effect.Effect<void>
 }
 
 export interface MockSyncBackendOptions {
@@ -47,10 +52,13 @@ export const makeMockSyncBackend = (
     const pushedEventsQueue = yield* Mailbox.make<LiveStoreEvent.Global.Encoded>()
 
     // Failure simulation state
-    const failPushRef = yield* Ref.make<FailureState<InvalidPushError, [ReadonlyArray<LiveStoreEvent.Global.Encoded>]>>(
-      { remaining: 0, error: undefined },
-    )
-    const failPullRef = yield* Ref.make<FailureState<InvalidPullError, []>>({ remaining: 0, error: undefined })
+    const failPushRef = yield* Ref.make<
+      FailureState<InvalidPushError | BackendIdMismatchError, [ReadonlyArray<LiveStoreEvent.Global.Encoded>]>
+    >({ remaining: 0, error: undefined })
+    const failPullRef = yield* Ref.make<FailureState<InvalidPullError | BackendIdMismatchError, []>>({
+      remaining: 0,
+      error: undefined,
+    })
 
     const nonLiveChunkSize = Math.max(1, options?.nonLiveChunkSize ?? 100)
 
@@ -194,11 +202,15 @@ export const makeMockSyncBackend = (
 
     const failNextPushes = (
       count: number,
-      error?: (batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>) => Effect.Effect<never, InvalidPushError>,
+      error?: (
+        batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
+      ) => Effect.Effect<never, InvalidPushError | BackendIdMismatchError>,
     ) => Ref.set(failPushRef, { remaining: count, error })
 
-    const failNextPulls = (count: number, error?: () => Effect.Effect<never, InvalidPullError>) =>
-      Ref.set(failPullRef, { remaining: count, error })
+    const failNextPulls = (
+      count: number,
+      error?: () => Effect.Effect<never, InvalidPullError | BackendIdMismatchError>,
+    ) => Ref.set(failPullRef, { remaining: count, error })
 
     return {
       pushedEvents: Mailbox.toStream(pushedEventsQueue),

--- a/packages/@livestore/common/src/sync/sync-backend.ts
+++ b/packages/@livestore/common/src/sync/sync-backend.ts
@@ -13,7 +13,7 @@ import {
 import type { UnknownError } from '../adapter-types.ts'
 import type * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { EventSequenceNumber } from '../schema/mod.ts'
-import type { InvalidPullError, InvalidPushError, IsOfflineError } from './errors.ts'
+import type { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError } from './errors.ts'
 
 export * from './sync-backend-kv.ts'
 
@@ -61,7 +61,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
        */
       live?: boolean
     },
-  ) => Stream.Stream<PullResItem<TSyncMetadata>, IsOfflineError | InvalidPullError>
+  ) => Stream.Stream<PullResItem<TSyncMetadata>, IsOfflineError | InvalidPullError | BackendIdMismatchError>
   // TODO support transactions (i.e. group of mutation events which need to be applied together)
   push: (
     /**
@@ -70,7 +70,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
      * - sequence numbers must be in ascending order
      * */
     batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-  ) => Effect.Effect<void, IsOfflineError | InvalidPushError>
+  ) => Effect.Effect<void, IsOfflineError | InvalidPushError | BackendIdMismatchError>
   ping: Effect.Effect<void, IsOfflineError | UnknownError | Cause.TimeoutException>
   // TODO also expose latency information additionally to whether the backend is connected
   isConnected: SubscriptionRef.SubscriptionRef<boolean>

--- a/packages/@livestore/common/src/sync/sync-backend.ts
+++ b/packages/@livestore/common/src/sync/sync-backend.ts
@@ -13,7 +13,7 @@ import {
 import type { UnknownError } from '../adapter-types.ts'
 import type * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { EventSequenceNumber } from '../schema/mod.ts'
-import type { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, ServerAheadError } from './errors.ts'
+import type { BackendIdMismatchError, IsOfflineError, ServerAheadError } from './errors.ts'
 
 export * from './sync-backend-kv.ts'
 
@@ -61,7 +61,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
        */
       live?: boolean
     },
-  ) => Stream.Stream<PullResItem<TSyncMetadata>, IsOfflineError | InvalidPullError | BackendIdMismatchError>
+  ) => Stream.Stream<PullResItem<TSyncMetadata>, IsOfflineError | BackendIdMismatchError | UnknownError >
   // TODO support transactions (i.e. group of mutation events which need to be applied together)
   push: (
     /**
@@ -70,7 +70,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
      * - sequence numbers must be in ascending order
      * */
     batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-  ) => Effect.Effect<void, IsOfflineError | InvalidPushError | ServerAheadError | BackendIdMismatchError>
+  ) => Effect.Effect<void, IsOfflineError | BackendIdMismatchError | UnknownError | ServerAheadError>
   ping: Effect.Effect<void, IsOfflineError | UnknownError | Cause.TimeoutException>
   // TODO also expose latency information additionally to whether the backend is connected
   isConnected: SubscriptionRef.SubscriptionRef<boolean>

--- a/packages/@livestore/common/src/sync/sync-backend.ts
+++ b/packages/@livestore/common/src/sync/sync-backend.ts
@@ -13,7 +13,7 @@ import {
 import type { UnknownError } from '../adapter-types.ts'
 import type * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { EventSequenceNumber } from '../schema/mod.ts'
-import type { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError } from './errors.ts'
+import type { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, ServerAheadError } from './errors.ts'
 
 export * from './sync-backend-kv.ts'
 
@@ -70,7 +70,7 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
      * - sequence numbers must be in ascending order
      * */
     batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-  ) => Effect.Effect<void, IsOfflineError | InvalidPushError | BackendIdMismatchError>
+  ) => Effect.Effect<void, IsOfflineError | InvalidPushError | ServerAheadError | BackendIdMismatchError>
   ping: Effect.Effect<void, IsOfflineError | UnknownError | Cause.TimeoutException>
   // TODO also expose latency information additionally to whether the backend is connected
   isConnected: SubscriptionRef.SubscriptionRef<boolean>

--- a/packages/@livestore/common/src/sync/validate-push-payload.ts
+++ b/packages/@livestore/common/src/sync/validate-push-payload.ts
@@ -1,7 +1,7 @@
 import { Effect } from '@livestore/utils/effect'
 
 import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
-import { InvalidPushError, ServerAheadError } from './sync.ts'
+import { ServerAheadError } from './sync.ts'
 
 // TODO proper batch validation
 export const validatePushPayload = (
@@ -10,11 +10,9 @@ export const validatePushPayload = (
 ) =>
   Effect.gen(function* () {
     if (batch[0]!.seqNum <= currentEventSequenceNumber) {
-      return yield* InvalidPushError.make({
-        cause: new ServerAheadError({
-          minimumExpectedNum: EventSequenceNumber.Global.make(currentEventSequenceNumber + 1),
-          providedNum: EventSequenceNumber.Global.make(batch[0]!.seqNum),
-        }),
+      return yield* new ServerAheadError({
+        minimumExpectedNum: EventSequenceNumber.Global.make(currentEventSequenceNumber + 1),
+        providedNum: EventSequenceNumber.Global.make(batch[0]!.seqNum),
       })
     }
   })

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -10,6 +10,7 @@ import {
   type InvalidPullError,
   LogConfig,
   type MaterializeError,
+  type BackendIdMismatchError,
   type MigrationsReport,
   provideOtel,
   type SyncError,
@@ -325,7 +326,7 @@ export const createStore = <
       const shutdown = (
         exit: Exit.Exit<
           IntentionalShutdownCause,
-          UnknownError | MaterializeError | SyncError | InvalidPullError
+          UnknownError | MaterializeError | SyncError | InvalidPullError | BackendIdMismatchError
         >,
       ) =>
         Effect.gen(function* () {

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -7,13 +7,12 @@ import {
   type ClientSessionDevtoolsChannel,
   type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
-  type InvalidPullError,
   LogConfig,
   type MaterializeError,
   type BackendIdMismatchError,
   type MigrationsReport,
   provideOtel,
-  type SyncError,
+  type ServerAheadError,
   UnknownError,
 } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
@@ -326,7 +325,7 @@ export const createStore = <
       const shutdown = (
         exit: Exit.Exit<
           IntentionalShutdownCause,
-          UnknownError | MaterializeError | SyncError | InvalidPullError | BackendIdMismatchError
+          UnknownError | MaterializeError | BackendIdMismatchError
         >,
       ) =>
         Effect.gen(function* () {

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -5,13 +5,11 @@ import {
   type ClientSessionSyncProcessor,
   type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
-  type InvalidPullError,
   isQueryBuilder,
   type MaterializeError,
   type QueryBuilder,
   type StoreInterrupted,
   type BackendIdMismatchError,
-  type SyncError,
   type UnknownError,
 } from '@livestore/common'
 import type { StreamEventsOptions } from '@livestore/common/leader-thread'
@@ -51,16 +49,16 @@ export type LiveStoreContext<TSchema extends LiveStoreSchema = LiveStoreSchema.A
     }
   | {
       stage: 'shutdown'
-      cause: IntentionalShutdownCause | StoreInterrupted | SyncError
+      cause: IntentionalShutdownCause | StoreInterrupted | UnknownError
     }
 
 export type ShutdownDeferred = Deferred.Deferred<
   IntentionalShutdownCause,
-  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError  | BackendIdMismatchError
+  UnknownError | StoreInterrupted | MaterializeError | BackendIdMismatchError
 >
 export const makeShutdownDeferred: Effect.Effect<ShutdownDeferred> = Deferred.make<
   IntentionalShutdownCause,
-  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | BackendIdMismatchError
+  UnknownError | StoreInterrupted | MaterializeError | BackendIdMismatchError
 >()
 
 /**

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -10,6 +10,7 @@ import {
   type MaterializeError,
   type QueryBuilder,
   type StoreInterrupted,
+  type BackendIdMismatchError,
   type SyncError,
   type UnknownError,
 } from '@livestore/common'
@@ -55,11 +56,11 @@ export type LiveStoreContext<TSchema extends LiveStoreSchema = LiveStoreSchema.A
 
 export type ShutdownDeferred = Deferred.Deferred<
   IntentionalShutdownCause,
-  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError
+  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError  | BackendIdMismatchError
 >
 export const makeShutdownDeferred: Effect.Effect<ShutdownDeferred> = Deferred.make<
   IntentionalShutdownCause,
-  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError
+  UnknownError | SyncError | StoreInterrupted | MaterializeError | InvalidPullError | BackendIdMismatchError
 >()
 
 /**

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -26,7 +26,7 @@ export const makeEndingPullStream = ({
   req: SyncMessage.PullRequest
   payload: Schema.JsonValue | undefined
   headers: ForwardedHeaders | undefined
-}): Stream.Stream<SyncMessage.PullResponse, InvalidPullError, DoCtx> =>
+}): Stream.Stream<SyncMessage.PullResponse, InvalidPullError | BackendIdMismatchError, DoCtx> =>
   Effect.gen(function* () {
     const { doOptions, backendId, storeId, storage } = yield* DoCtx
 
@@ -86,12 +86,11 @@ export const makeEndingPullStream = ({
   }).pipe(
     Stream.unwrap,
     Stream.mapError((cause) =>
-      InvalidPullError.make({
-        cause:
-          cause._tag === 'BackendIdMismatchError' || cause._tag === 'LiveStore.UnknownError'
-            ? cause
-            : new UnknownError({ cause }),
-      }),
+      cause._tag === 'BackendIdMismatchError'
+        ? cause
+        : InvalidPullError.make({
+            cause: cause._tag === 'LiveStore.UnknownError' ? cause : new UnknownError({ cause }),
+          }),
     ),
     Stream.withSpan('cloudflare-provider:pull'),
   )

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, SyncBackend, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, SyncBackend, UnknownError } from '@livestore/common'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { Chunk, Effect, Option, Schema, Stream } from '@livestore/utils/effect'
 
@@ -26,7 +26,7 @@ export const makeEndingPullStream = ({
   req: SyncMessage.PullRequest
   payload: Schema.JsonValue | undefined
   headers: ForwardedHeaders | undefined
-}): Stream.Stream<SyncMessage.PullResponse, InvalidPullError | BackendIdMismatchError, DoCtx> =>
+}): Stream.Stream<SyncMessage.PullResponse, UnknownError | BackendIdMismatchError, DoCtx> =>
   Effect.gen(function* () {
     const { doOptions, backendId, storeId, storage } = yield* DoCtx
 
@@ -86,11 +86,9 @@ export const makeEndingPullStream = ({
   }).pipe(
     Stream.unwrap,
     Stream.mapError((cause) =>
-      cause._tag === 'BackendIdMismatchError'
+      cause._tag === 'BackendIdMismatchError' || cause._tag === 'LiveStore.UnknownError'
         ? cause
-        : InvalidPullError.make({
-            cause: cause._tag === 'LiveStore.UnknownError' ? cause : new UnknownError({ cause }),
-          }),
+        : new UnknownError({ cause }),
     ),
     Stream.withSpan('cloudflare-provider:pull'),
   )

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -1,6 +1,5 @@
 import {
   BackendIdMismatchError,
-  InvalidPushError,
   ServerAheadError,
   SyncBackend,
   UnknownError,
@@ -202,9 +201,9 @@ export const makePush =
         }),
       ),
       Effect.mapError((cause) =>
-        cause._tag === 'BackendIdMismatchError' || cause._tag === 'ServerAheadError'
+        cause._tag === 'BackendIdMismatchError' || cause._tag === 'ServerAheadError' || cause._tag === 'LiveStore.UnknownError'
           ? cause
-          : InvalidPushError.make({ cause }),
+          : new UnknownError({ cause }),
       ),
       Effect.withSpan('sync-cf:do:push', { attributes: { storeId, batchSize: pushRequest.batch.length } }),
     )

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -201,7 +201,9 @@ export const makePush =
           }
         }),
       ),
-      Effect.mapError((cause) => InvalidPushError.make({ cause })),
+      Effect.mapError((cause) =>
+        cause._tag === 'BackendIdMismatchError' ? cause : InvalidPushError.make({ cause }),
+      ),
       Effect.withSpan('sync-cf:do:push', { attributes: { storeId, batchSize: pushRequest.batch.length } }),
     )
 

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -202,7 +202,9 @@ export const makePush =
         }),
       ),
       Effect.mapError((cause) =>
-        cause._tag === 'BackendIdMismatchError' ? cause : InvalidPushError.make({ cause }),
+        cause._tag === 'BackendIdMismatchError' || cause._tag === 'ServerAheadError'
+          ? cause
+          : InvalidPushError.make({ cause }),
       ),
       Effect.withSpan('sync-cf:do:push', { attributes: { storeId, batchSize: pushRequest.batch.length } }),
     )

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -60,7 +60,9 @@ export const createDoRpcHandler = (
           })),
           Stream.provideLayer(DoCtx.Default({ ...input, from: { storeId: req.storeId } })),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+              ? cause
+              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
           ),
           Stream.tapErrorCause(Effect.log),
         ),
@@ -73,7 +75,11 @@ export const createDoRpcHandler = (
           return yield* push(req)
         }).pipe(
           Effect.provide(DoCtx.Default({ ...input, from: { storeId: req.storeId } })),
-          Effect.mapError((cause) => (cause._tag === 'InvalidPushError' ? cause : InvalidPushError.make({ cause }))),
+          Effect.mapError((cause) =>
+            cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+              ? cause
+              : InvalidPushError.make({ cause }),
+          ),
           Effect.tapCauseLogPretty,
         ),
     })

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -76,7 +76,7 @@ export const createDoRpcHandler = (
         }).pipe(
           Effect.provide(DoCtx.Default({ ...input, from: { storeId: req.storeId } })),
           Effect.mapError((cause) =>
-            cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+            cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
               ? cause
               : InvalidPushError.make({ cause }),
           ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, UnknownError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { type CfTypes, toDurableObjectHandler } from '@livestore/common-cf'
 import {
   Effect,
@@ -60,9 +60,9 @@ export const createDoRpcHandler = (
           })),
           Stream.provideLayer(DoCtx.Default({ ...input, from: { storeId: req.storeId } })),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+            cause._tag === 'LiveStore.UnknownError' || cause._tag === 'BackendIdMismatchError'
               ? cause
-              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+              : new UnknownError({ cause }),
           ),
           Stream.tapErrorCause(Effect.log),
         ),
@@ -76,9 +76,9 @@ export const createDoRpcHandler = (
         }).pipe(
           Effect.provide(DoCtx.Default({ ...input, from: { storeId: req.storeId } })),
           Effect.mapError((cause) =>
-            cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
+            cause._tag === 'LiveStore.UnknownError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
               ? cause
-              : InvalidPushError.make({ cause }),
+              : new UnknownError({ cause }),
           ),
           Effect.tapCauseLogPretty,
         ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, UnknownError } from '@livestore/common'
+import { UnknownError } from '@livestore/common'
 import { WsContext } from '@livestore/common-cf'
 import { Effect, identity, Layer, RpcServer, Schema, Stream } from '@livestore/utils/effect'
 
@@ -18,9 +18,9 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
           req.live === true ? Stream.concat(Stream.never) : identity,
           Stream.provideLayer(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+            cause._tag === 'LiveStore.UnknownError' || cause._tag === 'BackendIdMismatchError'
               ? cause
-              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+              : new UnknownError({ cause }),
           ),
         )
       }).pipe(Stream.unwrap),
@@ -35,9 +35,9 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
       }).pipe(
         Effect.provide(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
+          cause._tag === 'LiveStore.UnknownError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
             ? cause
-            : InvalidPushError.make({ cause }),
+            : new UnknownError({ cause }),
         ),
         Effect.tapCauseLogPretty,
       ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -35,7 +35,7 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
       }).pipe(
         Effect.provide(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+          cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
             ? cause
             : InvalidPushError.make({ cause }),
         ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -18,7 +18,9 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
           req.live === true ? Stream.concat(Stream.never) : identity,
           Stream.provideLayer(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+              ? cause
+              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
           ),
         )
       }).pipe(Stream.unwrap),
@@ -32,7 +34,11 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
         return yield* push(req)
       }).pipe(
         Effect.provide(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
-        Effect.mapError((cause) => (cause._tag === 'InvalidPushError' ? cause : InvalidPushError.make({ cause }))),
+        Effect.mapError((cause) =>
+          cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+            ? cause
+            : InvalidPushError.make({ cause }),
+        ),
         Effect.tapCauseLogPretty,
       ),
   })

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -1,4 +1,4 @@
-import type { InvalidPullError, InvalidPushError } from '@livestore/common'
+import type { UnknownError } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
 import { Effect, Schema, UrlParams } from '@livestore/utils/effect'
 
@@ -27,9 +27,9 @@ export type CallbackContext = {
 
 export type MakeDurableObjectClassOptions = {
   onPush?: (message: SyncMessage.PushRequest, context: CallbackContext) => Effect.SyncOrPromiseOrEffect<void>
-  onPushRes?: (message: SyncMessage.PushAck | InvalidPushError) => Effect.SyncOrPromiseOrEffect<void>
+  onPushRes?: (message: SyncMessage.PushAck | UnknownError) => Effect.SyncOrPromiseOrEffect<void>
   onPull?: (message: SyncMessage.PullRequest, context: CallbackContext) => Effect.SyncOrPromiseOrEffect<void>
-  onPullRes?: (message: SyncMessage.PullResponse | InvalidPullError) => Effect.SyncOrPromiseOrEffect<void>
+  onPullRes?: (message: SyncMessage.PullResponse | UnknownError) => Effect.SyncOrPromiseOrEffect<void>
 
   /**
    * Forward request headers to `onPush`/`onPull` callbacks for authentication.

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -95,7 +95,9 @@ export const makeDoRpcSync =
           Stream.tap((res) => backendIdHelper.lazySet(res.backendId)),
           Stream.map((res) => omit(res, ['backendId'])),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+              ? cause
+              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
           ),
           Stream.withSpan('rpc-sync-client:pull'),
         )
@@ -126,7 +128,9 @@ export const makeDoRpcSync =
           }
         },
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' ? cause : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
+          cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+            ? cause
+            : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
         ),
       )
 

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, SyncBackend, UnknownError } from '@livestore/common'
+import { SyncBackend, UnknownError } from '@livestore/common'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { type CfTypes, layerProtocolDurableObject } from '@livestore/common-cf'
 import { omit, shouldNeverHappen } from '@livestore/utils'
@@ -95,9 +95,9 @@ export const makeDoRpcSync =
           Stream.tap((res) => backendIdHelper.lazySet(res.backendId)),
           Stream.map((res) => omit(res, ['backendId'])),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+            cause._tag === 'LiveStore.UnknownError' || cause._tag === 'BackendIdMismatchError'
               ? cause
-              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+              : new UnknownError({ cause }),
           ),
           Stream.withSpan('rpc-sync-client:pull'),
         )
@@ -119,7 +119,7 @@ export const makeDoRpcSync =
                 backendId,
               }),
             }),
-            Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
+            Effect.mapError((cause) => new UnknownError({ cause })),
           )
 
           for (const chunk of Chunk.toReadonlyArray(batchChunks)) {
@@ -128,9 +128,9 @@ export const makeDoRpcSync =
           }
         },
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
+          cause._tag === 'LiveStore.UnknownError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
             ? cause
-            : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
+            : new UnknownError({ cause }),
         ),
       )
 

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -128,7 +128,7 @@ export const makeDoRpcSync =
           }
         },
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+          cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
             ? cause
             : InvalidPushError.make({ cause: new UnknownError({ cause }) }),
         ),

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -205,7 +205,7 @@ export const makeHttpSync =
         },
         pushSemaphore.withPermits(1),
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+          cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
             ? cause
             : new InvalidPushError({ cause: new UnknownError({ cause }) }),
         ),

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, SyncBackend, UnknownError } from '@livestore/common'
+import { SyncBackend, UnknownError } from '@livestore/common'
 import type { EventSequenceNumber } from '@livestore/common/schema'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { omit } from '@livestore/utils'
@@ -168,9 +168,9 @@ export const makeHttpSync =
           Stream.tap((res) => backendIdHelper.lazySet(res.backendId)),
           Stream.map((res) => omit(res, ['backendId'])),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+            cause._tag === 'LiveStore.UnknownError' || cause._tag === 'BackendIdMismatchError'
               ? cause
-              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+              : new UnknownError({ cause }),
           ),
           Stream.withSpan('http-sync-client:pull'),
         )
@@ -195,7 +195,7 @@ export const makeHttpSync =
                 backendId,
               }),
             }),
-            Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
+            Effect.mapError((cause) => new UnknownError({ cause })),
           )
 
           for (const chunk of Chunk.toReadonlyArray(batchChunks)) {
@@ -205,9 +205,9 @@ export const makeHttpSync =
         },
         pushSemaphore.withPermits(1),
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
+          cause._tag === 'LiveStore.UnknownError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
             ? cause
-            : new InvalidPushError({ cause: new UnknownError({ cause }) }),
+            : new UnknownError({ cause }),
         ),
       )
 

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -168,7 +168,9 @@ export const makeHttpSync =
           Stream.tap((res) => backendIdHelper.lazySet(res.backendId)),
           Stream.map((res) => omit(res, ['backendId'])),
           Stream.mapError((cause) =>
-            cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+            cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+              ? cause
+              : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
           ),
           Stream.withSpan('http-sync-client:pull'),
         )
@@ -203,7 +205,9 @@ export const makeHttpSync =
         },
         pushSemaphore.withPermits(1),
         Effect.mapError((cause) =>
-          cause._tag === 'InvalidPushError' ? cause : new InvalidPushError({ cause: new UnknownError({ cause }) }),
+          cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+            ? cause
+            : new InvalidPushError({ cause: new UnknownError({ cause }) }),
         ),
       )
 

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -180,7 +180,7 @@ export const makeWsSync =
               backendId: backendIdHelper.get(),
             }).pipe(
               Effect.mapError((cause) =>
-                cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
+                cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
                   ? cause
                   : new InvalidPushError({ cause: new UnknownError({ cause }) }),
               ),

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, IsOfflineError, SyncBackend, UnknownError } from '@livestore/common'
+import { IsOfflineError, SyncBackend, UnknownError } from '@livestore/common'
 import type { LiveStoreEvent } from '@livestore/common/schema'
 import { splitChunkBySize } from '@livestore/common/sync'
 import { omit } from '@livestore/utils'
@@ -146,9 +146,9 @@ export const makeWsSync =
             Stream.mapError((cause) =>
               cause._tag === 'RpcClientError' && Socket.isSocketError(cause.cause) === true
                 ? new IsOfflineError({ cause: cause.cause })
-                : cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
+                : cause._tag === 'LiveStore.UnknownError' || cause._tag === 'BackendIdMismatchError'
                   ? cause
-                  : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+                  : new UnknownError({ cause }),
             ),
             Stream.withSpan('pull'),
           ),
@@ -169,7 +169,7 @@ export const makeWsSync =
               maxBytes: MAX_WS_MESSAGE_BYTES,
               encode: encodePayload,
             }),
-            Effect.mapError((cause) => new InvalidPushError({ cause: new UnknownError({ cause }) })),
+            Effect.mapError((cause) => new UnknownError({ cause })),
           )
 
           for (const sub of chunksChunk) {
@@ -180,9 +180,9 @@ export const makeWsSync =
               backendId: backendIdHelper.get(),
             }).pipe(
               Effect.mapError((cause) =>
-                cause._tag === 'InvalidPushError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
+                cause._tag === 'LiveStore.UnknownError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
                   ? cause
-                  : new InvalidPushError({ cause: new UnknownError({ cause }) }),
+                  : new UnknownError({ cause }),
               ),
             )
           }

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -146,7 +146,7 @@ export const makeWsSync =
             Stream.mapError((cause) =>
               cause._tag === 'RpcClientError' && Socket.isSocketError(cause.cause) === true
                 ? new IsOfflineError({ cause: cause.cause })
-                : cause._tag === 'InvalidPullError'
+                : cause._tag === 'InvalidPullError' || cause._tag === 'BackendIdMismatchError'
                   ? cause
                   : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
             ),
@@ -180,7 +180,7 @@ export const makeWsSync =
               backendId: backendIdHelper.get(),
             }).pipe(
               Effect.mapError((cause) =>
-                cause._tag === 'InvalidPushError'
+                cause._tag === 'InvalidPushError' || cause._tag === 'BackendIdMismatchError'
                   ? cause
                   : new InvalidPushError({ cause: new UnknownError({ cause }) }),
               ),

--- a/packages/@livestore/sync-cf/src/common/do-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/do-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -35,7 +35,7 @@ export class SyncDoRpc extends RpcGroup.make(
       rpcRequestId: Schema.String,
       ...SyncMessage.PullResponse.fields,
     }),
-    error: InvalidPullError,
+    error: Schema.Union(InvalidPullError, BackendIdMismatchError),
     stream: true,
   }),
   Rpc.make('SyncDoRpc.Push', {
@@ -44,7 +44,7 @@ export class SyncDoRpc extends RpcGroup.make(
       ...commonPayloadFields,
     },
     success: SyncMessage.PushAck,
-    error: InvalidPushError,
+    error: Schema.Union(InvalidPushError, BackendIdMismatchError),
   }),
   Rpc.make('SyncDoRpc.Ping', {
     payload: {

--- a/packages/@livestore/sync-cf/src/common/do-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/do-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError, ServerAheadError } from '@livestore/common'
+import { BackendIdMismatchError, ServerAheadError, UnknownError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -35,7 +35,7 @@ export class SyncDoRpc extends RpcGroup.make(
       rpcRequestId: Schema.String,
       ...SyncMessage.PullResponse.fields,
     }),
-    error: Schema.Union(InvalidPullError, BackendIdMismatchError),
+    error: Schema.Union(UnknownError, BackendIdMismatchError),
     stream: true,
   }),
   Rpc.make('SyncDoRpc.Push', {
@@ -44,7 +44,7 @@ export class SyncDoRpc extends RpcGroup.make(
       ...commonPayloadFields,
     },
     success: SyncMessage.PushAck,
-    error: Schema.Union(InvalidPushError, ServerAheadError, BackendIdMismatchError),
+    error: Schema.Union(UnknownError, ServerAheadError, BackendIdMismatchError),
   }),
   Rpc.make('SyncDoRpc.Ping', {
     payload: {

--- a/packages/@livestore/sync-cf/src/common/do-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/do-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError, ServerAheadError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -44,7 +44,7 @@ export class SyncDoRpc extends RpcGroup.make(
       ...commonPayloadFields,
     },
     success: SyncMessage.PushAck,
-    error: Schema.Union(InvalidPushError, BackendIdMismatchError),
+    error: Schema.Union(InvalidPushError, ServerAheadError, BackendIdMismatchError),
   }),
   Rpc.make('SyncDoRpc.Ping', {
     payload: {

--- a/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError, UnknownError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -18,7 +18,7 @@ export class SyncHttpRpc extends RpcGroup.make(
       ...SyncMessage.PullRequest.fields,
     }),
     success: SyncMessage.PullResponse,
-    error: InvalidPullError,
+    error: Schema.Union(InvalidPullError, BackendIdMismatchError),
     stream: true,
   }),
   Rpc.make('SyncHttpRpc.Push', {
@@ -28,7 +28,7 @@ export class SyncHttpRpc extends RpcGroup.make(
       ...SyncMessage.PushRequest.fields,
     }),
     success: SyncMessage.PushAck,
-    error: InvalidPushError,
+    error: Schema.Union(InvalidPushError, BackendIdMismatchError),
   }),
   Rpc.make('SyncHttpRpc.Ping', {
     payload: Schema.Struct({

--- a/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError, ServerAheadError, UnknownError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -28,7 +28,7 @@ export class SyncHttpRpc extends RpcGroup.make(
       ...SyncMessage.PushRequest.fields,
     }),
     success: SyncMessage.PushAck,
-    error: Schema.Union(InvalidPushError, BackendIdMismatchError),
+    error: Schema.Union(InvalidPushError, ServerAheadError, BackendIdMismatchError),
   }),
   Rpc.make('SyncHttpRpc.Ping', {
     payload: Schema.Struct({

--- a/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/http-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError, ServerAheadError, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, ServerAheadError, UnknownError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -18,7 +18,7 @@ export class SyncHttpRpc extends RpcGroup.make(
       ...SyncMessage.PullRequest.fields,
     }),
     success: SyncMessage.PullResponse,
-    error: Schema.Union(InvalidPullError, BackendIdMismatchError),
+    error: Schema.Union(UnknownError, BackendIdMismatchError),
     stream: true,
   }),
   Rpc.make('SyncHttpRpc.Push', {
@@ -28,7 +28,7 @@ export class SyncHttpRpc extends RpcGroup.make(
       ...SyncMessage.PushRequest.fields,
     }),
     success: SyncMessage.PushAck,
-    error: Schema.Union(InvalidPushError, ServerAheadError, BackendIdMismatchError),
+    error: Schema.Union(UnknownError, ServerAheadError, BackendIdMismatchError),
   }),
   Rpc.make('SyncHttpRpc.Ping', {
     payload: Schema.Struct({

--- a/packages/@livestore/sync-cf/src/common/ws-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/ws-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError, ServerAheadError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -30,7 +30,7 @@ export class SyncWsRpc extends RpcGroup.make(
       ...SyncMessage.PushRequest.fields,
     }),
     success: SyncMessage.PushAck,
-    error: Schema.Union(InvalidPushError, BackendIdMismatchError),
+    error: Schema.Union(InvalidPushError, ServerAheadError, BackendIdMismatchError),
   }),
   // Ping <> Pong is handled by DO WS auto-response
   // TODO add admin RPCs

--- a/packages/@livestore/sync-cf/src/common/ws-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/ws-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError, ServerAheadError } from '@livestore/common'
+import { BackendIdMismatchError, ServerAheadError, UnknownError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -20,7 +20,7 @@ export class SyncWsRpc extends RpcGroup.make(
       ...SyncMessage.PullRequest.fields,
     }),
     success: SyncMessage.PullResponse,
-    error: Schema.Union(InvalidPullError, BackendIdMismatchError),
+    error: Schema.Union(UnknownError, BackendIdMismatchError),
     stream: true,
   }),
   Rpc.make('SyncWsRpc.Push', {
@@ -30,7 +30,7 @@ export class SyncWsRpc extends RpcGroup.make(
       ...SyncMessage.PushRequest.fields,
     }),
     success: SyncMessage.PushAck,
-    error: Schema.Union(InvalidPushError, ServerAheadError, BackendIdMismatchError),
+    error: Schema.Union(UnknownError, ServerAheadError, BackendIdMismatchError),
   }),
   // Ping <> Pong is handled by DO WS auto-response
   // TODO add admin RPCs

--- a/packages/@livestore/sync-cf/src/common/ws-rpc-schema.ts
+++ b/packages/@livestore/sync-cf/src/common/ws-rpc-schema.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError } from '@livestore/common'
 import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
 
 import * as SyncMessage from './sync-message-types.ts'
@@ -20,7 +20,7 @@ export class SyncWsRpc extends RpcGroup.make(
       ...SyncMessage.PullRequest.fields,
     }),
     success: SyncMessage.PullResponse,
-    error: InvalidPullError,
+    error: Schema.Union(InvalidPullError, BackendIdMismatchError),
     stream: true,
   }),
   Rpc.make('SyncWsRpc.Push', {
@@ -30,7 +30,7 @@ export class SyncWsRpc extends RpcGroup.make(
       ...SyncMessage.PushRequest.fields,
     }),
     success: SyncMessage.PushAck,
-    error: InvalidPushError,
+    error: Schema.Union(InvalidPushError, BackendIdMismatchError),
   }),
   // Ping <> Pong is handled by DO WS auto-response
   // TODO add admin RPCs

--- a/packages/@livestore/sync-electric/src/index.ts
+++ b/packages/@livestore/sync-electric/src/index.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, type IsOfflineError, SyncBackend, UnknownError } from '@livestore/common'
+import { type IsOfflineError, SyncBackend, UnknownError } from '@livestore/common'
 import { LiveStoreEvent } from '@livestore/common/schema'
 import { notYetImplemented } from '@livestore/utils'
 import {
@@ -217,7 +217,7 @@ export const makeSyncBackend =
             Option.Option<SyncMetadata>,
           ]
         >,
-        InvalidPullError | IsOfflineError
+        UnknownError | IsOfflineError
       > =>
         Effect.gen(function* () {
           const argsJson = yield* Schema.encode(ApiSchema.ArgsSchema)(
@@ -229,10 +229,8 @@ export const makeSyncBackend =
 
           if (resp.status === 401) {
             const body = yield* resp.text.pipe(Effect.catchAll(() => Effect.succeed('-')))
-            return yield* InvalidPullError.make({
-              cause: new UnknownError({
-                cause: new Error(`Unauthorized (401): Couldn't connect to ElectricSQL: ${body}`),
-              }),
+            return yield* new UnknownError({
+              cause: new Error(`Unauthorized (401): Couldn't connect to ElectricSQL: ${body}`),
             })
           } else if (resp.status === 400) {
             // Electric returns 400 when table doesn't exist
@@ -252,9 +250,7 @@ export const makeSyncBackend =
             return notYetImplemented(`Electric shape not found`)
           } else if (resp.status < 200 || resp.status >= 300) {
             const body = yield* resp.text
-            return yield* InvalidPullError.make({
-              cause: new UnknownError({ cause: new Error(`Unexpected status code: ${resp.status}: ${body}`) }),
-            })
+            return yield* new UnknownError({ cause: new Error(`Unexpected status code: ${resp.status}: ${body}`) })
           }
 
           const headers = yield* HttpClientResponse.schemaHeaders(ResponseHeaders)(resp)
@@ -297,7 +293,7 @@ export const makeSyncBackend =
         }).pipe(
           Effect.scoped,
           Effect.mapError((cause) =>
-            cause._tag === 'InvalidPullError' ? cause : InvalidPullError.make({ cause: new UnknownError({ cause }) }),
+            cause._tag === 'LiveStore.UnknownError' ? cause : new UnknownError({ cause }),
           ),
           Effect.withSpan('electric-provider:runPull', { attributes: { handle, live } }),
         )
@@ -375,11 +371,11 @@ export const makeSyncBackend =
             Effect.andThen(httpClient.pipe(HttpClient.filterStatusOk).execute),
             Effect.andThen(HttpClientResponse.schemaBodyJson(Schema.Struct({ success: Schema.Boolean }))),
             Effect.scoped,
-            Effect.mapError((cause) => InvalidPushError.make({ cause: UnknownError.make({ cause }) })),
+            Effect.mapError((cause) => UnknownError.make({ cause })),
           )
 
           if (resp.success === false) {
-            return yield* InvalidPushError.make({ cause: new UnknownError({ cause: new Error('Push failed') }) })
+            return yield* new UnknownError({ cause: new Error('Push failed') })
           }
         }),
         ping,

--- a/packages/@livestore/sync-s2/src/sync-provider.ts
+++ b/packages/@livestore/sync-s2/src/sync-provider.ts
@@ -28,10 +28,10 @@
  *   DO NOT couple these systems together or assume 1:1 correspondence.
  *
  * Errors
- * - push → InvalidPushError on non‑2xx; pull → InvalidPullError on non‑2xx; ping/connect map timeouts to offline.
+ * - push → UnknownError on non‑2xx; pull → UnknownError on non‑2xx; ping/connect map timeouts to offline.
  * - The proxy should surface helpful status codes and error bodies.
  */
-import { InvalidPullError, InvalidPushError, SyncBackend, UnknownError } from '@livestore/common'
+import { SyncBackend, UnknownError } from '@livestore/common'
 import type { EventSequenceNumber } from '@livestore/common/schema'
 import { shouldNeverHappen } from '@livestore/utils'
 import {
@@ -72,9 +72,9 @@ export interface SyncS2Options {
   }
   retry?: {
     /** Custom retry schedule for non-live pulls (default: 2 recurs, 100ms spaced) */
-    pull?: Schedule.Schedule<number, InvalidPullError>
+    pull?: Schedule.Schedule<number, UnknownError>
     /** Custom retry schedule for pushes (default: 2 recurs, 100ms spaced) */
-    push?: Schedule.Schedule<number, InvalidPushError>
+    push?: Schedule.Schedule<number, UnknownError>
   }
 }
 
@@ -121,7 +121,7 @@ export const makeSyncBackend =
           metadata: Option.Option<SyncMetadata>
         }>,
         live: boolean,
-      ): Stream.Stream<SyncBackend.PullResItem<SyncMetadata>, InvalidPullError> => {
+      ): Stream.Stream<SyncBackend.PullResItem<SyncMetadata>, UnknownError> => {
         // Extract S2 seqNum from metadata for SSE cursor
         const s2SeqNum = cursor.pipe(
           Option.flatMap((_) => _.metadata),
@@ -145,9 +145,7 @@ export const makeSyncBackend =
                 const evt = msg.event.toLowerCase()
                 if (evt === 'ping') return Option.none()
                 if (evt === 'error') {
-                  return yield* new InvalidPullError({
-                    cause: new UnknownError({ cause: new Error(`SSE error: ${msg.data}`) }),
-                  })
+                  return yield* new UnknownError({ cause: new Error(`SSE error: ${msg.data}`) })
                 }
                 if (evt === 'batch') {
                   const readBatch = yield* Schema.decode(Schema.parseJson(HttpClientGenerated.ReadBatch))(msg.data)
@@ -180,7 +178,7 @@ export const makeSyncBackend =
             ),
             Stream.filterMap((_) => _), // filter out Option.none()
             Stream.mapError((cause) =>
-              cause._tag === 'InvalidPullError' ? cause : new InvalidPullError({ cause: new UnknownError({ cause }) }),
+              cause._tag === 'LiveStore.UnknownError' ? cause : new UnknownError({ cause }),
             ),
             Stream.retry(retry?.pull ?? defaultRetry),
           )
@@ -191,7 +189,7 @@ export const makeSyncBackend =
           eventSequenceNumber: EventSequenceNumber.Global.Type
           metadata: Option.Option<SyncMetadata>
         }>,
-      ): Stream.Stream<SyncBackend.PullResItem<SyncMetadata>, InvalidPullError> => {
+      ): Stream.Stream<SyncBackend.PullResItem<SyncMetadata>, UnknownError> => {
         const computeNextCursor = (
           lastItem: Option.Option<SyncBackend.PullResItem<SyncMetadata>>,
           current: Option.Option<{
@@ -217,7 +215,7 @@ export const makeSyncBackend =
             metadata: Option.Option<SyncMetadata>
           }>,
           isFirst: boolean,
-        ): Stream.Stream<SyncBackend.PullResItem<SyncMetadata>, InvalidPullError> => {
+        ): Stream.Stream<SyncBackend.PullResItem<SyncMetadata>, UnknownError> => {
           const sseStream = (live: boolean) =>
             runPullSse(cursor, live).pipe(
               Stream.emitIfEmpty({
@@ -253,13 +251,9 @@ export const makeSyncBackend =
         },
         push: (batch) =>
           Effect.gen(function* () {
-            const makeInvalidPushError = (cause: unknown): InvalidPushError => {
-              if (cause instanceof InvalidPushError) {
-                return cause
-              }
-
+            const toUnknownError = (cause: unknown): UnknownError => {
               if (cause instanceof UnknownError) {
-                return new InvalidPushError({ cause })
+                return cause
               }
 
               if (cause instanceof S2LimitExceededError) {
@@ -268,24 +262,22 @@ export const makeSyncBackend =
                     ? `S2 record exceeded ${cause.max} metered bytes (actual: ${cause.actual})`
                     : `S2 batch exceeded ${cause.max} (type: ${cause.limitType}, actual: ${cause.actual})`
 
-                return new InvalidPushError({
-                  cause: new UnknownError({
-                    cause,
-                    note,
-                    payload: {
-                      limitType: cause.limitType,
-                      max: cause.max,
-                      actual: cause.actual,
-                      recordIndex: cause.recordIndex,
-                    },
-                  }),
+                return new UnknownError({
+                  cause,
+                  note,
+                  payload: {
+                    limitType: cause.limitType,
+                    max: cause.max,
+                    actual: cause.actual,
+                    recordIndex: cause.recordIndex,
+                  },
                 })
               }
 
-              return new InvalidPushError({ cause: new UnknownError({ cause }) })
+              return new UnknownError({ cause })
             }
 
-            const chunks = yield* Effect.sync(() => chunkEventsForS2(batch)).pipe(Effect.mapError(makeInvalidPushError))
+            const chunks = yield* Effect.sync(() => chunkEventsForS2(batch)).pipe(Effect.mapError(toUnknownError))
 
             for (const chunk of chunks) {
               yield* HttpClientRequest.schemaBodyJson(ApiSchema.PushPayload)(HttpClientRequest.post(pushEndpoint), {
@@ -294,7 +286,7 @@ export const makeSyncBackend =
               }).pipe(
                 Effect.andThen(httpClient.pipe(HttpClient.filterStatusOk).execute),
                 Effect.andThen(HttpClientResponse.schemaBodyJson(ApiSchema.PushResponse)),
-                Effect.mapError(makeInvalidPushError),
+                Effect.mapError(toUnknownError),
                 Effect.retry(retry?.push ?? defaultRetry),
               )
             }

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -11,7 +11,6 @@ import {
   StaleRebaseGenerationError,
   type SyncOptions,
   UnknownError,
-  InvalidPullError,
 } from '@livestore/common'
 import type { MakeLeaderThreadLayerParams } from '@livestore/common/leader-thread'
 import { LeaderThreadCtx, makeLeaderThreadLayer, ShutdownChannel as Shutdown } from '@livestore/common/leader-thread'
@@ -219,9 +218,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
                   syncBackend.pull(cursor, pullOptions).pipe(Stream.take(1)),
                   Stream.fromEffect(
                     Effect.fail(
-                      new InvalidPullError({
-                        cause: new UnknownError({ cause: new Error('Simulated mid-pagination pull failure') }),
-                      }),
+                      new UnknownError({ cause: new Error('Simulated mid-pagination pull failure') }),
                     ),
                   ),
                 ),

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -1,8 +1,6 @@
 import {
   BackendIdMismatchError,
   type IntentionalShutdownCause,
-  InvalidPullError,
-  InvalidPushError,
   type MockSyncBackend,
   type MockSyncBackendOptions,
   makeMockSyncBackend,
@@ -13,6 +11,7 @@ import {
   StaleRebaseGenerationError,
   type SyncOptions,
   UnknownError,
+  InvalidPullError,
 } from '@livestore/common'
 import type { MakeLeaderThreadLayerParams } from '@livestore/common/leader-thread'
 import { LeaderThreadCtx, makeLeaderThreadLayer, ShutdownChannel as Shutdown } from '@livestore/common/leader-thread'
@@ -533,11 +532,9 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       yield* testContext.mockSyncBackend.failNextPushes(
         1,
         () =>
-          new InvalidPushError({
-            cause: new ServerAheadError({
-              minimumExpectedNum: EventSequenceNumber.Global.make(2),
-              providedNum: EventSequenceNumber.Global.make(1),
-            }),
+          new ServerAheadError({
+            minimumExpectedNum: EventSequenceNumber.Global.make(2),
+            providedNum: EventSequenceNumber.Global.make(1),
           }),
       )
 

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -641,17 +641,16 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
       // Fail the next push due to backend id mismatch
       yield* testContext.mockSyncBackend.failNextPushes(1, () =>
-        Effect.fail(new InvalidPushError({ cause: new BackendIdMismatchError({ expected: 'a', received: 'b' }) })),
+        Effect.fail(new BackendIdMismatchError({ expected: 'a', received: 'b' })),
       )
 
       // Trigger a local push
       yield* testContext.pushEncoded(eventFactory.todoCreated.next({ id: 'mismatch', text: 'x', completed: false }))
 
-      // Expect a shutdown message to be sent with InvalidPushError/BackendIdMismatchError
+      // Expect a shutdown message to be sent with BackendIdMismatchError
       const shutdownMsg = yield* testContext.shutdownDeferred.pipe(Effect.flip, Effect.timeout(3000))
 
-      expect(shutdownMsg._tag).toEqual('InvalidPushError')
-      expect((shutdownMsg as InvalidPushError).cause._tag).toEqual('BackendIdMismatchError')
+      expect(shutdownMsg._tag).toEqual('BackendIdMismatchError')
     }).pipe(
       withTestCtx({
         syncOptions: { onBackendIdMismatch: 'shutdown', livePull: false },
@@ -684,9 +683,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
       // Fail the next push due to backend id mismatch
       yield* testContext.mockSyncBackend.failNextPushes(1, () =>
-        Effect.fail(
-          new InvalidPushError({ cause: new BackendIdMismatchError({ expected: 'new-id', received: 'old-id' }) }),
-        ),
+        Effect.fail(new BackendIdMismatchError({ expected: 'new-id', received: 'old-id' })),
       )
 
       // Trigger another push that will fail
@@ -733,18 +730,16 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
       // Fail the next push due to backend id mismatch
       yield* testContext.mockSyncBackend.failNextPushes(1, () =>
-        Effect.fail(
-          new InvalidPushError({ cause: new BackendIdMismatchError({ expected: 'new-id', received: 'old-id' }) }),
-        ),
+        Effect.fail(new BackendIdMismatchError({ expected: 'new-id', received: 'old-id' })),
       )
 
       // Trigger another push that will fail
       yield* testContext.pushEncoded(eventFactory.todoCreated.next({ id: '2', text: 't2', completed: false }))
 
-      // Expect a shutdown message with InvalidPushError (not IntentionalShutdownCause)
+      // Expect a shutdown message with BackendIdMismatchError (not IntentionalShutdownCause)
       const shutdownMsg = yield* testContext.shutdownDeferred.pipe(Effect.flip, Effect.timeout(3000))
 
-      expect(shutdownMsg._tag).toEqual('InvalidPushError')
+      expect(shutdownMsg._tag).toEqual('BackendIdMismatchError')
 
       // Verify databases were NOT cleared
       const afterRows = leaderThreadCtx.dbEventlog.select<{ name: string }>(`SELECT name FROM eventlog`)
@@ -772,9 +767,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
       // Fail the next push due to backend id mismatch
       yield* testContext.mockSyncBackend.failNextPushes(1, () =>
-        Effect.fail(
-          new InvalidPushError({ cause: new BackendIdMismatchError({ expected: 'new-id', received: 'old-id' }) }),
-        ),
+        Effect.fail(new BackendIdMismatchError({ expected: 'new-id', received: 'old-id' })),
       )
 
       // Trigger another push that will fail

--- a/tests/sync-provider/src/electric-specific.test.ts
+++ b/tests/sync-provider/src/electric-specific.test.ts
@@ -102,12 +102,12 @@ Vitest.describe('ElectricSQL specific error handling', { timeout: 60000 }, () =>
       const pullResult = yield* syncBackend
         .pull(initialPullRes.pipe(Option.flatMap(SyncBackend.cursorFromPullResItem)), { live: true })
         .pipe(
-          // Drain items until the stream fails with InvalidPullError, then flip to capture the error as success
+          // Drain items until the stream fails with UnknownError, then flip to capture the error as success
           Stream.runDrain,
           Effect.flip,
         )
 
-      expect(pullResult._tag).toBe('InvalidPullError')
+      expect(pullResult._tag).toBe('LiveStore.UnknownError')
       const cause = pullResult.cause as any
       expect(cause._tag).toBe('InvalidOperationError')
       expect(cause.operation).toBe('delete')
@@ -150,7 +150,7 @@ Vitest.describe('ElectricSQL specific error handling', { timeout: 60000 }, () =>
         .pull(initialPullRes.pipe(Option.flatMap(SyncBackend.cursorFromPullResItem)), { live: true })
         .pipe(Stream.runDrain, Effect.flip)
 
-      expect(pullResult._tag).toBe('InvalidPullError')
+      expect(pullResult._tag).toBe('LiveStore.UnknownError')
       const cause = pullResult.cause as any
       expect(cause._tag).toBe('InvalidOperationError')
       expect(cause.operation).toBe('update')

--- a/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
+++ b/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, ServerAheadError, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, IsOfflineError, ServerAheadError, UnknownError } from '@livestore/common'
 import { LiveStoreEvent } from '@livestore/common/schema'
 import { SyncMessage } from '@livestore/sync-cf/common'
 /** Explicit type imports so TypeScript can name inferred types in declaration emit (fixes TS2742). */
@@ -29,7 +29,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
     }),
     // Mirror the PullResItem from SyncBackend
     success: SyncMessage.PullResponse,
-    error: Schema.Union(IsOfflineError, InvalidPullError, BackendIdMismatchError),
+    error: Schema.Union(IsOfflineError, UnknownError, BackendIdMismatchError),
     stream: true,
   }),
 
@@ -40,7 +40,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
       batch: Schema.Array(LiveStoreEvent.Global.Encoded),
     }),
     success: Schema.Void,
-    error: Schema.Union(IsOfflineError, InvalidPushError, ServerAheadError, BackendIdMismatchError),
+    error: Schema.Union(IsOfflineError, UnknownError, ServerAheadError, BackendIdMismatchError),
   }),
 
   // Mirror the ping method

--- a/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
+++ b/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
@@ -1,4 +1,4 @@
-import { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, ServerAheadError, UnknownError } from '@livestore/common'
 import { LiveStoreEvent } from '@livestore/common/schema'
 import { SyncMessage } from '@livestore/sync-cf/common'
 /** Explicit type imports so TypeScript can name inferred types in declaration emit (fixes TS2742). */
@@ -40,7 +40,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
       batch: Schema.Array(LiveStoreEvent.Global.Encoded),
     }),
     success: Schema.Void,
-    error: Schema.Union(IsOfflineError, InvalidPushError, BackendIdMismatchError),
+    error: Schema.Union(IsOfflineError, InvalidPushError, ServerAheadError, BackendIdMismatchError),
   }),
 
   // Mirror the ping method

--- a/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
+++ b/tests/sync-provider/src/providers/cloudflare/do-rpc-proxy-schema.ts
@@ -1,4 +1,4 @@
-import { InvalidPullError, InvalidPushError, IsOfflineError, UnknownError } from '@livestore/common'
+import { BackendIdMismatchError, InvalidPullError, InvalidPushError, IsOfflineError, UnknownError } from '@livestore/common'
 import { LiveStoreEvent } from '@livestore/common/schema'
 import { SyncMessage } from '@livestore/sync-cf/common'
 /** Explicit type imports so TypeScript can name inferred types in declaration emit (fixes TS2742). */
@@ -29,7 +29,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
     }),
     // Mirror the PullResItem from SyncBackend
     success: SyncMessage.PullResponse,
-    error: Schema.Union(IsOfflineError, InvalidPullError),
+    error: Schema.Union(IsOfflineError, InvalidPullError, BackendIdMismatchError),
     stream: true,
   }),
 
@@ -40,7 +40,7 @@ export class DoRpcProxyRpcs extends RpcGroup.make(
       batch: Schema.Array(LiveStoreEvent.Global.Encoded),
     }),
     success: Schema.Void,
-    error: Schema.Union(IsOfflineError, InvalidPushError),
+    error: Schema.Union(IsOfflineError, InvalidPushError, BackendIdMismatchError),
   }),
 
   // Mirror the ping method

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
 
-import { BackendIdMismatchError, InvalidPullError, SyncBackend } from '@livestore/common'
+import { BackendIdMismatchError, SyncBackend } from '@livestore/common'
 import { EventFactory } from '@livestore/common/testing'
 import type { LiveStoreEvent } from '@livestore/livestore'
 import { EventSequenceNumber, nanoid } from '@livestore/livestore'
@@ -637,8 +637,8 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
   )
 
   /**
-   * Tests that InvalidPullError with BackendIdMismatchError is properly serialized
-   * and deserialized over the RPC boundary.
+   * Tests that BackendIdMismatchError is properly serialized and deserialized
+   * over the RPC boundary.
    *
    * This test creates the error, encodes it to JSON, and verifies all fields
    * are preserved - which was broken before the fix for issue #981 where
@@ -646,36 +646,30 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
    *
    * @see https://github.com/livestorejs/livestore/issues/981
    */
-  Vitest.scopedLive('InvalidPullError with BackendIdMismatchError serializes correctly', (test) =>
+  Vitest.scopedLive('BackendIdMismatchError serializes correctly', (test) =>
     Effect.gen(function* () {
-      // This test verifies the type system fix: InvalidPullError.cause now accepts
-      // BackendIdMismatchError (and UnknownError) instead of Schema.Defect
-
-      const originalError = InvalidPullError.make({
-        cause: new BackendIdMismatchError({
-          expected: 'expected-backend-id-123',
-          received: 'received-backend-id-456',
-        }),
+      const originalError = new BackendIdMismatchError({
+        expected: 'expected-backend-id-123',
+        received: 'received-backend-id-456',
       })
 
       // Verify the error structure before serialization
-      expect(originalError._tag).toBe('InvalidPullError')
-      expect(originalError.cause._tag).toBe('BackendIdMismatchError')
-      expect((originalError.cause as BackendIdMismatchError).expected).toBe('expected-backend-id-123')
-      expect((originalError.cause as BackendIdMismatchError).received).toBe('received-backend-id-456')
+      expect(originalError._tag).toBe('BackendIdMismatchError')
+      expect(originalError.expected).toBe('expected-backend-id-123')
+      expect(originalError.received).toBe('received-backend-id-456')
 
       // Simulate what happens during RPC: encode to JSON and decode back
       const str = yield* Schema.encode(Schema.parseJson())(originalError)
       const encoded = (yield* Schema.decodeUnknown(Schema.parseJson())(str)) as {
         _tag: string
-        cause: { _tag: string; expected: string; received: string }
+        expected: string
+        received: string
       }
 
       // The encoded form should preserve the structure (this was broken before the fix)
-      expect(encoded._tag).toBe('InvalidPullError')
-      expect(encoded.cause._tag).toBe('BackendIdMismatchError')
-      expect(encoded.cause.expected).toBe('expected-backend-id-123')
-      expect(encoded.cause.received).toBe('received-backend-id-456')
+      expect(encoded._tag).toBe('BackendIdMismatchError')
+      expect(encoded.expected).toBe('expected-backend-id-123')
+      expect(encoded.received).toBe('received-backend-id-456')
     }).pipe(withTestCtx()(test)),
   )
 })


### PR DESCRIPTION
## Problem

`BackendIdMismatchError` and `ServerAheadError` were nested inside `InvalidPushError.cause` and `InvalidPullError.cause`, making them invisible in the type signatures of `SyncBackend.push` and `SyncBackend.pull`:

```ts
// Consumer sees this contract:
push: (batch: ...) => Effect<void, IsOfflineError | InvalidPushError>
pull: (...) => Stream<..., IsOfflineError | InvalidPullError>
```

Nothing in these signatures tells the consumer that a backend identity mismatch or a server-ahead condition can occur. These failure modes are hidden inside `InvalidPushError.cause`'s schema union — discoverable only by reading source code or inspecting the `cause` field at runtime.

This matters because both errors require fundamentally different responses than a normal push/pull failure:
- **`BackendIdMismatchError`**: the sync backend was reset — the session needs to shut down, reset local state, or explicitly ignore the mismatch
- **`ServerAheadError`**: the server is ahead of the client — the client should wait for the pull stream to catch up, not retry the push

These are completely different recovery strategies, and the type system should enforce that consumers think about each — not silently collapse the distinction by nesting them inside a wrapper.

> [!NOTE]
> **General rule for when to wrap vs surface an error in Effect:**
> - **Wrap an error** when the `cause` field is *informational* — the caller's recovery strategy is the same regardless of the inner cause, and the wrapper is the meaningful abstraction.
> - **Surface an error** when the `cause` field is *decisional* — the caller must branch on the inner error to choose a different recovery path. If a `catchTag` handler contains an `if` on `err.cause._tag`, that's a sign the inner error should be a top-level peer, not a nested variant.

Builds on #1091.

## Solution

Surface `BackendIdMismatchError` and `ServerAheadError` as top-level errors, then remove the now-hollow `InvalidPushError` and `InvalidPullError` wrappers entirely — leaving every error in the contract independently decisional:

```ts
push: (batch: ...) => Effect<void, IsOfflineError | UnknownError | ServerAheadError | BackendIdMismatchError>
pull: (...) => Stream<..., IsOfflineError | UnknownError | BackendIdMismatchError>
```

Each error drives a distinct recovery strategy:
- **`IsOfflineError`** → retry until reconnected
- **`UnknownError`** → retry with exponential backoff (transient failure)
- **`ServerAheadError`** → wait for pull stream to catch up, don't retry push
- **`BackendIdMismatchError`** → shutdown, reset local state, or ignore (based on config)

Key changes:

- **Error model**: Remove `InvalidPushError`, `InvalidPullError`, and the `SyncError` union from `errors.ts`. After extracting `BackendIdMismatchError` and `ServerAheadError`, both wrappers were thin shells around `UnknownError` with no caller ever branching on them differently.
- **Handler simplification**: `LeaderSyncProcessor` now uses `Effect.catchTag('BackendIdMismatchError', ...)` before `catchAllCause`, replacing the runtime cause chain inspection. `isRetryable` simplified from `err._tag === 'InvalidPushError' && err.cause._tag === 'LiveStore.UnknownError'` to `err._tag === 'LiveStore.UnknownError'`.
- **`handleBackendIdMismatch`**: Accepts the error directly instead of unwrapping from a `Cause`.
- **`validatePushPayload`**: Returns `ServerAheadError` directly instead of wrapping in `InvalidPushError`.
- **RPC schemas**: All transport layers (do-rpc, http-rpc, ws-rpc) use `UnknownError` directly in error unions, removing the wrapper construction/passthrough logic.
- **Transport layers**: `mapError` calls now wrap unknown errors directly into `UnknownError` instead of `InvalidPushError`/`InvalidPullError`, with passthrough guards for `BackendIdMismatchError`, `ServerAheadError`, and existing `UnknownError` to avoid double-wrapping.
- **Type signatures**: `ShutdownChannel.All`, `ClientSession.shutdown`, `ShutdownDeferred`, and all sync provider interfaces updated to use the flattened error types.

## Validation

- `LeaderSyncProcessor.test.ts` — backend-id-mismatch tests assert `BackendIdMismatchError` directly; server-ahead tests assert `ServerAheadError` directly
- `sync-provider.test.ts` — serialization roundtrip test simplified to test `BackendIdMismatchError` directly
- `electric-specific.test.ts` — error assertions updated to check `LiveStore.UnknownError` tag directly

## Related issues

- Related to #981