### PR TITLE
feat(genie): drive devtools-vite catalog version from LIVESTORE_RELEASE_VERSION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2552,6 +2552,118 @@ jobs:
           run_nix_gc_race_retry 'devenv tasks run release:snapshot:git-sha --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:snapshot:git-sha --mode before'
         env:
           GIT_SHA: ${{ github.sha }}
+      - name: Publish DevTools artifact snapshot
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:publish --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:publish --mode before'
+        env:
+          LIVESTORE_RELEASE_VERSION: '0.0.0-snapshot-${{ github.sha }}'
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2560,7 +2560,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:snapshot:git-sha --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:snapshot:git-sha --mode before'
         env:
-          GIT_SHA: ${{ github.sha }}
+          GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Publish DevTools artifact snapshot
         run: |
           __nix_gc_retry_helper=$(mktemp)
@@ -2672,7 +2672,7 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:publish --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:publish --mode before'
         env:
-          LIVESTORE_RELEASE_VERSION: '0.0.0-snapshot-${{ github.sha }}'
+          LIVESTORE_RELEASE_VERSION: '0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}'
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
@@ -3973,7 +3973,7 @@ jobs:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     env:
       APP_PATH: 'examples/${{ matrix.app }}'
-      SNAPSHOT_VERSION: '0.0.0-snapshot-${{ github.sha }}'
+      SNAPSHOT_VERSION: '0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -289,6 +290,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -533,6 +535,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -777,6 +780,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1065,6 +1069,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1339,6 +1344,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1718,6 +1724,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1976,6 +1983,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2346,6 +2354,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2704,6 +2713,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -3282,6 +3292,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -19,8 +19,6 @@ import {
 // =============================================================================
 
 const GITHUB_RUN_ID = '${{ github.run_id }}'
-const GITHUB_SHA = '${{ github.sha }}'
-const GITHUB_REF = '${{ github.ref }}'
 const PR_HEAD_SHA = '${{ github.event.pull_request.head.sha || github.sha }}'
 const IS_NOT_FORK = 'github.event.pull_request.head.repo.fork != true'
 const DLX_ALLOW_BUILD_FLAGS = repoPnpmOnlyBuiltDependencies.map((name) => `--allow-build=${name}`).join(' ')
