### PR TITLE
Remove stale react-window ts-expect-error

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -64,6 +64,7 @@ export const livestoreOnlyCatalog = {
   '@types/hast': '3.0.4',
   '@types/jasmine': '5.1.4',
   '@types/jsdom': '21.1.7',
+  '@types/react-window': '1.8.8',
   '@types/wicg-file-system-access': '2023.10.6',
   '@vitest/ui': '3.2.4',
   'solid-js': '1.9.10',

--- a/packages/@livestore/react/package.json
+++ b/packages/@livestore/react/package.json
@@ -43,6 +43,7 @@
     "@testing-library/react": "16.3.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
+    "@types/react-window": "1.8.8",
     "jsdom": "26.1.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/@livestore/react/package.json.genie.ts
+++ b/packages/@livestore/react/package.json.genie.ts
@@ -26,6 +26,7 @@ const runtimeDeps = catalog.compose({
       '@testing-library/react',
       '@types/react',
       '@types/react-dom',
+      '@types/react-window',
       'jsdom',
       'react',
       'react-dom',

--- a/packages/@livestore/react/src/useQuery.test.tsx
+++ b/packages/@livestore/react/src/useQuery.test.tsx
@@ -1,6 +1,5 @@
 import * as ReactTesting from '@testing-library/react'
 import React from 'react'
-// @ts-expect-error no types
 import * as ReactWindow from 'react-window'
 import { expect } from 'vitest'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3307,6 +3307,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.7)
+      '@types/react-window':
+        specifier: 1.8.8
+        version: 1.8.8
       jsdom:
         specifier: 26.1.0
         version: 26.1.0


### PR DESCRIPTION
## Summary
- remove the stale comment in useQuery.test.tsx
- unblock downstream typecheck surfaces that now see typed react-window

## Testing
- overeng raw tsc -b moves past this exact failure
