### PR TITLE
refactor: remove leaderPushQueue from ClientSessionSyncProcessor

### DIFF
--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -1,18 +1,6 @@
 /// <reference lib="dom" />
 import { LS_DEV, shouldNeverHappen, TRACE_VERBOSE } from '@livestore/utils'
-import {
-  BucketQueue,
-  Effect,
-  Exit,
-  FiberHandle,
-  Option,
-  Queue,
-  type Runtime,
-  Schema,
-  type Scope,
-  Stream,
-  Subscribable,
-} from '@livestore/utils/effect'
+import { Effect, Exit, Option, Queue, type Runtime, Schema, type Scope, Stream, Subscribable } from '@livestore/utils/effect'
 
 import { type ClientSession, type UnknownError } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
@@ -47,7 +35,7 @@ export const makeClientSessionSyncProcessor = ({
   materializeEvent,
   rollback,
   refreshTables,
-  params,
+  params: _params,
   confirmUnsavedChanges,
 }: {
   schema: LiveStoreSchema
@@ -69,10 +57,7 @@ export const makeClientSessionSyncProcessor = ({
   >
   rollback: (changeset: Uint8Array<ArrayBuffer>) => void
   refreshTables: (tables: Set<string>) => void
-  params: {
-    leaderPushBatchSize: number
-    simulation?: ClientSessionSyncProcessorSimulationParams
-  }
+  params?: Record<string, never>
   /**
    * Currently only used in the web adapter:
    * If true, registers a beforeunload event listener to confirm unsaved changes.
@@ -80,11 +65,6 @@ export const makeClientSessionSyncProcessor = ({
   confirmUnsavedChanges: boolean
 }): ClientSessionSyncProcessor => {
   const eventSchema = LiveStoreEvent.Client.makeSchemaMemo(schema)
-
-  const simSleep = <TKey extends keyof ClientSessionSyncProcessorSimulationParams>(
-    key: TKey,
-    key2: keyof ClientSessionSyncProcessorSimulationParams[TKey],
-  ) => Effect.sleep((params.simulation?.[key]?.[key2] ?? 0) as number)
 
   const syncStateRef = {
     // The initial state is identical to the leader's initial state
@@ -101,8 +81,19 @@ export const makeClientSessionSyncProcessor = ({
   const isClientEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
-  /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
-  const leaderPushQueue = BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>().pipe(Effect.runSync)
+  /** Serializes pushes to the leader to satisfy the "no concurrent push" contract on the proxy interface. */
+  const leaderPushSemaphore = Effect.makeSemaphore(1).pipe(Effect.runSync)
+
+  /** Fire-and-forget push to the leader, serialized by the semaphore. Rejected pushes are silently ignored — the pull stream will deliver a rebase. */
+  const pushToLeader = (batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) =>
+    leaderPushSemaphore.withPermits(1)(
+      clientSession.leaderThread.events.push(batch).pipe(
+        Effect.catchIf(isRejectedPushError, () => {
+          debugInfo.rejectCount++
+          return Effect.void
+        }),
+      ),
+    ).pipe(Effect.interruptible, Effect.tapCauseLogPretty, Effect.forkDaemon)
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(function* (batch) {
     // TODO validate batch
@@ -172,9 +163,8 @@ export const makeClientSessionSyncProcessor = ({
       event.meta.materializerHashSession = materializerHash
     }
 
-    // Trigger push to leader
-    // console.debug('pushToLeader', encodedEventDefs.length, ...encodedEventDefs.map((_) => _.toJSON()))
-    yield* BucketQueue.offerAll(leaderPushQueue, encodedEventDefs)
+    // Fire-and-forget push to leader
+    yield* pushToLeader(encodedEventDefs)
 
     return { writeTables }
   })
@@ -203,20 +193,6 @@ export const makeClientSessionSyncProcessor = ({
         () => Effect.sync(() => window.removeEventListener('beforeunload', onBeforeUnload)),
       )
     }
-
-    const leaderPushingFiberHandle = yield* FiberHandle.make()
-
-    const backgroundLeaderPushing = Effect.gen(function* () {
-      const batch = yield* BucketQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
-      yield* clientSession.leaderThread.events.push(batch).pipe(
-        Effect.catchIf(isRejectedPushError, () => {
-          debugInfo.rejectCount++
-          return BucketQueue.clear(leaderPushQueue)
-        }),
-      )
-    }).pipe(Effect.forever, Effect.interruptible, Effect.tapCauseLogPretty)
-
-    yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>
@@ -254,17 +230,6 @@ export const makeClientSessionSyncProcessor = ({
 
             debugInfo.rebaseCount++
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
-
-            yield* FiberHandle.clear(leaderPushingFiberHandle)
-
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
-
-            // Reset the leader push queue since we're rebasing and will push again
-            yield* BucketQueue.clear(leaderPushQueue)
-
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
-
             if (LS_DEV === true) {
               yield* Effect.logDebug(
                 'merge:pull:rebase: rollback',
@@ -281,13 +246,10 @@ export const makeClientSessionSyncProcessor = ({
               }
             }
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
-
-            yield* BucketQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
-
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
-
-            yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+            // Re-push rebased pending events to the leader
+            if (mergeResult.newSyncState.pending.length > 0) {
+              yield* pushToLeader(mergeResult.newSyncState.pending)
+            }
           } else {
             yield* Effect.spanEvent('merge:pull:advance', {
               payloadTag: payload._tag,
@@ -357,13 +319,6 @@ export const makeClientSessionSyncProcessor = ({
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
           console.log('syncState', syncStateRef.current)
-          const pushQueueSize = yield* BucketQueue.size(leaderPushQueue)
-          console.log('pushQueueSize', pushQueueSize)
-          const pushQueueItems = yield* BucketQueue.peekAll(leaderPushQueue)
-          console.log(
-            'pushQueueItems',
-            pushQueueItems.map((_) => _.toJSON()),
-          )
         }).pipe(Effect.provide(runtime), Effect.runSync),
       debugInfo: () => debugInfo,
     },
@@ -387,18 +342,3 @@ export interface ClientSessionSyncProcessor {
     }
   }
 }
-
-// TODO turn this into a build-time "macro" so all simulation snippets are removed for production builds
-const SIMULATION_ENABLED = true
-
-// Warning: High values for the simulation params can lead to very long test runs since those get multiplied with the number of events
-export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
-  pull: Schema.Struct({
-    '1_before_leader_push_fiber_interrupt': Schema.Int.pipe(Schema.between(0, 15)),
-    '2_before_leader_push_queue_clear': Schema.Int.pipe(Schema.between(0, 15)),
-    '3_before_rebase_rollback': Schema.Int.pipe(Schema.between(0, 15)),
-    '4_before_leader_push_queue_offer': Schema.Int.pipe(Schema.between(0, 15)),
-    '5_before_leader_push_fiber_run': Schema.Int.pipe(Schema.between(0, 15)),
-  }),
-})
-type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -35,7 +35,6 @@ export const makeClientSessionSyncProcessor = ({
   materializeEvent,
   rollback,
   refreshTables,
-  params: _params,
   confirmUnsavedChanges,
 }: {
   schema: LiveStoreSchema
@@ -57,7 +56,6 @@ export const makeClientSessionSyncProcessor = ({
   >
   rollback: (changeset: Uint8Array<ArrayBuffer>) => void
   refreshTables: (tables: Set<string>) => void
-  params?: Record<string, never>
   /**
    * Currently only used in the web adapter:
    * If true, registers a beforeunload event listener to confirm unsaved changes.

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -21,13 +21,6 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
       "_name": "client-session-sync-processor:pull",
       "attributes": {
         "code.stacktrace": "<STACKTRACE>",
@@ -77,6 +70,13 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -102,13 +102,6 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -161,6 +154,13 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -186,13 +186,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -291,6 +284,13 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -316,13 +316,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -421,6 +414,13 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -446,13 +446,6 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -551,6 +544,13 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -576,20 +576,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -714,6 +700,13 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -748,6 +741,13 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -773,13 +773,6 @@ exports[`otel > otel 3`] = `
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -867,6 +860,13 @@ exports[`otel > otel 4`] = `
                 },
               },
             ],
+          },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
           },
         ],
       },
@@ -1068,13 +1068,6 @@ exports[`otel > with thunks 7`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
       "_name": "client-session-sync-processor:pull",
       "attributes": {
         "code.stacktrace": "<STACKTRACE>",
@@ -1166,6 +1159,13 @@ exports[`otel > with thunks 8`] = `
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -1191,13 +1191,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -1291,6 +1284,13 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
                 },
               },
             ],
+          },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
           },
         ],
       },

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -5,7 +5,6 @@ import {
   type BootStatus,
   type ClientSession,
   type ClientSessionDevtoolsChannel,
-  type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
   LogConfig,
   type MaterializeError,
@@ -209,13 +208,8 @@ export interface CreateStoreOptions<
   syncPayload?: Schema.Schema.Type<TSyncPayloadSchema>
   /** Options provided to the Store constructor. */
   params?: {
-    /** Max events pushed to the leader per write batch. */
-    leaderPushBatchSize?: number
     /** Chunk size used when the stream replays confirmed events. */
     eventQueryBatchSize?: number
-    simulation?: {
-      clientSessionSyncProcessor: typeof ClientSessionSyncProcessorSimulationParams.Type
-    }
   }
   debug?: {
     instanceId?: string
@@ -395,9 +389,7 @@ export const createStore = <
         batchUpdates: (run) => run(),
         storeId,
         params: {
-          leaderPushBatchSize: params?.leaderPushBatchSize ?? STORE_DEFAULT_PARAMS.leaderPushBatchSize,
           eventQueryBatchSize: params?.eventQueryBatchSize ?? STORE_DEFAULT_PARAMS.eventQueryBatchSize,
-          ...omitUndefineds({ simulation: params?.simulation }),
         },
       })
 

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -3,7 +3,6 @@ import type * as otel from '@opentelemetry/api'
 import {
   type ClientSession,
   type ClientSessionSyncProcessor,
-  type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
   isQueryBuilder,
   type MaterializeError,
@@ -195,11 +194,7 @@ export type StoreConstructorParams<TSchema extends LiveStoreSchema = LiveStoreSc
   confirmUnsavedChanges: boolean
   batchUpdates: (runUpdates: () => void) => void
   params: {
-    leaderPushBatchSize: number
     eventQueryBatchSize?: number
-    simulation?: {
-      clientSessionSyncProcessor: typeof ClientSessionSyncProcessorSimulationParams.Type
-    }
   }
   __runningInDevtools: boolean
 }

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -311,7 +311,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         }
         reactivityGraph.setRefs(tablesToUpdate)
       },
-      params: {},
       confirmUnsavedChanges,
     })
 

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -78,7 +78,6 @@ if (isDevEnv() === true) {
  * Default parameters for the Store. Also used in `create-store.ts`
  */
 export const STORE_DEFAULT_PARAMS = {
-  leaderPushBatchSize: 100,
   eventQueryBatchSize: 100,
 }
 
@@ -312,14 +311,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         }
         reactivityGraph.setRefs(tablesToUpdate)
       },
-      params: {
-        ...omitUndefineds({
-          leaderPushBatchSize: params.leaderPushBatchSize,
-        }),
-        ...(params.simulation?.clientSessionSyncProcessor !== undefined
-          ? { simulation: params.simulation.clientSessionSyncProcessor }
-          : {}),
-      },
+      params: {},
       confirmUnsavedChanges,
     })
 

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -21,20 +21,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
       "_name": "client-session-sync-processor:pull",
       "attributes": {
         "code.stacktrace": "<STACKTRACE>",
@@ -215,6 +201,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -253,6 +246,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -278,20 +278,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       PRAGMA temp_store='MEMORY';
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
       },
     },
     {
@@ -413,6 +399,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -450,6 +443,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
                 },
               },
             ],