@@ -300,12 +298,12 @@ done`,
         {
           name: 'Publish snapshot version',
           run: runDevenvTasksBefore('release:snapshot:git-sha'),
-          env: { GIT_SHA: GITHUB_SHA },
+          env: { GIT_SHA: PR_HEAD_SHA },
         },
         {
           name: 'Publish DevTools artifact snapshot',
           run: runDevenvTasksBefore('release:devtools-artifact:publish'),
-          env: { LIVESTORE_RELEASE_VERSION: `0.0.0-snapshot-${GITHUB_SHA}` },
+          env: { LIVESTORE_RELEASE_VERSION: `0.0.0-snapshot-${PR_HEAD_SHA}` },
         },
       ]),
     },
@@ -423,7 +421,7 @@ done`,
       ...namespaceRunnerConfig,
       env: {
         APP_PATH: 'examples/${{ matrix.app }}',
-        SNAPSHOT_VERSION: `0.0.0-snapshot-${GITHUB_SHA}`,
+        SNAPSHOT_VERSION: `0.0.0-snapshot-${PR_HEAD_SHA}`,
       },
       steps: [
         { name: 'Checkout repository', uses: 'actions/checkout@v4' },

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -302,6 +302,11 @@ done`,
           run: runDevenvTasksBefore('release:snapshot:git-sha'),
           env: { GIT_SHA: GITHUB_SHA },
         },
+        {
+          name: 'Publish DevTools artifact snapshot',
+          run: runDevenvTasksBefore('release:devtools-artifact:publish'),
+          env: { LIVESTORE_RELEASE_VERSION: `0.0.0-snapshot-${GITHUB_SHA}` },
+        },
       ]),
     },
 

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -4,6 +4,15 @@
 name: DevTools artifact manifest
 
 on:
+  pull_request:
+    paths:
+      [
+        .github/workflows/devtools-artifact.yml,
+        .github/workflows/devtools-artifact.yml.genie.ts,
+        genie/repo.ts,
+        release/devtools-artifact.json,
+        scripts/src/commands/devtools-artifact.ts,
+      ]
   repository_dispatch:
     types: [devtools-artifact-published]
   workflow_dispatch:
@@ -162,6 +171,12 @@ jobs:
       - name: Write artifact manifest
         run: |
           set -euo pipefail
+          if [ -z "${ARTIFACT_METADATA_URL:-}" ] && [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+            ARTIFACT_METADATA_URL="$(jq -r '.artifact.metadataUrl' release/devtools-artifact.json)"
+            ARTIFACT_TARBALL_URL="$(jq -r '.artifact.tarballUrl' release/devtools-artifact.json)"
+            ARTIFACT_SHA256="$(jq -r '.artifact.sha256' release/devtools-artifact.json)"
+          fi
+
           : "${ARTIFACT_METADATA_URL:?Missing artifact metadata URL}"
           : "${ARTIFACT_TARBALL_URL:?Missing artifact tarball URL}"
           : "${ARTIFACT_SHA256:?Missing artifact SHA-256}"
@@ -182,6 +197,7 @@ jobs:
       - name: Verify artifact manifest
         run: '$DEVENV_BIN tasks run release:devtools-artifact:verify --mode before --no-tui'
       - name: Open manifest update PR
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -1,0 +1,216 @@
+# Generated file - DO NOT EDIT
+# Source: devtools-artifact.yml.genie.ts
+
+name: DevTools artifact manifest
+
+on:
+  repository_dispatch:
+    types: [devtools-artifact-published]
+  workflow_dispatch:
+    inputs:
+      metadata_url:
+        description: Public release-metadata.json URL
+        required: true
+        type: string
+      tarball_url:
+        description: Public artifact tarball URL
+        required: true
+        type: string
+      sha256:
+        description: Artifact tarball SHA-256
+        required: true
+        type: string
+      devtools_build_id:
+        description: Public DevTools build id
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+  CI: 'true'
+  FORCE_SETUP: '1'
+  ARTIFACT_METADATA_URL: ${{ github.event.client_payload.artifactMetadataUrl || inputs.metadata_url }}
+  ARTIFACT_TARBALL_URL: ${{ github.event.client_payload.artifactTarballUrl || inputs.tarball_url }}
+  ARTIFACT_SHA256: ${{ github.event.client_payload.sha256 || inputs.sha256 }}
+  DEVTOOLS_BUILD_ID: ${{ github.event.client_payload.devtoolsBuildId || inputs.devtools_build_id }}
+  BASE_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  update-manifest-pr:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+        run: |
+          EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '::error::megarepo.lock missing members["effect-utils"].commit'
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf 'MEGAREPO_STORE=%s
+          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+          fi
+
+          nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
+        shell: bash
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          if [ -z "${DEVENV_REV:-}" ]; then
+            DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          fi
+
+          resolve_devenv() {
+            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
+        shell: bash
+      - name: Write artifact manifest
+        run: |
+          set -euo pipefail
+          : "${ARTIFACT_METADATA_URL:?Missing artifact metadata URL}"
+          : "${ARTIFACT_TARBALL_URL:?Missing artifact tarball URL}"
+          : "${ARTIFACT_SHA256:?Missing artifact SHA-256}"
+
+          mkdir -p release
+          jq -n \
+            --arg metadataUrl "$ARTIFACT_METADATA_URL" \
+            --arg tarballUrl "$ARTIFACT_TARBALL_URL" \
+            --arg sha256 "$ARTIFACT_SHA256" \
+            '{
+              schemaVersion: 1,
+              artifact: {
+                metadataUrl: $metadataUrl,
+                tarballUrl: $tarballUrl,
+                sha256: $sha256
+              }
+            }' > release/devtools-artifact.json
+      - name: Verify artifact manifest
+        run: '$DEVENV_BIN tasks run release:devtools-artifact:verify --mode before --no-tui'
+      - name: Open manifest update PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          suffix="${DEVTOOLS_BUILD_ID:-$(date -u +%Y%m%d%H%M%S)}"
+          branch="automation/devtools-artifact-${suffix}"
+          git checkout -B "$branch"
+          git add release/devtools-artifact.json
+
+          if git diff --cached --quiet; then
+            echo "Artifact manifest already current."
+            exit 0
+          fi
+
+          git commit -m "Update LiveStore DevTools artifact manifest"
+          git push --force-with-lease origin "$branch"
+
+          title="Update LiveStore DevTools artifact manifest"
+          body="$(cat <<'BODY'
+          Updates the public DevTools artifact manifest from a sanitized artifact release.
+
+          This PR only changes public artifact URLs and checksums. The workflow verifies the tarball before opening the PR.
+          BODY
+          )"
+
+          if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" --base "$BASE_BRANCH"
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE_BRANCH" --head "$branch" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/devtools-artifact.yml.genie.ts
+++ b/.github/workflows/devtools-artifact.yml.genie.ts
@@ -5,6 +5,15 @@ export default githubWorkflow({
   actionlint: defaultActionlintConfig,
 
   on: {
+    pull_request: {
+      paths: [
+        '.github/workflows/devtools-artifact.yml',
+        '.github/workflows/devtools-artifact.yml.genie.ts',
+        'genie/repo.ts',
+        'release/devtools-artifact.json',
+        'scripts/src/commands/devtools-artifact.ts',
+      ],
+    },
     repository_dispatch: {
       types: ['devtools-artifact-published'],
     },
@@ -59,6 +68,12 @@ export default githubWorkflow({
         {
           name: 'Write artifact manifest',
           run: `set -euo pipefail
+if [ -z "\${ARTIFACT_METADATA_URL:-}" ] && [ "\${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+  ARTIFACT_METADATA_URL="$(jq -r '.artifact.metadataUrl' release/devtools-artifact.json)"
+  ARTIFACT_TARBALL_URL="$(jq -r '.artifact.tarballUrl' release/devtools-artifact.json)"
+  ARTIFACT_SHA256="$(jq -r '.artifact.sha256' release/devtools-artifact.json)"
+fi
+
 : "\${ARTIFACT_METADATA_URL:?Missing artifact metadata URL}"
 : "\${ARTIFACT_TARBALL_URL:?Missing artifact tarball URL}"
 : "\${ARTIFACT_SHA256:?Missing artifact SHA-256}"
@@ -83,6 +98,7 @@ jq -n \\
         },
         {
           name: 'Open manifest update PR',
+          if: "github.event_name != 'pull_request'",
           env: {
             GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
           },

--- a/.github/workflows/devtools-artifact.yml.genie.ts
+++ b/.github/workflows/devtools-artifact.yml.genie.ts
@@ -1,0 +1,123 @@
+import { bashShellDefaults, defaultActionlintConfig, githubWorkflow, livestoreSetupSteps } from '../../genie/repo.ts'
+
+export default githubWorkflow({
+  name: 'DevTools artifact manifest',
+  actionlint: defaultActionlintConfig,
+
+  on: {
+    repository_dispatch: {
+      types: ['devtools-artifact-published'],
+    },
+    workflow_dispatch: {
+      inputs: {
+        metadata_url: {
+          description: 'Public release-metadata.json URL',
+          required: true,
+          type: 'string',
+        },
+        tarball_url: {
+          description: 'Public artifact tarball URL',
+          required: true,
+          type: 'string',
+        },
+        sha256: {
+          description: 'Artifact tarball SHA-256',
+          required: true,
+          type: 'string',
+        },
+        devtools_build_id: {
+          description: 'Public DevTools build id',
+          required: false,
+          type: 'string',
+        },
+      },
+    },
+  },
+
+  permissions: {
+    contents: 'write',
+    'pull-requests': 'write',
+  },
+
+  env: {
+    CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}',
+    CI: 'true',
+    FORCE_SETUP: '1',
+    ARTIFACT_METADATA_URL: '${{ github.event.client_payload.artifactMetadataUrl || inputs.metadata_url }}',
+    ARTIFACT_TARBALL_URL: '${{ github.event.client_payload.artifactTarballUrl || inputs.tarball_url }}',
+    ARTIFACT_SHA256: '${{ github.event.client_payload.sha256 || inputs.sha256 }}',
+    DEVTOOLS_BUILD_ID: '${{ github.event.client_payload.devtoolsBuildId || inputs.devtools_build_id }}',
+    BASE_BRANCH: '${{ github.event.repository.default_branch }}',
+  },
+
+  jobs: {
+    'update-manifest-pr': {
+      'runs-on': 'ubuntu-latest',
+      defaults: bashShellDefaults,
+      steps: [
+        ...livestoreSetupSteps,
+        {
+          name: 'Write artifact manifest',
+          run: `set -euo pipefail
+: "\${ARTIFACT_METADATA_URL:?Missing artifact metadata URL}"
+: "\${ARTIFACT_TARBALL_URL:?Missing artifact tarball URL}"
+: "\${ARTIFACT_SHA256:?Missing artifact SHA-256}"
+
+mkdir -p release
+jq -n \\
+  --arg metadataUrl "$ARTIFACT_METADATA_URL" \\
+  --arg tarballUrl "$ARTIFACT_TARBALL_URL" \\
+  --arg sha256 "$ARTIFACT_SHA256" \\
+  '{
+    schemaVersion: 1,
+    artifact: {
+      metadataUrl: $metadataUrl,
+      tarballUrl: $tarballUrl,
+      sha256: $sha256
+    }
+  }' > release/devtools-artifact.json`,
+        },
+        {
+          name: 'Verify artifact manifest',
+          run: '$DEVENV_BIN tasks run release:devtools-artifact:verify --mode before --no-tui',
+        },
+        {
+          name: 'Open manifest update PR',
+          env: {
+            GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+          },
+          run: `set -euo pipefail
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+suffix="\${DEVTOOLS_BUILD_ID:-$(date -u +%Y%m%d%H%M%S)}"
+branch="automation/devtools-artifact-\${suffix}"
+git checkout -B "$branch"
+git add release/devtools-artifact.json
+
+if git diff --cached --quiet; then
+  echo "Artifact manifest already current."
+  exit 0
+fi
+
+git commit -m "Update LiveStore DevTools artifact manifest"
+git push --force-with-lease origin "$branch"
+
+title="Update LiveStore DevTools artifact manifest"
+body="$(cat <<'BODY'
+Updates the public DevTools artifact manifest from a sanitized artifact release.
+
+This PR only changes public artifact URLs and checksums. The workflow verifies the tarball before opening the PR.
+BODY
+)"
+
+if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+  gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" --base "$BASE_BRANCH"
+else
+  gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE_BRANCH" --head "$branch" --title "$title" --body "$body"
+fi`,
+        },
+      ],
+    },
+  },
+})

--- a/devenv.nix
+++ b/devenv.nix
@@ -27,22 +27,6 @@ let
     inherit pkgs oxlintNpm;
   };
 
