### PR TITLE
Add Livestore core and tooling workspace projections

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1775034251,
-        "narHash": "sha256-wz8RzKSS/ylXmUlOmZo5jfkUyJCfTJvw0dXzCt8UxX0=",
+        "lastModified": 1774940186,
+        "narHash": "sha256-QJlw3nwOQKS4qVVARUw7YAHz6ag8qDdygbKn45HqeGA=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "cb07ccc9cfbb2b61cfec2884b4e49b1f0741c3db",
+        "rev": "88f362706635fc645ebe368e4c7005ac832c3221",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1775034251,
-        "narHash": "sha256-wz8RzKSS/ylXmUlOmZo5jfkUyJCfTJvw0dXzCt8UxX0=",
+        "lastModified": 1774940186,
+        "narHash": "sha256-QJlw3nwOQKS4qVVARUw7YAHz6ag8qDdygbKn45HqeGA=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "cb07ccc9cfbb2b61cfec2884b4e49b1f0741c3db",
+        "rev": "88f362706635fc645ebe368e4c7005ac832c3221",
         "type": "github"
       },
       "original": {
@@ -277,11 +277,11 @@
         "typescript-src": "typescript-src"
       },
       "locked": {
-        "lastModified": 1774889517,
-        "narHash": "sha256-wl+OjG7kVWMt6B9ROP2keiT3CELQkNyL0bh1SoCKXh0=",
+        "lastModified": 1773387039,
+        "narHash": "sha256-v7O3R7RxDqK/T+ot3JPEZcBcLZsAMIjD2EbpYy1/t1I=",
         "owner": "Effect-TS",
         "repo": "tsgo",
-        "rev": "24a8a96ec80681a1d15243da30c2423d73cb1193",
+        "rev": "c219f226cb0579a8c077fab3192d7ddf190ba77a",
         "type": "github"
       },
       "original": {
@@ -293,17 +293,17 @@
     "typescript-go-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774829605,
-        "narHash": "sha256-t6imfxEDl9Vm2weZjkumqSL+K5z3YcYm7w2GgNMrpSA=",
+        "lastModified": 1773275612,
+        "narHash": "sha256-S5TnTCE3/e7ZyQgsBKYzBp5aqCvecflo1JAEL0LDv4Q=",
         "owner": "microsoft",
         "repo": "typescript-go",
-        "rev": "8a834dad086d6912b091e8b467e98499dab68cd9",
+        "rev": "8b515c6ce5f821ed382cdb540c6df488738bb515",
         "type": "github"
       },
       "original": {
         "owner": "microsoft",
         "repo": "typescript-go",
-        "rev": "8a834dad086d6912b091e8b467e98499dab68cd9",
+        "rev": "8b515c6ce5f821ed382cdb540c6df488738bb515",
         "type": "github"
       }
     },

--- a/genie/projections/core/pnpm-workspace.yaml
+++ b/genie/projections/core/pnpm-workspace.yaml
@@ -1,0 +1,52 @@
+# Generated file - DO NOT EDIT
+# Source: pnpm-workspace.yaml.genie.ts
+
+dedupePeerDependents: true
+
+strictPeerDependencies: true
+
+enableGlobalVirtualStore: true
+
+optimisticRepeatInstall: false
+
+verifyDepsBeforeRun: false
+
+supportedArchitectures:
+  os: [linux, darwin]
+  cpu: [x64, arm64]
+  libc: [glibc, musl]
+
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  msgpackr-extract: true
+  sharp: true
+  unix-dgram: true
+
+packages:
+  - ../../../packages/@livestore/adapter-cloudflare
+  - ../../../packages/@livestore/adapter-expo
+  - ../../../packages/@livestore/adapter-node
+  - ../../../packages/@livestore/adapter-web
+  - ../../../packages/@livestore/cli
+  - ../../../packages/@livestore/common
+  - ../../../packages/@livestore/common-cf
+  - ../../../packages/@livestore/devtools-expo
+  - ../../../packages/@livestore/devtools-web-common
+  - ../../../packages/@livestore/effect-playwright
+  - ../../../packages/@livestore/framework-toolkit
+  - ../../../packages/@livestore/graphql
+  - ../../../packages/@livestore/livestore
+  - ../../../packages/@livestore/peer-deps
+  - ../../../packages/@livestore/react
+  - ../../../packages/@livestore/solid
+  - ../../../packages/@livestore/sqlite-wasm
+  - ../../../packages/@livestore/svelte
+  - ../../../packages/@livestore/sync-cf
+  - ../../../packages/@livestore/sync-electric
+  - ../../../packages/@livestore/sync-s2
+  - ../../../packages/@livestore/utils
+  - ../../../packages/@livestore/utils-dev
+  - ../../../packages/@livestore/wa-sqlite
+  - ../../../packages/@livestore/webmesh
+  - ../../../packages/@local/shared

