### PR TITLE
Fix `toSorted` polyfill infinite recursion

### DIFF
--- a/packages/@livestore/adapter-expo/src/polyfill.ts
+++ b/packages/@livestore/adapter-expo/src/polyfill.ts
@@ -6,7 +6,7 @@
 
 if (typeof Array.prototype.toSorted === 'undefined') {
   Array.prototype.toSorted = function (compareFn) {
-    // eslint-disable-next-line unicorn/no-array-sort -- this is the toSorted polyfill itself
+    // oxlint-disable-next-line unicorn/no-array-sort -- this is the toSorted polyfill itself
     return this.slice().sort(compareFn)
   }
 }

--- a/packages/@livestore/adapter-expo/src/polyfill.ts
+++ b/packages/@livestore/adapter-expo/src/polyfill.ts
@@ -6,6 +6,6 @@
 
 if (typeof Array.prototype.toSorted === 'undefined') {
   Array.prototype.toSorted = function (compareFn) {
-    return this.toSorted(compareFn)
+    return this.slice().sort(compareFn)
   }
 }

--- a/packages/@livestore/adapter-expo/src/polyfill.ts
+++ b/packages/@livestore/adapter-expo/src/polyfill.ts
@@ -6,6 +6,7 @@
 
 if (typeof Array.prototype.toSorted === 'undefined') {
   Array.prototype.toSorted = function (compareFn) {
+    // eslint-disable-next-line unicorn/no-array-sort -- this is the toSorted polyfill itself
     return this.slice().sort(compareFn)
   }
 }


### PR DESCRIPTION
## Problem

The `toSorted` polyfill in `adapter-expo` was changed from `this.sort(compareFn)` to `this.toSorted(compareFn)` in #996, which calls itself recursively and crashes with a stack overflow.

## Solution

Use `this.slice().sort(compareFn)` which correctly implements `toSorted` semantics: returns a **new** sorted array without mutating the original.

Fixes #1115

## Test plan

- [x] Verified the polyfill no longer recurses into itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)