-  # Pre-compiled Grafana dashboards for livestore OTEL traces
-  livestoreDashboards = effectUtils.lib.buildOtelDashboards {
-    inherit pkgs;
-    src = ./nix/otel-dashboards;
-    dashboardNames = [
-      "livestore-overview"
-      "livestore-cli"
-      "livestore-sync"
-      "livestore-test-runs"
-      "livestore-leader-thread"
-      "livestore-sync-providers"
-      "livestore-browser"
-      "livestore-sql"
-    ];
-  };
-
   # Packages managed by pnpm (shared between pnpm and clean modules)
   # NOTE: Using pnpm temporarily due to bun bugs. Plan to switch back once fixed.
   # See: effect-utils/context/workarounds/bun-issues.md
@@ -93,14 +77,10 @@ in
     # dt command for running devenv tasks
     effectUtils.devenvModules.dt
     # OTEL observability stack with livestore-specific dashboards
-    (effectUtils.devenvModules.otel {
-      extraDashboards = [
-        {
-          name = "livestore";
-          path = livestoreDashboards;
-        }
-      ];
-    })
+    # Keep release/task automation independent from user machine-level OTEL
+    # dashboard sync state. System OTEL remains useful for interactive shells,
+    # but the repository task contract needs deterministic local module wiring.
+    (effectUtils.devenvModules.otel { mode = "local"; })
     # Playwright browser drivers and environment setup
     inputs.playwright.devenvModules.default
     # Shared task modules from effect-utils