--- a/genie/projections/core/pnpm-workspace.yaml.genie.ts
+++ b/genie/projections/core/pnpm-workspace.yaml.genie.ts
@@ -1,0 +1,28 @@
+import { coreWorkspacePackages } from '../../../package.json.genie.ts'
+import { createGenieOutput } from '../../../repos/effect-utils/packages/@overeng/genie/src/runtime/core.ts'
+import { stringify } from '../../../repos/effect-utils/packages/@overeng/genie/src/runtime/utils/yaml.ts'
+import { commonPnpmPolicySettings, pnpmWorkspaceYaml } from '../../repo.ts'
+
+const coreWorkspaceRoot = pnpmWorkspaceYaml.root({
+  packages: coreWorkspacePackages,
+  repoName: 'livestore',
+  ...commonPnpmPolicySettings,
+})
+
+/**
+ * Core install projection for Livestore.
+ *
+ * This keeps the full repo workspace authoritative while exposing a smaller
+ * install root for downstream consumers and CI tasks that do not need examples,
+ * docs, tests, scripts, or local demos.
+ */
+const coreWorkspaceData = {
+  ...coreWorkspaceRoot.data,
+  packages: coreWorkspaceRoot.data.packages.map((memberPath) => `../../../${memberPath}`),
+}
+
+export default createGenieOutput({
+  data: coreWorkspaceData,
+  stringify: () => stringify(coreWorkspaceData),
+  validate: coreWorkspaceRoot.validate,
+})

--- a/genie/projections/tooling/pnpm-workspace.yaml
+++ b/genie/projections/tooling/pnpm-workspace.yaml
@@ -1,0 +1,83 @@
+# Generated file - DO NOT EDIT
+# Source: pnpm-workspace.yaml.genie.ts
+
+dedupePeerDependents: true
+
+strictPeerDependencies: false
+
+enableGlobalVirtualStore: true
+
+optimisticRepeatInstall: false
+
+verifyDepsBeforeRun: false
+
+supportedArchitectures:
+  os: [linux, darwin]
+  cpu: [x64, arm64]
+  libc: [glibc, musl]
+
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  msgpackr-extract: true
+  sharp: true
+  unix-dgram: true
+  '@mixedbread/cli': true
+  cbor-extract: true
+  dtrace-provider: true
+  protobufjs: true
+  puppeteer: true
+  workerd: true
+
+packageExtensions:
+  react-error-boundary:
+    dependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3
+  starlight-auto-sidebar:
+    dependencies:
+      astro: '>=5.0.0'
+  starlight-links-validator:
+    dependencies:
+      astro: '>=5.0.0'
+  starlight-sidebar-topics:
+    dependencies:
+      astro: '>=5.0.0'
+  typedoc:
+    dependencies:
+      typedoc-plugin-markdown: ^4.8.1
+
+packages:
+  - ../../../docs
+  - ../../../docs/src/content/_assets/code
+  - ../../../packages/@livestore/adapter-cloudflare
+  - ../../../packages/@livestore/adapter-expo
+  - ../../../packages/@livestore/adapter-node
+  - ../../../packages/@livestore/adapter-web
+  - ../../../packages/@livestore/cli
+  - ../../../packages/@livestore/common
+  - ../../../packages/@livestore/common-cf
+  - ../../../packages/@livestore/devtools-expo
+  - ../../../packages/@livestore/devtools-web-common
+  - ../../../packages/@livestore/effect-playwright
+  - ../../../packages/@livestore/framework-toolkit
+  - ../../../packages/@livestore/graphql
+  - ../../../packages/@livestore/livestore
+  - ../../../packages/@livestore/peer-deps
+  - ../../../packages/@livestore/react
+  - ../../../packages/@livestore/solid
+  - ../../../packages/@livestore/sqlite-wasm
+  - ../../../packages/@livestore/svelte
+  - ../../../packages/@livestore/sync-cf
+  - ../../../packages/@livestore/sync-electric
+  - ../../../packages/@livestore/sync-s2
+  - ../../../packages/@livestore/utils
+  - ../../../packages/@livestore/utils-dev
+  - ../../../packages/@livestore/wa-sqlite
+  - ../../../packages/@livestore/webmesh
+  - ../../../packages/@local/astro-tldraw
+  - ../../../packages/@local/astro-twoslash-code
+  - ../../../packages/@local/shared
+  - ../../../scripts
+  - ../../../tests/integration
+  - ../../../tests/sync-provider

