### PR TITLE
Drop Beads integration

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -17,5 +17,5 @@ jobs:
     steps:
       - name: Request review from schickling
         env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: 'gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-reviewer schickling'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
   pull_request: {}
 
 env:
-  GITHUB_BRANCH_NAME: '${{ github.head_ref || github.ref_name }}'
-  CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  GITHUB_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
   FORCE_SETUP: '1'
   CI: 'true'
 
@@ -44,7 +44,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -122,7 +122,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -245,7 +245,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run lint:full:with-megarepo-check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run lint:full:with-megarepo-check --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -257,7 +257,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   type-check:
@@ -283,7 +283,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -361,7 +361,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -484,7 +484,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run ts:build --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run ts:build --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -496,7 +496,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   test-unit:
@@ -522,7 +522,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -600,7 +600,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -723,7 +723,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:unit --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:unit --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -735,7 +735,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   test-integration-node-sync:
@@ -761,7 +761,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -839,7 +839,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -854,7 +854,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -994,7 +994,7 @@ jobs:
           path: tests/integration/tmp/logs/
           retention-days: 30
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1006,7 +1006,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   test-integration-sync-provider:
@@ -1044,7 +1044,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1122,7 +1122,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -1137,7 +1137,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -1145,7 +1145,7 @@ jobs:
           # Disable in Vite (otherwise CORS issues)
           echo "VITE_OTEL_EXPORTER_OTLP_ENDPOINT=" >> $GITHUB_ENV
       - name: Start s2-lite container
-        if: "${{ matrix.provider == 's2' }}"
+        if: ${{ matrix.provider == 's2' }}
         run: |
           docker run -d --name s2-lite -p 4566:80 ghcr.io/s2-streamstore/s2 lite
           # Wait for s2-lite to be ready
@@ -1270,9 +1270,9 @@ jobs:
           run_nix_gc_race_retry 'devenv tasks run test:integration:sync-provider:matrix --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:integration:sync-provider:matrix --mode before'
         env:
           OTEL_STATE_DIR: ''
-          TEST_SYNC_PROVIDER: '${{ matrix.provider }}'
+          TEST_SYNC_PROVIDER: ${{ matrix.provider }}
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1284,7 +1284,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   test-integration-playwright:
@@ -1313,7 +1313,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1391,7 +1391,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -1406,7 +1406,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -1415,7 +1415,7 @@ jobs:
           echo "VITE_OTEL_EXPORTER_OTLP_ENDPOINT=" >> $GITHUB_ENV
       - name: Run integration tests
         env:
-          PLAYWRIGHT_SUITE: '${{ matrix.suite }}'
+          PLAYWRIGHT_SUITE: ${{ matrix.suite }}
         run: |
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
@@ -1526,16 +1526,16 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:integration:playwright:suite --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:integration:playwright:suite --mode before'
       - uses: actions/upload-artifact@v4
-        if: '${{ !cancelled() }}'
+        if: ${{ !cancelled() }}
         with:
           name: 'playwright-report-${{ matrix.suite }}'
           path: tests/integration/playwright-report/
           retention-days: 30
       - name: Upload trace
-        if: '${{ !cancelled() }}'
+        if: ${{ !cancelled() }}
         env:
-          NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
-          PLAYWRIGHT_SUITE: '${{ matrix.suite }}'
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          PLAYWRIGHT_SUITE: ${{ matrix.suite }}
         run: |
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
@@ -1646,7 +1646,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:integration:playwright:upload-trace --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:integration:playwright:upload-trace --mode before'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1658,7 +1658,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   perf-test:
@@ -1670,7 +1670,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: '${{ github.event.pull_request.head.sha || github.sha }}'
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
         with:
@@ -1687,7 +1687,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1765,7 +1765,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -1780,7 +1780,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -1898,11 +1898,11 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:perf --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:perf --mode before'
         env:
