### PR TITLE
fix: Crypto polyfill not working in Expo anymore

### DIFF
--- a/examples/expo-linearlite/src/app/_layout.tsx
+++ b/examples/expo-linearlite/src/app/_layout.tsx
@@ -1,5 +1,4 @@
 import 'react-native-reanimated'
-import '../polyfill.ts'
 import { Stack } from 'expo-router'
 import { Suspense, useMemo, useState } from 'react'
 import { LogBox, Platform } from 'react-native'

--- a/examples/expo-linearlite/src/polyfill.ts
+++ b/examples/expo-linearlite/src/polyfill.ts
@@ -1,8 +1,0 @@
-import { getRandomValues } from 'expo-crypto'
-
-// Minimal, typed shims required by a few deps under React Native
-globalThis.crypto ??= {} as Crypto
-globalThis.crypto.getRandomValues ??= getRandomValues as Crypto['getRandomValues']
-
-globalThis.performance.mark ??= () => {}
-globalThis.performance.measure ??= () => {}

--- a/examples/expo-todomvc-sync-cf/src/AppEntry.ts
+++ b/examples/expo-todomvc-sync-cf/src/AppEntry.ts
@@ -1,4 +1,3 @@
-import './polyfill.ts'
 import { registerRootComponent } from 'expo'
 
 import { Root } from './Root.tsx'

--- a/examples/expo-todomvc-sync-cf/src/polyfill.ts
+++ b/examples/expo-todomvc-sync-cf/src/polyfill.ts
@@ -1,8 +1,0 @@
-import { getRandomValues } from 'expo-crypto'
-
-globalThis.crypto = globalThis.crypto ?? {}
-
-globalThis.crypto.getRandomValues = (arr) => getRandomValues(arr as any)
-
-globalThis.performance.mark = globalThis.performance.mark ?? (() => {})
-globalThis.performance.measure = globalThis.performance.measure ?? (() => {})

--- a/packages/@livestore/utils/package.json
+++ b/packages/@livestore/utils/package.json
@@ -23,7 +23,7 @@
     "./bun": "./src/bun/mod.ts",
     "./cuid": {
       "browser": "./src/cuid/cuid.browser.ts",
-      "react-native": "./src/cuid/cuid.browser.ts",
+      "react-native": "./src/cuid/cuid.react-native.ts",
       "default": "./src/cuid/cuid.node.ts"
     },
     "./effect": "./src/effect/mod.ts",

--- a/packages/@livestore/utils/src/cuid/cuid.react-native.ts
+++ b/packages/@livestore/utils/src/cuid/cuid.react-native.ts
@@ -1,0 +1,90 @@
+/**
+ * Based on:
+ *
+ * cuid.js
+ * Collision-resistant UID generator for browsers and node.
+ * Sequential for fast db lookups and recency sorting.
+ * Safe for element IDs and server-side lookups.
+ *
+ * Extracted from CLCTR
+ *
+ * Copyright (c) Eric Elliott 2012
+ * MIT License
+ */
+
+const lim = 2 ** 32 - 1
+
+import { getRandomValues } from 'expo-crypto';
+
+const getRandomValue = () => {
+  return Math.abs(getRandomValues(new Uint32Array(1))[0]! / lim)
+}
+
+const pad = (num: number | string, size: number) => {
+  const s = `000000000${num}`
+  return s.slice(s.length - size)
+}
+
+const env = typeof window === 'object' ? window : self
+const globalCount = Object.keys(env).length
+
+const clientId = 'rn'
+
+const fingerprint = () => clientId
+
+let c = 0
+const blockSize = 4
+const base = 36
+const discreteValues = base ** blockSize
+
+const randomBlock = () => {
+  return pad(Math.trunc(getRandomValue() * discreteValues).toString(base), blockSize)
+}
+
+const safeCounter = () => {
+  c = c < discreteValues ? c : 0
+  c++ // this is not subliminal
+  return c - 1
+}
+
+export const cuid = () => {
+  // Starting with a lowercase letter makes
+  // it HTML element ID friendly.
+  const letter = 'c' // hard-coded allows for sequential access
+  // timestamp
+  // warning: this exposes the exact date and time
+  // that the uid was created.
+  const timestamp = Date.now().toString(base)
+  // Prevent same-machine collisions.
+  const counter = pad(safeCounter().toString(base), blockSize)
+  // A few chars to generate distinct ids for different
+  // clients (so different computers are far less
+  // likely to generate the same id)
+  const print = fingerprint()
+  // Grab some more chars from Math.random()
+  const random = randomBlock() + randomBlock()
+
+  return letter + timestamp + counter + print + random
+}
+
+export const slug = () => {
+  const date = Date.now().toString(36)
+  const counter = safeCounter().toString(36).slice(-4)
+  const print = fingerprint().slice(0, 1) + fingerprint().slice(-1)
+  const random = randomBlock().slice(-2)
+
+  return date.slice(-2) + counter + print + random
+}
+
+export const isCuid = (stringToCheck: string) => {
+  if (typeof stringToCheck !== 'string') return false
+  if (stringToCheck.startsWith('c') === true) return true
+  return false
+}
+
+export const isSlug = (stringToCheck: string) => {
+  if (typeof stringToCheck !== 'string') return false
+  const stringLength = stringToCheck.length
+  if (stringLength >= 7 && stringLength <= 10) return true
+  return false
+}


### PR DESCRIPTION
## Problem

Starting in Version `0.4.0-dev.22` the previously used polyfill used in the expo example apps doesn't work anymore, throwing an error in `cuid.browser.ts`, which is currently used for React Native.

I couldn't figure out why that is, however I found that importing the `getRandomValues` function directly `expo-crypto` inside of the `cuid.browser.ts` file did work. 

## Solution
Since the polyfill used in the examples used that same function from expo-crypto, thus already having the library as an implicit dependency, I propose adding another "variant" of the cuid script, specifically for react native, that imports the function directly, without requiring `crypto` on the `globalThis` object.

The package.json of the utils package has also been updated, to use that file for react-native 

## Validation
Since I don't know how to locally build/publish the packages to test them in my app, I can't test that.
However I am running my app with the following patch file that does work, so I am assuming this PR should work aswell.



<details><summary>Patch file</summary>
<p>

```diff
diff --git a/node_modules/@livestore/utils/.bun-tag-1fafa1948dfe8999 b/.bun-tag-1fafa1948dfe8999
new file mode 100644
index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
diff --git a/dist/cuid/cuid.browser.js b/dist/cuid/cuid.browser.js
index 0859885683a2ff14c87bf45289f05356a4c4171e..e86190c7c0689e12317e2228509bb923c9cd5ddd 100644
--- a/dist/cuid/cuid.browser.js
+++ b/dist/cuid/cuid.browser.js
@@ -12,9 +12,9 @@
  * MIT License
  */
 const lim = 2 ** 32 - 1;
-const crypto = globalThis.crypto;
+import { getRandomValues } from 'expo-crypto';
 const getRandomValue = () => {
-  return Math.abs(crypto.getRandomValues(new Uint32Array(1))[0] / lim);
+  return Math.abs(getRandomValues(new Uint32Array(1))[0] / lim);
 };
 const pad = (num, size) => {
   const s = `000000000${num}`;
```

</p>
</details> 