@@ -242,6 +222,68 @@ in
   tasks."lint:check:format".execIfModified = lib.mkForce [ ];
   tasks."lint:check:oxlint".execIfModified = lib.mkForce [ ];
 
+  tasks."release:devtools-artifact:verify" = {
+    description = "Verify a public LiveStore DevTools artifact handoff";
+    exec = ''
+      set -euo pipefail
+      cd "$DEVENV_ROOT"
+
+      artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
+      if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" ]]; then
+        : "''${LIVESTORE_DEVTOOLS_METADATA:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
+        : "''${LIVESTORE_DEVTOOLS_TARBALL:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
+        artifact_args=(--metadata "$LIVESTORE_DEVTOOLS_METADATA" --tarball "$LIVESTORE_DEVTOOLS_TARBALL")
+      fi
+
+      bun scripts/src/commands/devtools-artifact.ts verify "''${artifact_args[@]}"
+    '';
+    after = [ "pnpm:install" ];
+  };
+
+  tasks."release:devtools-artifact:repack-dryrun" = {
+    description = "Verify and repack a public LiveStore DevTools artifact for a LiveStore release version";
+    exec = ''
+      set -euo pipefail
+      cd "$DEVENV_ROOT"
+
+      : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
+      artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
+      if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" ]]; then
+        : "''${LIVESTORE_DEVTOOLS_METADATA:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
+        : "''${LIVESTORE_DEVTOOLS_TARBALL:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
+        artifact_args=(--metadata "$LIVESTORE_DEVTOOLS_METADATA" --tarball "$LIVESTORE_DEVTOOLS_TARBALL")
+      fi
+
+      bun scripts/src/commands/devtools-artifact.ts repack \
+        "''${artifact_args[@]}" \
+        --version "$LIVESTORE_RELEASE_VERSION" \
+        --dry-run
+    '';
+    after = [ "pnpm:install" ];
+  };
+
+  tasks."release:devtools-artifact:publish" = {
+    description = "Verify, repack, and publish a public LiveStore DevTools artifact for a LiveStore release version";
+    exec = ''
+      set -euo pipefail
+      cd "$DEVENV_ROOT"
+
+      : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
+      artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
+      if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" ]]; then
+        : "''${LIVESTORE_DEVTOOLS_METADATA:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
+        : "''${LIVESTORE_DEVTOOLS_TARBALL:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
+        artifact_args=(--metadata "$LIVESTORE_DEVTOOLS_METADATA" --tarball "$LIVESTORE_DEVTOOLS_TARBALL")
+      fi
+
+      bun scripts/src/commands/devtools-artifact.ts repack \
+        "''${artifact_args[@]}" \
+        --version "$LIVESTORE_RELEASE_VERSION" \
+        --publish
+    '';
+    after = [ "pnpm:install" ];
+  };
+
   # NOTE: check:quick is provided by effect-utils taskModules.check.
 
   git-hooks.enable = true;
@@ -314,7 +356,9 @@ in
 
     # Setup runs via setup module (taskModules.setup) - auto-wired to enterShell
 