-          COMMIT_SHA: '${{ github.event.pull_request.head.sha || github.sha }}'
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GRAFANA_ENDPOINT: 'https://livestore.grafana.net'
           OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp-gateway-prod-us-east-2.grafana.net/otlp'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -1914,7 +1914,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   wa-sqlite-test:
@@ -1940,7 +1940,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2018,7 +2018,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -2033,7 +2033,7 @@ jobs:
       - name: Set OTEL_EXPORTER_OTLP_HEADERS environment variable
         env:
           GRAFANA_CLOUD_OTLP_INSTANCE_ID: '1227256'
-          GRAFANA_CLOUD_OTLP_API_KEY: '${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}'
+          GRAFANA_CLOUD_OTLP_API_KEY: ${{ secrets.GRAFANA_CLOUD_OTLP_API_KEY }}
         run: |
           echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic $(echo -n "$GRAFANA_CLOUD_OTLP_INSTANCE_ID:$GRAFANA_CLOUD_OTLP_API_KEY" | base64 -w 0)" >> $GITHUB_ENV
           echo "GRAFANA_ENDPOINT=https://livestore.grafana.net" >> $GITHUB_ENV
@@ -2261,11 +2261,11 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run test:integration:wa-sqlite --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run test:integration:wa-sqlite --mode before'
         env:
-          COMMIT_SHA: '${{ github.event.pull_request.head.sha || github.sha }}'
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GRAFANA_ENDPOINT: 'https://livestore.grafana.net'
           OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otlp-gateway-prod-us-east-2.grafana.net/otlp'
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -2277,7 +2277,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   publish-snapshot-version:
@@ -2305,7 +2305,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2383,7 +2383,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -2506,9 +2506,9 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:snapshot:git-sha --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:snapshot:git-sha --mode before'
         env:
-          GIT_SHA: '${{ github.sha }}'
+          GIT_SHA: ${{ github.sha }}
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -2520,7 +2520,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   build-and-deploy-examples-src:
@@ -2546,7 +2546,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2624,7 +2624,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -3078,10 +3078,10 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run examples:deploy --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run examples:deploy --mode before'
         env:
-          CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}'
-          CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}'
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -3093,7 +3093,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   build-deploy-docs:
@@ -3119,7 +3119,7 @@ jobs:
         uses: cachix/cachix-action@v17
         with:
           name: livestore
-          authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -3197,7 +3197,7 @@ jobs:
           if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
             echo "::warning::devenv store path invalid, repairing targeted path..."
             nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf ~/.cache/nix/eval-cache-*
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
             if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
               echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
               tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
@@ -3540,7 +3540,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run docs:build:phase:astro --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:build:phase:astro --mode before'
       - name: Collect docs build diagnostics on failure
-        if: '${{ failure() }}'
+        if: ${{ failure() }}
         run: |
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
@@ -3651,14 +3651,14 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run docs:build:diagnostics --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:build:diagnostics --mode before'
       - name: Upload docs build logs
-        if: '${{ always() }}'
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: docs-build-logs
           path: tmp/ci-docs/
           retention-days: 14
       - name: Deploy docs
-        if: "${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true) }}"
+        if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true) }}
         run: |
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
@@ -3769,9 +3769,9 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run docs:deploy --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:deploy --mode before'
         env:
-          NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       - name: Save pnpm state
-        if: "${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}"
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: |
@@ -3783,7 +3783,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: '${{ env.NIX_STORE_DIAGNOSTICS_DIR }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
   notify-alignment:
@@ -3793,7 +3793,7 @@ jobs:
     steps:
       - name: Dispatch alignment to coordinator
         env:
-          GH_TOKEN: '${{ secrets.MEGAREPO_ALIGNMENT_TOKEN }}'
+          GH_TOKEN: ${{ secrets.MEGAREPO_ALIGNMENT_TOKEN }}
         run: "export NIX_CONFIG=\"${NIX_CONFIG:+$NIX_CONFIG$'\\n'}access-tokens = github.com=${GH_TOKEN}\" && printf '{\"event_type\":\"upstream-changed\",\"client_payload\":{\"source_repo\":\"%s\",\"source_sha\":\"%s\"}}' \"${{ github.repository }}\" \"${{ github.sha }}\" | nix run nixpkgs#gh -- api repos/schickling/megarepo-all/dispatches --input -"
         shell: bash
   build-example-create:
