### PR TITLE
refactor: split `push` into `encodeEvents`, `push`, and `materializeEvents`

### DIFF
--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -101,90 +101,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>()
 
-  const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn('client-session-sync-processor:encode-events')(function* (
-    events,
-  ) {
-    let baseEventSequenceNumber = syncStateRef.current.localHead
-    return yield* Effect.forEach(events, ({ name, args }) =>
-      Effect.gen(function* () {
-        const eventDef = yield* Effect.fromNullable(schema.eventsDefsMap.get(name)).pipe(Effect.orDieDebugger)
-        const nextNumPair = EventSequenceNumber.Client.nextPair({
-          seqNum: baseEventSequenceNumber,
-          isClient: eventDef.options.clientOnly,
-          rebaseGeneration: baseEventSequenceNumber.rebaseGeneration,
-        })
-        baseEventSequenceNumber = nextNumPair.seqNum
-        return new LiveStoreEvent.Client.EncodedWithMeta(
-          Schema.encodeUnknownSync(eventSchema)({
-            name,
-            args,
-            ...nextNumPair,
-            clientId: clientSession.clientId,
-            sessionId: clientSession.sessionId,
-          }),
-        )
-      }),
-    )
-  })
-
-  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(function* (
-    encodedEvents,
-  ) {
-    const mergeResult = yield* SyncState.merge({
-      syncState: syncStateRef.current,
-      payload: { _tag: 'local-push', newEvents: encodedEvents },
-      isClientEvent,
-      isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-    }).pipe(
-      Effect.filterOrDieMessage(
-        (r) => r._tag === 'advance',
-        'Expected advance from local-push merge',
-      ),
-    )
-
-    yield* Effect.annotateCurrentSpan({
-      batchSize: encodedEvents.length,
-      mergeResultTag: mergeResult._tag,
-      eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
-        acc[event.name] = (acc[event.name] ?? 0) + 1
-        return acc
-      }, {}),
-      ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-    })
-
-    syncStateRef.current = mergeResult.newSyncState
-    yield* syncStateUpdateQueue.offer(mergeResult.newSyncState)
-    yield* BucketQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
-  })
-
-  const materializeEvents: ClientSessionSyncProcessor['materializeEvents'] = Effect.fn('client-session-sync-processor:materialize-events')(function* (
-    events,
-  ) {
-    const writeTables = new Set<string>()
-    for (const event of events) {
-      const {
-        writeTables: newWriteTables,
-        sessionChangeset,
-        materializerHash,
-      } = yield* materializeEvent(event, {
-        withChangeset: true,
-        materializerHashLeader: Option.none(),
-      })
-      for (const table of newWriteTables) {
-        writeTables.add(table)
-      }
-      event.meta.sessionChangeset = sessionChangeset
-      event.meta.materializerHashSession = materializerHash
-    }
-    return { writeTables }
-  })
-
-  const debugInfo = {
-    rebaseCount: 0,
-    advanceCount: 0,
-    rejectCount: 0,
-  }
-
   const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
       confirmUnsavedChanges === true &&
@@ -347,11 +263,95 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     )
   })()
 
