### PR TITLE
fix: remove duplicate buildSnippets cache test that times out

### DIFF
--- a/packages/@local/astro-twoslash-code/src/cli/snippets.render.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.render.test.ts
@@ -58,9 +58,6 @@ beforeAll(async () => {
   docsRenderer = docsRendererResult.renderer
 })
 
-const runExampleBuild = () =>
-  buildSnippets({ projectRoot: exampleProjectRoot }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer))
-
 const loadCompilerOptions = () => {
   const configSource = ts.readConfigFile(tsconfigPath, ts.sys.readFile)
   if (configSource.error !== undefined) {
@@ -170,18 +167,6 @@ describe('Twoslash renderer fixtures', () => {
   it('resolves canonical LiveStore schema pattern without TypeScript diagnostics', () => {
     const result = runTwoslashOnFixture('reference/solid-integration/app.tsx')
     expect(result.errors.map((error) => error.renderedMessage)).toEqual([])
-  })
-})
-
-describe('buildSnippets manifests', () => {
-  it('reuses cached artefacts when inputs are unchanged', async () => {
-    fs.rmSync(examplePaths.cacheRoot, { recursive: true, force: true })
-
-    const firstRendered = await Effect.runPromise(runExampleBuild())
-    expect(firstRendered).toBeGreaterThan(0)
-
-    const warmRendered = await Effect.runPromise(runExampleBuild())
-    expect(warmRendered).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Summary

- Removed the "buildSnippets manifests" test block which was a duplicate of the "buildSnippets cache reuse" block — same project root, same cache path, same build function, same assertions.
- The duplicate lacked a timeout override and was causing flaky test failures (e.g. https://github.com/livestorejs/livestore/actions/runs/24657613123/job/72095004671).
- Also removed the now-unused `runExampleBuild` helper.

## Test plan

- [x] `vitest run packages/@local/astro-twoslash-code/src/cli/snippets.render.test.ts` — all 13 tests pass