### PR TITLE
refactor: adopt `Effect.fn` and remove `runtime` parameter

### DIFF
--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -7,7 +7,6 @@ import {
   FiberHandle,
   Option,
   Queue,
-  type Runtime,
   Schema,
   type Scope,
   Stream,
@@ -43,7 +42,6 @@ const jsonStringify = Schema.encodeSync(Schema.parseJson())
 export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncProcessor')(function* ({
   schema,
   clientSession,
-  runtime,
   materializeEvent,
   rollback,
   refreshTables,
@@ -52,7 +50,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 }: {
   schema: LiveStoreSchema
   clientSession: ClientSession
-  runtime: Runtime.Runtime<Scope.Scope>
   materializeEvent: (
     eventEncoded: LiveStoreEvent.Client.EncodedWithMeta,
     options: { withChangeset: boolean; materializerHashLeader: Option.Option<number> },
@@ -366,7 +363,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             'pushQueueItems',
             pushQueueItems.map((_) => _.toJSON()),
           )
-        }).pipe(Effect.provide(runtime), Effect.runSync),
+        }).pipe(Effect.runSync),
       debugInfo: () => debugInfo,
     },
   } satisfies ClientSessionSyncProcessor

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -185,7 +185,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     rejectCount: 0,
   }
 
-  const boot: ClientSessionSyncProcessor['boot'] = Effect.gen(function* () {
+  const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
       confirmUnsavedChanges === true &&
       typeof window !== 'undefined' &&
@@ -345,7 +345,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.tapCauseLogPretty,
       Effect.forkScoped,
     )
-  })
+  })()
 
   return {
     push,

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -40,7 +40,7 @@ const jsonStringify = Schema.encodeSync(Schema.parseJson())
  * - The leader sync processor pulls regular LiveStore events, while the session sync processor pulls SyncState.PayloadUpstream items
  * - The session sync processor has no downstream nodes.
  */
-export const makeClientSessionSyncProcessor = ({
+export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncProcessor')(function* ({
   schema,
   clientSession,
   runtime,
@@ -78,7 +78,7 @@ export const makeClientSessionSyncProcessor = ({
    * If true, registers a beforeunload event listener to confirm unsaved changes.
    */
   confirmUnsavedChanges: boolean
-}): ClientSessionSyncProcessor => {
+}): Effect.fn.Return<ClientSessionSyncProcessor> {
   const eventSchema = LiveStoreEvent.Client.makeSchemaMemo(schema)
 
   const simSleep = <TKey extends keyof ClientSessionSyncProcessorSimulationParams>(
@@ -97,12 +97,12 @@ export const makeClientSessionSyncProcessor = ({
   }
 
   /** Only used for debugging / observability / testing, it's not relied upon for correctness of the sync processor. */
-  const syncStateUpdateQueue = Queue.unbounded<SyncState.SyncState>().pipe(Effect.runSync)
+  const syncStateUpdateQueue = yield* Queue.unbounded<SyncState.SyncState>()
   const isClientEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
-  const leaderPushQueue = BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>().pipe(Effect.runSync)
+  const leaderPushQueue = yield* BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>()
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(function* (batch) {
     // TODO validate batch
@@ -370,7 +370,7 @@ export const makeClientSessionSyncProcessor = ({
       debugInfo: () => debugInfo,
     },
   } satisfies ClientSessionSyncProcessor
-}
+})
 
 export interface ClientSessionSyncProcessor {
   push: (

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -9,6 +9,9 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -21,19 +24,24 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -93,6 +101,9 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -105,19 +116,24 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -177,6 +193,9 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -189,19 +208,24 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -307,6 +331,9 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -319,19 +346,24 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -437,6 +469,9 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -449,19 +484,24 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -567,6 +607,9 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -579,26 +622,31 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -764,6 +812,9 @@ exports[`otel > otel 3`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -776,19 +827,24 @@ exports[`otel > otel 3`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -1056,6 +1112,9 @@ exports[`otel > with thunks 7`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -1068,19 +1127,24 @@ exports[`otel > with thunks 7`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -1182,6 +1246,9 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -1194,19 +1261,24 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -210,7 +210,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     const syncProcessor = makeClientSessionSyncProcessor({
       schema,
       clientSession,
-      runtime: effectContext.runtime,
       materializeEvent: Effect.fn('client-session-sync-processor:materialize-event')(
         (eventEncoded, { withChangeset, materializerHashLeader }) =>
           // We need to use `Effect.gen` (even though we're using `Effect.fn`) so that we can pass `this` to the function

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -321,7 +321,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
           : {}),
       },
       confirmUnsavedChanges,
-    })
+    }).pipe(Runtime.runSync(effectContext.runtime))
 
     // TODO generalize the `tableRefs` concept to allow finer-grained refs
     const tableRefs: { [key: string]: Ref<null, ReactivityGraphContext, RefreshReason> } = {}

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`useClientDocument > otel > should update the data based on component ke
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -21,26 +24,31 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",
@@ -269,6 +277,9 @@ exports[`useClientDocument > otel > should update the data based on component ke
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -281,26 +292,31 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
-    },
-    {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -9,6 +9,9 @@ exports[`useClientDocument > otel > should update the data based on component ke
   },
   "children": [
     {
+      "_name": "makeClientSessionSyncProcessor",
+    },
+    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -21,19 +24,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
       },
     },
     {
-      "_name": "client-session-sync-processor:pull",
-      "attributes": {
-        "code.stacktrace": "<STACKTRACE>",
-        "span.label": "⚠︎ Interrupted",
-        "status.interrupted": true,
-      },
-    },
-    {
-      "_name": "@livestore/common:LeaderSyncProcessor:push",
-      "attributes": {
-        "batch": "undefined",
-        "batchSize": 1,
-      },
+      "_name": "client-session-sync-processor:boot",
+      "children": [
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+      ],
     },
     {
       "_name": "LiveStore:commits",

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -383,7 +383,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         debugInstanceId: 'test-instance',
       }
 
-      const syncProcessor = makeClientSessionSyncProcessor({
+      const syncProcessor = yield* makeClientSessionSyncProcessor({
         schema: schema as LiveStoreSchema,
         clientSession,
         runtime,
@@ -557,7 +557,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         debugInstanceId: 'test-instance',
       } satisfies ClientSession
 
-      const syncProcessor = makeClientSessionSyncProcessor({
+      const syncProcessor = yield* makeClientSessionSyncProcessor({
         schema: schema as LiveStoreSchema,
         clientSession,
         runtime,

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -343,7 +343,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
   Vitest.scopedLive('rebased pushes carry rebase generation forward', (test) =>
     Effect.gen(function* () {
       const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
-      const runtime = yield* Effect.runtime<Scope.Scope>()
+
 
       const baseHead = EventSequenceNumber.Client.Composite.make({ global: 10, client: 0, rebaseGeneration: 4 })
       const recordedEvents: LiveStoreEvent.Client.EncodedWithMeta[] = []
@@ -386,7 +386,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const syncProcessor = yield* makeClientSessionSyncProcessor({
         schema: schema as LiveStoreSchema,
         clientSession,
-        runtime,
         materializeEvent: (event) =>
           Effect.sync(() => {
             recordedEvents.push(event)
@@ -493,7 +492,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const upstreamQueue = yield* Queue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
       const materializedEvents: LiveStoreEvent.Client.EncodedWithMeta[] = []
       const materialized = yield* Deferred.make<void>()
-      const runtime = yield* Effect.runtime<Scope.Scope>()
+
 
       const lockStatus = yield* SubscriptionRef.make<'has-lock' | 'no-lock'>('has-lock')
 
@@ -560,7 +559,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const syncProcessor = yield* makeClientSessionSyncProcessor({
         schema: schema as LiveStoreSchema,
         clientSession,
-        runtime,
         materializeEvent,
         rollback: () => undefined,
         refreshTables: () => undefined,


### PR DESCRIPTION
## Problem

`makeClientSessionSyncProcessor` is a plain function that uses `Effect.runSync` to eagerly create queues, and its `boot` method lacks tracing. The `runtime` parameter exists only to provide `Scope` for `debug.print`, adding unnecessary coupling.

## Solution

- Convert `makeClientSessionSyncProcessor` to `Effect.fn` with `Effect.fn.Return`, replacing `Effect.runSync` for queue creation with proper `yield*`.
- Convert `boot` to `Effect.fn` for tracing (`'client-session-sync-processor:boot'`).
- Remove the `runtime` parameter — BucketQueue operations have no requirements, so `Effect.runSync` works directly in `debug.print`.

Call sites updated to run the returned effect.

## Validation

No behavioural changes — the function now returns an Effect instead of a plain value. Existing tests continue to pass.