+  const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn('client-session-sync-processor:encode-events')(function* (
+    events,
+  ) {
+    let baseEventSequenceNumber = syncStateRef.current.localHead
+    return yield* Effect.forEach(events, ({ name, args }) =>
+      Effect.gen(function* () {
+        const eventDef = yield* Effect.fromNullable(schema.eventsDefsMap.get(name)).pipe(Effect.orDieDebugger)
+        const nextNumPair = EventSequenceNumber.Client.nextPair({
+          seqNum: baseEventSequenceNumber,
+          isClient: eventDef.options.clientOnly,
+          rebaseGeneration: baseEventSequenceNumber.rebaseGeneration,
+        })
+        baseEventSequenceNumber = nextNumPair.seqNum
+        return new LiveStoreEvent.Client.EncodedWithMeta(
+          Schema.encodeUnknownSync(eventSchema)({
+            name,
+            args,
+            ...nextNumPair,
+            clientId: clientSession.clientId,
+            sessionId: clientSession.sessionId,
+          }),
+        )
+      }),
+    )
+  })
+
+  const materializeEvents: ClientSessionSyncProcessor['materializeEvents'] = Effect.fn('client-session-sync-processor:materialize-events')(function* (
+    events,
+  ) {
+    const writeTables = new Set<string>()
+    for (const event of events) {
+      const {
+        writeTables: newWriteTables,
+        sessionChangeset,
+        materializerHash,
+      } = yield* materializeEvent(event, {
+        withChangeset: true,
+        materializerHashLeader: Option.none(),
+      })
+      for (const table of newWriteTables) {
+        writeTables.add(table)
+      }
+      event.meta.sessionChangeset = sessionChangeset
+      event.meta.materializerHashSession = materializerHash
+    }
+    return { writeTables }
+  })
+
+  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(function* (
+    encodedEvents,
+  ) {
+    const mergeResult = yield* SyncState.merge({
+      syncState: syncStateRef.current,
+      payload: { _tag: 'local-push', newEvents: encodedEvents },
+      isClientEvent,
+      isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+    }).pipe(
+      Effect.filterOrDieMessage(
+        (r) => r._tag === 'advance',
+        'Expected advance from local-push merge',
+      ),
+    )
+
+    yield* Effect.annotateCurrentSpan({
+      batchSize: encodedEvents.length,
+      mergeResultTag: mergeResult._tag,
+      eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
+        acc[event.name] = (acc[event.name] ?? 0) + 1
+        return acc
+      }, {}),
+      ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+    })
+
+    syncStateRef.current = mergeResult.newSyncState
+    yield* syncStateUpdateQueue.offer(mergeResult.newSyncState)
+    yield* BucketQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+  })
+
+  const debugInfo = {
+    rebaseCount: 0,
+    advanceCount: 0,
+    rejectCount: 0,
+  }
+
   return {
-    encodeEvents,
-    push,
-    materializeEvents,
     boot,
+    encodeEvents,
+    materializeEvents,
+    push,
     syncState: Subscribable.make({
       get: Effect.sync(() => syncStateRef.current),
       changes: Stream.fromQueue(syncStateUpdateQueue),
@@ -375,6 +375,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 })
 
 export interface ClientSessionSyncProcessor {
+  boot: Effect.Effect<void, never, Scope.Scope>
   encodeEvents: (
     events: ReadonlyArray<LiveStoreEvent.Input.Decoded>,
   ) => Effect.Effect<ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>>
@@ -384,7 +385,6 @@ export interface ClientSessionSyncProcessor {
   materializeEvents: (
     events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
   ) => Effect.Effect<{ writeTables: Set<string> }, MaterializeError>
-  boot: Effect.Effect<void, never, Scope.Scope>
   /**
    * Only used for debugging / observability.
    */

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -101,11 +101,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>()
 
-  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(function* (batch) {
-    // TODO validate batch
-
+  const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn('client-session-sync-processor:encodeEvents')(function* (
+    events,
+  ) {
     let baseEventSequenceNumber = syncStateRef.current.localHead
-    const encodedEventDefs = yield* Effect.forEach(batch, ({ name, args }) =>
+    return yield* Effect.forEach(events, ({ name, args }) =>
       Effect.gen(function* () {
         const eventDef = yield* Effect.fromNullable(schema.eventsDefsMap.get(name)).pipe(Effect.orDieDebugger)
         const nextNumPair = EventSequenceNumber.Client.nextPair({
@@ -125,10 +125,14 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         )
       }),
     )
+  })
 
+  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(function* (
+    encodedEvents,
+  ) {
     const mergeResult = yield* SyncState.merge({
       syncState: syncStateRef.current,
-      payload: { _tag: 'local-push', newEvents: encodedEventDefs },
+      payload: { _tag: 'local-push', newEvents: encodedEvents },
       isClientEvent,
       isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
     }).pipe(
@@ -139,9 +143,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     )
 
     yield* Effect.annotateCurrentSpan({
-      batchSize: encodedEventDefs.length,
+      batchSize: encodedEvents.length,
       mergeResultTag: mergeResult._tag,
-      eventCounts: encodedEventDefs.reduce<Record<string, number>>((acc, event) => {
+      eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
         acc[event.name] = (acc[event.name] ?? 0) + 1
         return acc
       }, {}),
@@ -150,31 +154,29 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     syncStateRef.current = mergeResult.newSyncState
     yield* syncStateUpdateQueue.offer(mergeResult.newSyncState)
-
-    // Materialize events to state
-    const writeTables = new Set<string>()
-    for (const event of mergeResult.newEvents) {
-      const {
-        writeTables: newWriteTables,
-        sessionChangeset,
-        materializerHash,
-      } = yield* materializeEvent(event, {
-        withChangeset: true,
-        materializerHashLeader: Option.none(),
-      })
-      for (const table of newWriteTables) {
-        writeTables.add(table)
-      }
-      event.meta.sessionChangeset = sessionChangeset
-      event.meta.materializerHashSession = materializerHash
-    }
-
-    // Trigger push to leader
-    // console.debug('pushToLeader', encodedEventDefs.length, ...encodedEventDefs.map((_) => _.toJSON()))
-    yield* BucketQueue.offerAll(leaderPushQueue, encodedEventDefs)
-
-    return { writeTables }
+    yield* BucketQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
   })
+
+  const materializeEvents: ClientSessionSyncProcessor['materializeEvents'] = (events) =>
+    Effect.gen(function* () {
+      const writeTables = new Set<string>()
+      for (const event of events) {
+        const {
+          writeTables: newWriteTables,
+          sessionChangeset,
+          materializerHash,
+        } = yield* materializeEvent(event, {
+          withChangeset: true,
+          materializerHashLeader: Option.none(),
+        })
+        for (const table of newWriteTables) {
+          writeTables.add(table)
+        }
+        event.meta.sessionChangeset = sessionChangeset
+        event.meta.materializerHashSession = materializerHash
+      }
+      return { writeTables }
+    })
 
   const debugInfo = {
     rebaseCount: 0,
@@ -345,7 +347,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   })()
 
   return {
+    encodeEvents,
     push,
+    materializeEvents,
     boot,
     syncState: Subscribable.make({
       get: Effect.sync(() => syncStateRef.current),
@@ -370,8 +374,14 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 })
 
 export interface ClientSessionSyncProcessor {
+  encodeEvents: (
+    events: ReadonlyArray<LiveStoreEvent.Input.Decoded>,
+  ) => Effect.Effect<ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>>
   push: (
-    batch: ReadonlyArray<LiveStoreEvent.Input.Decoded>,
+    events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+  ) => Effect.Effect<void>
+  materializeEvents: (
+    events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
   ) => Effect.Effect<{ writeTables: Set<string> }, MaterializeError>
   boot: Effect.Effect<void, never, Scope.Scope>
   /**

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -101,7 +101,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* BucketQueue.make<LiveStoreEvent.Client.EncodedWithMeta>()
 
-  const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn('client-session-sync-processor:encodeEvents')(function* (
+  const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn('client-session-sync-processor:encode-events')(function* (
     events,
   ) {
     let baseEventSequenceNumber = syncStateRef.current.localHead

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -157,26 +157,27 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     yield* BucketQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
   })
 
-  const materializeEvents: ClientSessionSyncProcessor['materializeEvents'] = (events) =>
-    Effect.gen(function* () {
-      const writeTables = new Set<string>()
-      for (const event of events) {
-        const {
-          writeTables: newWriteTables,
-          sessionChangeset,
-          materializerHash,
-        } = yield* materializeEvent(event, {
-          withChangeset: true,
-          materializerHashLeader: Option.none(),
-        })
-        for (const table of newWriteTables) {
-          writeTables.add(table)
-        }
-        event.meta.sessionChangeset = sessionChangeset
-        event.meta.materializerHashSession = materializerHash
+  const materializeEvents: ClientSessionSyncProcessor['materializeEvents'] = Effect.fn('client-session-sync-processor:materialize-events')(function* (
+    events,
+  ) {
+    const writeTables = new Set<string>()
+    for (const event of events) {
+      const {
+        writeTables: newWriteTables,
+        sessionChangeset,
+        materializerHash,
+      } = yield* materializeEvent(event, {
+        withChangeset: true,
+        materializerHashLeader: Option.none(),
+      })
+      for (const table of newWriteTables) {
+        writeTables.add(table)
       }
-      return { writeTables }
-    })
+      event.meta.sessionChangeset = sessionChangeset
+      event.meta.materializerHashSession = materializerHash
+    }
+    return { writeTables }
+  })
 
   const debugInfo = {
     rebaseCount: 0,

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -68,13 +68,18 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -161,13 +166,18 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -300,13 +310,18 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -439,13 +454,18 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -578,13 +598,18 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -750,13 +775,18 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -785,13 +815,18 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -914,13 +949,18 @@ exports[`otel > otel 4`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -1221,13 +1261,18 @@ exports[`otel > with thunks 8`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },
@@ -1356,13 +1401,18 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-            },
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+            ],
           },
         ],
       },

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -65,6 +65,20 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -73,19 +87,6 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -157,6 +158,20 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -165,19 +180,6 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -295,6 +297,20 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -303,19 +319,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -433,6 +436,20 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -441,19 +458,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -571,6 +575,20 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -579,19 +597,6 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -742,6 +747,20 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -750,19 +769,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -776,6 +782,20 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -784,19 +804,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -904,6 +911,20 @@ exports[`otel > otel 4`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -912,19 +933,6 @@ exports[`otel > otel 4`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -1210,6 +1218,20 @@ exports[`otel > with thunks 8`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -1218,19 +1240,6 @@ exports[`otel > with thunks 8`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -1344,6 +1353,20 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -1352,19 +1375,6 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -65,7 +65,7 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -163,7 +163,7 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -307,7 +307,7 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -451,7 +451,7 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -595,7 +595,7 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -772,7 +772,7 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -812,7 +812,7 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -946,7 +946,7 @@ exports[`otel > otel 4`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -1258,7 +1258,7 @@ exports[`otel > with thunks 8`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -1398,7 +1398,7 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -802,23 +802,20 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
       const localRuntime = yield* Effect.runtime()
 
-      const materializeEventsTx = Effect.try({
-        try: () => {
-          const runMaterializeEvents = () => {
-            return this[StoreInternalsSymbol].syncProcessor.push(events).pipe(Runtime.runSync(localRuntime))
-          }
+      const encodedEvents = yield* this[StoreInternalsSymbol].syncProcessor.encodeEvents(events)
 
-          if (events.length > 1) {
-            return this[StoreInternalsSymbol].sqliteDbWrapper.txn(runMaterializeEvents)
-          } else {
-            return runMaterializeEvents()
-          }
+      const { writeTables } = yield* Effect.try({
+        try: () => {
+          const materialize = () =>
+            this[StoreInternalsSymbol].syncProcessor.materializeEvents(encodedEvents).pipe(Runtime.runSync(localRuntime))
+          return events.length > 1
+            ? this[StoreInternalsSymbol].sqliteDbWrapper.txn(materialize)
+            : materialize()
         },
         catch: (cause) => UnknownError.make({ cause }),
       })
 
-      // Materialize events to state
-      const { writeTables } = yield* materializeEventsTx
+      yield* this[StoreInternalsSymbol].syncProcessor.push(encodedEvents)
 
       const tablesToUpdate: [Ref<null, ReactivityGraphContext, RefreshReason>, null][] = []
       for (const tableName of writeTables) {

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -202,17 +202,22 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
       INSERT INTO 'UserInfo' (id, value)
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
     ",
-            },
+                },
+              },
+            ],
           },
         ],
       },
@@ -241,17 +246,22 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
       INSERT INTO 'UserInfo' (id, value)
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
     ",
-            },
+                },
+              },
+            ],
           },
         ],
       },
@@ -410,17 +420,22 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
       INSERT INTO 'UserInfo' (id, value)
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
     ",
-            },
+                },
+              },
+            ],
           },
         ],
       },
@@ -449,17 +464,22 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
       INSERT INTO 'UserInfo' (id, value)
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
     ",
-            },
+                },
+              },
+            ],
           },
         ],
       },

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -199,6 +199,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -207,23 +225,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -237,6 +238,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -245,23 +264,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -405,6 +407,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -413,23 +433,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -443,6 +446,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -451,23 +472,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -243,7 +243,7 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -417,7 +417,7 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -461,7 +461,7 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -133,17 +133,22 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
       INSERT INTO 'UserInfo' (id, value)
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
     ",
-            },
+                },
+              },
+            ],
           },
         ],
       },
@@ -172,17 +177,22 @@ exports[`useClientDocument > otel > should update the data based on component ke
         "_name": "client-session-sync-processor:encodeEvents",
       },
       {
-        "_name": "client-session-sync-processor:materialize-event",
+        "_name": "client-session-sync-processor:materialize-events",
         "children": [
           {
-            "_name": "livestore.in-memory-db:execute",
-            "attributes": {
-              "sql.query": "
+            "_name": "client-session-sync-processor:materialize-event",
+            "children": [
+              {
+                "_name": "livestore.in-memory-db:execute",
+                "attributes": {
+                  "sql.query": "
       INSERT INTO 'UserInfo' (id, value)
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
     ",
-            },
+                },
+              },
+            ],
           },
         ],
       },

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -130,6 +130,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
+    ",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -138,23 +156,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(json_set(value, ?, json(?)), ?, json(?))
-    ",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },
@@ -168,6 +169,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
+        "_name": "client-session-sync-processor:encodeEvents",
+      },
+      {
+        "_name": "client-session-sync-processor:materialize-event",
+        "children": [
+          {
+            "_name": "livestore.in-memory-db:execute",
+            "attributes": {
+              "sql.query": "
+      INSERT INTO 'UserInfo' (id, value)
+      VALUES (?, ?)
+      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
+    ",
+            },
+          },
+        ],
+      },
+      {
         "_name": "client-session-sync-processor:push",
         "attributes": {
           "batchSize": 1,
@@ -176,23 +195,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
 }",
           "mergeResultTag": "advance",
         },
-        "children": [
-          {
-            "_name": "client-session-sync-processor:materialize-event",
-            "children": [
-              {
-                "_name": "livestore.in-memory-db:execute",
-                "attributes": {
-                  "sql.query": "
-      INSERT INTO 'UserInfo' (id, value)
-      VALUES (?, ?)
-      ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
-    ",
-                },
-              },
-            ],
-          },
-        ],
       },
     ],
   },

--- a/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
+++ b/packages/@livestore/solid/src/__snapshots__/useClientDocument.client.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",
@@ -174,7 +174,7 @@ exports[`useClientDocument > otel > should update the data based on component ke
     },
     "children": [
       {
-        "_name": "client-session-sync-processor:encodeEvents",
+        "_name": "client-session-sync-processor:encode-events",
       },
       {
         "_name": "client-session-sync-processor:materialize-events",

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -403,7 +403,11 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         confirmUnsavedChanges: false,
       })
 
-      yield* syncProcessor.push([events.todoCreated({ id: 'post-rebase', text: 'after', completed: false })])
+      const encoded = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'post-rebase', text: 'after', completed: false }),
+      ])
+      yield* syncProcessor.push(encoded)
+      yield* syncProcessor.materializeEvents(encoded)
 
       expect(recordedEvents).toHaveLength(1)
       const event = recordedEvents[0]!

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -406,8 +406,8 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const encoded = yield* syncProcessor.encodeEvents([
         events.todoCreated({ id: 'post-rebase', text: 'after', completed: false }),
       ])
-      yield* syncProcessor.push(encoded)
       yield* syncProcessor.materializeEvents(encoded)
+      yield* syncProcessor.push(encoded)
 
       expect(recordedEvents).toHaveLength(1)
       const event = recordedEvents[0]!


### PR DESCRIPTION
## Problem

The `push` method on `ClientSessionSyncProcessor` bundles three concerns: event encoding, sync-state merging, and SQLite materialization. This prevents the caller from composing these steps independently — for example, encoding events before entering a SQLite transaction or pushing to the leader only after materialization succeeds.

## Solution

Split `push` into three methods on the `ClientSessionSyncProcessor` interface:
- `encodeEvents` — schema encoding + sequence numbering (synchronous, no Effect)
- `push` — sync-state merge + leader enqueue
- `materializeEvents` — SQLite materialization

The caller in `store.ts` now composes them: encode first (outside the transaction), materialize (inside the transaction), then push to the leader.

## Validation

No behavioural changes — the same operations happen in the same order, just composed by the caller. Test updated to call the three methods explicitly. Existing tests continue to pass.