### PR TITLE
fix(expo): close SQLite connections on store disposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### SQLite & Storage
 
+- Fix SQLite connections not closed on store disposal, preventing database reset after file deletion in the Expo adapter. Also fix in-memory database connections not closed in the Node adapter ([#1171](https://github.com/livestorejs/livestore/issues/1171)). Thanks @OrkhanAlikhanov for the detailed repro and patch.
 - Fix in-memory SQLite database connection handling in Expo adapter
 - Fix OPFS file pool capacity exhaustion from old state databases (#569)
 - Upgrade wa-sqlite to SQLite 3.50.4 (#581)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,7 +434,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### SQLite & Storage
 
-- Fix SQLite connections not closed on store disposal, preventing database reset after file deletion in the Expo adapter ([#1171](https://github.com/livestorejs/livestore/issues/1171)). Thanks @OrkhanAlikhanov for the detailed repro and patch.
+- Fix SQLite connections not closed on store disposal, preventing database reset after file deletion in the Expo adapter ([#1171](https://github.com/livestorejs/livestore/issues/1171)). Thanks @OrkhanAlikhanov for the detailed repro.
 - Fix in-memory SQLite database connection handling in Expo adapter
 - Fix OPFS file pool capacity exhaustion from old state databases (#569)
 - Upgrade wa-sqlite to SQLite 3.50.4 (#581)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,7 +434,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### SQLite & Storage
 
-- Fix SQLite connections not closed on store disposal, preventing database reset after file deletion in the Expo adapter. Also fix in-memory database connections not closed in the Node adapter ([#1171](https://github.com/livestorejs/livestore/issues/1171)). Thanks @OrkhanAlikhanov for the detailed repro and patch.
+- Fix SQLite connections not closed on store disposal, preventing database reset after file deletion in the Expo adapter ([#1171](https://github.com/livestorejs/livestore/issues/1171)). Thanks @OrkhanAlikhanov for the detailed repro and patch.
 - Fix in-memory SQLite database connection handling in Expo adapter
 - Fix OPFS file pool capacity exhaustion from old state databases (#569)
 - Upgrade wa-sqlite to SQLite 3.50.4 (#581)

--- a/packages/@livestore/adapter-expo/src/index.ts
+++ b/packages/@livestore/adapter-expo/src/index.ts
@@ -177,7 +177,9 @@ export const makePersistedAdapter =
         devtoolsUrl,
       })
 
-      const sqliteDb = yield* makeSqliteDb({ _tag: 'in-memory' })
+      const sqliteDb = yield* makeSqliteDb({ _tag: 'in-memory' }).pipe(
+        Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)),
+      )
       sqliteDb.import(initialSnapshot)
 
       const clientSession = yield* makeClientSession({
@@ -246,8 +248,12 @@ const makeLeaderThread = ({
       schema,
     })
 
-    const dbState = yield* makeSqliteDb({ _tag: 'file', databaseName: stateDatabaseName, directory })
-    const dbEventlog = yield* makeSqliteDb({ _tag: 'file', databaseName: eventlogDatabaseName, directory })
+    const dbState = yield* makeSqliteDb({ _tag: 'file', databaseName: stateDatabaseName, directory }).pipe(
+      Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)),
+    )
+    const dbEventlog = yield* makeSqliteDb({ _tag: 'file', databaseName: eventlogDatabaseName, directory }).pipe(
+      Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)),
+    )
 
     const devtoolsOptions = yield* makeDevtoolsOptions({
       devtoolsEnabled,

--- a/packages/@livestore/adapter-expo/src/index.ts
+++ b/packages/@livestore/adapter-expo/src/index.ts
@@ -177,8 +177,9 @@ export const makePersistedAdapter =
         devtoolsUrl,
       })
 
-      const sqliteDb = yield* makeSqliteDb({ _tag: 'in-memory' }).pipe(
-        Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)),
+      const sqliteDb = yield* Effect.acquireRelease(
+        makeSqliteDb({ _tag: 'in-memory' }),
+        (db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)
       )
       sqliteDb.import(initialSnapshot)
 
@@ -248,11 +249,13 @@ const makeLeaderThread = ({
       schema,
     })
 
-    const dbState = yield* makeSqliteDb({ _tag: 'file', databaseName: stateDatabaseName, directory }).pipe(
-      Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)),
+    const dbState = yield* Effect.acquireRelease(
+      makeSqliteDb({ _tag: 'file', databaseName: stateDatabaseName, directory }),
+      (db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged),
     )
-    const dbEventlog = yield* makeSqliteDb({ _tag: 'file', databaseName: eventlogDatabaseName, directory }).pipe(
-      Effect.acquireRelease((db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged)),
+    const dbEventlog = yield* Effect.acquireRelease(
+      makeSqliteDb({ _tag: 'file', databaseName: eventlogDatabaseName, directory }),
+      (db) => Effect.try(() => db.close()).pipe(Effect.ignoreLogged),
     )
 
     const devtoolsOptions = yield* makeDevtoolsOptions({

--- a/packages/@livestore/adapter-node/src/leader-thread-shared.ts
+++ b/packages/@livestore/adapter-node/src/leader-thread-shared.ts
@@ -81,7 +81,7 @@ export const makeLeaderThread = ({
             _tag: 'in-memory',
             configureDb: (db) =>
               configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
-          })
+          }).pipe(Effect.acquireRelease((db) => Effect.sync(() => db.close())))
         : makeSqliteDb({
             _tag: 'fs',
             directory: path.join(storage.baseDirectory ?? '', storeId),

--- a/packages/@livestore/adapter-node/src/leader-thread-shared.ts
+++ b/packages/@livestore/adapter-node/src/leader-thread-shared.ts
@@ -77,20 +77,28 @@ export const makeLeaderThread = ({
       }
 
       return storage.type === 'in-memory'
-        ? makeSqliteDb({
-            _tag: 'in-memory',
-            configureDb: (db) =>
-              configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
-          }).pipe(Effect.acquireRelease((db) => Effect.sync(() => db.close())))
-        : makeSqliteDb({
-            _tag: 'fs',
-            directory: path.join(storage.baseDirectory ?? '', storeId),
-            fileName:
-              kind === 'state' ? getStateDbFileName(schemaHashSuffix) : `eventlog@${liveStoreStorageFormatVersion}.db`,
-            // TODO enable WAL for nodejs
-            configureDb: (db) =>
-              configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
-          }).pipe(Effect.acquireRelease((db) => Effect.sync(() => db.close())))
+        ? Effect.acquireRelease(
+            makeSqliteDb({
+              _tag: 'in-memory',
+              configureDb: (db) =>
+                configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
+            }),
+            (db) => Effect.sync(() => db.close()),
+          )
+        : Effect.acquireRelease(
+            makeSqliteDb({
+              _tag: 'fs',
+              directory: path.join(storage.baseDirectory ?? '', storeId),
+              fileName:
+                kind === 'state'
+                  ? getStateDbFileName(schemaHashSuffix)
+                  : `eventlog@${liveStoreStorageFormatVersion}.db`,
+              // TODO enable WAL for nodejs
+              configureDb: (db) =>
+                configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
+            }),
+            (db) => Effect.sync(() => db.close()),
+          )
     }
 
     // Might involve some async work, so we're running them concurrently

--- a/packages/@livestore/adapter-node/src/leader-thread-shared.ts
+++ b/packages/@livestore/adapter-node/src/leader-thread-shared.ts
@@ -77,28 +77,20 @@ export const makeLeaderThread = ({
       }
 
       return storage.type === 'in-memory'
-        ? Effect.acquireRelease(
-            makeSqliteDb({
-              _tag: 'in-memory',
-              configureDb: (db) =>
-                configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
-            }),
-            (db) => Effect.sync(() => db.close()),
-          )
-        : Effect.acquireRelease(
-            makeSqliteDb({
-              _tag: 'fs',
-              directory: path.join(storage.baseDirectory ?? '', storeId),
-              fileName:
-                kind === 'state'
-                  ? getStateDbFileName(schemaHashSuffix)
-                  : `eventlog@${liveStoreStorageFormatVersion}.db`,
-              // TODO enable WAL for nodejs
-              configureDb: (db) =>
-                configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
-            }),
-            (db) => Effect.sync(() => db.close()),
-          )
+        ? makeSqliteDb({
+            _tag: 'in-memory',
+            configureDb: (db) =>
+              configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
+          })
+        : makeSqliteDb({
+            _tag: 'fs',
+            directory: path.join(storage.baseDirectory ?? '', storeId),
+            fileName:
+              kind === 'state' ? getStateDbFileName(schemaHashSuffix) : `eventlog@${liveStoreStorageFormatVersion}.db`,
+            // TODO enable WAL for nodejs
+            configureDb: (db) =>
+              configureConnection(db, { foreignKeys: true }).pipe(Effect.provide(runtime), Effect.runSync),
+          }).pipe(Effect.acquireRelease((db) => Effect.sync(() => db.close())))
     }
 
     // Might involve some async work, so we're running them concurrently


### PR DESCRIPTION
## Problem

`makeSqliteDb` in `@livestore/adapter-expo` opens native SQLite connections via `expo-sqlite`'s `openDatabaseSync()` but never registers an Effect finalizer to close them when the store's scope exits.

Because `expo-sqlite` caches connections internally by database name, reopening a database after deleting its files returns the stale cached connection with old data still in its page cache. This makes it impossible to reset a store's persisted data — a requirement for auth flows (logout/login with different accounts).

## Solution

Wrap all three `makeSqliteDb` calls in the Expo adapter (`dbState`, `dbEventlog`, and the in-memory client session db) with `Effect.acquireRelease` so connections are closed when the store's lifetime scope exits.

Uses `Effect.try` + `Effect.ignoreLogged` in the release function since Expo's `close()` can throw (it finalizes prepared statements and calls `closeSync()`).

## Validation

- No Expo adapter tests exist in the repo. Verified by code inspection that the `acquireRelease` finalizers align with the existing pattern used in the Node and web adapters.

## Related issues

- Closes #1171