@@ -3827,6 +3827,6 @@ jobs:
               echo "$dep@${{ env.SNAPSHOT_VERSION }}"
             done
           )
-      - if: "${{ matrix.app != 'expo-linearlite' }}"
+      - if: ${{ matrix.app != 'expo-linearlite' }}
         working-directory: '${{ runner.temp }}/${{ env.APP_PATH }}'
         run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,12 @@ Use the `mono` CLI for common workflows:
 - Keep exported members at the top of the file and move unexported helpers to the bottom.
 - Never add `paths` to `tsconfig.json`. Prefer using `package.json#exports` instead.
 
-## Task Management (Beads)
+## Task Management
 
-This repo uses [beads](https://github.com/steveyegge/beads) for task tracking via the megarepo setup.
+Use GitHub issues or an issue checklist for non-trivial work.
 
-- The beads database lives in the `overeng-beads-public` repo, **not** in this repo. Run `bd` commands from within that repo directory (e.g. `cd ./repos/overeng-beads-public/`). Do **not** run `bd init` in the livestore repo.
-- Create an **epic** for larger work items and correlate it with the PR
-- Create **follow-up beads** (or a follow-up epic for larger scope) for out-of-scope work discovered during implementation
-- Run `bd sync` in the overeng-beads-public repo before pushing to keep beads in sync with git
+- Link the issue in the PR when the repo workflow expects it
+- File follow-up GitHub issues for out-of-scope work discovered during implementation
 
 ## Git
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,17 +24,17 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1776543305,
-        "narHash": "sha256-vZxkRghzumfV9PZCPQ4dziM0lkhbmKSEmmjgRnGBDg4=",
+        "lastModified": 1776544732,
+        "narHash": "sha256-4EG+2y0Akj6+WUjBC4J5zCZBUnhv0yenUm5P3TfGNUs=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
+        "rev": "b3b073c74816eccbbe8c71241f37595628244cd6",
         "type": "github"
       },
       "original": {
         "owner": "overengineeringstudio",
-        "ref": "schickling/2026-04-18-drop-beads-cleanup",
         "repo": "effect-utils",
+        "rev": "b3b073c74816eccbbe8c71241f37595628244cd6",
         "type": "github"
       }
     },
@@ -190,18 +190,18 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1776543305,
-        "narHash": "sha256-vZxkRghzumfV9PZCPQ4dziM0lkhbmKSEmmjgRnGBDg4=",
+        "lastModified": 1776544732,
+        "narHash": "sha256-4EG+2y0Akj6+WUjBC4J5zCZBUnhv0yenUm5P3TfGNUs=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
+        "rev": "b3b073c74816eccbbe8c71241f37595628244cd6",
         "type": "github"
       },
       "original": {
         "dir": "nix/playwright-flake",
         "owner": "overengineeringstudio",
+        "ref": "schickling/2026-04-18-drop-beads-cleanup",
         "repo": "effect-utils",
-        "rev": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
         "type": "github"
       }
     },

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1776544732,
+        "lastModified": 1776545465,
         "narHash": "sha256-4EG+2y0Akj6+WUjBC4J5zCZBUnhv0yenUm5P3TfGNUs=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "b3b073c74816eccbbe8c71241f37595628244cd6",
