### PR TITLE
fix: trigger session shutdown when push fiber fails with non-`RejectedPushError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,6 +440,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### Concurrency & Lifecycle
 
+- Fix background push fiber dying silently on non-`RejectedPushError` failures in `ClientSessionSyncProcessor`, leaving sessions unable to push ([#1133](https://github.com/livestorejs/livestore/issues/1133))
 - Fix correct type assertion in withLock function
 - Fix finalizers execution order (#450)
 - Ensure large batches no longer leave follower sessions behind by reconciling leader/follower heads correctly (#362)

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -214,7 +214,12 @@ export const makeClientSessionSyncProcessor = ({
           return BucketQueue.clear(leaderPushQueue)
         }),
       )
-    }).pipe(Effect.forever, Effect.interruptible, Effect.tapCauseLogPretty)
+    }).pipe(
+      Effect.forever,
+      Effect.interruptible,
+      Effect.tapCauseLogPretty,
+      Effect.catchAllCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
+    )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -592,6 +592,44 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
+  Vitest.scopedLive('push fiber triggers shutdown on non-RejectedPushError', (test) =>
+    Effect.gen(function* () {
+      const pushError = new Error('unexpected transport failure')
+
+      const { makeStore, shutdownDeferred } = yield* TestContext
+
+      const store = yield* makeStore({
+        testing: {
+          overrides: {
+            clientSession: {
+              leaderThreadProxy: (leader) => ({
+                events: {
+                  pull: leader.events.pull,
+                  push: () => Effect.die(pushError),
+                  stream: leader.events.stream,
+                },
+              }),
+            },
+          },
+        },
+      })
+
+      store.commit(events.todoCreated({ id: 'trigger', text: 'boom', completed: false }))
+
+      const exit = yield* Effect.exit(shutdownDeferred)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      assert(Exit.isFailure(exit))
+
+      const defect = Cause.dieOption(exit.cause)
+      expect(defect._tag).toBe('Some')
+      assert(defect._tag === 'Some')
+      expect(defect.value).toBeInstanceOf(Error)
+      assert(defect.value instanceof Error)
+      expect(defect.value.message).toBe('unexpected transport failure')
+    }).pipe(withTestCtx(test)),
+  )
+
   // TODO write tests for:
   // - leader re-election
 })


### PR DESCRIPTION
## Problem

The background push loop in `ClientSessionSyncProcessor` only recovers `RejectedPushError`. Any other failure (e.g. worker crash, serialization error) kills the fiber via `tapCauseLogPretty` without triggering session shutdown or surfacing a processor-level error. This leaves the session half-alive: it can still pull events from the leader but can never push again.

## Solution

Add `catchAllCause` to the background push fiber to trigger session shutdown on unrecoverable errors, matching the pull stream's existing error handling pattern at line 332.

```
Before: push fiber dies → session stuck in pull-only mode
After:  push fiber fails → catchAllCause → session.shutdown()
```

Closes #1133
Related to #1124

## Test plan

- [x] Added test `push fiber triggers shutdown on non-RejectedPushError` — stubs `push` to `Effect.die(error)`, commits an event, and verifies the shutdown deferred receives the original error.
- [x] All 12 `ClientSessionSyncProcessor` tests pass.
- [x] `dt ts:check` passes.
- [x] `dt lint:full:fix` clean.