### PR TITLE
refactor: remove dead code and narrow `boot` error type

### DIFF
--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -14,7 +14,7 @@ import {
   Subscribable,
 } from '@livestore/utils/effect'
 
-import { type ClientSession, type UnknownError } from '../adapter-types.ts'
+import type { ClientSession } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
 import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
@@ -379,7 +379,7 @@ export interface ClientSessionSyncProcessor {
   push: (
     batch: ReadonlyArray<LiveStoreEvent.Input.Decoded>,
   ) => Effect.Effect<{ writeTables: Set<string> }, MaterializeError>
-  boot: Effect.Effect<void, UnknownError, Scope.Scope>
+  boot: Effect.Effect<void, never, Scope.Scope>
   /**
    * Only used for debugging / observability.
    */

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -350,11 +350,7 @@ export const makeClientSessionSyncProcessor = ({
     push,
     boot,
     syncState: Subscribable.make({
-      get: Effect.gen(function* () {
-        const syncState = syncStateRef.current
-        if (syncStateRef === undefined) return shouldNeverHappen('Not initialized')
-        return syncState
-      }),
+      get: Effect.sync(() => syncStateRef.current),
       changes: Stream.fromQueue(syncStateUpdateQueue),
     }),
     debug: {


### PR DESCRIPTION
## Problem

`ClientSessionSyncProcessor` has two pieces of dead/misleading code:
- `boot`'s error channel includes `UnknownError`, but the error is never produced — this misleads callers about possible failures.
- A `syncStateRef === undefined` guard can never trigger since `syncStateRef` is always the `{ current: ... }` object initialized at construction time.

## Solution

- Narrow `boot`'s error channel from `UnknownError` to `never`.
- Replace the dead guard with a direct `Effect.sync(() => syncStateRef.current)`.

## Validation

No behavioural changes — only type narrowing and dead code removal. Existing tests continue to pass.