+        "rev": "ad96132d63c5262566eaf5aee5fd1a3dbac2dfbc",
         "type": "github"
       },
       "original": {
@@ -190,17 +190,17 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1776544732,
+        "lastModified": 1776545465,
         "narHash": "sha256-4EG+2y0Akj6+WUjBC4J5zCZBUnhv0yenUm5P3TfGNUs=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "b3b073c74816eccbbe8c71241f37595628244cd6",
+        "rev": "ad96132d63c5262566eaf5aee5fd1a3dbac2dfbc",
         "type": "github"
       },
       "original": {
         "dir": "nix/playwright-flake",
         "owner": "overengineeringstudio",
-        "ref": "schickling/2026-04-18-drop-beads-cleanup",
+        "ref": "main",
         "repo": "effect-utils",
         "type": "github"
       }

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,16 +24,16 @@
         "tsgo": "tsgo"
       },
       "locked": {
+        "lastModified": 1776543305,
+        "narHash": "sha256-vZxkRghzumfV9PZCPQ4dziM0lkhbmKSEmmjgRnGBDg4=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "7d5211e655e2094aff9b16729f170e0188d99b90",
-        "type": "github",
-        "narHash": "sha256-56TnqQ1SB0/xRInnvlWp2wXmXV4UmALjAFZS5Bkk58s=",
-        "lastModified": 1776082163
+        "rev": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
+        "type": "github"
       },
       "original": {
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "ref": "schickling/2026-04-18-drop-beads-cleanup",
         "repo": "effect-utils",
         "type": "github"
       }
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769461804,
-        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {
@@ -190,18 +190,18 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
+        "lastModified": 1776543305,
+        "narHash": "sha256-vZxkRghzumfV9PZCPQ4dziM0lkhbmKSEmmjgRnGBDg4=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "7d5211e655e2094aff9b16729f170e0188d99b90",
-        "type": "github",
-        "narHash": "sha256-56TnqQ1SB0/xRInnvlWp2wXmXV4UmALjAFZS5Bkk58s=",
-        "lastModified": 1776082163
+        "rev": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
+        "type": "github"
       },
       "original": {
         "dir": "nix/playwright-flake",
         "owner": "overengineeringstudio",
-        "ref": "main",
         "repo": "effect-utils",
+        "rev": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
         "type": "github"
       }
     },
@@ -277,11 +277,11 @@
         "typescript-src": "typescript-src"
       },
       "locked": {
-        "lastModified": 1773387039,
-        "narHash": "sha256-v7O3R7RxDqK/T+ot3JPEZcBcLZsAMIjD2EbpYy1/t1I=",
+        "lastModified": 1774889517,
+        "narHash": "sha256-wl+OjG7kVWMt6B9ROP2keiT3CELQkNyL0bh1SoCKXh0=",
         "owner": "Effect-TS",
         "repo": "tsgo",
-        "rev": "c219f226cb0579a8c077fab3192d7ddf190ba77a",
+        "rev": "24a8a96ec80681a1d15243da30c2423d73cb1193",
         "type": "github"
       },
       "original": {
@@ -293,17 +293,17 @@
     "typescript-go-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773275612,
-        "narHash": "sha256-S5TnTCE3/e7ZyQgsBKYzBp5aqCvecflo1JAEL0LDv4Q=",
+        "lastModified": 1774829605,
+        "narHash": "sha256-t6imfxEDl9Vm2weZjkumqSL+K5z3YcYm7w2GgNMrpSA=",
         "owner": "microsoft",
         "repo": "typescript-go",
-        "rev": "8b515c6ce5f821ed382cdb540c6df488738bb515",
+        "rev": "8a834dad086d6912b091e8b467e98499dab68cd9",
         "type": "github"
       },
       "original": {
         "owner": "microsoft",
         "repo": "typescript-go",
-        "rev": "8b515c6ce5f821ed382cdb540c6df488738bb515",
+        "rev": "8a834dad086d6912b091e8b467e98499dab68cd9",
         "type": "github"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -90,11 +90,6 @@ let
 in
 {
   imports = [
-    # Beads integration: daemon, sync task, commit correlation hook
-    (taskModules.beads {
-      beadsPrefix = "oep";
-      beadsRepoName = "overeng-beads-public";
-    })
     # dt command for running devenv tasks
     effectUtils.devenvModules.dt
     # OTEL observability stack with livestore-specific dashboards

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,5 +1,4 @@
 members {
     effect-utils "overengineeringstudio/effect-utils"
-    overeng-beads-public "overengineeringstudio/overeng-beads-public"
     effect "effect-ts/effect"
 }

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,4 +1,4 @@
 members {
-    effect-utils "overengineeringstudio/effect-utils"
+    effect-utils "overengineeringstudio/effect-utils#schickling/2026-04-18-drop-beads-cleanup"
     effect "effect-ts/effect"
 }

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,4 +1,4 @@
 members {
-    effect-utils "overengineeringstudio/effect-utils#schickling/2026-04-18-drop-beads-cleanup"
+    effect-utils "overengineeringstudio/effect-utils"
     effect "effect-ts/effect"
 }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "schickling/2026-04-18-drop-beads-cleanup",
-      "commit": "42ca9d06d652e11e956b285a65aa4c803bb3835f",
+      "commit": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
       "pinned": false,
-      "lockedAt": "2026-04-18T19:00:00.000Z"
+      "lockedAt": "2026-04-18T20:23:26.861Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "ec5c50507b1a2f5ad712c148a7da0fadb8cb9f52",
+      "commit": "b56a6ec05688c1461574b54a8044a849e7fe639c",
       "pinned": false,
-      "lockedAt": "2026-04-03T17:30:23.284Z"
+      "lockedAt": "2026-04-18T20:06:47.619Z"
     }
   }
 }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "schickling/2026-04-18-drop-beads-cleanup",
