### PR TITLE
feat(sync): add connectionStatus to NetworkStatus for reconnection UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,8 @@ Key improvements include streaming pull operations (faster initial sync), a two-
 - Resilience: Improve sync provider robustness and align test helpers for CI and local development (#682, #646).
 - Header forwarding: Added `forwardHeaders` option to `makeDurableObject()` for cookie-based authentication. Headers are stored in WebSocket attachments to survive hibernation and accessible via `context.headers` in `onPush`/`onPull` callbacks (#929).
 - **Backend reset detection:** LiveStore now detects when a sync backend has been reset and handles it based on the `onBackendIdMismatch` option in `SyncOptions`. Default behaviour (`'reset'`) clears local storage and shuts down so the app can restart with fresh data. Alternative modes include `'shutdown'` (shut down without clearing) and `'ignore'` (continue with stale data). See [Backend Reset Detection docs](https://livestore.dev/building-with-livestore/syncing#backend-reset-detection) (#980).
+- **WebSocket retry backoff:** Replaced fixed 1-second retry with exponential backoff (1s to 30s cap, jittered) to reduce unnecessary requests during extended outages (#1111).
+- **Connection status:** `store.networkStatus` now includes a `connectionStatus` field (`'connected'`, `'disconnected'`, or `'reconnecting'`) so apps can distinguish active reconnection attempts from a fully disconnected state (#1111).
 
 ##### S2 sync backend
 

--- a/docs/src/content/_assets/code/patterns/offline/tracking-connectivity.ts
+++ b/docs/src/content/_assets/code/patterns/offline/tracking-connectivity.ts
@@ -11,6 +11,13 @@ if (status.isConnected === false) {
   console.warn('Sync backend offline since', new Date(status.timestampMs))
 }
 
+// Use connectionStatus for richer state — distinguishes active reconnection from disconnected
+if (status.connectionStatus === 'reconnecting') {
+  console.log('Attempting to reconnect...')
+} else if (status.connectionStatus === 'disconnected') {
+  console.log('Disconnected — no active reconnection attempt')
+}
+
 await store.networkStatus.changes.pipe(
   Stream.tap((next) => Effect.sync(() => console.log('network status updated', next))),
   Stream.runDrain,

--- a/docs/src/content/docs/patterns/offline.mdx
+++ b/docs/src/content/docs/patterns/offline.mdx
@@ -12,6 +12,8 @@ import TrackingConnectivitySnippet from '../../_assets/code/patterns/offline/tra
 
 Use `store.networkStatus` to react to connectivity transitions. The subscribable emits every time the sync backend connection flips or the devtools latch simulates an offline state.
 
+The `connectionStatus` field provides richer state than `isConnected`: it can be `'connected'`, `'disconnected'`, or `'reconnecting'`. Use it to show UI indicators when the client is actively trying to re-establish a connection after a transient failure.
+
 <TrackingConnectivitySnippet />
 
 When devtools close the sync latch to simulate an offline client, `status.devtools.latchClosed` is `true`, allowing you to differentiate between real and simulated outages. Remember to dispose of long-lived subscriptions using the Effect scope you already manage for your runtime.

--- a/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
+++ b/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
@@ -378,17 +378,22 @@ const listenToDevtools = ({
                 // This is probably the same "flaky databrowser loading" bug as we're seeing in the playwright tests
                 yield* Effect.sleep(1000)
 
+                const connectionStatusStream = syncBackend.connectionStatus.changes
+
+                const latchStream = devtools.enabled === true
+                  ? devtools.syncBackendLatchState.changes
+                  : Stream.make({ latchClosed: false })
+
                 yield* Stream.zipLatest(
-                  syncBackend.isConnected.changes,
-                  devtools.enabled === true
-                    ? devtools.syncBackendLatchState.changes
-                    : Stream.make({ latchClosed: false }),
+                  connectionStatusStream,
+                  latchStream,
                 ).pipe(
-                  Stream.tap(([isConnected, { latchClosed }]) =>
+                  Stream.tap(([connectionStatus, { latchClosed }]) =>
                     sendMessage(
                       Devtools.Leader.NetworkStatusRes.make({
                         networkStatus: {
-                          isConnected,
+                          isConnected: connectionStatus === 'connected',
+                          connectionStatus,
                           timestampMs: Date.now(),
                           devtools: { latchClosed },
                         },

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.test.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.test.ts
@@ -23,6 +23,7 @@ Vitest.describe('makeNetworkStatusSubscribable', () => {
 
       const initial = yield* networkStatus
       Vitest.expect(initial.isConnected).toBe(false)
+      Vitest.expect(initial.connectionStatus).toBe('disconnected')
       Vitest.expect(initial.devtools.latchClosed).toBe(false)
 
       const waitFor = (predicate: (status: SyncBackend.NetworkStatus) => boolean) =>
@@ -32,7 +33,26 @@ Vitest.describe('makeNetworkStatusSubscribable', () => {
       yield* mockBackend.connect
       const online = yield* onlineFiber
       Vitest.expect(online.isConnected).toBe(true)
+      Vitest.expect(online.connectionStatus).toBe('connected')
       Vitest.expect(online.timestampMs).toBeGreaterThan(initial.timestampMs)
+
+      // Simulate reconnecting state
+      const reconnectingFiber = yield* waitFor((status) => status.connectionStatus === 'reconnecting').pipe(
+        Effect.forkScoped,
+      )
+      yield* mockBackend.reconnecting
+      const reconnecting = yield* reconnectingFiber
+      Vitest.expect(reconnecting.isConnected).toBe(false)
+      Vitest.expect(reconnecting.connectionStatus).toBe('reconnecting')
+
+      // Reconnect
+      const reconnectedFiber = yield* waitFor((status) => status.connectionStatus === 'connected').pipe(
+        Effect.forkScoped,
+      )
+      yield* mockBackend.connect
+      const reconnected = yield* reconnectedFiber
+      Vitest.expect(reconnected.isConnected).toBe(true)
+      Vitest.expect(reconnected.connectionStatus).toBe('connected')
 
       const latchedFiber = yield* waitFor((status) => status.devtools.latchClosed).pipe(Effect.forkScoped)
       yield* SubscriptionRef.set(latchStateRef, { latchClosed: true })

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -407,13 +407,19 @@ export const makeNetworkStatusSubscribable = ({
 
     const networkStatusRef = yield* SubscriptionRef.make<SyncBackend.NetworkStatus>({
       isConnected: initialIsConnected,
+      connectionStatus: initialIsConnected ? 'connected' : 'disconnected',
       timestampMs: Date.now(),
       devtools: { latchClosed: initialLatchClosed },
     })
 
-    const updateNetworkStatus = (patch: { isConnected?: boolean; latchClosed?: boolean }) =>
+    const updateNetworkStatus = (patch: {
+      isConnected?: boolean
+      connectionStatus?: SyncBackend.ConnectionStatus
+      latchClosed?: boolean
+    }) =>
       SubscriptionRef.update(networkStatusRef, (previous) => ({
         isConnected: patch.isConnected ?? previous.isConnected,
+        connectionStatus: patch.connectionStatus ?? previous.connectionStatus,
         timestampMs: Date.now(),
         devtools: {
           latchClosed: patch.latchClosed ?? previous.devtools.latchClosed,
@@ -421,8 +427,10 @@ export const makeNetworkStatusSubscribable = ({
       }))
 
     if (syncBackend !== undefined) {
-      yield* syncBackend.isConnected.changes.pipe(
-        Stream.tap((isConnected) => updateNetworkStatus({ isConnected })),
+      yield* syncBackend.connectionStatus.changes.pipe(
+        Stream.tap((connectionStatus) =>
+          updateNetworkStatus({ isConnected: connectionStatus === 'connected', connectionStatus }),
+        ),
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -11,6 +11,8 @@ export interface MockSyncBackend {
   pushedEvents: Stream.Stream<LiveStoreEvent.Global.Encoded>
   connect: Effect.Effect<void>
   disconnect: Effect.Effect<void>
+  /** Simulate a reconnecting state (disconnected but actively retrying) */
+  reconnecting: Effect.Effect<void>
   makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
   advance: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
   /** Fail the next N push calls with an UnknownError, ServerAheadError, BackendIdMismatchError, or custom error */
@@ -46,6 +48,9 @@ export const makeMockSyncBackend = (
     const syncHeadRef = yield* Ref.make(EventSequenceNumber.Client.ROOT.global)
     const allEventsRef = yield* Ref.make<LiveStoreEvent.Global.Encoded[]>([])
     const syncIsConnectedRef = yield* SubscriptionRef.make(options?.startConnected ?? false)
+    const syncConnectionStatusRef = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>(
+      options?.startConnected ? 'connected' : 'disconnected',
+    )
 
     // Queues for streaming
     const syncPullQueue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
@@ -136,7 +141,11 @@ export const makeMockSyncBackend = (
       // mirroring how some real providers behave during transient disconnects.
       return SyncBackend.of({
         isConnected: syncIsConnectedRef,
-        connect: SubscriptionRef.set(syncIsConnectedRef, true),
+        connectionStatus: syncConnectionStatusRef,
+        connect: Effect.all([
+          SubscriptionRef.set(syncIsConnectedRef, true),
+          SubscriptionRef.set(syncConnectionStatusRef, 'connected'),
+        ]).pipe(Effect.asVoid),
         ping: Effect.void,
         pull: (cursor, pullOptions) =>
           Stream.fromEffect(
@@ -210,8 +219,18 @@ export const makeMockSyncBackend = (
 
     return {
       pushedEvents: Mailbox.toStream(pushedEventsQueue),
-      connect: SubscriptionRef.set(syncIsConnectedRef, true),
-      disconnect: SubscriptionRef.set(syncIsConnectedRef, false),
+      connect: Effect.all([
+        SubscriptionRef.set(syncIsConnectedRef, true),
+        SubscriptionRef.set(syncConnectionStatusRef, 'connected'),
+      ]).pipe(Effect.asVoid),
+      disconnect: Effect.all([
+        SubscriptionRef.set(syncIsConnectedRef, false),
+        SubscriptionRef.set(syncConnectionStatusRef, 'disconnected'),
+      ]).pipe(Effect.asVoid),
+      reconnecting: Effect.all([
+        SubscriptionRef.set(syncIsConnectedRef, false),
+        SubscriptionRef.set(syncConnectionStatusRef, 'reconnecting'),
+      ]).pipe(Effect.asVoid),
       makeSyncBackend,
       advance,
       failNextPushes,

--- a/packages/@livestore/common/src/sync/sync-backend.ts
+++ b/packages/@livestore/common/src/sync/sync-backend.ts
@@ -17,6 +17,9 @@ import type { BackendIdMismatchError, IsOfflineError, ServerAheadError } from '.
 
 export * from './sync-backend-kv.ts'
 
+export const ConnectionStatus = Schema.Literal('connected', 'disconnected', 'reconnecting')
+export type ConnectionStatus = typeof ConnectionStatus.Type
+
 /**
  * Those arguments can be used to implement multi-tenancy etc and are passed in from the store.
  */
@@ -75,6 +78,10 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
   // TODO also expose latency information additionally to whether the backend is connected
   isConnected: SubscriptionRef.SubscriptionRef<boolean>
   /**
+   * Richer connection state that distinguishes between "disconnected" and "reconnecting".
+   */
+  connectionStatus: SubscriptionRef.SubscriptionRef<ConnectionStatus>
+  /**
    * Metadata describing the sync backend. (Currently only used by devtools.)
    */
   metadata: { name: string; description: string } & Record<string, Schema.JsonValue>
@@ -98,6 +105,11 @@ export type SyncBackend<TSyncMetadata = Schema.JsonValue> = {
 export const NetworkStatus = Schema.Struct({
   /** True when the upstream sync backend is reachable and responding to health checks. */
   isConnected: Schema.Boolean,
+  /**
+   * Richer connection state: "connected", "disconnected", or "reconnecting".
+   * Falls back to a value derived from `isConnected` for backends that don't track this.
+   */
+  connectionStatus: ConnectionStatus,
   /** Unix epoch timestamp (ms) of the latest connectivity state transition. */
   timestampMs: Schema.Number,
   /** Devtools specific metadata describing simulator overrides. */

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -50,6 +50,7 @@ export const makeDoRpcSync =
   ({ storeId, payload }) =>
     Effect.gen(function* () {
       const isConnected = yield* SubscriptionRef.make(true)
+      const connectionStatus = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>('connected')
 
       const ProtocolLive = layerProtocolDurableObject({
         callRpc: (payload) => syncBackendStub.rpc(payload),
@@ -142,6 +143,7 @@ export const makeDoRpcSync =
       return SyncBackend.of({
         connect,
         isConnected,
+        connectionStatus,
         pull,
         push,
         ping,

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -70,6 +70,7 @@ export const makeHttpSync =
     Effect.gen(function* () {
       // Based on ping responses
       const isConnected = yield* SubscriptionRef.make(false)
+      const connectionStatus = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>('disconnected')
 
       const livePullInterval = options.livePull?.pollInterval ?? 5_000
 
@@ -103,10 +104,13 @@ export const makeHttpSync =
         yield* rpcClient.SyncHttpRpc.Ping({ storeId, payload })
 
         yield* SubscriptionRef.set(isConnected, true)
+        yield* SubscriptionRef.set(connectionStatus, 'connected')
       }).pipe(
         UnknownError.mapToUnknownError,
         Effect.timeout(pingTimeout),
-        Effect.catchTag('TimeoutException', () => SubscriptionRef.set(isConnected, false)),
+        Effect.catchTag('TimeoutException', () =>
+          Effect.all([SubscriptionRef.set(isConnected, false), SubscriptionRef.set(connectionStatus, 'disconnected')]),
+        ),
       )
 
       const pingInterval = options.ping?.requestInterval ?? 10_000
@@ -214,6 +218,7 @@ export const makeHttpSync =
       return SyncBackend.of({
         connect,
         isConnected,
+        connectionStatus,
         pull,
         push,
         ping,

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -80,6 +80,7 @@ export const makeWsSync =
       const wsUrl = `${options.url}?${UrlParams.toString(urlParams)}`
 
       const isConnected = yield* SubscriptionRef.make(false)
+      const connectionStatus = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>('disconnected')
 
       // TODO bring this back in a cross-platform way
       // If the browser already tells us we're offline, then we'll at least wait until the browser
@@ -96,6 +97,7 @@ export const makeWsSync =
 
       const ProtocolLive = RpcClient.layerProtocolSocketWithIsConnected({
         isConnected,
+        connectionStatus,
         retryTransientErrors: Schedule.exponential('1 seconds').pipe(
           Schedule.union(Schedule.fixed('30 seconds')),
           Schedule.jittered,
@@ -120,9 +122,15 @@ export const makeWsSync =
         const pinger = yield* RpcClient.SocketPinger.pipe(Effect.provide(ctx))
         yield* pinger.ping
         yield* SubscriptionRef.set(isConnected, true)
+        yield* SubscriptionRef.set(connectionStatus, 'connected')
       }).pipe(
         Effect.timeout(pingTimeout),
-        Effect.catchTag('TimeoutException', () => SubscriptionRef.set(isConnected, false)),
+        Effect.catchTag('TimeoutException', () =>
+          Effect.all([
+            SubscriptionRef.set(isConnected, false),
+            SubscriptionRef.set(connectionStatus, 'disconnected'),
+          ]),
+        ),
         UnknownError.mapToUnknownError,
         Effect.withSpan('ping'),
       )
@@ -131,6 +139,7 @@ export const makeWsSync =
 
       return SyncBackend.of<SyncMetadata>({
         isConnected,
+        connectionStatus,
         connect: ping,
         pull: (cursor, options) =>
           rpcClient.SyncWsRpc.Pull({

--- a/packages/@livestore/sync-electric/src/index.ts
+++ b/packages/@livestore/sync-electric/src/index.ts
@@ -196,6 +196,7 @@ export const makeSyncBackend =
   ({ storeId, payload }) =>
     Effect.gen(function* () {
       const isConnected = yield* SubscriptionRef.make(false)
+      const connectionStatus = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>('disconnected')
       const pullEndpoint = typeof endpoint === 'string' ? endpoint : endpoint.pull
       const pushEndpoint = typeof endpoint === 'string' ? endpoint : endpoint.push
       const pingEndpoint = typeof endpoint === 'string' ? endpoint : endpoint.ping
@@ -308,10 +309,13 @@ export const makeSyncBackend =
         yield* httpClient.pipe(HttpClient.filterStatusOk).head(pingEndpoint)
 
         yield* SubscriptionRef.set(isConnected, true)
+        yield* SubscriptionRef.set(connectionStatus, 'connected')
       }).pipe(
         UnknownError.mapToUnknownError,
         Effect.timeout(pingTimeout),
-        Effect.catchTag('TimeoutException', () => SubscriptionRef.set(isConnected, false)),
+        Effect.catchTag('TimeoutException', () =>
+          Effect.all([SubscriptionRef.set(isConnected, false), SubscriptionRef.set(connectionStatus, 'disconnected')]),
+        ),
         Effect.withSpan('electric-provider:ping'),
       )
 
@@ -329,6 +333,7 @@ export const makeSyncBackend =
 
       return SyncBackend.of({
         connect,
+        connectionStatus,
         pull: (cursor, options) => {
           let hasEmittedAtLeastOnce = false
 
@@ -380,6 +385,7 @@ export const makeSyncBackend =
         }),
         ping,
         isConnected,
+        connectionStatus,
         metadata: {
           name: '@livestore/sync-electric',
           description: 'LiveStore sync backend implementation using ElectricSQL',

--- a/packages/@livestore/sync-s2/src/sync-provider.ts
+++ b/packages/@livestore/sync-s2/src/sync-provider.ts
@@ -97,6 +97,7 @@ export const makeSyncBackend =
   ({ storeId, payload }) =>
     Effect.gen(function* () {
       const isConnected = yield* SubscriptionRef.make(false)
+      const connectionStatus = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>('disconnected')
       const pullEndpoint = typeof endpoint === 'string' ? endpoint : endpoint.pull
       const pushEndpoint = typeof endpoint === 'string' ? endpoint : endpoint.push
       const pingEndpoint = typeof endpoint === 'string' ? endpoint : endpoint.ping
@@ -112,10 +113,13 @@ export const makeSyncBackend =
       const ping: SyncBackend.SyncBackend<SyncMetadata>['ping'] = Effect.gen(function* () {
         yield* httpClient.pipe(HttpClient.filterStatusOk).head(pingEndpoint)
         yield* SubscriptionRef.set(isConnected, true)
+        yield* SubscriptionRef.set(connectionStatus, 'connected')
       }).pipe(
         UnknownError.mapToUnknownError,
         Effect.timeout(pingTimeout),
-        Effect.catchTag('TimeoutException', () => SubscriptionRef.set(isConnected, false)),
+        Effect.catchTag('TimeoutException', () =>
+          Effect.all([SubscriptionRef.set(isConnected, false), SubscriptionRef.set(connectionStatus, 'disconnected')]),
+        ),
       )
 
       const pingInterval = pingOptions?.requestInterval ?? 10_000
@@ -249,6 +253,7 @@ export const makeSyncBackend =
 
       return SyncBackend.of({
         connect,
+        connectionStatus,
         pull: (cursor, options) => {
           if (options?.live === true) {
             return ssePull(cursor)

--- a/packages/@livestore/utils/src/effect/RpcClient.ts
+++ b/packages/@livestore/utils/src/effect/RpcClient.ts
@@ -18,6 +18,7 @@ export const layerProtocolSocketWithIsConnected = (options: {
   readonly url: string
   readonly retryTransientErrors?: Schedule.Schedule<unknown> | undefined
   readonly isConnected: SubscriptionRef.SubscriptionRef<boolean>
+  readonly connectionStatus?: SubscriptionRef.SubscriptionRef<'connected' | 'disconnected' | 'reconnecting'> | undefined
   readonly pingSchedule?: Schedule.Schedule<unknown> | undefined
 }): Layer.Layer<Protocol, never, RpcSerialization.RpcSerialization | Socket.Socket> =>
   Layer.scoped(Protocol, makeProtocolSocketWithIsConnected(options))
@@ -27,6 +28,7 @@ export const makeProtocolSocketWithIsConnected = (options: {
   readonly retryTransientErrors?: Schedule.Schedule<unknown> | undefined
   // CHANGED: add isConnected subscription ref
   readonly isConnected: SubscriptionRef.SubscriptionRef<boolean>
+  readonly connectionStatus?: SubscriptionRef.SubscriptionRef<'connected' | 'disconnected' | 'reconnecting'> | undefined
   // CHANGED: add ping schedule
   readonly pingSchedule?: Schedule.Schedule<unknown> | undefined
 }): Effect.Effect<Protocol['Type'], never, Scope.Scope | RpcSerialization.RpcSerialization | Socket.Socket> =>
@@ -70,6 +72,9 @@ export const makeProtocolSocketWithIsConnected = (options: {
                       Effect.fn(function* () {
                         if (options?.isConnected !== undefined) {
                           yield* SubscriptionRef.set(options.isConnected, true)
+                        }
+                        if (options?.connectionStatus !== undefined) {
+                          yield* SubscriptionRef.set(options.connectionStatus, 'connected')
                         }
                       }),
                     ),
@@ -119,11 +124,16 @@ export const makeProtocolSocketWithIsConnected = (options: {
             }
 
             const error = Cause.failureOption(cause)
-            if (
+            const isTransient =
               options?.retryTransientErrors !== undefined &&
-              Option.isSome(error) === true &&
+              Option.isSome(error) &&
               (error.value.reason === 'Open' || error.value.reason === 'OpenTimeout')
-            ) {
+
+            if (options?.connectionStatus !== undefined) {
+              yield* SubscriptionRef.set(options.connectionStatus, isTransient ? 'reconnecting' : 'disconnected')
+            }
+
+            if (isTransient) {
               return
             }
             // yield* Effect.logError('Error in socket', cause)

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -500,6 +500,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const networkStatus = Subscribable.make<SyncBackend.NetworkStatus, never, never>({
         get: Effect.succeed({
           isConnected: true,
+          connectionStatus: 'connected' as const,
           timestampMs: 0,
           devtools: { latchClosed: false },
         }),

--- a/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
+++ b/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
@@ -96,6 +96,7 @@ const makeProxyDoRpcSync = ({
   // TODO pass through clientId, payload, storeId to worker/DO
   Effect.fn(function* ({ clientId, storeId, payload }) {
     const socketConnectionRef = yield* SubscriptionRef.make(false)
+    const connectionStatus = yield* SubscriptionRef.make<SyncBackend.ConnectionStatus>('disconnected')
 
     const ProtocolLive = RpcClient.layerProtocolSocketWithIsConnected({
       url: `ws://localhost:${port}/do-rpc-ws-proxy`,
@@ -118,6 +119,13 @@ const makeProxyDoRpcSync = ({
       false,
     )
 
+    // Mirror isConnected into connectionStatus
+    yield* isConnected.changes.pipe(
+      Stream.tap((c) => SubscriptionRef.set(connectionStatus, c ? 'connected' : 'disconnected')),
+      Stream.runDrain,
+      Effect.forkScoped,
+    )
+
     const metadata = yield* client.GetMetadata({ clientId, storeId, payload })
     const backendIdHelper = yield* SyncBackend.makeBackendIdHelper
 
@@ -126,6 +134,7 @@ const makeProxyDoRpcSync = ({
         .Connect({ clientId, storeId, payload })
         .pipe(Effect.catchTag('RpcClientError', (e) => Effect.die(e))),
       isConnected,
+      connectionStatus,
       pull: (cursor, options) =>
         client
           .Pull({

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -100,6 +100,7 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
       expect(syncBackend.pull).toBeDefined()
       expect(syncBackend.push).toBeDefined()
       expect(syncBackend.isConnected).toBeDefined()
+      expect(syncBackend.connectionStatus).toBeDefined()
     }).pipe(withTestCtx()(test)),
   )
 
@@ -118,6 +119,8 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
       // Check initial state
       const initialConnected = yield* syncBackend.isConnected.get
       expect(initialConnected).toBe(false)
+      const initialConnectionStatus = yield* syncBackend.connectionStatus.get
+      expect(initialConnectionStatus).toBe('disconnected')
 
       // Connect
       yield* syncBackend.connect
@@ -125,6 +128,8 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
       // Check connected state
       const connected = yield* syncBackend.isConnected
       expect(connected).toBe(true)
+      const connectionStatus = yield* syncBackend.connectionStatus
+      expect(connectionStatus).toBe('connected')
     }).pipe(withTestCtx()(test)),
   )
 


### PR DESCRIPTION
## Summary

- Adds `connectionStatus: 'connected' | 'disconnected' | 'reconnecting'` to `NetworkStatus` alongside existing `isConnected` boolean
- Non-breaking for consumers — `isConnected` stays as-is, `connectionStatus` is an additional field

## Problem

Previously, `store.networkStatus` only exposed `isConnected: boolean`. When a WebSocket connection dropped and the client was actively retrying with exponential backoff, the status showed `false` — identical to a fully disconnected state. Apps had no way to distinguish "offline and retrying" from "offline and idle", making it impossible to show meaningful reconnection indicators in the UI (e.g., "Reconnecting..." vs "Disconnected").

Linear example:
<img width="1460" height="580" alt="CleanShot 2026-04-01 at 14 31 13@2x" src="https://github.com/user-attachments/assets/d80a904c-0df0-478f-997f-10d9ea144330" />


## How it works

- `RpcClient` sets `'reconnecting'` on transient socket errors (`Open`/`OpenTimeout`) when retry is configured, `'disconnected'` otherwise, `'connected'` on successful pong
- `connectionStatus` is the single source of truth — `isConnected` is derived from it in the aggregation layer to keep both fields in sync
- Backends without reconnection logic (HTTP, DO, Electric, S2) mirror `isConnected` — always `'connected'` or `'disconnected'`

## Known limitations

- No integration test for the `'reconnecting'` state through `RpcClient` — would require a mock socket layer. Unit test covers the state propagation through `makeNetworkStatusSubscribable`.

## Ideas for follow-up

- React `useNetworkStatus` hook (similar to existing `useSyncStatus`)
- Usage examples in example projects (e.g., showing a reconnection banner in todomvc)

Ref: #1111