### PR TITLE
fix(react): resolve useStore hook-order violation in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,8 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### Concurrency & Lifecycle
 
+- Fix `useStore` hook-order violation in React strict mode by moving the `retain` effect after the `React.use()` suspension point ([#1181](https://github.com/livestorejs/livestore/issues/1181))
+
 - Fix background push fiber dying silently on non-`RejectedPushError` failures in `ClientSessionSyncProcessor`, leaving sessions unable to push ([#1133](https://github.com/livestorejs/livestore/issues/1133))
 - Fix `toGlobal()` leaking a debug `toJSON` method onto the returned `Global.Encoded` object, causing `JSON.stringify` to produce string seqNums instead of integers in custom sync backends (#1165). Thanks @OrkhanAlikhanov for diagnosing the root cause.
 - Fix correct type assertion in withLock function

--- a/packages/@livestore/react/src/useStore.ts
+++ b/packages/@livestore/react/src/useStore.ts
@@ -63,14 +63,6 @@ export const useStore = <
 ): Store<TSchema, TContext> & ReactApi => {
   const storeRegistry = useStoreRegistry()
 
-  // NOTE: retain() is called in useEffect (after render), while getOrLoadPromise() is called
-  // during render. This creates a timing gap where with very short unusedCacheTime
-  // values (e.g., 0), the store could theoretically be disposed before the effect fires.
-  // In practice, this is not an issue with the default 60s cache time, but it becomes an issue when
-  // `unusedCacheTime` is configured to values less than ~100ms.
-  // See https://github.com/livestorejs/livestore/issues/916
-  React.useEffect(() => storeRegistry.retain(options), [storeRegistry, options])
-
   // Called on every render (intentionally not memoized). For already-loaded stores this returns
   // the Store synchronously, so React.use() is skipped entirely. Caching the initial Promise via
   // useMemo would cause React.use() to be called with a resolved Promise on subsequent renders,
@@ -78,6 +70,21 @@ export const useStore = <
   const storeOrPromise = storeRegistry.getOrLoadPromise(options)
 
   const store = storeOrPromise instanceof Promise ? React.use(storeOrPromise) : storeOrPromise
+
+  // NOTE: retain() must be declared AFTER the React.use() call above. When React.use() suspends
+  // the component, any hooks declared before it get committed while hooks after the suspension
+  // point (including those in the caller) don't. On re-render when the store resolves synchronously,
+  // those late hooks appear for the first time, causing a hook-order violation in strict mode.
+  // By placing useEffect after React.use(), no effect hooks are committed during suspension,
+  // so React treats all effects as fresh mounts on the first successful render.
+  //
+  // retain() is called in useEffect (after render), while getOrLoadPromise() is called during
+  // render. This creates a timing gap where with very short unusedCacheTime values (e.g., 0),
+  // the store could theoretically be disposed before the effect fires. In practice, this is not
+  // an issue with the default 60s cache time, but it becomes an issue when `unusedCacheTime` is
+  // configured to values less than ~100ms.
+  // See https://github.com/livestorejs/livestore/issues/916
+  React.useEffect(() => storeRegistry.retain(options), [storeRegistry, options])
 
   return withReactApi(store)
 }


### PR DESCRIPTION
## Problem

In React strict mode with concurrent rendering, `useStore` produces a hook-order violation warning because the `retain` `useEffect` was declared **before** `React.use()`. When `React.use()` suspends the component, the effect hook gets committed, but hooks after the suspension point (e.g. in `@testing-library/react`'s `TestComponent`) don't. On re-render when the store resolves synchronously, those late hooks appear for the first time, causing the violation.

## Solution

Move `useEffect(() => storeRegistry.retain(options), ...)` **after** the `React.use()` call. This ensures no effect hooks are committed during a suspended render, so React treats all effects as fresh mounts on the first successful render.

The timing of `retain` is unchanged — `useEffect` fires after render commit regardless of its position in the function body, and suspended renders never commit effects.

Closes #1181

## Test plan

- [x] Existing `useStore` test suite passes (all 8 tests, including strict mode)
- [x] Verified that the `useActionState` transition test still passes (no regression from the reordering)