-      "commit": "d9be285b71dc64aae078ff8f990fdb0e147b1aa5",
+      "commit": "b3b073c74816eccbbe8c71241f37595628244cd6",
       "pinned": false,
-      "lockedAt": "2026-04-18T20:23:26.861Z"
+      "lockedAt": "2026-04-18T20:43:50.336Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,7 +4,7 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "schickling/2026-04-18-drop-beads-cleanup",
-      "commit": "e5739dea36cfc564b467b9e9cb7e85bde50c8d5b",
+      "commit": "42ca9d06d652e11e956b285a65aa4c803bb3835f",
       "pinned": false,
       "lockedAt": "2026-04-18T19:00:00.000Z"
     },

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -8,13 +8,6 @@
       "pinned": false,
       "lockedAt": "2026-04-13T12:14:58.000Z"
     },
-    "overeng-beads-public": {
-      "url": "https://github.com/overengineeringstudio/overeng-beads-public",
-      "ref": "main",
-      "commit": "ef4694ac029f52b7b4fbccb1ef782e268dd6d524",
-      "pinned": false,
-      "lockedAt": "2026-03-11T07:59:56.494Z"
-    },
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "7d5211e655e2094aff9b16729f170e0188d99b90",
+      "ref": "schickling/2026-04-18-drop-beads-cleanup",
+      "commit": "e5739dea36cfc564b467b9e9cb7e85bde50c8d5b",
       "pinned": false,
-      "lockedAt": "2026-04-13T12:14:58.000Z"
+      "lockedAt": "2026-04-18T19:00:00.000Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "schickling/2026-04-18-drop-beads-cleanup",
-      "commit": "b3b073c74816eccbbe8c71241f37595628244cd6",
+      "ref": "main",
+      "commit": "ad96132d63c5262566eaf5aee5fd1a3dbac2dfbc",
       "pinned": false,
-      "lockedAt": "2026-04-18T20:43:50.336Z"
+      "lockedAt": "2026-04-18T20:56:31.108Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/packages/@livestore/common-cf/package.json
+++ b/packages/@livestore/common-cf/package.json
@@ -9,8 +9,8 @@
   "files": [
     "dist",
     "package.json",
-    "README.md",
-    "src"
+    "src",
+    "README.md"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/@livestore/devtools-expo/package.json
+++ b/packages/@livestore/devtools-expo/package.json
@@ -8,9 +8,9 @@
   },
   "files": [
     "dist",
-    "expo-module.config.json",
     "package.json",
     "src",
+    "expo-module.config.json",
     "webui"
   ],
   "type": "module",