-    [ -f "$WORKSPACE_ROOT/scripts/completions.sh" ] && source "$WORKSPACE_ROOT/scripts/completions.sh"
+    if [ "''${CI:-}" != "true" ] && [ "''${LIVESTORE_SKIP_COMPLETIONS:-}" != "1" ]; then
+      [ -f "$WORKSPACE_ROOT/scripts/completions.sh" ] && source "$WORKSPACE_ROOT/scripts/completions.sh"
+    fi
 
     if [ -d "$WORKSPACE_ROOT/scripts/.completions/zsh/site-functions" ]; then
       export FPATH="$WORKSPACE_ROOT/scripts/.completions/zsh/site-functions''${FPATH:+:''${FPATH}}"

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -48,7 +48,12 @@ export const livestoreWorkspaceCatalog = {
 
 /** LiveStore-only versions not provided by effect-utils base catalog. */
 export const livestoreOnlyCatalog = {
-  '@livestore/devtools-vite': '0.4.0-dev.22',
+  /**
+   * Snapshot releases pin every `@livestore/*` package — including the
+   * externally-published `devtools-vite` from overeng — to the same
+   * `LIVESTORE_RELEASE_VERSION`. Default to the dev tag for normal builds.
+   */
+  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.22',
   /** Tanstack router sub-packages not in effect-utils catalog (react-router/react-start/router-plugin are there) */
   '@tanstack/router-core': '1.145.7',
   '@tanstack/history': '1.145.7',

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -222,7 +222,6 @@ import {
   dispatchAlignmentStep,
   namespaceRunner as namespaceRunnerBase,
   installNixStep,
-  cachixStep,
   applyMegarepoLockStep,
   checkoutStep,
   preparePinnedDevenvStep,
@@ -252,7 +251,15 @@ export const livestoreSetupStepsAfterCheckout = [
     extraConf:
       'extra-substituters = https://cache.nixos.org\nextra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=',
   }),
-  cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' }),
+  {
+    name: 'Enable Cachix cache',
+    uses: 'cachix/cachix-action@v17',
+    with: {
+      name: 'livestore',
+      authToken: '${{ env.CACHIX_AUTH_TOKEN }}',
+      skipPush: true,
+    },
+  },
   applyMegarepoLockStep(),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "artifact": {
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-0.4.0-dev.22-dt-20260428-05ca43eb/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-0.4.0-dev.22-dt-20260428-05ca43eb/livestore-devtools-vite.tgz",
+    "sha256": "37552cd2670decb442a124c7695221eca673ac5186ad6b5384ee24d434a16f6c"
+  }
+}

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -321,7 +321,10 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
     run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
   }
   if (hasFlag(flags, 'publish') === true) {
-    run(['npm', 'publish', '--tag', publishTag, '--access', 'public', repackedPath], { cwd: workDir })
+    const publishArgs = ['npm', 'publish', '--tag', publishTag, '--access', 'public']
+    if (process.env.GITHUB_ACTIONS === 'true') publishArgs.push('--provenance')
+    publishArgs.push(repackedPath)
+    run(publishArgs, { cwd: workDir })
   }
 
   console.log(JSON.stringify({ repackedPath, sha256: sha256(repackedPath) }, null, 2))

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -1,0 +1,351 @@
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import {
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { get as httpGet } from 'node:http'
+import { get as httpsGet } from 'node:https'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pipeline } from 'node:stream/promises'
+
+type CompatibleLivestore =
+  | { readonly kind: 'range'; readonly range: string }
+  | { readonly kind: 'snapshot'; readonly gitSha: string; readonly version: string }
+
+type ArtifactMetadata = {
+  readonly schemaVersion: 1
+  readonly artifactName: 'livestore-devtools-vite'
+  readonly packageName: '@livestore/devtools-vite'
+  readonly devtoolsVersion: string
+  readonly devtoolsBuildId: string
+  readonly compatibleLivestore: CompatibleLivestore
+  readonly files: {
+    readonly tarball: {
+      readonly name: string
+      readonly sha256: string
+      readonly integrity: string
+    }
+  }
+}
+
+type ArtifactManifest = {
+  readonly schemaVersion: 1
+  readonly artifact: {
+    readonly metadataUrl: string
+    readonly tarballUrl: string
+    readonly sha256?: string
+  }
+}
+
+const usage = `Usage:
+  bun scripts/src/commands/devtools-artifact.ts verify (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>)
+  bun scripts/src/commands/devtools-artifact.ts repack (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>) --version <version> [--dry-run|--publish]
+
+Options:
+  --manifest <file>        Checked-in public artifact manifest
+  --metadata <url-or-file>  Public release-metadata.json URL or local path
+  --tarball <url-or-file>   Public artifact tarball URL or local path
+  --version <version>       LiveStore release-group package version for repack
+  --out-dir <dir>           Output directory for verified/repacked artifacts
+  --dry-run                 Run npm publish dry-run for the repacked package
+  --publish                 Publish the repacked package to npm
+`
+
+const parseArgs = (argv: ReadonlyArray<string>) => {
+  const [maybeCommand = 'help', ...maybeRest] = argv
+  const firstArgIsFlag = maybeCommand.startsWith('--') === true
+  const command = firstArgIsFlag === true ? 'help' : maybeCommand
+  const rest = firstArgIsFlag === true ? argv : maybeRest
+  const flags = new Map<string, string | true>()
+
+  for (let index = 0; index < rest.length; index++) {
+    const arg = rest[index]!
+    if (arg.startsWith('--') === false) throw new Error(`Unexpected positional argument: ${arg}`)
+    const name = arg.slice(2)
+    const next = rest[index + 1]
+    if (next !== undefined && next.startsWith('--') === false) {
+      flags.set(name, next)
+      index++
+    } else {
+      flags.set(name, true)
+    }
+  }
+
+  return { command, flags }
+}
+
+const readFlag = (flags: Map<string, string | true>, name: string): string | undefined => {
+  const value = flags.get(name)
+  if (value === true) throw new Error(`--${name} requires a value`)
+  return value
+}
+
+const hasFlag = (flags: Map<string, string | true>, name: string): boolean => flags.get(name) === true
+
+const run = (command: ReadonlyArray<string>, options: { readonly cwd?: string } = {}) => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    cwd: options.cwd,
+    env: process.env,
+    stdio: 'inherit',
+  })
+  if (result.status !== 0) throw new Error(`Command failed (${result.status ?? 'signal'}): ${command.join(' ')}`)
+}
+
+const runCapture = (command: ReadonlyArray<string>, options: { readonly cwd?: string } = {}) => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    cwd: options.cwd,
+    env: process.env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status ?? 'signal'}): ${command.join(' ')}\n${result.stderr}`)
+  }
+  return result.stdout
+}
+
+const sha256 = (file: string) => createHash('sha256').update(readFileSync(file)).digest('hex')
+const integrity = (file: string) => `sha512-${createHash('sha512').update(readFileSync(file)).digest('base64')}`
+
+const downloadToFile = async (source: string, target: string, redirects = 0): Promise<void> => {
+  if (redirects > 5) throw new Error(`Too many redirects while fetching ${source}`)
+
+  await new Promise<void>((resolve, reject) => {
+    const get = source.startsWith('https://') === true ? httpsGet : httpGet
+    const request = get(source, (response) => {
+      const status = response.statusCode ?? 0
+      const location = response.headers.location
+
+      if (status >= 300 && status < 400 && location !== undefined) {
+        response.resume()
+        downloadToFile(new URL(location, source).toString(), target, redirects + 1).then(resolve, reject)
+        return
+      }
+
+      if (status < 200 || status >= 300) {
+        response.resume()
+        reject(new Error(`Failed to fetch ${source}: ${status}`))
+        return
+      }
+
+      pipeline(response, createWriteStream(target)).then(resolve, reject)
+    })
+    request.on('error', reject)
+  })
+}
+
+const fetchToFile = async (source: string, target: string) => {
+  mkdirSync(path.dirname(target), { recursive: true })
+  if (source.startsWith('http://') === true || source.startsWith('https://') === true) {
+    await downloadToFile(source, target)
+    return
+  }
+
+  const sourcePath = path.resolve(source)
+  writeFileSync(target, readFileSync(sourcePath))
+}
+
+const prepareInputs = async (flags: Map<string, string | true>) => {
+  const manifestSource = readFlag(flags, 'manifest')
+  let metadataSource = readFlag(flags, 'metadata')
+  let tarballSource = readFlag(flags, 'tarball')
+  let expectedTarballSha256: string | undefined
+
+  if (manifestSource !== undefined) {
+    if (metadataSource !== undefined || tarballSource !== undefined) {
+      throw new Error('--manifest cannot be combined with --metadata or --tarball')
+    }
+    const manifest = JSON.parse(readFileSync(path.resolve(manifestSource), 'utf8')) as ArtifactManifest
+    if (manifest.schemaVersion !== 1) throw new Error('Unsupported artifact manifest schemaVersion')
+    metadataSource = manifest.artifact.metadataUrl
+    tarballSource = manifest.artifact.tarballUrl
+    expectedTarballSha256 = manifest.artifact.sha256
+  }
+
+  if (metadataSource === undefined) throw new Error('--metadata or --manifest is required')
+  if (tarballSource === undefined) throw new Error('--tarball or --manifest is required')
+
+  const workDir = path.resolve(readFlag(flags, 'out-dir') ?? mkdtempSync(path.join(tmpdir(), 'livestore-devtools-')))
+  const metadataPath = path.join(workDir, 'release-metadata.json')
+  const tarballPath = path.join(workDir, 'livestore-devtools-vite.tgz')
+  await fetchToFile(metadataSource, metadataPath)
+  await fetchToFile(tarballSource, tarballPath)
+  if (expectedTarballSha256 !== undefined && sha256(tarballPath) !== expectedTarballSha256) {
+    throw new Error('Manifest tarball SHA-256 mismatch')
+  }
+
+  const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as ArtifactMetadata
+  return { workDir, metadata, metadataPath, tarballPath }
+}
+
+const forbiddenPatterns: ReadonlyArray<string | RegExp> = [
+  '/home/',
+  '/Users/',
+  'op://',
+  /npm_[A-Za-z0-9]{20,}/,
+  /github_pat_[A-Za-z0-9_]{20,}/,
+  'GITHUB_TOKEN',
+  'NPM_TOKEN',
+  'BEGIN PRIVATE KEY',
+]
+
+const forbiddenPatternName = (pattern: string | RegExp) => (typeof pattern === 'string' ? pattern : pattern.source)
+
+const containsForbiddenPattern = (content: string, pattern: string | RegExp) =>
+  typeof pattern === 'string' ? content.includes(pattern) : pattern.test(content)
+
+const assertMetadata = (metadata: ArtifactMetadata, tarballPath: string) => {
+  if (metadata.schemaVersion !== 1) throw new Error('Unsupported metadata schemaVersion')
+  if (metadata.artifactName !== 'livestore-devtools-vite') throw new Error('Unexpected artifactName')
+  if (metadata.packageName !== '@livestore/devtools-vite') throw new Error('Unexpected packageName')
+  if (metadata.files.tarball.sha256 !== sha256(tarballPath)) throw new Error('Tarball SHA-256 mismatch')
+  if (metadata.files.tarball.integrity !== integrity(tarballPath)) throw new Error('Tarball integrity mismatch')
+
+  const serialized = JSON.stringify(metadata)
+  for (const pattern of forbiddenPatterns) {
+    if (containsForbiddenPattern(serialized, pattern) === true) {
+      throw new Error(`Metadata contains forbidden pattern: ${forbiddenPatternName(pattern)}`)
+    }
+  }
+}
+
+const assertTarballEntries = (tarballPath: string) => {
+  const entries = runCapture(['tar', '-tzf', tarballPath])
+    .split('\n')
+    .filter((line) => line.length > 0)
+
+  for (const entry of entries) {
+    if (entry.startsWith('package/') === false) throw new Error(`Unexpected tarball prefix: ${entry}`)
+    if (entry.includes('/src/') === true) throw new Error(`Source directory leaked into artifact: ${entry}`)
+    if (entry.endsWith('.map') === true) throw new Error(`Sourcemap leaked into artifact: ${entry}`)
+    if (entry.endsWith('.ts') === true && entry.endsWith('.d.ts') === false) {
+      throw new Error(`TypeScript source leaked into artifact: ${entry}`)
+    }
+    if (entry.includes('/node_modules/') === true) throw new Error(`node_modules leaked into artifact: ${entry}`)
+  }
+}
+
+const walkFiles = async (dir: string): Promise<ReadonlyArray<string>> => {
+  const entries = await readdir(dir)
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const file = path.join(dir, entry)
+      const fileStat = await stat(file)
+      if (fileStat.isDirectory() === true) return walkFiles(file)
+      return [file]
+    }),
+  )
+  return files.flat()
+}
+
+const textLike = (file: string) =>
+  /\.(?:json|js|css|html|txt|md|d\.ts|mjs|cjs)$/.test(file) || path.basename(file) === 'package.json'
+
+const assertNoForbiddenText = async (tarballPath: string) => {
+  const unpackDir = mkdtempSync(path.join(tmpdir(), 'livestore-devtools-public-audit-'))
+  try {
+    run(['tar', '-xzf', tarballPath, '-C', unpackDir])
+    for (const file of await walkFiles(unpackDir)) {
+      if (textLike(file) === false) continue
+      const content = await readFile(file, 'utf8')
+      for (const pattern of forbiddenPatterns) {
+        if (containsForbiddenPattern(content, pattern) === true) {
+          throw new Error(
+            `Artifact text file contains forbidden pattern ${forbiddenPatternName(pattern)}: ${path.relative(unpackDir, file)}`,
+          )
+        }
+      }
+    }
+  } finally {
+    rmSync(unpackDir, { recursive: true, force: true })
+  }
+}
+
+const verifyArtifact = async (flags: Map<string, string | true>) => {
+  const { metadata, tarballPath, workDir } = await prepareInputs(flags)
+  assertMetadata(metadata, tarballPath)
+  assertTarballEntries(tarballPath)
+  await assertNoForbiddenText(tarballPath)
+  return { metadata, tarballPath, workDir }
+}
+
+const repackArtifact = async (flags: Map<string, string | true>) => {
+  const version = readFlag(flags, 'version')
+  if (version === undefined) throw new Error('--version is required')
+
+  const { metadata, tarballPath, workDir } = await verifyArtifact(flags)
+  const unpackDir = path.join(workDir, 'package-src')
+  rmSync(unpackDir, { recursive: true, force: true })
+  mkdirSync(unpackDir, { recursive: true })
+  run(['tar', '-xzf', tarballPath, '-C', unpackDir])
+
+  const packageDir = path.join(unpackDir, 'package')
+  const packageJsonPath = path.join(packageDir, 'package.json')
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    version?: string
+    dependencies?: Record<string, string>
+  }
+  pkg.version = version
+  pkg.dependencies = {
+    ...pkg.dependencies,
+    '@livestore/adapter-web': version,
+    '@livestore/utils': version,
+    vite: '*',
+  }
+  writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)
+  writeFileSync(
+    path.join(packageDir, 'dist/release-metadata.json'),
+    `${JSON.stringify({ schemaVersion: 1, devtoolsArtifact: metadata, livestoreVersion: version }, null, 2)}\n`,
+  )
+
+  const packedJson = runCapture(['npm', 'pack', '--json', '--pack-destination', workDir], {
+    cwd: packageDir,
+  })
+  const packed = JSON.parse(packedJson) as ReadonlyArray<{ readonly filename: string }>
+  const firstPacked = packed[0]
+  if (firstPacked === undefined) throw new Error('npm pack did not produce a tarball')
+  const repackedPath = path.join(workDir, `livestore-devtools-vite-${version}.tgz`)
+  renameSync(path.join(workDir, firstPacked.filename), repackedPath)
+
+  const publishTag = version.includes('-') === true ? 'snapshot' : 'latest'
+  if (hasFlag(flags, 'dry-run') === true) {
+    run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
+  }
+  if (hasFlag(flags, 'publish') === true) {
+    run(['npm', 'publish', '--tag', publishTag, '--access', 'public', repackedPath], { cwd: workDir })
+  }
+
+  console.log(JSON.stringify({ repackedPath, sha256: sha256(repackedPath) }, null, 2))
+}
+
+const main = async () => {
+  const { command, flags } = parseArgs(process.argv.slice(2))
+  if (command === 'help' || hasFlag(flags, 'help') === true) {
+    console.log(usage)
+    return
+  }
+  if (command === 'verify') {
+    const result = await verifyArtifact(flags)
+    console.log(JSON.stringify({ devtoolsBuildId: result.metadata.devtoolsBuildId, workDir: result.workDir }, null, 2))
+    return
+  }
+  if (command === 'repack') {
+    await repackArtifact(flags)
+    return
+  }
+  throw new Error(`Unknown command: ${command}\n\n${usage}`)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -293,8 +293,18 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
   const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
     version?: string
     dependencies?: Record<string, string>
+    homepage?: string
+    repository?: string | { readonly type?: string; readonly url?: string; readonly directory?: string }
+    bugs?: { readonly url?: string }
   }
   pkg.version = version
+  pkg.repository = {
+    type: 'git',
+    url: 'https://github.com/livestorejs/livestore',
+    directory: 'packages/@livestore/devtools-vite',
+  }
+  pkg.homepage = 'https://github.com/livestorejs/livestore/tree/main/packages/@livestore/devtools-vite'
+  pkg.bugs = { url: 'https://github.com/livestorejs/livestore/issues' }
   pkg.dependencies = {
     ...pkg.dependencies,
     '@livestore/adapter-web': version,

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -14,6 +14,18 @@ import {
 
 const isGithubAction = process.env.GITHUB_ACTIONS === 'true'
 
+const ciUnitTestPackageConcurrency = (() => {
+  const raw = process.env.LIVESTORE_TEST_UNIT_CONCURRENCY
+  if (raw === undefined || raw === '') return 4
+
+  const parsed = Number.parseInt(raw, 10)
+  if (Number.isFinite(parsed) === false || parsed < 1) {
+    throw new Error(`LIVESTORE_TEST_UNIT_CONCURRENCY must be a positive integer, got ${JSON.stringify(raw)}`)
+  }
+
+  return parsed
+})()
+
 // GitHub actions log groups
 const runTestGroup =
   (name: string) =>
@@ -208,7 +220,7 @@ export const testUnitCommand = Cli.Command.make(
                   : ['vitest', 'run', `${workspaceRoot}/${target.path}`]
               return cmd(args).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
             },
-            { concurrency: 'unbounded' },
+            { concurrency: ciUnitTestPackageConcurrency },
           ),
         )
       }


### PR DESCRIPTION
## Summary

This PR makes the public LiveStore repo self-contained for consuming and republishing public LiveStore DevTools artifacts as part of the LiveStore release group.

- Adds `release/devtools-artifact.json` as the checked-in public artifact manifest.
- Adds a Bun/Node `devtools-artifact` command with `verify` and `repack` modes.
- Verifies artifact metadata, tarball SHA-256/integrity, package shape, and forbidden public-leak patterns before republishing.
- Repackages the public artifact as `@livestore/devtools-vite` with the exact LiveStore release version.
- Publishes the DevTools package from the same CI snapshot publish job as the rest of LiveStore.
- Adds a pre-merge-testable `DevTools artifact manifest` workflow. On PRs it verifies the checked-in manifest; after merge, dispatch/manual runs can open a manifest update PR.
- Makes snapshot versions use the PR head SHA so npm versions, checked-out examples, and PR review source all correlate directly.
- Makes CI Cachix usage pull-only to avoid non-critical post-job cache upload failures masking successful validation jobs.

## Public Artifact Flow

The public repo does not need private DevTools source access. It consumes a public artifact manifest containing:

- public `release-metadata.json` URL
- public artifact tarball URL
- tarball SHA-256

The current manifest points at the public artifact release:

- `livestorejs/livestore-devtools-artifacts`: `devtools-artifact-0.4.0-dev.22-dt-20260428-05ca43eb`

During release, CI verifies the artifact and republishes it as the matching `@livestore/devtools-vite@<livestore-version>` package.

## Safety

The LiveStore-side verifier rejects artifacts with unexpected tar entries, source trees, sourcemaps, `node_modules`, local machine paths, op refs, token-like strings, private-key markers, and other private/sensitive markers. The republished npm package also carries public LiveStore repository metadata for traceability.

## End-to-End Proof

Latest validated PR head: `b7b6d149d7628d8b1ea9296de9dfcd6dd7274ad5`.

CI published and verified:

- `@livestore/livestore@0.0.0-snapshot-b7b6d149d7628d8b1ea9296de9dfcd6dd7274ad5`
- `@livestore/devtools-vite@0.0.0-snapshot-b7b6d149d7628d8b1ea9296de9dfcd6dd7274ad5`

## Test Plan

- [x] `update-manifest-pr` workflow passed on this PR before merge
- [x] `lint` passed
- [x] `type-check` passed
- [x] `test-unit` passed
- [x] integration/provider/playwright matrix passed
- [x] docs/examples/perf/wa-sqlite checks passed
- [x] `publish-snapshot-version` passed
- [x] `build-example-create` passed for `web-todomvc`, `web-linearlite`, and `expo-linearlite`
- [x] npm registry lookup confirms both LiveStore and DevTools snapshot packages exist

## Companion PR

- overengineeringstudio/overeng#184

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌐 co2-corona |
| `agent_session_id` | 96339caa-c76e-464c-9d18-1104326cbfdb |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-04-26-genie-snapshot-version |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@2edf09b-dirty |
</details>
<!-- agent-footer:end -->