+          },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
           },
         ],
       },

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -29,13 +29,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
       "_name": "LiveStore:commits",
     },
     {

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -139,6 +139,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
               },
             ],
           },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
+          },
         ],
       },
     ],
@@ -176,6 +183,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
                 },
               },
             ],
+          },
+          {
+            "_name": "@livestore/common:LeaderSyncProcessor:push",
+            "attributes": {
+              "batch": "undefined",
+              "batchSize": 1,
+            },
           },
         ],
       },

--- a/tests/integration/src/tests/node-sync/client-node-worker.ts
+++ b/tests/integration/src/tests/node-sync/client-node-worker.ts
@@ -35,7 +35,7 @@ class WorkerContext extends Context.Tag('WorkerContext')<
 >() {}
 
 const runner = WorkerRunner.layerSerialized(WorkerSchema.Request, {
-  InitialMessage: ({ storeId, clientId, adapterType, storageType, params, syncUrl }) =>
+  InitialMessage: ({ storeId, clientId, adapterType, storageType, syncUrl }) =>
     Effect.gen(function* () {
       const storage =
         storageType === 'fs'
@@ -71,10 +71,6 @@ const runner = WorkerRunner.layerSerialized(WorkerSchema.Request, {
         storeId,
         disableDevtools: true,
         shutdownDeferred,
-        params: {
-          leaderPushBatchSize: params?.leaderPushBatchSize,
-          simulation: params?.simulation !== undefined ? { clientSessionSyncProcessor: params.simulation } : undefined,
-        },
       })
       // @ts-expect-error for debugging
       globalThis.store = store

--- a/tests/integration/src/tests/node-sync/node-sync.test.ts
+++ b/tests/integration/src/tests/node-sync/node-sync.test.ts
@@ -3,7 +3,6 @@ import * as ChildProcess from 'node:child_process'
 
 import { expect } from 'vitest'
 
-import { ClientSessionSyncProcessorSimulationParams } from '@livestore/common'
 import { IS_CI, stringifyObject } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 import { WranglerDevServerService } from '@livestore/utils-dev/wrangler'
@@ -25,7 +24,7 @@ import { makeFileLogger } from './fixtures/file-logger.ts'
 import * as WorkerSchema from './worker-schema.ts'
 
 // Timeout needs to be long enough to allow for all the test runs to complete, especially in CI where the environment is slower.
-// A single test run can take significant time depending on the passed todo count and simulation params.
+// A single test run can take significant time depending on the passed todo count.
 const testTimeout = Duration.toMillis(IS_CI === true ? Duration.minutes(10) : Duration.minutes(15))
 
 // We might need to also run the tests in a CPU-limited environment as it might change the concurrency characteristics of the tests
@@ -83,10 +82,8 @@ Vitest.describe.concurrent('node-sync', { timeout: testTimeout }, () => {
     { fastCheck: { numRuns: 4 } },
   )
 
-  // Warning: A high CreateCount coupled with high simulation params can lead to very long test runs since those get multiplied with the number of todos.
   const CreateCount = Schema.Int.pipe(Schema.between(1, 400))
   const CommitBatchSize = Schema.Literal(1, 2, 10, 100)
-  const LEADER_PUSH_BATCH_SIZE = Schema.Literal(1, 2, 10, 100)
   // TODO introduce random delays in async operations as part of prop testing
 
   // TODO investigate why stoping this test in VSC Vitest UI often doesn't stop the test runs
@@ -101,17 +98,6 @@ Vitest.describe.concurrent('node-sync', { timeout: testTimeout }, () => {
           todoCountA: Schema.Literal(3),
           todoCountB: Schema.Literal(391),
           commitBatchSize: Schema.Literal(1),
-          leaderPushBatchSize: Schema.Literal(2),
-          simulationParams: Schema.Struct({
-            // Keep values within allowed 0..15 range to avoid parse errors
-            pull: Schema.Struct({
-              '1_before_leader_push_fiber_interrupt': Schema.Literal(0),
-              '2_before_leader_push_queue_clear': Schema.Literal(10),
-              '3_before_rebase_rollback': Schema.Literal(0),
-              '4_before_leader_push_queue_offer': Schema.Literal(15),
-              '5_before_leader_push_fiber_run': Schema.Literal(0),
-            }),
-          }),
         }
       : {
           storageType: WorkerSchema.StorageType,
@@ -119,15 +105,8 @@ Vitest.describe.concurrent('node-sync', { timeout: testTimeout }, () => {
           todoCountA: CreateCount,
           todoCountB: CreateCount,
           commitBatchSize: CommitBatchSize,
-          leaderPushBatchSize: LEADER_PUSH_BATCH_SIZE,
-          // TODO extend simulation tests to cover all parts of the client session and leader sync processor
-          simulationParams: ClientSessionSyncProcessorSimulationParams,
         },
-    (
-      { storageType, adapterType, todoCountA, todoCountB, commitBatchSize, leaderPushBatchSize, simulationParams },
-      test,
-      { numRuns, runIndex },
-    ) =>
+    ({ storageType, adapterType, todoCountA, todoCountB, commitBatchSize }, test, { numRuns, runIndex }) =>
       Effect.gen(function* () {
         console.log(`Run ${runIndex + 1}/${numRuns}`, {
           storageType,
@@ -135,8 +114,6 @@ Vitest.describe.concurrent('node-sync', { timeout: testTimeout }, () => {
           todoCountA,
           todoCountB,
           commitBatchSize,
-          leaderPushBatchSize,
-          simulationParams,
         })
 
         const storeId = nanoid(10)
@@ -147,15 +124,12 @@ Vitest.describe.concurrent('node-sync', { timeout: testTimeout }, () => {
           todoCountA,
           todoCountB,
           commitBatchSize,
-          leaderPushBatchSize,
-          simulationParams,
         })
-        const params = { leaderPushBatchSize, simulation: simulationParams }
 
         const [clientA, clientB] = yield* Effect.all(
           [
-            makeWorker({ clientId: 'client-a', storeId, adapterType, storageType, params }),
-            makeWorker({ clientId: 'client-b', storeId, adapterType, storageType, params }),
+            makeWorker({ clientId: 'client-a', storeId, adapterType, storageType }),
+            makeWorker({ clientId: 'client-b', storeId, adapterType, storageType }),
           ],
           { concurrency: 'unbounded' },
         )
@@ -198,8 +172,6 @@ Vitest.describe.concurrent('node-sync', { timeout: testTimeout }, () => {
             todoCountA,
             todoCountB,
             commitBatchSize,
-            leaderPushBatchSize,
-            simulationParams,
           }),
         })(test),
         // Logging without context (to make sure log is always displayed)
@@ -216,13 +188,11 @@ const makeWorker = ({
   storeId,
   adapterType,
   storageType,
-  params,
 }: {
   clientId: string
   storeId: string
   adapterType: typeof WorkerSchema.AdapterType.Type
   storageType: typeof WorkerSchema.StorageType.Type
-  params?: WorkerSchema.Params
 }) =>
   Effect.gen(function* () {
     // Warning: we need to build the layer here eagerly to tie it to the scope
@@ -241,7 +211,7 @@ const makeWorker = ({
       size: 1,
       concurrency: 100,
       initialMessage: () =>
-        WorkerSchema.InitialMessage.make({ storeId, clientId, adapterType, storageType, params, syncUrl: server.url }),
+        WorkerSchema.InitialMessage.make({ storeId, clientId, adapterType, storageType, syncUrl: server.url }),
     }).pipe(
       Effect.provide(childProcessWorkerContext),
       Effect.tapCauseLogPretty,

--- a/tests/integration/src/tests/node-sync/worker-schema.ts
+++ b/tests/integration/src/tests/node-sync/worker-schema.ts
@@ -1,4 +1,3 @@
-import { ClientSessionSyncProcessorSimulationParams } from '@livestore/common'
 import { ShutdownChannel } from '@livestore/common/leader-thread'
 import { Schema } from '@livestore/utils/effect'
 
@@ -7,10 +6,7 @@ import { tables } from './schema.ts'
 export const StorageType = Schema.Literal('in-memory', 'fs')
 export const AdapterType = Schema.Literal('single-threaded', 'worker')
 
-export const Params = Schema.Struct({
-  leaderPushBatchSize: Schema.optional(Schema.Number),
-  simulation: Schema.optional(ClientSessionSyncProcessorSimulationParams),
-})
+export const Params = Schema.Struct({})
 
 export type Params = typeof Params.Type
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -400,7 +400,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         rollback: () => undefined,
         refreshTables: () => undefined,
 
-        params: { leaderPushBatchSize: 10 },
+        params: {},
         confirmUnsavedChanges: false,
       })
 
@@ -565,7 +565,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         rollback: () => undefined,
         refreshTables: () => undefined,
 
-        params: { leaderPushBatchSize: 10 },
+        params: {},
         confirmUnsavedChanges: false,
       })
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -400,7 +400,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         rollback: () => undefined,
         refreshTables: () => undefined,
 
-        params: {},
         confirmUnsavedChanges: false,
       })
 
@@ -565,7 +564,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         rollback: () => undefined,
         refreshTables: () => undefined,
 
-        params: {},
         confirmUnsavedChanges: false,
       })
 


### PR DESCRIPTION
Replace the BucketQueue + background push fiber + FiberHandle with a semaphore-guarded fire-and-forget push. The leader's localPushesQueue already batches events and its generation filter rejects stale pushes, making the client-side queue redundant.

This eliminates:
- leaderPushQueue (BucketQueue) and background push fiber
- The 5-step rebase dance (interrupt/clear/rollback/refill/restart)
- 5 simulation checkpoints and ClientSessionSyncProcessorSimulationParams
- leaderPushBatchSize parameter from public API

The rebase path simplifies to: rollback changesets, then re-push rebased pending events via the same fire-and-forget helper.

<!-- Use a title that captures the problem and the approach, e.g. "Fix backlog replay flake by stabilizing event helper" -->

## Problem

What problem does this pull request address?

## Solution

How does this change resolve the problem? Mention trade-offs when relevant. Did you consider any other solution ideas?

## Validation

What did you do to verify the change (tests, manual checks, or "not run" with reasoning)?

### Demo (optional)

Share logs, screenshots, CLI output, or quick diagrams (Mermaid/ASCII) that illustrate the change when it helps reviewers grok the impact quickly.

## Related issues

- #...
