### PR TITLE
Fix generated release PR validation dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 on:
   push:
     branches: [main, dev]
+  workflow_dispatch: {}
   pull_request: {}
 
 env:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -87,6 +87,7 @@ export default githubWorkflow({
       // Only run on pushes to main/dev to keep docs deploys consistent
       branches: ['main', 'dev'],
     },
+    workflow_dispatch: {},
     pull_request: {},
   },
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ on:
         required: true
         default: latest
         type: string
+      mode:
+        description: Release workflow mode
+        required: true
+        default: create-release-pr
+        type: choice
+        options: [create-release-pr, validate-release-plan]
   pull_request:
     paths:
       - .github/workflows/release.yml
@@ -38,9 +44,10 @@ env:
 
 jobs:
   create-release-pr:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'create-release-pr'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       id-token: write
       pull-requests: write
@@ -279,10 +286,12 @@ jobs:
       - name: Open release plan PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIVESTORE_NPM_TAG: ${{ inputs.npm_tag }}
         run: |
           set -euo pipefail
           LIVESTORE_RELEASE_VERSION="$(jq -r '.version' release/release-plan.json)"
           : "${LIVESTORE_RELEASE_VERSION:?Missing generated release version}"
+          : "${LIVESTORE_NPM_TAG:?Missing npm tag}"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -309,9 +318,9 @@ jobs:
           fi
 
           body="$(cat <<BODY
-          Prepares a LiveStore release group for `$LIVESTORE_RELEASE_VERSION` from the pending Changesets.
+          Prepares a LiveStore release group for $LIVESTORE_RELEASE_VERSION from the pending Changesets.
 
-          The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into `dev`, the same workflow publishes the release group.
+          The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group.
 
           ## Rationale
 
@@ -329,8 +338,13 @@ jobs:
               --title "Prepare LiveStore $LIVESTORE_RELEASE_VERSION release" \
               --body "$body"
           fi
+
+          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$branch"
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" \
+            -f mode=validate-release-plan \
+            -f npm_tag="$LIVESTORE_NPM_TAG"
   validate-release-plan:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')
     runs-on: ubuntu-24.04
     defaults:
       run:

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -40,6 +40,13 @@ export default githubWorkflow({
           default: 'latest',
           type: 'string',
         },
+        mode: {
+          description: 'Release workflow mode',
+          required: true,
+          default: 'create-release-pr',
+          type: 'choice',
+          options: ['create-release-pr', 'validate-release-plan'],
+        },
       },
     },
     pull_request: {
@@ -64,9 +71,10 @@ export default githubWorkflow({
 
   jobs: {
     'create-release-pr': {
-      if: "github.event_name == 'workflow_dispatch'",
+      if: "github.event_name == 'workflow_dispatch' && inputs.mode == 'create-release-pr'",
       'runs-on': 'ubuntu-latest',
       permissions: {
+        actions: 'write',
         contents: 'write',
         'id-token': 'write',
         'pull-requests': 'write',
@@ -92,10 +100,12 @@ export default githubWorkflow({
           name: 'Open release plan PR',
           env: {
             GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+            LIVESTORE_NPM_TAG: '${{ inputs.npm_tag }}',
           },
           run: `set -euo pipefail
 LIVESTORE_RELEASE_VERSION="$(jq -r '.version' release/release-plan.json)"
 : "\${LIVESTORE_RELEASE_VERSION:?Missing generated release version}"
+: "\${LIVESTORE_NPM_TAG:?Missing npm tag}"
 
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -122,9 +132,9 @@ else
 fi
 
 body="$(cat <<BODY
-Prepares a LiveStore release group for \`$LIVESTORE_RELEASE_VERSION\` from the pending Changesets.
+Prepares a LiveStore release group for $LIVESTORE_RELEASE_VERSION from the pending Changesets.
 
-The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into \`dev\`, the same workflow publishes the release group.
+The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group.
 
 ## Rationale
 
@@ -141,13 +151,18 @@ else
     --head "$branch" \\
     --title "Prepare LiveStore $LIVESTORE_RELEASE_VERSION release" \\
     --body "$body"
-fi`,
+fi
+
+gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$branch"
+gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" \\
+  -f mode=validate-release-plan \\
+  -f npm_tag="$LIVESTORE_NPM_TAG"`,
         },
       ],
     },
 
     'validate-release-plan': {
-      if: "github.event_name == 'pull_request'",
+      if: "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')",
       'runs-on': 'ubuntu-24.04',
       defaults: bashShellDefaults,
       steps: withNixDiagnosticsOnFailure([


### PR DESCRIPTION
Fixes the generated release PR flow after the workflow-dispatch test exposed two issues:\n\n- Avoid Markdown backticks in the shell-generated PR body so Bash does not treat the version and branch names as command substitutions.\n- Explicitly dispatch CI and release-plan validation for generated release PR branches, because branches pushed with GITHUB_TOKEN do not trigger pull_request workflows recursively.\n\n## Rationale\n\nThe release PR is the supervised gate for a stable release, so it must be self-verifying without relying on a local operator to remember follow-up checks. Workflow dispatch is the GitHub-supported escape hatch for this recursion guard and keeps stable publishing gated on merging the generated release PR.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-04-26-genie-snapshot-version/tmp/livestore-changesets-flow |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->