### PR TITLE
Fix Store.Tag R channel mismatch between yield* and methods

### DIFF
--- a/packages/@livestore/livestore/src/effect/LiveStore.test.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from 'vitest'
+import { Effect, Layer } from '@livestore/utils/effect'
+import type { OtelTracer } from '@livestore/utils/effect'
+import { schema } from '../utils/tests/fixture.ts'
+import { Store, type StoreTagClass } from './LiveStore.ts'
+
+/**
+ * Regression test for https://github.com/livestorejs/livestore/issues/1103
+ *
+ * `yield* MyStore` and `MyStore.query(...)` must produce the same R channel type
+ * so that a single layer provision satisfies both.
+ */
+describe('Store.Tag R channel consistency', () => {
+  class MainStore extends Store.Tag(schema, 'main') {}
+
+  const storeLayer = MainStore.layer({ adapter: {} as any, batchUpdates: (_: () => void) => {} })
+
+  it('yield* and method R channels unify so layer provision eliminates all requirements', () => {
+    const prog = Effect.gen(function* () {
+      const { store } = yield* MainStore
+      void store
+
+      const _queryResult = yield* MainStore.query({ get: () => 42 } as any)
+      void _queryResult
+
+      yield* MainStore.commit()
+    })
+
+    /** Providing the store layer must fully eliminate MainStore from R */
+    const _provided: Effect.Effect<void, unknown, OtelTracer.OtelTracer> = prog.pipe(
+      Effect.provide(storeLayer),
+    )
+    void _provided
+  })
+
+  it('use() helper R channel is satisfied by the same layer', () => {
+    const prog = MainStore.use(({ store }) => Effect.succeed(store))
+
+    const _provided: Effect.Effect<unknown, unknown, OtelTracer.OtelTracer> = prog.pipe(
+      Effect.provide(storeLayer),
+    )
+    void _provided
+  })
+
+  it('fromDeferred layer output satisfies the same R channel', () => {
+    const prog = Effect.gen(function* () {
+      yield* MainStore
+    })
+
+    /** fromDeferred + DeferredLayer should satisfy MainStore in R */
+    const _provided = prog.pipe(
+      Effect.provide(Layer.merge(MainStore.fromDeferred, MainStore.DeferredLayer)),
+    )
+
+    type _R = Effect.Effect.Context<typeof _provided>
+    /** MainStore should not be in R after providing fromDeferred */
+    type _MainStoreNotInR = StoreTagClass<typeof schema, 'main'> extends _R ? false : true
+    const _check: _MainStoreNotInR = true
+    void _check
+  })
+})

--- a/packages/@livestore/livestore/src/effect/LiveStore.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.ts
@@ -110,12 +110,20 @@ export type StoreLayerProps<TSchema extends LiveStoreSchema, TContext = {}> = Om
  *
  * Note: This uses a type alias with a new() signature to make it extendable.
  */
-export type StoreTagClass<TSchema extends LiveStoreSchema, TStoreId extends string> = {
+/**
+ * Type for a Store.Tag class. Uses self-referential identifier so that `yield*`
+ * and method R channels resolve to the same type, enabling proper layer composition.
+ *
+ * Uses `interface` (not `type`) to allow the self-referential identifier without
+ * triggering TS2456 (circular type alias).
+ */
+export interface StoreTagClass<TSchema extends LiveStoreSchema, TStoreId extends string>
+  extends Context.Tag<StoreTagClass<TSchema, TStoreId>, LiveStoreContextRunningType<TSchema>> {
   /** Constructor signature (makes the type extendable as a class) */
-  new (): Context.Tag<StoreContextId<TSchema, TStoreId>, LiveStoreContextRunningType<TSchema>>
+  new (): Context.Tag<StoreTagClass<TSchema, TStoreId>, LiveStoreContextRunningType<TSchema>>
 
   /** Tag identity type (from Context.Tag) */
-  readonly Id: StoreContextId<TSchema, TStoreId>
+  readonly Id: StoreTagClass<TSchema, TStoreId>
 
   /** Service type (from Context.Tag) */
   readonly Type: LiveStoreContextRunningType<TSchema>
@@ -127,7 +135,7 @@ export type StoreTagClass<TSchema extends LiveStoreSchema, TStoreId extends stri
   readonly storeId: TStoreId
 
   /** Creates a layer that initializes the store */
-  layer<TContext = {}>(
+  layer<TContext>(
     props: StoreLayerProps<TSchema, TContext>,
   ): Layer.Layer<StoreTagClass<TSchema, TStoreId>, UnknownError | Cause.TimeoutException, OtelTracer.OtelTracer>
 
@@ -155,7 +163,7 @@ export type StoreTagClass<TSchema extends LiveStoreSchema, TStoreId extends stri
   use<A, E, R>(
     f: (ctx: LiveStoreContextRunningType<TSchema>) => Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E, R | StoreTagClass<TSchema, TStoreId>>
-} & Context.Tag<StoreContextId<TSchema, TStoreId>, LiveStoreContextRunningType<TSchema>>
+}
 
 /**
  * Create a typed store context class for use with Effect.


### PR DESCRIPTION
## Problem

`Store.Tag()` returns a `StoreTagClass` type whose `Context.Tag` identifier was `StoreContextId`, but method R channels used `StoreTagClass`. This caused a type-level split:

- `yield* MyStore` → R gets `StoreContextId` (from Tag identifier)
- `MyStore.query(...)` → R gets `StoreTagClass` (from method signature)

Providing a layer only eliminated one, leaving the other unsatisfied. This broke layer composition in downstream apps. (#1103)

## Solution

Changed `StoreTagClass` to use itself as the `Context.Tag` identifier (self-referential interface). Now `yield*` and all methods resolve to the same R type, and a single layer provision satisfies everything.

Key changes:
- Converted `StoreTagClass` from `type` (intersection) to `interface extends Context.Tag<StoreTagClass, ...>` — interfaces support self-referential types without triggering TS2456
- Updated `Id` and `new()` constructor fields to use `StoreTagClass` instead of `StoreContextId`

This mirrors how Effect's own `Context.Tag<Self, Service>` pattern works, where the class itself is the identifier.

## Rationale

Option A (self-referential identifier) was chosen over alternatives:
- **Option B** (align methods to `StoreContextId`): Would work but users see opaque phantom types in errors instead of `MyStore`
- **Option C** (curried class factory): Most idiomatic but requires breaking API change
- **Option D** (`Effect.Service`): Doesn't fit the parameterized layer creation pattern

## Test plan

- [x] Added type-level regression test (`LiveStore.test.ts`) verifying `yield*` and method R channels unify after layer provision
- [x] All 70 existing tests pass
- [x] TypeScript build clean (no new errors)

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)