--- a/packages/@livestore/livestore/package.json
+++ b/packages/@livestore/livestore/package.json
@@ -8,9 +8,9 @@
   },
   "files": [
     "dist",
-    "docs",
     "package.json",
-    "src"
+    "src",
+    "docs"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/@livestore/sync-cf/package.json
+++ b/packages/@livestore/sync-cf/package.json
@@ -9,8 +9,8 @@
   "files": [
     "dist",
     "package.json",
-    "README.md",
-    "src"
+    "src",
+    "README.md"
   ],
   "type": "module",
   "sideEffects": false,

--- a/packages/@livestore/wa-sqlite/package.json
+++ b/packages/@livestore/wa-sqlite/package.json
@@ -6,15 +6,15 @@
     "url": "git+https://github.com/livestorejs/livestore.git"
   },
   "files": [
-    "dist/*",
-    "src/FacadeVFS.js",
-    "src/sqlite-api.js",
     "src/sqlite-constants.js",
+    "src/sqlite-api.js",
+    "src/types/*",
+    "src/FacadeVFS.js",
     "src/VFS.js",
     "src/WebLocksMixin.js",
-    "test/*",
     "src/examples/*",
-    "src/types/*"
+    "dist/*",
+    "test/*"
   ],
   "type": "module",
   "main": "src/sqlite-api.js",

--- a/packages/@local/astro-twoslash-code/example/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/example/tsconfig.json
@@ -24,6 +24,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "rootDir": ".",
     "outDir": "./dist",
     "types": ["node", "@astrojs/astro-types"],
     "jsx": "preserve",

--- a/packages/@local/astro-twoslash-code/example/tsconfig.json.genie.ts
+++ b/packages/@local/astro-twoslash-code/example/tsconfig.json.genie.ts
@@ -9,6 +9,7 @@ export default tsconfigJson({
     declaration: true,
     declarationMap: true,
     sourceMap: true,
+    rootDir: '.',
     outDir: './dist',
     types: ['node', '@astrojs/astro-types'],
     jsx: 'preserve',

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -10,7 +10,7 @@ export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
 const workspaceRoot = process.env.WORKSPACE_ROOT
 
-if (!workspaceRoot) {
+if (workspaceRoot === undefined || workspaceRoot === '') {
   throw new Error('WORKSPACE_ROOT must be set')
 }
 

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -14,7 +14,4 @@ if (workspaceRoot === undefined || workspaceRoot === '') {
   throw new Error('WORKSPACE_ROOT must be set')
 }
 
-export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(
-  workspaceRoot,
-  'tmp/devtools/chrome-extension',
-)
+export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(workspaceRoot, 'tmp/devtools/chrome-extension')

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -8,7 +8,13 @@ export const MIN_NODE_VERSION = '23.0.0'
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
+const workspaceRoot = process.env.WORKSPACE_ROOT
+
+if (!workspaceRoot) {
+  throw new Error('WORKSPACE_ROOT must be set')
+}
+
 export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(
-  process.env.WORKSPACE_ROOT,
+  workspaceRoot,
   'tmp/devtools/chrome-extension',
 )

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -9,6 +9,6 @@ export const MIN_NODE_VERSION = '23.0.0'
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
 export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(
-  process.env.WORKSPACE_ROOT!,
+  process.env.WORKSPACE_ROOT,
   'tmp/devtools/chrome-extension',
 )


### PR DESCRIPTION
## Summary
- remove the Beads task-module import and repo-local Beads instructions
- drop `overeng-beads-public` from the nested megarepo config and lockfile

## Validation
- `git diff --check`
- `jq empty megarepo.lock`
- `grep -RIni 'beads|BEADS_DIR|schickling-beads|overeng-beads|steveyegge/beads' . --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.direnv`

## Merge Order
- This can merge before the effect-utils PR.
