### PR TITLE
fix: use `deepEqual` for event args comparison to ignore key order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -450,6 +450,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Stop advancing the backend head when materializers crash so subsequent boots no longer fail (#409)
 - Prevent `store.subscribe` reentrancy crashes by restoring the reactive debug context after nested commits (#577, #656)
 - Fix `subscribe` with `skipInitialRun` to properly register reactive dependencies while suppressing the initial callback (#847)
+- Fix event equality check failing when args key order differs, which caused duplicate events when syncing with backends that reorder JSON keys (e.g. PostgreSQL `jsonb`) (#1160)
 
 ##### TypeScript & Build
 

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -4,7 +4,7 @@ import { Option } from '@livestore/utils/effect'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 
 import * as EventSequenceNumber from '../EventSequenceNumber/mod.ts'
-import { EncodedWithMeta } from './client.ts'
+import { EncodedWithMeta, isEqualEncoded, Encoded } from './client.ts'
 
 Vitest.describe('EncodedWithMeta', () => {
   Vitest.test('toGlobal() produces numeric seqNums through JSON.stringify', () => {
@@ -28,5 +28,52 @@ Vitest.describe('EncodedWithMeta', () => {
 
     expect(parsed.seqNum).toBe(5)
     expect(parsed.parentSeqNum).toBe(4)
+  })
+})
+
+Vitest.describe('isEqualEncoded', () => {
+  const makeEncodedEvent = (args: unknown): Encoded => ({
+    name: 'testEvent-v1',
+    args,
+    seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+    parentSeqNum: EventSequenceNumber.Client.Composite.make(EventSequenceNumber.Client.ROOT),
+    clientId: 'client-1',
+    sessionId: 'session-1',
+  })
+
+  Vitest.it('should consider events with identical args as equal', () => {
+    const a = makeEncodedEvent({ id: 'abc', text: 'hello' })
+    const b = makeEncodedEvent({ id: 'abc', text: 'hello' })
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should consider events with different key order in args as equal', () => {
+    const a = makeEncodedEvent({ b: 2, a: 1 })
+    const b = makeEncodedEvent({ a: 1, b: 2 })
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should consider events with different key order in nested args as equal', () => {
+    const a = makeEncodedEvent({ outer: { b: 2, a: 1 }, x: 'y' })
+    const b = makeEncodedEvent({ x: 'y', outer: { a: 1, b: 2 } })
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should consider events with different args values as not equal', () => {
+    const a = makeEncodedEvent({ id: 'abc' })
+    const b = makeEncodedEvent({ id: 'def' })
+    expect(isEqualEncoded(a, b)).toBe(false)
+  })
+
+  Vitest.it('should consider events with different args keys as not equal', () => {
+    const a = makeEncodedEvent({ a: 1 })
+    const b = makeEncodedEvent({ b: 1 })
+    expect(isEqualEncoded(a, b)).toBe(false)
+  })
+
+  Vitest.it('should consider events with different names as not equal', () => {
+    const a = { ...makeEncodedEvent({ id: 'abc' }), name: 'eventA' }
+    const b = { ...makeEncodedEvent({ id: 'abc' }), name: 'eventB' }
+    expect(isEqualEncoded(a, b)).toBe(false)
   })
 })

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -71,6 +71,24 @@ Vitest.describe('isEqualEncoded', () => {
     expect(isEqualEncoded(a, b)).toBe(false)
   })
 
+  Vitest.it('should handle null args', () => {
+    const a = makeEncodedEvent(null)
+    const b = makeEncodedEvent(null)
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should handle array args', () => {
+    const a = makeEncodedEvent([1, 2, 3])
+    const b = makeEncodedEvent([1, 2, 3])
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should handle empty object args', () => {
+    const a = makeEncodedEvent({})
+    const b = makeEncodedEvent({})
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
   Vitest.it('should consider events with different names as not equal', () => {
     const a = { ...makeEncodedEvent({ id: 'abc' }), name: 'eventA' }
     const b = { ...makeEncodedEvent({ id: 'abc' }), name: 'eventB' }

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -4,7 +4,7 @@ import { Option } from '@livestore/utils/effect'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 
 import * as EventSequenceNumber from '../EventSequenceNumber/mod.ts'
-import { EncodedWithMeta, isEqualEncoded, Encoded } from './client.ts'
+import { EncodedWithMeta, isEqualEncoded, type Encoded } from './client.ts'
 
 Vitest.describe('EncodedWithMeta', () => {
   Vitest.test('toGlobal() produces numeric seqNums through JSON.stringify', () => {

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
@@ -1,4 +1,4 @@
-import { memoizeByRef } from '@livestore/utils'
+import { deepEqual, memoizeByRef } from '@livestore/utils'
 import { Option, Schema } from '@livestore/utils/effect'
 
 import type { EventDef } from '../EventDef/mod.ts'
@@ -194,7 +194,7 @@ export const isEqualEncoded = (a: Encoded, b: Encoded) =>
   a.name === b.name &&
   a.clientId === b.clientId &&
   a.sessionId === b.sessionId &&
-  JSON.stringify(a.args) === JSON.stringify(b.args) // TODO use schema equality here
+  deepEqual(a.args, b.args) // TODO use schema equality here
 
 /**
  * Creates an Effect Schema union for all event types in a schema (with composite sequence numbers).


### PR DESCRIPTION
## Problem

`isEqualEncoded` uses `JSON.stringify` to compare event args, which is key-order dependent. When a backend (e.g. PostgreSQL with `jsonb` columns) reorders object keys, semantically identical events like `{"a": 1, "b": 2}` and `{"b": 2, "a": 1}` are treated as different, causing duplicate events during sync.

## Solution

Replace `JSON.stringify(a.args) === JSON.stringify(b.args)` with `deepEqual(a.args, b.args)` from `@livestore/utils`, which performs recursive structural comparison regardless of key order. This utility is already used elsewhere in the codebase (reactive queries, React/Solid hooks).

The existing `TODO use schema equality here` comment is preserved for future consideration.

## Validation

Added 9 unit tests for `isEqualEncoded` covering:
- Identical args
- Different key order in flat args (was failing before fix)
- Different key order in nested args (was failing before fix)
- Different values (correctly not equal)
- Different keys (correctly not equal)
- Different event names (correctly not equal)
- Null args
- Array args
- Empty object args

```
 ✓ |@livestore/common| src/schema/LiveStoreEvent/client.test.ts (9 tests) 3ms
   Tests  9 passed (9)
```

## Related issues

- Closes #1160