### PR TITLE
fix: make schema-derived table `insert()` allow omitting nullable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 - Fix TypeScript build issues and examples restructuring
 - Fix TypeScript erasableSyntaxOnly compatibility issues (#459)
+- **`table.insert()` now correctly omits nullable fields:** Schema-derived table definitions previously required all fields in `insert()` calls. Nullable columns (e.g. `S.NullOr`) are now correctly omittable, matching SQL semantics where nullable columns implicitly default to `NULL` (#1117).
 
 #### Docs & Examples
 

--- a/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
@@ -19,12 +19,12 @@ export type ColumnDefaultValue<T> = T | null | ColumnDefaultThunk<T | null> | Sq
 export const resolveColumnDefault = <T>(value: ColumnDefaultValue<T>): T | null | SqlDefaultValue =>
   isDefaultThunk(value) === true ? value() : value
 
-export type ColumnDefinition<TEncoded, TDecoded> = {
+export type ColumnDefinition<TEncoded, TDecoded, TNullable extends boolean = boolean> = {
   readonly columnType: FieldColumnType
   readonly schema: Schema.Schema<TDecoded, TEncoded>
   readonly default: Option.Option<ColumnDefaultValue<TDecoded>>
   /** @default false */
-  readonly nullable: boolean
+  readonly nullable: TNullable
   /** @default false */
   readonly primaryKey: boolean
   /** @default false */

--- a/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/mod.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/mod.ts
@@ -196,8 +196,7 @@ export namespace FromColumns {
   }
 
   export type NullableColumnNames<TColumns extends Columns> = keyof {
-    // TODO double check why there is a `true` in the type
-    [K in keyof TColumns as TColumns[K] extends ColumnDefinition<any, true> ? K : never]: {}
+    [K in keyof TColumns as TColumns[K]['nullable'] extends true ? K : never]: {}
   }
 
   export type RequiredInsertColumns<TColumns extends Columns> = {

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -357,12 +357,20 @@ export namespace QueryBuilder {
     >
 
     /**
-     * Insert a new row into the table
+     * Insert a new row into the table.
      *
-     * Example:
+     * @remarks
+     *
+     * Follows SQL semantics: nullable columns and columns with defaults are omittable.
+     * `NullOr(S)` and `optional(NullOr(S))` both produce nullable columns, so both are omittable.
+     *
+     * @example
+     *
      * ```ts
      * db.todos.insert({ id: '123', text: 'Buy milk', status: 'active' })
      * ```
+     *
+     * @param values - The row values to insert.
      */
     readonly insert: (
       values: TTableDef['insertSchema']['Type'],

--- a/packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts
@@ -1,7 +1,7 @@
 import { objectToString } from '@livestore/utils'
 
 import { Schema } from '@livestore/utils/effect'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
 import { State } from '../../mod.ts'
 
@@ -318,6 +318,50 @@ describe('table function overloads', () => {
     expect(userTable.sqliteDef.columns.active.columnType).toBe('integer')
     expect(userTable.sqliteDef.columns.metadata.columnType).toBe('text')
     expect(userTable.sqliteDef.columns.metadata.nullable).toBe(true)
+  })
+
+  it('should allow omitting nullable fields in insert()', () => {
+    const UserSchema = Schema.Struct({
+      id: Schema.String.pipe(State.SQLite.withPrimaryKey),
+      undefined: Schema.Undefined,
+      null: Schema.Null,
+      undefinedOrString: Schema.UndefinedOr(Schema.String),
+      nullOrString: Schema.NullOr(Schema.String),
+      optionalString: Schema.optional(Schema.String),
+      optionalNullOrString: Schema.optional(Schema.NullOr(Schema.String)),
+    })
+
+    const usersTable = State.SQLite.table({
+      name: 'users',
+      schema: UserSchema,
+    })
+
+    // Non-nullable fields (id) are required — omitting id should be rejected
+    expectTypeOf<{ undefined: undefined }>().not.toExtend<Parameters<typeof usersTable.insert>[0]>()
+
+    // Nullable fields (NullOr, optional+NullOr) are omittable — SQL defaults to NULL
+    expectTypeOf(usersTable.insert)
+      .toBeCallableWith({ id: '1' })
+      .toBeCallableWith({ id: '1', undefined: undefined })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: undefined })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string' })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: null })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string' })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string', optionalString: 'string' })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string', optionalString: 'string', optionalNullOrString: null })
+      .toBeCallableWith({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string', optionalString: 'string', optionalNullOrString: 'string' })
+
+    expect(() => usersTable.insert({ id: '1' }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: undefined }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string' }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: null }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string' }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string', optionalString: 'string' }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string', optionalString: 'string', optionalNullOrString: null }).asSql()).not.toThrow()
+    expect(() => usersTable.insert({ id: '1', undefined: undefined, null: null, undefinedOrString: 'string', nullOrString: 'string', optionalString: 'string', optionalNullOrString: 'string' }).asSql()).not.toThrow()
   })
 
   it('supports discriminated unions with parsed JSON payloads', () => {

--- a/packages/@livestore/common/src/schema/state/sqlite/table-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/table-def.ts
@@ -369,15 +369,16 @@ export type ToColumns<TColumns extends SqliteDsl.Columns | SqliteDsl.ColumnDefin
       : never
 
 export declare namespace SchemaToColumns {
-  // Type helper to create column definition with proper schema
-  export type ColumnDefForType<TEncoded, TType> = SqliteDsl.ColumnDefinition<TEncoded, TType>
+  /** Checks if `null` or `undefined` is assignable to `T`, matching the runtime nullable detection. */
+  type IsNullable<T> = null extends T ? true : undefined extends T ? true : false
 
-  // Create columns type from schema Type and Encoded
+  // Type helper to create column definition with proper schema
+  export type ColumnDefForType<TEncoded, TType> = SqliteDsl.ColumnDefinition<TEncoded, TType, IsNullable<TEncoded>>
+
   export type FromTypes<TType, TEncoded> =
     TEncoded extends Record<string, any>
       ? {
-          [K in keyof TEncoded]-?: ColumnDefForType<
-            TEncoded[K],
+          [K in keyof TEncoded]-?: ColumnDefForType<TEncoded[K],
             TType extends Record<string, any> ? (K extends keyof TType ? TType[K] : TEncoded[K]) : TEncoded[K]
           >
         }


### PR DESCRIPTION
## Summary

- **Problem:** When defining a SQLite table via `State.SQLite.table({ schema })`, `insert()` treated all columns as required at the TypeScript level, even for nullable fields like `S.NullOr(S.String)`.
- **Root cause:** `SchemaToColumns.ColumnDefForType` resolved to `SqliteDsl.ColumnDefinition<TEncoded, TType>` which has `nullable: boolean`. Since `boolean extends true` is `false`, `RequiredInsertColumns` treated every schema-derived column as required.
- **Fix:** Add a `TNullable` generic parameter to `ColumnDefinition` (defaulting to `boolean` for backwards compatibility) and use `IsNullable<T>` in `SchemaToColumns` to narrow it. `IsNullable` checks `null extends T` or `undefined extends T`, matching the runtime logic where both null and undefined make a column nullable.

**Semantics (SQL):** `insert()` follows SQL semantics for both column-based and schema-based tables. A column is omittable if it is nullable or has a default value:

| Schema type | Nullable column? | Omittable in insert? |
|---|---|---|
| `S.String` | no | no |
| `S.NullOr(S.String)` | yes | yes |
| `S.optional(S.String)` | yes | yes |
| `S.optional(S.NullOr(S.String))` | yes | yes |
| `S.Null` | yes | yes |
| `S.Undefined` | yes | yes |

Closes #1117

## Test plan

- [x] `should allow omitting nullable fields in insert()` — covers `Undefined`, `Null`, `NullOr`, `optional`, and `optional(NullOr)` fields with progressive type and runtime assertions
- [x] All 16 table-def tests + 32 query-builder tests pass
- [x] Type-checking passes