### PR TITLE
fix(ci): use pre-installed gh CLI in notify-alignment job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3794,8 +3794,10 @@ jobs:
       - name: Dispatch alignment to coordinator
         env:
           GH_TOKEN: ${{ secrets.MEGAREPO_ALIGNMENT_TOKEN }}
-        run: "export NIX_CONFIG=\"${NIX_CONFIG:+$NIX_CONFIG$'\\n'}access-tokens = github.com=${GH_TOKEN}\" && printf '{\"event_type\":\"upstream-changed\",\"client_payload\":{\"source_repo\":\"%s\",\"source_sha\":\"%s\"}}' \"${{ github.repository }}\" \"${{ github.sha }}\" | nix run nixpkgs#gh -- api repos/schickling/megarepo-all/dispatches --input -"
-        shell: bash
+        run: |
+          printf '{"event_type":"upstream-changed","client_payload":{"source_repo":"%s","source_sha":"%s"}}' \
+            "${{ github.repository }}" "${{ github.sha }}" \
+          | gh api repos/schickling/megarepo-all/dispatches --input -
   build-example-create:
     if: github.event.pull_request.head.repo.fork != true
     needs: publish-snapshot-version


### PR DESCRIPTION
## Summary

- Fixes the `notify-alignment` job which has been failing on every `dev` push since ~March 8 due to `nix: command not found` on the `ubuntu-latest` runner
- Replaces `nix run nixpkgs#gh` with the pre-installed `gh` CLI — Nix was only used to obtain `gh`, which is already available on GitHub-hosted runners

Closes #1183

## Context

The `dispatchAlignmentStep` generator in `effect-utils` was fixed in [overengineeringstudio/effect-utils#417](https://github.com/overengineeringstudio/effect-utils/pull/417) (March 20), briefly reverted in [#422](https://github.com/overengineeringstudio/effect-utils/pull/422), then fixed again in [#443](https://github.com/overengineeringstudio/effect-utils/pull/443). The generator currently produces the correct output (plain `gh`), but the livestore `ci.yml` was never regenerated with this change — the most recent regeneration on April 18 (`3b4fbda3d`) did not pick up the `dispatchAlignmentStep` fix despite the local effect-utils worktree containing it.

This PR manually applies the fix to bring `ci.yml` in sync with what the generator would produce.

## Test plan

- [ ] Merge to `dev` and verify the `notify-alignment` job passes (dispatches to `schickling/megarepo-all`)