### PR TITLE
feat: support per-store `unusedCacheTime` in `StoreRegistry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,6 +384,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 #### API & DX
 
+- **Per-store `unusedCacheTime` in `StoreRegistry`:** Each store managed by a `StoreRegistry` can now specify its own `unusedCacheTime` via `storeOptions()`, overriding the registry-level default. Short-lived ephemeral stores can be disposed quickly while persistent stores stay cached longer ([#917](https://github.com/livestorejs/livestore/issues/917)).
 - **Store:** `store.networkStatus` now surfaces sync backend connectivity so apps can read the latest status or subscribe directly; the signal is no longer re-exposed on client sessions (livestorejs/livestore#394).
 - `LiveStoreSchema.Any` type alias simplifies schema composition across adapters.
 - Query builder const assertions improve type inference, and `store.subscribe()` now accepts query builders (#371, thanks @rgbkrk).

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -126,7 +126,7 @@ Options:
 - `storeId` - Unique identifier for this store instance
 - `schema` - The LiveStore schema
 - `adapter` - The platform adapter
-- `unusedCacheTime?` - Time in ms to keep unused stores in cache (default: `60_000` in browser, `Infinity` in non-browser environments)
+- `unusedCacheTime?` - Time in ms to keep this store in cache after it becomes unused (default: `60_000` in browser, `Infinity` in non-browser environments). Overrides the registry-level default when set.
 - `batchUpdates?` - Function for batching React updates (recommended)
 - `boot?` - Function called when the store is loaded
 - `onBootStatus?` - Callback for boot status updates

--- a/packages/@livestore/livestore/src/store/StoreRegistry.test.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.test.ts
@@ -195,29 +195,52 @@ describe('StoreRegistry', () => {
     await nextStore.shutdownPromise()
   })
 
-  // This test is skipped because Effect doesn't yet support different `idleTimeToLive` values for each resource in `RcMap`
-  // See https://github.com/livestorejs/livestore/issues/917
-  it.skip('allows call-site options to override default options', async () => {
+  it('allows call-site options to override default options', async () => {
     const storeRegistry = new StoreRegistry({
       defaultOptions: {
-        unusedCacheTime: 1000, // Default is long
+        unusedCacheTime: 10_000, // Long default
       },
     })
 
+    const unusedCacheTimeOverride = 25
     const options = testStoreOptions({
-      unusedCacheTime: 10, // Override with shorter time
+      unusedCacheTime: unusedCacheTimeOverride,
     })
 
     const store = await storeRegistry.getOrLoadPromise(options)
 
-    // Wait for the override time (10ms)
-    await sleep(10)
+    // Wait for the override time + buffer
+    await sleep(unusedCacheTimeOverride + 100)
 
     // Should be disposed according to the override time, not default
     const nextStore = await storeRegistry.getOrLoadPromise(options)
     expect(nextStore).not.toBe(store)
 
     await nextStore.shutdownPromise()
+  })
+
+  it('disposes different stores according to their own unusedCacheTime', async () => {
+    const storeRegistry = new StoreRegistry({
+      defaultOptions: { unusedCacheTime: 1000 },
+    })
+
+    const shortOptions = testStoreOptions({ storeId: 'short-lived', unusedCacheTime: 25 })
+    const longOptions = testStoreOptions({ storeId: 'long-lived', unusedCacheTime: 10_000 })
+
+    const shortStore = await storeRegistry.getOrLoadPromise(shortOptions)
+    const longStore = await storeRegistry.getOrLoadPromise(longOptions)
+
+    // Wait for short store's unusedCacheTime to expire + buffer
+    await sleep(25 + 100)
+
+    // Short store should be disposed, long store should still be cached
+    const nextShortStore = await storeRegistry.getOrLoadPromise(shortOptions)
+    expect(nextShortStore).not.toBe(shortStore)
+    expect(storeRegistry.getOrLoadPromise(longOptions)).toBe(longStore)
+
+    // Clean up
+    await nextShortStore.shutdownPromise()
+    await longStore.shutdownPromise()
   })
 
   // This test is skipped because we don't yet support dynamic `unusedCacheTime` updates for cached stores.

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -17,7 +17,7 @@ import {
   type Scope,
 } from '@livestore/utils/effect'
 
-import { type CreateStoreOptions, createStore } from './create-store.ts'
+import { createStore, type CreateStoreOptions } from './create-store.ts'
 import type { Store } from './store.ts'
 import type { OtelOptions } from './store-types.ts'
 
@@ -66,10 +66,10 @@ export interface RegistryStoreOptions<
    * have unmounted.
    *
    * @remarks
-   * - **Limitation:** Per-store values are not yet supported. Only the registry-level default
-   *   (via `StoreRegistry` constructor's `defaultOptions.unusedCacheTime`) is used.
-   *   See {@link https://github.com/livestorejs/livestore/issues/917 | #917} for per-store support
-   *   and {@link https://github.com/livestorejs/livestore/issues/918 | #918} for dynamic "longest wins" behavior.
+   * - Per-store values override the registry-level default (set via `StoreRegistry` constructor's
+   *   `defaultOptions.unusedCacheTime`)
+   * - The value is fixed when the store is first loaded into the registry. If the same `storeId` is
+   *   requested again with a different `unusedCacheTime`, the original value is kept.
    * - If set to `Infinity`, will disable automatic disposal
    * - The maximum allowed time is about {@link https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value | 24 days}
    *
@@ -205,9 +205,7 @@ export class StoreRegistry {
           ),
         )
       },
-      // TODO: Make idleTimeToLive vary for each store when Effect supports per-resource TTL
-      // See https://github.com/livestorejs/livestore/issues/917
-      idleTimeToLive: config.defaultOptions?.unusedCacheTime ?? DEFAULT_UNUSED_CACHE_TIME,
+      idleTimeToLive: ({ options }: StoreCacheKey) => options.unusedCacheTime ?? config.defaultOptions?.unusedCacheTime ?? DEFAULT_UNUSED_CACHE_TIME,
     }).pipe(Runtime.runSync(this.#runtime))
   }
 


### PR DESCRIPTION
## Summary

- Use `RcMap`'s per-key `idleTimeToLive` function (added in Effect 3.21.0) to allow each store to specify its own `unusedCacheTime`, overriding the registry-level default.
- Requires the Effect ecosystem bump from [#1140](https://github.com/livestorejs/livestore/pull/1140) (`effect ≥3.21.0`) for the function-form `idleTimeToLive` API in `RcMap`.

Closes #917

## Changes

- **`StoreRegistry.ts`**: Changed `idleTimeToLive` from a static value to a per-key function that reads `unusedCacheTime` from each `StoreCacheKey`, falling back to the registry default and then `DEFAULT_UNUSED_CACHE_TIME`.
- **`StoreRegistry.ts` TSDoc**: Removed the "Limitation: Per-store values are not yet supported" notice. Added a remark that the value is fixed at first load (subsequent calls with different values for the same `storeId` are ignored).
- **`StoreRegistry.test.ts`**: Enabled the previously skipped "allows call-site options to override default options" test. Added a new "disposes different stores according to their own unusedCacheTime" test verifying two stores with different TTLs are disposed independently.
- **`react-integration.mdx`**: Clarified that per-store `unusedCacheTime` overrides the registry default.
- **`CHANGELOG.md`**: Added entry under Core Runtime & Storage.

## Test plan

- [x] Enabled test: "allows call-site options to override default options" — verifies a call-site `unusedCacheTime` override causes disposal at the override time, not the registry default.
- [x] New test: "disposes different stores according to their own unusedCacheTime" — verifies a short-lived store is disposed while a long-lived store remains cached.
- [x] All 21 existing StoreRegistry tests continue to pass (1 skipped for unrelated #918).