### PR TITLE
[codex] fix common-cf DO RPC msgpack handling on workers

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -99,6 +99,7 @@ export const livestoreOnlyCatalog = {
   'qrcode-generator': '1.4.4',
   '@iarna/toml': '3.0.0',
   '@graphql-typed-document-node/core': '3.2.0',
+  msgpackr: '1.11.9',
   'astro-expressive-code': '0.41.5',
   'expressive-code': '0.41.5',
   'expressive-code-twoslash': '0.5.3',

--- a/packages/@livestore/common-cf/package.json
+++ b/packages/@livestore/common-cf/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/utils": "workspace:^"
+    "@livestore/utils": "workspace:^",
+    "msgpackr": "1.11.9"
   },
   "devDependencies": {
     "@livestore/utils-dev": "workspace:^",

--- a/packages/@livestore/common-cf/package.json.genie.ts
+++ b/packages/@livestore/common-cf/package.json.genie.ts
@@ -12,7 +12,7 @@ const runtimeDeps = catalog.compose({
   workspace: workspaceMember('packages/@livestore/common-cf'),
   dependencies: {
     workspace: [utilsPkg],
-    external: catalog.pick('@cloudflare/workers-types'),
+    external: catalog.pick('@cloudflare/workers-types', 'msgpackr'),
   },
   devDependencies: {
     workspace: [utilsDevPkg],

--- a/packages/@livestore/common-cf/src/do-rpc/client.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.ts
@@ -1,15 +1,7 @@
-import {
-  Effect,
-  Fiber,
-  FiberMap,
-  Layer,
-  RpcClient,
-  type RpcMessage,
-  RpcSerialization,
-  type Scope,
-} from '@livestore/utils/effect'
+import { Effect, Fiber, FiberMap, Layer, RpcClient, type RpcMessage, type Scope } from '@livestore/utils/effect'
 
 import type * as CfTypes from '../cf-types.ts'
+import { decodeStreamChunk, makeMsgPackParser, type MsgPackParser, normalizeDecodedMessages } from './msgpack.ts'
 
 /**
  * Processes a ReadableStream response from streaming RPCs.
@@ -17,11 +9,12 @@ import type * as CfTypes from '../cf-types.ts'
  */
 const processReadableStream = (
   stream: CfTypes.ReadableStream,
-  parser: ReturnType<typeof RpcSerialization.msgPack.unsafeMake>,
-  writeResponse: (response: any) => Effect.Effect<void>,
+  parser: MsgPackParser,
+  writeResponse: (response: RpcMessage.FromServerEncoded) => Effect.Effect<void>,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const reader = stream.getReader()
+    let pending: Uint8Array<ArrayBufferLike> = new Uint8Array()
 
     yield* Effect.gen(function* () {
       while (true) {
@@ -31,23 +24,31 @@ const processReadableStream = (
           break
         }
 
-        // Decode the chunk
-        const decoded = parser.decode(value as Uint8Array)
+        const { messages, pending: nextPending } = decodeStreamChunk(parser, value as Uint8Array, pending)
+        pending = nextPending
 
-        // Handle array of messages from server.
-        // Server sends `parser.encode([message])` per enqueue, so each decoded value is `[message]`.
-        // When CF DO RPC merges enqueues in production, we get `[[msg1], [msg2], ...]`.
-        // `flat(1)` normalizes both single and merged cases to `[msg1, msg2, ...]`.
-        let messages: any[]
-        if (Array.isArray(decoded) === true) {
-          messages = decoded.flat(1)
-        } else {
-          messages = [decoded]
+        for (const decoded of messages) {
+          const responses = normalizeDecodedMessages(decoded) as RpcMessage.FromServerEncoded[]
+
+          for (const response of responses) {
+            yield* writeResponse(response)
+          }
+        }
+      }
+
+      if (pending.length > 0) {
+        const { messages, pending: finalPending } = decodeStreamChunk(parser, new Uint8Array(), pending)
+
+        for (const decoded of messages) {
+          const responses = normalizeDecodedMessages(decoded) as RpcMessage.FromServerEncoded[]
+
+          for (const response of responses) {
+            yield* writeResponse(response)
+          }
         }
 
-        // Write each message
-        for (const message of messages) {
-          yield* writeResponse(message)
+        if (finalPending.length > 0) {
+          throw new Error(`Incomplete MessagePack data at stream end (${finalPending.length} bytes pending)`)
         }
       }
     }).pipe(
@@ -70,9 +71,8 @@ interface MakeDoRpcProtocolArgs {
  * Creates a Protocol layer that uses Cloudflare Durable Object RPC calls.
  * This enables direct RPC communication with Durable Objects using Cloudflare's native RPC.
  */
-export const layerProtocolDurableObject = (
-  args: MakeDoRpcProtocolArgs,
-): Layer.Layer<RpcClient.Protocol> => Layer.scoped(RpcClient.Protocol, makeProtocolDurableObject(args))
+export const layerProtocolDurableObject = (args: MakeDoRpcProtocolArgs): Layer.Layer<RpcClient.Protocol> =>
+  Layer.scoped(RpcClient.Protocol, makeProtocolDurableObject(args))
 
 /**
  * Implementation of the RPC Protocol interface using Cloudflare Durable Object RPC calls.
@@ -82,13 +82,13 @@ const makeProtocolDurableObject = ({
   callRpc,
 }: MakeDoRpcProtocolArgs): Effect.Effect<RpcClient.Protocol['Type'], never, Scope.Scope> =>
   RpcClient.Protocol.make(
-    Effect.fnUntraced(function* (writeResponse) {
-      const parser = RpcSerialization.msgPack.unsafeMake()
+    Effect.fnUntraced(function* (writeResponse: (response: RpcMessage.FromServerEncoded) => Effect.Effect<void>) {
+      const parser = makeMsgPackParser()
       // Not using an actual `FiberMap` here because it seems to shutdown to early
       // const fiberMap = new Map<string, Fiber.RuntimeFiber<void, never>>()
       const fiberMap = yield* FiberMap.make<string, void, never>()
 
-  const send = (message: RpcMessage.FromClientEncoded): Effect.Effect<void> => {
+      const send = (message: RpcMessage.FromClientEncoded): Effect.Effect<void> => {
         if (message._tag !== 'Request') {
           if (message._tag === 'Interrupt') {
             return Effect.gen(function* () {
@@ -101,7 +101,7 @@ const makeProtocolDurableObject = ({
         }
 
         // Wrap single Request in array to match server expected format
-        const serializedPayload = parser.encode([message]) as Uint8Array
+        const serializedPayload = parser.encode([message])
 
         return Effect.gen(function* () {
           const serializedResponse = yield* Effect.tryPromise(() => callRpc(serializedPayload)).pipe(Effect.orDie) // Convert errors to defects to match never error type
@@ -128,13 +128,7 @@ const makeProtocolDurableObject = ({
           // Handle regular Uint8Array responses
           const decoded = parser.decode(serializedResponse as Uint8Array)
 
-          // Normalize nested arrays from server serialization (same as streaming path)
-          let responseArray: any[]
-          if (Array.isArray(decoded) === true) {
-            responseArray = decoded.flat(1)
-          } else {
-            responseArray = [decoded]
-          }
+          const responseArray = normalizeDecodedMessages(decoded) as RpcMessage.FromServerEncoded[]
 
           // Process each response
           for (const response of responseArray) {

--- a/packages/@livestore/common-cf/src/do-rpc/msgpack.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/msgpack.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeStreamChunk, makeMsgPackParser, normalizeDecodedMessages } from './msgpack.ts'
+
+const concatUint8Arrays = (...arrays: readonly Uint8Array[]): Uint8Array => {
+  const totalLength = arrays.reduce((sum, array) => sum + array.length, 0)
+  const merged = new Uint8Array(totalLength)
+  let offset = 0
+
+  for (const array of arrays) {
+    merged.set(array, offset)
+    offset += array.length
+  }
+
+  return merged
+}
+
+const toBytes = (value: Uint8Array): number[] => Array.from(value)
+
+describe('do-rpc msgpack stream decoding', () => {
+  it('buffers a split frame until the remaining bytes arrive', () => {
+    const parser = makeMsgPackParser()
+    const message = { _tag: 'Chunk', requestId: 'req-1', values: [1, 4, 9] }
+    const encoded = parser.encode([message])
+
+    const midpoint = Math.floor(encoded.length / 2)
+    const firstChunk = decodeStreamChunk(parser, encoded.subarray(0, midpoint), new Uint8Array())
+
+    expect(firstChunk.messages).toEqual([])
+    expect(toBytes(firstChunk.pending)).toEqual(toBytes(encoded.subarray(0, midpoint)))
+
+    const secondChunk = decodeStreamChunk(parser, encoded.subarray(midpoint), firstChunk.pending)
+
+    expect(secondChunk.pending).toEqual(new Uint8Array())
+    expect(secondChunk.messages.flatMap(normalizeDecodedMessages)).toEqual([message])
+  })
+
+  it('decodes multiple frames delivered in a single read', () => {
+    const parser = makeMsgPackParser()
+    const firstMessage = { _tag: 'Chunk', requestId: 'req-1', values: [1] }
+    const secondMessage = { _tag: 'Exit', requestId: 'req-1', exit: { _tag: 'Success' } }
+    const merged = concatUint8Arrays(parser.encode([firstMessage]), parser.encode([secondMessage]))
+
+    const decoded = decodeStreamChunk(parser, merged, new Uint8Array())
+
+    expect(decoded.pending).toEqual(new Uint8Array())
+    expect(decoded.messages.flatMap(normalizeDecodedMessages)).toEqual([firstMessage, secondMessage])
+  })
+
+  it('returns completed frames and keeps trailing partial bytes pending', () => {
+    const parser = makeMsgPackParser()
+    const firstMessage = { _tag: 'Chunk', requestId: 'req-1', values: [1, 4, 9] }
+    const secondMessage = { _tag: 'Exit', requestId: 'req-1', exit: { _tag: 'Success' } }
+    const firstEncoded = parser.encode([firstMessage])
+    const secondEncoded = parser.encode([secondMessage])
+    const splitIndex = secondEncoded.length - 3
+    const firstRead = concatUint8Arrays(firstEncoded, secondEncoded.subarray(0, splitIndex))
+
+    const decoded = decodeStreamChunk(parser, firstRead, new Uint8Array())
+
+    expect(decoded.messages.flatMap(normalizeDecodedMessages)).toEqual([firstMessage])
+    expect(toBytes(decoded.pending)).toEqual(toBytes(secondEncoded.subarray(0, splitIndex)))
+
+    const flushed = decodeStreamChunk(parser, secondEncoded.subarray(splitIndex), decoded.pending)
+
+    expect(flushed.pending).toEqual(new Uint8Array())
+    expect(flushed.messages.flatMap(normalizeDecodedMessages)).toEqual([secondMessage])
+  })
+})

--- a/packages/@livestore/common-cf/src/do-rpc/msgpack.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/msgpack.ts
@@ -1,0 +1,73 @@
+import { Packr, Unpackr } from 'msgpackr'
+
+export const makeMsgPackParser = () => {
+  const packr = new Packr({ useRecords: false, mapsAsObjects: true })
+  const unpackr = new Unpackr({ useRecords: false, mapsAsObjects: true })
+
+  return {
+    encode: (value: unknown) => packr.pack(value) as Uint8Array<ArrayBufferLike>,
+    decode: (value: Uint8Array<ArrayBufferLike>) => unpackr.unpack(value),
+    unpackMultiple: (value: Uint8Array<ArrayBufferLike>) => unpackr.unpackMultiple(value),
+  }
+}
+
+export type MsgPackParser = ReturnType<typeof makeMsgPackParser>
+
+type DecodedChunk = {
+  messages: unknown[]
+  pending: Uint8Array<ArrayBufferLike>
+}
+
+export const normalizeDecodedMessages = (decoded: unknown): unknown[] => {
+  if (Array.isArray(decoded) === true && decoded.length === 1 && Array.isArray(decoded[0]) === true) {
+    return decoded[0]
+  }
+
+  if (Array.isArray(decoded) === true) {
+    return decoded
+  }
+
+  return [decoded]
+}
+
+const mergeChunks = (
+  pending: Uint8Array<ArrayBufferLike>,
+  chunk: Uint8Array<ArrayBufferLike>,
+): Uint8Array<ArrayBufferLike> => {
+  if (pending.length === 0) return chunk
+  if (chunk.length === 0) return pending
+
+  const merged = new Uint8Array(pending.length + chunk.length)
+  merged.set(pending)
+  merged.set(chunk, pending.length)
+  return merged
+}
+
+export const decodeStreamChunk = (
+  parser: MsgPackParser,
+  chunk: Uint8Array<ArrayBufferLike>,
+  pending: Uint8Array<ArrayBufferLike>,
+): DecodedChunk => {
+  const buffer = mergeChunks(pending, chunk)
+
+  if (buffer.length === 0) {
+    return { messages: [], pending: new Uint8Array() }
+  }
+
+  try {
+    const decoded = parser.unpackMultiple(buffer)
+    return { messages: decoded, pending: new Uint8Array() }
+  } catch (error) {
+    if (error != null && typeof error === 'object' && (error as { incomplete?: boolean }).incomplete === true) {
+      const messageValues = (error as { values?: unknown }).values
+      const messages = Array.isArray(messageValues) === true ? messageValues : []
+      const lastPositionCandidate = (error as { lastPosition?: number }).lastPosition
+      const lastPosition = typeof lastPositionCandidate === 'number' ? lastPositionCandidate : 0
+      const pendingBytes = lastPosition > 0 ? buffer.subarray(lastPosition) : buffer
+
+      return { messages, pending: pendingBytes }
+    }
+
+    throw error
+  }
+}

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -1,4 +1,5 @@
 import {
+  type Cause,
   Chunk,
   Effect,
   Exit,
@@ -10,13 +11,13 @@ import {
   type RpcGroup,
   type RpcMessage,
   RpcSchema,
-  RpcSerialization,
   Schema,
   type Scope,
   Stream,
 } from '@livestore/utils/effect'
 
 import type * as CfTypes from '../cf-types.ts'
+import { makeMsgPackParser, type MsgPackParser } from './msgpack.ts'
 
 export interface ClientDoWithRpcCallback {
   __DURABLE_OBJECT_BRAND: never
@@ -41,7 +42,7 @@ export const toDurableObjectHandler =
   ) => Effect.Effect<Uint8Array<ArrayBuffer> | CfTypes.ReadableStream>) =>
   (serializedPayload) =>
     Effect.gen(function* () {
-      const parser = RpcSerialization.msgPack.unsafeMake()
+      const parser = makeMsgPackParser()
 
       // Decode incoming requests - client sends array of requests
       const decoded = parser.decode(serializedPayload)
@@ -130,7 +131,7 @@ export const toDurableObjectHandler =
             exit: encodedExit,
           }
         }).pipe(
-          Effect.catchAllCause((cause) => {
+          Effect.catchAllCause((cause: Cause.Cause<unknown>) => {
             // Get the exit schema for this RPC
             // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
             const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Schema<any>
@@ -199,7 +200,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
   rpc: Rpc.AnyWithProps,
   entry: Rpc.Handler<Rpcs['_tag']>,
   request: any,
-  parser: ReturnType<typeof RpcSerialization.msgPack.unsafeMake>,
+  parser: MsgPackParser,
   layer: Layer.Layer<Rpc.ToHandler<Rpcs> | Rpc.Middleware<Rpcs>, LE>,
 ): Effect.Effect<CfTypes.ReadableStream, never, Scope.Scope> =>
   Effect.gen(function* () {
@@ -231,7 +232,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
         // Run the stream and send chunks + final exit
         const runStream = Effect.gen(function* () {
           // Process stream chunks - let chunk encoder handle Effect objects properly
-          yield* Stream.runForEachChunk(stream, (chunk) =>
+          yield* Stream.runForEachChunk(stream, (chunk: Chunk.Chunk<any>) =>
             Effect.gen(function* () {
               const chunkArray = Chunk.toReadonlyArray(chunk)
               if (chunkArray.length === 0) return
@@ -268,7 +269,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
           controller.enqueue(exitSerialized)
           controller.close()
         }).pipe(
-          Effect.catchAllCause((cause) =>
+          Effect.catchAllCause((cause: Cause.Cause<unknown>) =>
             Effect.gen(function* () {
               // Send error exit with proper schema encoding
               const rawExit = Exit.failCause(cause)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2682,6 +2682,9 @@ importers:
       effect:
         specifier: 3.21.0
         version: 3.21.0
+      msgpackr:
+        specifier: 1.11.9
+        version: 1.11.9
     devDependencies:
       '@livestore/utils-dev':
         specifier: workspace:^


### PR DESCRIPTION
## Summary

- switch `@livestore/common-cf` DO RPC off `RpcSerialization.msgPack.unsafeMake()` and onto a direct `msgpackr` parser configuration that avoids the eval-dependent path in workerd
- buffer partial MessagePack payloads across `ReadableStream` reads and decode concatenated frames with `unpackMultiple()`
- add focused regression coverage for split and merged DO RPC stream frames

## Why

After [#1163](https://github.com/livestorejs/livestore/pull/1163), the monorepo has a workspace patch for `@effect/rpc`, but published consumers can still hit the same workerd CSP issue because `@livestore/common-cf` was still using `RpcSerialization.msgPack.unsafeMake()` directly.

This change makes the consumer-facing DO RPC path use a workers-safe parser directly in `common-cf` and fixes the related stream framing issue where a single MessagePack payload can be split across multiple `ReadableStream` reads.

## Root Cause

- Cloudflare workerd blocks the eval-based fast path used by the default msgpack setup
- the DO RPC streaming client assumed each `ReadableStream` read contained a complete MessagePack payload, which is not guaranteed when frames are split or concatenated by the transport

## Validation

- `pnpm --dir packages/@livestore/common-cf exec vitest run`
