### PR TITLE
feat(sync-cf): use exponential backoff for WS retry

### DIFF
--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -96,7 +96,10 @@ export const makeWsSync =
 
       const ProtocolLive = RpcClient.layerProtocolSocketWithIsConnected({
         isConnected,
-        retryTransientErrors: Schedule.fixed(1000),
+        retryTransientErrors: Schedule.exponential('1 seconds').pipe(
+          Schedule.union(Schedule.fixed('30 seconds')),
+          Schedule.jittered,
+        ),
         pingSchedule: Schedule.once.pipe(Schedule.andThen(Schedule.fixed(pingInterval))),
         url: wsUrl,
       }).pipe(


### PR DESCRIPTION
## Problem

The `sync-cf` WebSocket RPC client retries failed connections every 1 second (`Schedule.fixed(1000)`), indefinitely, with no backoff. This causes thundering herd after server restarts and unnecessary load during outages — each open tab sends 1 req/sec, each billable as a CF Worker invocation.

## Solution

Replace with exponential backoff (1s base → 30s cap, indefinite, jittered):

```ts
Schedule.exponential('1 seconds').pipe(
  Schedule.union(Schedule.fixed('30 seconds')),
  Schedule.jittered,
)
```

This follows the pattern already used by `LeaderSyncProcessor` for push retries, with added jitter to prevent synchronized retries across clients. Better default, not a new configuration surface — per discussion on #1111.

## Testing

No new tests — the schedule is inlined in `makeWsSync`, so unit tests would only verify Effect's combinators, and the `SyncBackend` interface doesn't expose retry timing for integration-level assertions. The existing `cf-ws-*` sync provider integration tests pass and confirm connectivity isn't broken.

## Considered but deferred

- **Browser `online` event**: The commented-out TODO for waiting on connectivity before retrying requires a separate PR — Chrome/Edge don't fire `online`/`offline` events inside Web Workers ([crbug.com/114475](https://crbug.com/114475)), and `visibilitychange` is main-thread only. Both need main-thread → worker message forwarding.

- **UI reconnection state**: Exposing a "reconnecting" indicator to the UI is a cross-cutting change. The `isConnected` boolean flows from `RpcClient` → `SyncBackend` → `NetworkStatus` → `store.networkStatus` → framework hooks. Widening it to a tri-state (connected/disconnected/reconnecting) touches ~5 packages. Separate issue/PR.

Refs #1111