--- a/genie/projections/tooling/pnpm-workspace.yaml.genie.ts
+++ b/genie/projections/tooling/pnpm-workspace.yaml.genie.ts
@@ -1,0 +1,32 @@
+import { toolingWorkspacePackages } from '../../../package.json.genie.ts'
+import { createGenieOutput } from '../../../repos/effect-utils/packages/@overeng/genie/src/runtime/core.ts'
+import { stringify } from '../../../repos/effect-utils/packages/@overeng/genie/src/runtime/utils/yaml.ts'
+import { commonPnpmPolicySettings, pnpmWorkspaceYaml, repoPackageExtensions, repoPnpmAllowBuilds } from '../../repo.ts'
+
+const toolingWorkspaceRoot = pnpmWorkspaceYaml.root({
+  packages: toolingWorkspacePackages,
+  repoName: 'livestore',
+  ...commonPnpmPolicySettings,
+  allowBuilds: repoPnpmAllowBuilds,
+  packageExtensions: repoPackageExtensions,
+  /** Relaxed until @livestore/devtools-vite publishes with updated Effect peer ranges */
+  strictPeerDependencies: false,
+})
+
+/**
+ * Tooling install projection for Livestore.
+ *
+ * This extends the core install root with the local/docs/test packages needed by
+ * downstream devtools and release workflows while still avoiding the full repo
+ * workspace breadth.
+ */
+const toolingWorkspaceData = {
+  ...toolingWorkspaceRoot.data,
+  packages: toolingWorkspaceRoot.data.packages.map((memberPath) => `../../../${memberPath}`),
+}
+
+export default createGenieOutput({
+  data: toolingWorkspaceData,
+  stringify: () => stringify(toolingWorkspaceData),
+  validate: toolingWorkspaceRoot.validate,
+})

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -126,6 +126,14 @@ export const repoPnpmOnlyBuiltDependencies = Object.entries(repoPnpmAllowBuilds)
   .map(([name]) => name)
   .toSorted()
 
+/** Repo-specific pnpm packageExtensions for starlight/typedoc peer resolution */
+export const repoPackageExtensions = {
+  'starlight-auto-sidebar': { dependencies: { astro: '>=5.0.0' } },
+  'starlight-links-validator': { dependencies: { astro: '>=5.0.0' } },
+  'starlight-sidebar-topics': { dependencies: { astro: '>=5.0.0' } },
+  typedoc: { dependencies: { 'typedoc-plugin-markdown': '^4.8.1' } },
+} as const
+
 // =============================================================================
 // Package Config Exports
 // =============================================================================

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "2395677ff2d33969825a2b29f9a613923fe21474",
+      "commit": "1b35c4ee8670c6d8a624495cc0424f29484b34a4",
       "pinned": false,
