### PR TITLE
Disable notify-alignment job until #1183 is fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3786,16 +3786,6 @@ jobs:
           path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
-  notify-alignment:
-    runs-on: ubuntu-latest
-    needs: [test-unit, test-integration-node-sync, test-integration-sync-provider, test-integration-playwright]
-    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'
-    steps:
-      - name: Dispatch alignment to coordinator
-        env:
-          GH_TOKEN: ${{ secrets.MEGAREPO_ALIGNMENT_TOKEN }}
-        run: "export NIX_CONFIG=\"${NIX_CONFIG:+$NIX_CONFIG$'\\n'}access-tokens = github.com=${GH_TOKEN}\" && printf '{\"event_type\":\"upstream-changed\",\"client_payload\":{\"source_repo\":\"%s\",\"source_sha\":\"%s\"}}' \"${{ github.repository }}\" \"${{ github.sha }}\" | nix run nixpkgs#gh -- api repos/schickling/megarepo-all/dispatches --input -"
-        shell: bash
   build-example-create:
     if: github.event.pull_request.head.repo.fork != true
     needs: publish-snapshot-version

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -394,17 +394,18 @@ done`,
       ]),
     },
 
-    'notify-alignment': {
-      'runs-on': 'ubuntu-latest',
-      needs: [
-        'test-unit',
-        'test-integration-node-sync',
-        'test-integration-sync-provider',
-        'test-integration-playwright',
-      ],
-      if: "(github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'",
-      steps: [dispatchAlignmentStep({ targetRepo: 'schickling/megarepo-all' })],
-    },
+    // TODO(#1183): Disable notify job until root cause is fixed.
+    // 'notify-alignment': {
+    //   'runs-on': 'ubuntu-latest',
+    //   needs: [
+    //     'test-unit',
+    //     'test-integration-node-sync',
+    //     'test-integration-sync-provider',
+    //     'test-integration-playwright',
+    //   ],
+    //   if: "(github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'",
+    //   steps: [dispatchAlignmentStep({ targetRepo: 'schickling/megarepo-all' })],
+    // },
 
     'build-example-create': {
       if: IS_NOT_FORK,


### PR DESCRIPTION
## Summary
- Disable the `notify-alignment` job in CI workflow to prevent megarepo-alignment dispatch failures referenced in #1183
- Commented out both in source (ci.yml.genie.ts) and generated (ci.yml) files

## Rationale
The notify-alignment job is causing issues that need to be addressed before re-enabling. This is a temporary disable with a TODO comment referencing the issue.