### PR TITLE
fix(common): prevent `EncodedWithMeta.toJSON` leaking onto `toGlobal()` result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,6 +440,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### Concurrency & Lifecycle
 
+- Fix `toGlobal()` leaking a debug `toJSON` method onto the returned `Global.Encoded` object, causing `JSON.stringify` to produce string seqNums instead of integers in custom sync backends (#1165). Thanks @OrkhanAlikhanov for diagnosing the root cause.
 - Fix correct type assertion in withLock function
 - Fix finalizers execution order (#450)
 - Ensure large batches no longer leave follower sessions behind by reconciling leader/follower heads correctly (#362)

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'vitest'
+
+import { Option } from '@livestore/utils/effect'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+
+import * as EventSequenceNumber from '../EventSequenceNumber/mod.ts'
+import { EncodedWithMeta } from './client.ts'
+
+Vitest.describe('EncodedWithMeta', () => {
+  Vitest.test('toGlobal() produces numeric seqNums through JSON.stringify', () => {
+    const event = new EncodedWithMeta({
+      name: 'test-v1',
+      args: { id: '1' },
+      seqNum: EventSequenceNumber.Client.Composite.make({ global: 5, client: 0 }),
+      parentSeqNum: EventSequenceNumber.Client.Composite.make({ global: 4, client: 0 }),
+      clientId: 'client-1',
+      sessionId: 'session-1',
+      meta: {
+        sessionChangeset: { _tag: 'unset' },
+        syncMetadata: Option.none(),
+        materializerHashLeader: Option.none(),
+        materializerHashSession: Option.none(),
+      },
+    })
+
+    const global = event.toGlobal()
+    const parsed = JSON.parse(JSON.stringify(global))
+
+    expect(parsed.seqNum).toBe(5)
+    expect(parsed.parentSeqNum).toBe(4)
+  })
+})

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
@@ -175,9 +175,12 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
     })
 
   toGlobal = (): Global.Encoded => ({
-    ...this,
+    name: this.name,
+    args: this.args,
     seqNum: this.seqNum.global,
     parentSeqNum: this.parentSeqNum.global,
+    clientId: this.clientId,
+    sessionId: this.sessionId,
   })
 }
 


### PR DESCRIPTION
## Problem

`EncodedWithMeta.toGlobal()` used `...this` to spread all own properties onto the returned object. Because `toJSON` is defined as an arrow function (class field), it became an own property of the instance and was copied onto the result. When `JSON.stringify()` was called on the returned `Global.Encoded` (e.g. in a custom sync backend's `push` implementation), the engine invoked the debug `toJSON` method, serializing `seqNum` as `"e1 → e0 (client-1, session-1)"` instead of the expected integer.

## Solution

Replaced the `...this` spread with explicit field picks (`name`, `args`, `seqNum`, `parentSeqNum`, `clientId`, `sessionId`) so `toGlobal()` returns a plain object matching `Global.Encoded` exactly, with no leaked methods or extra properties like `meta`, `rebase`, or `toGlobal`.

## Validation

- New unit test in `packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts` — creates an `EncodedWithMeta`, calls `toGlobal()`, round-trips through `JSON.stringify`/`JSON.parse`, and asserts `seqNum`/`parentSeqNum` are numbers.

## Related issues

- Closes #1165. Thanks @OrkhanAlikhanov for diagnosing the root cause.