-      "lockedAt": "2026-04-01T06:00:00.000Z"
+      "lockedAt": "2026-04-01T10:30:00.000Z"
     },
     "overeng-beads-public": {
       "url": "https://github.com/overengineeringstudio/overeng-beads-public",

--- a/package.json.genie.ts
+++ b/package.json.genie.ts
@@ -79,6 +79,60 @@ export const rootWorkspacePackages = [
   testsWaSqlitePkg,
 ] as const
 
+const coreWorkspaceExclusions = [
+  'docs',
+  'scripts',
+  'tests',
+  'packages/@local/astro-tldraw',
+  'packages/@local/astro-twoslash-code',
+] as const
+
+const isWorkspacePackageExcluded = (
+  excludedPaths: readonly string[],
+  workspacePackage: (typeof rootWorkspacePackages)[number],
+) =>
+  excludedPaths.some(
+    (excludedPath) =>
+      workspacePackage.meta.workspace.memberPath === excludedPath ||
+      workspacePackage.meta.workspace.memberPath.startsWith(`${excludedPath}/`),
+  )
+
+const isCoreWorkspacePackage = (workspacePackage: (typeof rootWorkspacePackages)[number]) =>
+  isWorkspacePackageExcluded(coreWorkspaceExclusions, workspacePackage) === false
+
+/**
+ * Livestore core workspace packages.
+ *
+ * This is the install-projection used by the core workspace root in
+ * `genie/projections/core/`.
+ * It intentionally excludes examples, docs, tests, scripts, and local demo packages
+ * so downstream consumers can install the production/library graph without the
+ * full repo breadth.
+ */
+export const coreWorkspacePackages = rootWorkspacePackages.filter(isCoreWorkspacePackage)
+
+const toolingWorkspacePackagesByPath = new Set([
+  ...coreWorkspacePackages.map((workspacePackage) => workspacePackage.meta.workspace.memberPath),
+  'docs',
+  'docs/src/content/_assets/code',
+  'packages/@local/astro-tldraw',
+  'packages/@local/astro-twoslash-code',
+  'scripts',
+  'tests/integration',
+  'tests/sync-provider',
+])
+
+/**
+ * Livestore tooling workspace packages.
+ *
+ * This extends the core projection with the local/docs/tooling packages needed
+ * by downstream devtools and release workflows without pulling in the full repo
+ * workspace breadth.
+ */
+export const toolingWorkspacePackages = rootWorkspacePackages.filter((workspacePackage) =>
+  toolingWorkspacePackagesByPath.has(workspacePackage.meta.workspace.memberPath),
+)
+
 const rootWorkspace = packageJson.aggregateFromPackages({
   packages: rootWorkspacePackages,
   name: 'livestore-workspace',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -666,7 +666,7 @@ importers:
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.8
-        version: 2.4.9
+        version: 2.4.10
       '@cloudflare/vite-plugin':
         specifier: ^1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
@@ -736,7 +736,7 @@ importers:
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.8
-        version: 2.4.9
+        version: 2.4.10
       '@cloudflare/vite-plugin':
         specifier: ^1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
@@ -1072,7 +1072,7 @@ importers:
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.8
-        version: 2.4.9
+        version: 2.4.10
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.1.18(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -5800,59 +5800,59 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.9':
-    resolution: {integrity: sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==}
+  '@biomejs/biome@2.4.10':
+    resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.9':
-    resolution: {integrity: sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==}
+  '@biomejs/cli-darwin-arm64@2.4.10':
+    resolution: {integrity: sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.9':
-    resolution: {integrity: sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==}
+  '@biomejs/cli-darwin-x64@2.4.10':
+    resolution: {integrity: sha512-14fzASRo+BPotwp7nWULy2W5xeUyFnTaq1V13Etrrxkrih+ez/2QfgFm5Ehtf5vSjtgx/IJycMMpn5kPd5ZNaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.9':
-    resolution: {integrity: sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==}
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
+    resolution: {integrity: sha512-WrJY6UuiSD/Dh+nwK2qOTu8kdMDlLV3dLMmychIghHPAysWFq1/DGC1pVZx8POE3ZkzKR3PUUnVrtZfMfaJjyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.9':
-    resolution: {integrity: sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==}
+  '@biomejs/cli-linux-arm64@2.4.10':
+    resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.9':
-    resolution: {integrity: sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==}
+  '@biomejs/cli-linux-x64-musl@2.4.10':
+    resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.9':
-    resolution: {integrity: sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==}
+  '@biomejs/cli-linux-x64@2.4.10':
+    resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.9':
-    resolution: {integrity: sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==}
+  '@biomejs/cli-win32-arm64@2.4.10':
+    resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.9':
-    resolution: {integrity: sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==}
+  '@biomejs/cli-win32-x64@2.4.10':
+    resolution: {integrity: sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -7240,8 +7240,8 @@ packages:
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.12':
+    resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -10584,30 +10584,30 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/project-service@8.57.2':
-    resolution: {integrity: sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==}
+  '@typescript-eslint/project-service@8.58.0':
+    resolution: {integrity: sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/tsconfig-utils@8.57.2':
-    resolution: {integrity: sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==}
+  '@typescript-eslint/tsconfig-utils@8.58.0':
+    resolution: {integrity: sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.57.2':
-    resolution: {integrity: sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==}
+  '@typescript-eslint/types@8.58.0':
+    resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@8.57.2':
-    resolution: {integrity: sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==}
+  '@typescript-eslint/typescript-estree@8.58.0':
+    resolution: {integrity: sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.57.2':
-    resolution: {integrity: sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==}
+  '@typescript-eslint/visitor-keys@8.58.0':
+    resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.4':
@@ -10908,10 +10908,9 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+  '@xmldom/xmldom@0.8.12':
+    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -11347,8 +11346,8 @@ packages:
       bare-buffer:
         optional: true
 
-  bare-os@3.8.4:
-    resolution: {integrity: sha512-4JboWUl7/2LhgU536tjUszzaVC8/WEWKtyX5crayvlN71ih8+O2SdvBhotQeDsuhhmPZmLCrPBJEcwVPhI/kkQ==}
+  bare-os@3.8.6:
+    resolution: {integrity: sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==}
     engines: {bare: '>=1.14.0'}
 
   bare-path@3.0.0:
@@ -11466,8 +11465,8 @@ packages:
   brotli@1.3.3:
     resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -11582,8 +11581,8 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  caniuse-lite@1.0.30001781:
-    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
+  caniuse-lite@1.0.30001782:
+    resolution: {integrity: sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==}
 
   canvaskit-wasm@0.39.1:
     resolution: {integrity: sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==}
@@ -12627,8 +12626,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.328:
-    resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
+  electron-to-chromium@1.5.329:
+    resolution: {integrity: sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==}
 
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
@@ -14221,8 +14220,8 @@ packages:
     resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
     engines: {node: '>= 18.0.0'}
 
-  isbot@5.1.36:
-    resolution: {integrity: sha512-C/ZtXyJqDPZ7G7JPr06ApWyYoHjYexQbS6hPYD4WYCzpv2Qes6Z+CCEfTX4Owzf+1EJ933PoI2p+B9v7wpGZBQ==}
+  isbot@5.1.37:
+    resolution: {integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==}
     engines: {node: '>=18'}
 
   isexe@2.0.0:
@@ -14491,8 +14490,8 @@ packages:
     peerDependencies:
       kysely: '*'
 
-  kysely@0.28.14:
-    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
+  kysely@0.28.15:
+    resolution: {integrity: sha512-r2clcf7HLWvDXaVUEvQymXJY4i3bSOIV3xsL/Upy3ZfSv5HeKsk9tsqbBptLvth5qHEIhxeHTA2jNLyQABkLBA==}
     engines: {node: '>=20.0.0'}
 
   lambda-local@2.2.0:
@@ -15279,8 +15278,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -16233,8 +16232,8 @@ packages:
       prosemirror-state: ^1.4.2
       prosemirror-view: ^1.33.8
 
-  prosemirror-transform@1.11.0:
-    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
 
   prosemirror-view@1.41.7:
     resolution: {integrity: sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==}
@@ -19396,7 +19395,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -19962,39 +19961,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.4.9':
+  '@biomejs/biome@2.4.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.9
-      '@biomejs/cli-darwin-x64': 2.4.9
-      '@biomejs/cli-linux-arm64': 2.4.9
-      '@biomejs/cli-linux-arm64-musl': 2.4.9
-      '@biomejs/cli-linux-x64': 2.4.9
-      '@biomejs/cli-linux-x64-musl': 2.4.9
-      '@biomejs/cli-win32-arm64': 2.4.9
-      '@biomejs/cli-win32-x64': 2.4.9
+      '@biomejs/cli-darwin-arm64': 2.4.10
+      '@biomejs/cli-darwin-x64': 2.4.10
+      '@biomejs/cli-linux-arm64': 2.4.10
+      '@biomejs/cli-linux-arm64-musl': 2.4.10
+      '@biomejs/cli-linux-x64': 2.4.10
+      '@biomejs/cli-linux-x64-musl': 2.4.10
+      '@biomejs/cli-win32-arm64': 2.4.10
+      '@biomejs/cli-win32-x64': 2.4.10
 
-  '@biomejs/cli-darwin-arm64@2.4.9':
+  '@biomejs/cli-darwin-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.9':
+  '@biomejs/cli-darwin-x64@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.9':
+  '@biomejs/cli-linux-arm64-musl@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.9':
+  '@biomejs/cli-linux-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.9':
+  '@biomejs/cli-linux-x64-musl@2.4.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.9':
+  '@biomejs/cli-linux-x64@2.4.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.9':
+  '@biomejs/cli-win32-arm64@2.4.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.9':
+  '@biomejs/cli-win32-x64@2.4.10':
     optional: true
 
   '@braintree/sanitize-url@7.1.2': {}
@@ -21250,7 +21249,7 @@ snapshots:
       '@expo/json-file': 10.0.12
       '@expo/metro': 54.0.0
       '@expo/spawn-async': 1.7.2
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.4.7
@@ -21370,7 +21369,7 @@ snapshots:
 
   '@expo/plist@0.4.8':
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -21613,7 +21612,7 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  '@hono/node-server@1.19.11(hono@4.12.9)':
+  '@hono/node-server@1.19.12(hono@4.12.9)':
     dependencies:
       hono: 4.12.9
 
@@ -21932,7 +21931,7 @@ snapshots:
   '@kitschpatrol/tldraw-cli@5.0.1(typescript@5.9.3)':
     dependencies:
       '@fontsource/inter': 5.2.8
-      '@hono/node-server': 1.19.11(hono@4.12.9)
+      '@hono/node-server': 1.19.12(hono@4.12.9)
       hono: 4.12.9
       puppeteer: 24.40.0(typescript@5.9.3)
       uint8array-extras: 1.5.0
@@ -22462,7 +22461,7 @@ snapshots:
       glob: 10.5.0
       inquirer: 9.3.8(@types/node@25.3.3)
       mime-types: 3.0.2
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       ora: 8.2.0
       p-limit: 6.2.0
       yaml: 2.8.1
@@ -22864,7 +22863,7 @@ snapshots:
       junk: 4.0.1
       locate-path: 7.2.0
       merge-options: 3.0.4
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       normalize-path: 3.0.0
       p-map: 7.0.4
       path-exists: 5.0.0
@@ -25782,7 +25781,7 @@ snapshots:
       '@tanstack/history': 1.139.0
       '@tanstack/react-store': 0.8.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/router-core': 1.139.14
-      isbot: 5.1.36
+      isbot: 5.1.37
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       tiny-invariant: 1.3.3
@@ -25793,7 +25792,7 @@ snapshots:
       '@tanstack/history': 1.139.0
       '@tanstack/react-store': 0.8.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-core': 1.139.14
-      isbot: 5.1.36
+      isbot: 5.1.37
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       tiny-invariant: 1.3.3
@@ -26276,7 +26275,7 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-tables: 1.8.5
       prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.7
 
   '@tiptap/react@3.12.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.12.1(@tiptap/pm@3.12.1))(@tiptap/pm@3.12.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -26342,7 +26341,7 @@ snapshots:
 
   '@ts-morph/common@0.28.1':
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       path-browserify: 1.0.1
       tinyglobby: 0.2.15
 
@@ -26797,29 +26796,29 @@ snapshots:
       '@types/node': 25.3.3
     optional: true
 
-  '@typescript-eslint/project-service@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.58.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/tsconfig-utils@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/types@8.57.2': {}
+  '@typescript-eslint/types@8.58.0': {}
 
-  '@typescript-eslint/typescript-estree@8.57.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.58.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/visitor-keys': 8.57.2
+      '@typescript-eslint/project-service': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/visitor-keys': 8.58.0
       debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -26827,9 +26826,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.57.2':
+  '@typescript-eslint/visitor-keys@8.58.0':
     dependencies:
-      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
   '@typescript/vfs@1.6.4(typescript@5.9.3)':
@@ -27488,7 +27487,7 @@ snapshots:
 
   '@xmldom/xmldom@0.7.13': {}
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.8.12': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -28083,11 +28082,11 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  bare-os@3.8.4: {}
+  bare-os@3.8.6: {}
 
   bare-path@3.0.0:
     dependencies:
-      bare-os: 3.8.4
+      bare-os: 3.8.6
 
   bare-stream@2.11.0(bare-events@2.8.2):
     dependencies:
@@ -28204,13 +28203,13 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
 
-  browserslist@4.28.1:
+  browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.12
-      caniuse-lite: 1.0.30001781
-      electron-to-chromium: 1.5.328
+      caniuse-lite: 1.0.30001782
+      electron-to-chromium: 1.5.329
       node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bs58@5.0.0:
     dependencies:
@@ -28319,7 +28318,7 @@ snapshots:
 
   camelcase@8.0.0: {}
 
-  caniuse-lite@1.0.30001781: {}
+  caniuse-lite@1.0.30001782: {}
 
   canvaskit-wasm@0.39.1:
     dependencies:
@@ -28736,7 +28735,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
 
   core-util-is@1.0.3: {}
 
@@ -29262,7 +29261,7 @@ snapshots:
 
   detective-typescript@14.0.0(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       ast-module-types: 6.0.1
       node-source-walk: 7.0.1
       typescript: 5.9.3
@@ -29500,7 +29499,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.328: {}
+  electron-to-chromium@1.5.329: {}
 
   emmet@2.4.11:
     dependencies:
@@ -29828,7 +29827,7 @@ snapshots:
   esrap@2.2.4:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@typescript-eslint/types': 8.57.2
+      '@typescript-eslint/types': 8.58.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -30824,14 +30823,14 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -31691,7 +31690,7 @@ snapshots:
 
   isbinaryfile@5.0.7: {}
 
-  isbot@5.1.36: {}
+  isbot@5.1.37: {}
 
   isexe@2.0.0: {}
 
@@ -32048,11 +32047,11 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  kysely-do@0.0.1-rc.1(kysely@0.28.14):
+  kysely-do@0.0.1-rc.1(kysely@0.28.15):
     dependencies:
-      kysely: 0.28.14
+      kysely: 0.28.15
 
-  kysely@0.28.14: {}
+  kysely@0.28.15: {}
 
   lambda-local@2.2.0:
     dependencies:
@@ -33321,7 +33320,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  minimatch@10.2.4:
+  minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
 
@@ -34020,7 +34019,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -34203,7 +34202,7 @@ snapshots:
 
   prosemirror-changeset@2.4.0:
     dependencies:
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-collab@1.3.1:
     dependencies:
@@ -34213,12 +34212,12 @@ snapshots:
     dependencies:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-dropcursor@1.8.2:
     dependencies:
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.7
 
   prosemirror-gapcursor@1.4.1:
@@ -34231,14 +34230,14 @@ snapshots:
   prosemirror-history@1.5.0:
     dependencies:
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.7
       rope-sequence: 1.3.4
 
   prosemirror-inputrules@1.5.1:
     dependencies:
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-keymap@1.2.3:
     dependencies:
@@ -34270,12 +34269,12 @@ snapshots:
     dependencies:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-state@1.4.4:
     dependencies:
       prosemirror-model: 1.25.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.7
 
   prosemirror-tables@1.8.5:
@@ -34283,7 +34282,7 @@ snapshots:
       prosemirror-keymap: 1.2.3
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.7
 
   prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7):
@@ -34294,7 +34293,7 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.7
 
-  prosemirror-transform@1.11.0:
+  prosemirror-transform@1.12.0:
     dependencies:
       prosemirror-model: 1.25.4
 
@@ -34302,7 +34301,7 @@ snapshots:
     dependencies:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   protobufjs@7.5.4:
     dependencies:
@@ -35563,8 +35562,8 @@ snapshots:
       glob: 11.0.3
       ignore: 7.0.5
       jsonc-parser: 3.3.1
-      kysely: 0.28.14
-      kysely-do: 0.0.1-rc.1(kysely@0.28.14)
+      kysely: 0.28.15
+      kysely-do: 0.0.1-rc.1(kysely@0.28.15)
       lodash: 4.17.23
       magic-string: 0.30.21
       picocolors: 1.1.1
@@ -36963,9 +36962,9 @@ snapshots:
       consola: 3.4.2
       pathe: 1.1.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -37640,7 +37639,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.1
       es-module-lexer: 2.0.0

--- a/pnpm-workspace.yaml.genie.ts
+++ b/pnpm-workspace.yaml.genie.ts
@@ -18,7 +18,7 @@ const examplesWorkspaceSettings = {
   },
 } as const
 
-const repoPackageExtensions = {
+export const repoPackageExtensions = {
   'starlight-auto-sidebar': {
     dependencies: {
       astro: '>=5.0.0',


### PR DESCRIPTION
## What
- Add a generated `core/` pnpm workspace projection for Livestore core/library packages only.
- Add a generated `tooling/` pnpm workspace projection for downstream tooling consumers that also need local docs/scripts/test helper packages.
- Derive both package sets from the authoritative root workspace list in `package.json.genie.ts`.
- Keep the root workspace generation unchanged.

## Why
- Some downstream consumers only need the Livestore library graph.
- Others, such as `overeng`, also need Livestore tooling packages like `@local/scripts` and `@local/astro-twoslash-code`, but still do not need the full workspace breadth.
- These projections provide smaller install roots without introducing custom downstream filter logic.

## Projections
- `core/`: production and library graph only
- `tooling/`: `core/` plus `docs`, `docs/src/content/_assets/code`, `scripts`, `@local/astro-tldraw`, `@local/astro-twoslash-code`, `tests/integration`, and `tests/sync-provider`

## Verified scope
- root workspace: `39` members
- `core/`: `26` members
- `tooling/`: `33` members

## Validation
- `CI=1 genie --check`
- `oxfmt --check package.json.genie.ts tooling/pnpm-workspace.yaml.genie.ts`
- `pnpm install --dir tooling --ignore-scripts --lockfile-only --config.confirmModulesPurge=false --no-frozen-lockfile --no-strict-peer-dependencies`

## Rationale
- The projections are generated from the root workspace source of truth, so they stay aligned with the repo topology.
- Keeping `core/` and `tooling/` separate preserves a minimal library-focused install root while still giving downstream tooling consumers a principled non-root install owner.
- This avoids widening `core/` just to satisfy tooling-heavy downstreams.

## Notes
- The projection install still surfaces the repo's existing peer-dependency warnings under the current dependency set.
- This PR is about install-surface shaping, not peer-dependency cleanup.

---
Filed by an AI assistant on behalf of @schickling
