### PR TITLE
refactor: replace `shouldNeverHappen` with Effect error primitives

### DIFF
--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -108,27 +108,26 @@ export const makeClientSessionSyncProcessor = ({
     // TODO validate batch
 
     let baseEventSequenceNumber = syncStateRef.current.localHead
-    const encodedEventDefs = batch.map(({ name, args }) => {
-      const eventDef = schema.eventsDefsMap.get(name)
-      if (eventDef === undefined) {
-        return shouldNeverHappen(`No event definition found for \`${name}\`.`)
-      }
-      const nextNumPair = EventSequenceNumber.Client.nextPair({
-        seqNum: baseEventSequenceNumber,
-        isClient: eventDef.options.clientOnly,
-        rebaseGeneration: baseEventSequenceNumber.rebaseGeneration,
-      })
-      baseEventSequenceNumber = nextNumPair.seqNum
-      return new LiveStoreEvent.Client.EncodedWithMeta(
-        Schema.encodeUnknownSync(eventSchema)({
-          name,
-          args,
-          ...nextNumPair,
-          clientId: clientSession.clientId,
-          sessionId: clientSession.sessionId,
-        }),
-      )
-    })
+    const encodedEventDefs = yield* Effect.forEach(batch, ({ name, args }) =>
+      Effect.gen(function* () {
+        const eventDef = yield* Effect.fromNullable(schema.eventsDefsMap.get(name)).pipe(Effect.orDieDebugger)
+        const nextNumPair = EventSequenceNumber.Client.nextPair({
+          seqNum: baseEventSequenceNumber,
+          isClient: eventDef.options.clientOnly,
+          rebaseGeneration: baseEventSequenceNumber.rebaseGeneration,
+        })
+        baseEventSequenceNumber = nextNumPair.seqNum
+        return new LiveStoreEvent.Client.EncodedWithMeta(
+          Schema.encodeUnknownSync(eventSchema)({
+            name,
+            args,
+            ...nextNumPair,
+            clientId: clientSession.clientId,
+            sessionId: clientSession.sessionId,
+          }),
+        )
+      }),
+    )
 
     const mergeResult = yield* SyncState.merge({
       syncState: syncStateRef.current,

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { LS_DEV, shouldNeverHappen, TRACE_VERBOSE } from '@livestore/utils'
+import { LS_DEV, TRACE_VERBOSE } from '@livestore/utils'
 import {
   BucketQueue,
   Effect,
@@ -134,7 +134,12 @@ export const makeClientSessionSyncProcessor = ({
       payload: { _tag: 'local-push', newEvents: encodedEventDefs },
       isClientEvent,
       isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-    })
+    }).pipe(
+      Effect.filterOrDieMessage(
+        (r) => r._tag === 'advance',
+        'Expected advance from local-push merge',
+      ),
+    )
 
     yield* Effect.annotateCurrentSpan({
       batchSize: encodedEventDefs.length,
@@ -145,10 +150,6 @@ export const makeClientSessionSyncProcessor = ({
       }, {}),
       ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
     })
-
-    if (mergeResult._tag !== 'advance') {
-      return shouldNeverHappen(`Expected advance, got ${mergeResult._tag}`)
-    }
 
     syncStateRef.current = mergeResult.newSyncState
     yield* syncStateUpdateQueue.offer(mergeResult.newSyncState)
@@ -239,11 +240,12 @@ export const makeClientSessionSyncProcessor = ({
             payload,
             isClientEvent,
             isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-          })
-
-          if (mergeResult._tag === 'reject') {
-            return shouldNeverHappen('Unexpected reject in client-session-sync-processor', mergeResult)
-          }
+          }).pipe(
+            Effect.filterOrDieMessage(
+              (r) => r._tag !== 'reject',
+              'Unexpected reject in client-session-sync-processor',
+            ),
+          )
 
           syncStateRef.current = mergeResult.newSyncState
 


### PR DESCRIPTION
## Problem

`ClientSessionSyncProcessor` uses `shouldNeverHappen` (a custom throw helper) for invariant checks. This bypasses Effect's defect tracking, making failures harder to observe and diagnose.

## Solution

- Replace `shouldNeverHappen` in push event encoding with `Effect.fromNullable` + `Effect.orDieDebugger`, using `Effect.forEach` instead of `.map()`.
- Replace remaining `shouldNeverHappen` calls with `Effect.filterOrDieMessage` for merge-result invariant checks in both push and pull paths.

This eliminates all `shouldNeverHappen` usage from the file.

## Validation

No behavioural changes — invariant violations now surface as Effect defects instead of thrown errors. Existing tests continue to pass.