### PR TITLE
chore: validate effect-utils devenv perf update

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,17 +3,16 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774649847,
-        "narHash": "sha256-2h7rrOzLjyQdt20yHKPnK0fA+v0fj+whGaDBnmfGahY=",
+        "lastModified": 1774687639,
+        "narHash": "sha256-nYuCwx89sBq7V0TveX9LnMnlh/tuJ+oeC5Hyz45WJEg=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "61170924d98492ad8842dca02ad8b912305d308b",
+        "rev": "b4ea96c18cfb3ac57d8658802e06ff53bbbc7001",
         "type": "github"
       },
       "original": {
         "dir": "src/modules",
         "owner": "cachix",
-        "rev": "61170924d98492ad8842dca02ad8b912305d308b",
         "repo": "devenv",
         "type": "github"
       }

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774687639,
-        "narHash": "sha256-nYuCwx89sBq7V0TveX9LnMnlh/tuJ+oeC5Hyz45WJEg=",
+        "lastModified": 1774574416,
+        "narHash": "sha256-lSDwajbwYOAXggD0EAs/pOaBcnSfRjX1ScPo4fk8+tI=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b4ea96c18cfb3ac57d8658802e06ff53bbbc7001",
+        "rev": "4dbca34da522d2169cffb62e56965e4b8ee2453d",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,16 +3,17 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774574416,
-        "narHash": "sha256-lSDwajbwYOAXggD0EAs/pOaBcnSfRjX1ScPo4fk8+tI=",
+        "lastModified": 1774649847,
+        "narHash": "sha256-2h7rrOzLjyQdt20yHKPnK0fA+v0fj+whGaDBnmfGahY=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "4dbca34da522d2169cffb62e56965e4b8ee2453d",
+        "rev": "61170924d98492ad8842dca02ad8b912305d308b",
         "type": "github"
       },
       "original": {
         "dir": "src/modules",
         "owner": "cachix",
+        "rev": "61170924d98492ad8842dca02ad8b912305d308b",
         "repo": "devenv",
         "type": "github"
       }
@@ -24,16 +25,16 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1774694313,
-        "narHash": "sha256-aoi3cC2mqxMfI/+/Xk8r94dLQMq1SlU3FsCbW092aBE=",
+        "lastModified": 1774711838,
+        "narHash": "sha256-5oYNrfED/rk+IEw9gyYC0VZU02zitn5Bb28s6hB9zHw=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "1bd4b185346ba3d45cb075be405d38123e5e2f13",
+        "rev": "21e8c79a387cdd146e734c9ad9832e4f2ece1059",
         "type": "github"
       },
       "original": {
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "rev": "21e8c79a387cdd146e734c9ad9832e4f2ece1059",
         "repo": "effect-utils",
         "type": "github"
       }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -12,4 +12,4 @@ inputs:
       nixpkgs:
         follows: nixpkgs
   effect-utils:
-    url: github:overengineeringstudio/effect-utils/main
+    url: github:overengineeringstudio/effect-utils?rev=21e8c79a387cdd146e734c9ad9832e4f2ece1059

--- a/docs/src/content/_assets/code/.oxlintrc.json.genie.ts
+++ b/docs/src/content/_assets/code/.oxlintrc.json.genie.ts
@@ -5,7 +5,7 @@ import {
   livestoreOxlintPlugins,
   livestoreOxlintRules,
 } from '../../../../../.oxlintrc.json.genie.ts'
