### PR TITLE
fix(common-cf):  handle merged DO RPC stream chunks in client decode

### DIFF
--- a/packages/@livestore/common-cf/src/do-rpc/client.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.ts
@@ -34,14 +34,13 @@ const processReadableStream = (
         // Decode the chunk
         const decoded = parser.decode(value as Uint8Array)
 
-        // Handle array of messages - we get [[message]] from server
+        // Handle array of messages from server.
+        // Server sends `parser.encode([message])` per enqueue, so each decoded value is `[message]`.
+        // When CF DO RPC merges enqueues in production, we get `[[msg1], [msg2], ...]`.
+        // `flat(1)` normalizes both single and merged cases to `[msg1, msg2, ...]`.
         let messages: any[]
-        if (Array.isArray(decoded) === true && decoded.length === 1 && Array.isArray(decoded[0]) === true) {
-          // Double-wrapped array [[message]] -> [message]
-          messages = decoded[0]
-        } else if (Array.isArray(decoded) === true) {
-          // Single array [message]
-          messages = decoded
+        if (Array.isArray(decoded) === true) {
+          messages = decoded.flat(1)
         } else {
           messages = [decoded]
         }
@@ -129,14 +128,10 @@ const makeProtocolDurableObject = ({
           // Handle regular Uint8Array responses
           const decoded = parser.decode(serializedResponse as Uint8Array)
 
-          // Handle potential nested array from server serialization
+          // Normalize nested arrays from server serialization (same as streaming path)
           let responseArray: any[]
-          if (Array.isArray(decoded) === true && decoded.length === 1 && Array.isArray(decoded[0]) === true) {
-            // Double-wrapped array [[Exit]] -> [Exit]
-            responseArray = decoded[0]
-          } else if (Array.isArray(decoded) === true) {
-            // Single array [Exit]
-            responseArray = decoded
+          if (Array.isArray(decoded) === true) {
+            responseArray = decoded.flat(1)
           } else {
             responseArray = [decoded]
           }


### PR DESCRIPTION
## Problem

The DO RPC client decode logic uses conditional array unwrapping that only handles the single-message case (`[[message]]` → `[message]`). In production CF Workers, multiple `controller.enqueue()` calls on the server can be merged into fewer `reader.read()` responses, producing nested arrays like `[[msg1], [msg2], ...]` that the previous logic didn't handle correctly.

## Fix

Replace the fragile conditional unwrapping with `flat(1)` in both streaming and non-streaming decode paths. This normalizes both single and merged cases consistently:

- `[[msg1]]` → `[msg1]`
- `[[msg1], [msg2], [msg3]]` → `[msg1, msg2, msg3]`

Single non-array values are still wrapped in `[decoded]` as before.