-import { oxlintConfig } from '../../../../../repos/effect-utils/genie/external.ts'
+import { oxlintConfig } from '#mr/effect-utils/genie/external.ts'
 
 export default oxlintConfig({
   plugins: livestoreOxlintPlugins,

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -41,8 +41,8 @@ import {
   type WorkspaceMetadata,
   type WorkspacePackage,
   type WorkspacePackageLike,
-} from '../repos/effect-utils/genie/external.ts'
-import { baseOxfmtIgnorePatterns, baseOxfmtOptions } from '../repos/effect-utils/genie/oxfmt-base.ts'
+} from '#mr/effect-utils/genie/external.ts'
+import { baseOxfmtIgnorePatterns, baseOxfmtOptions } from '#mr/effect-utils/genie/oxfmt-base.ts'
 import { livestoreOnlyCatalog, livestoreWorkspaceCatalog } from './external.ts'
 
 export { baseTsconfigCompilerOptions, domLib, reactJsx }
@@ -223,7 +223,7 @@ import {
   nixDiagnosticsArtifactStep,
   savePnpmStoreStep,
   validateNixStoreStep,
-} from '../repos/effect-utils/genie/ci-workflow.ts'
+} from '#mr/effect-utils/genie/ci-workflow.ts'
 
 export const devenvShellDefaults = {
   run: { shell: 'devenv shell bash -- -e {0}' },

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "1bd4b185346ba3d45cb075be405d38123e5e2f13",
+      "ref": "schickling/2026-03-26-devenv-perf",
+      "commit": "21e8c79a387cdd146e734c9ad9832e4f2ece1059",
       "pinned": false,
-      "lockedAt": "2026-03-28T11:04:24.000Z"
+      "lockedAt": "2026-03-28T16:56:00.000Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",

--- a/tests/integration/.oxlintrc.json.genie.ts
+++ b/tests/integration/.oxlintrc.json.genie.ts
@@ -5,7 +5,7 @@ import {
   livestoreOxlintPlugins,
   livestoreOxlintRules,
 } from '../../.oxlintrc.json.genie.ts'
-import { oxlintConfig } from '../../repos/effect-utils/genie/external.ts'
+import { oxlintConfig } from '#mr/effect-utils/genie/external.ts'
 
 export default oxlintConfig({
   plugins: livestoreOxlintPlugins,

--- a/tests/perf-eventlog/.oxlintrc.json.genie.ts
+++ b/tests/perf-eventlog/.oxlintrc.json.genie.ts
@@ -5,7 +5,7 @@ import {
   livestoreOxlintPlugins,
   livestoreOxlintRules,
 } from '../../.oxlintrc.json.genie.ts'
-import { oxlintConfig } from '../../repos/effect-utils/genie/external.ts'
+import { oxlintConfig } from '#mr/effect-utils/genie/external.ts'
 
 export default oxlintConfig({
   plugins: livestoreOxlintPlugins,

--- a/tests/perf/.oxlintrc.json.genie.ts
+++ b/tests/perf/.oxlintrc.json.genie.ts
@@ -5,7 +5,7 @@ import {
   livestoreOxlintPlugins,
   livestoreOxlintRules,
 } from '../../.oxlintrc.json.genie.ts'
-import { oxlintConfig } from '../../repos/effect-utils/genie/external.ts'
+import { oxlintConfig } from '#mr/effect-utils/genie/external.ts'
 
 export default oxlintConfig({
   plugins: livestoreOxlintPlugins,


### PR DESCRIPTION
## What
- pin `effect-utils` in `devenv.yaml` / `devenv.lock` to `overengineeringstudio/effect-utils@21e8c79a387cdd146e734c9ad9832e4f2ece1059`
- point `megarepo.lock`'s `effect-utils` member at `schickling/2026-03-26-devenv-perf@21e8c79a387cdd146e734c9ad9832e4f2ece1059`
- keep the downstream root `devenv` pin on the current `dev` rev to isolate the `effect-utils` impact

## Why
This is a validation branch for overengineeringstudio/effect-utils#464 so we can see how the devenv perf / shell-entry changes behave in a real downstream repo without conflating them with a separate downstream `devenv` rev bump.

## Local validation
### Before update
Using the current downstream inputs with local `devenv 2.0.6+55d2bb4` and a scrubbed OTEL env:
- `devenv shell --no-tui true`
  - `Configuring shell`: `24.9s`
  - `devenv:files:cleanup`: `3.46s`
  - `devenv:files`: `3.53s`
  - `devenv:git-hooks:install`: failed after `1.44s`
  - `genie:run`: failed after `7.67s`
- With the host OTEL env left intact, the old pin failed even earlier after `Configuring shell in 42.4s` with:
  - `[otel] ERROR: extraDashboards is not supported in OTEL_MODE=system`

### After update
Local steady-state benchmarking is still noisy in this repo because the old downstream baseline already has unrelated shell-entry failures (`git-hooks` install / `genie` drift). Downstream CI is the trustworthy validation signal here.

## Combined-pin experiment
I first tried validating both the `effect-utils` pin and a downstream top-level `devenv` bump together.

Baseline: latest `dev` CI run [23687145502](https://github.com/livestorejs/livestore/actions/runs/23687145502)
Rejected combined-pin run: [23689175081](https://github.com/livestorejs/livestore/actions/runs/23689175081)

### Workflow summary
| Scope | Baseline | Combined pin | Δ | Δ % |
| --- | ---: | ---: | ---: | ---: |
| Main CI fan-out (excluding `publish-snapshot-version`, `notify-alignment`, and downstream example-create jobs) | 10:47 | 13:53 | +186s | +28.7% |

### Shared setup overhead
| Step | Baseline avg | Combined pin avg | Δ | Δ % |
| --- | ---: | ---: | ---: | ---: |
| Sync megarepo dependencies | 0:16 | 0:40 | +24s | +148.8% |
| Resolve devenv | 0:24 | 2:23 | +119s | +492.4% |
| Save pnpm store | 0:10 | 0:10 | -0s | -0.5% |

That run made it clear the downstream top-level `devenv` bump was the dominant regression source, especially in `Resolve devenv`.

## Isolated validation
Current isolated run: [23689947083](https://github.com/livestorejs/livestore/actions/runs/23689947083)

### Shared bootstrap
Across both isolated attempts, the shared setup path is back at baseline:

| Step | Baseline avg | Isolated attempt 1 | Isolated attempt 2 |
| --- | ---: | ---: | ---: |
| Sync megarepo dependencies | 0:16.1 | 0:15.8 | 0:15.8 |
| Resolve devenv | 0:24.2 | 0:23.9 | 0:23.9 |

### Job-level drift vs baseline
| Measurement | Attempt 1 | Attempt 2 |
| --- | ---: | ---: |
| Avg job delta | +24.1s / +7.3% | +12.9s / +4.1% |
| Median job delta | +20s / +7.1% | +14s / +4.3% |
| Worst observed delta | +112s | +34s |

### Repeatability notes
The second isolated attempt materially improved several jobs that were noisy outliers in the first attempt:
- `build-deploy-docs`: `+112s -> +32s`
- `test-integration-sync-provider (cf-ws-d1)`: `+67s -> -11s`
- `test-integration-playwright (todomvc)`: `+31s -> +4s`
- `type-check`: `+14s -> -5s`

For context, another recent `dev` run already shows meaningful job-level variance of its own, e.g.:
- `build-and-deploy-examples-src`: `+89s`
- `lint`: `+21s`

## Current conclusion
The major downstream regression was caused by the extra downstream `devenv` bump, not by the `effect-utils` pin itself. Once isolated, the shared bootstrap path is neutral and the remaining drift is much smaller and not stable across attempts.

## Rationale
- keep the downstream diff minimal: only the `effect-utils` validation pins needed to exercise PR 464 downstream
- avoid conflating `effect-utils` changes with a separate downstream `devenv` bootstrap regression
- leave this as a draft until we decide whether a third isolated attempt is worth the extra noise budget

