### PR TITLE
Prepare LiveStore 0.4.0-dev.23 release

### DIFF
--- a/release/release-plan.json
+++ b/release/release-plan.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "version": "0.4.0-dev.23",
+  "npmTag": "dev"
+}

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -116,6 +116,17 @@ const runCapture = (command: ReadonlyArray<string>, options: { readonly cwd?: st
 const sha256 = (file: string) => createHash('sha256').update(readFileSync(file)).digest('hex')
 const integrity = (file: string) => `sha512-${createHash('sha512').update(readFileSync(file)).digest('base64')}`
 
+const publishTagForVersion = (version: string) => {
+  const prerelease = version.split('-')[1]
+  if (prerelease === undefined) return 'latest'
+
+  const prereleaseChannel = prerelease.split(/[.-]/)[0]
+  if (prereleaseChannel === 'dev') return 'dev'
+  if (prereleaseChannel === 'snapshot') return 'snapshot'
+
+  return 'next'
+}
+
 const downloadToFile = async (source: string, target: string, redirects = 0): Promise<void> => {
   if (redirects > 5) throw new Error(`Too many redirects while fetching ${source}`)
 
@@ -326,7 +337,7 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
   const repackedPath = path.join(workDir, `livestore-devtools-vite-${version}.tgz`)
   renameSync(path.join(workDir, firstPacked.filename), repackedPath)
 
-  const publishTag = version.includes('-') === true ? 'snapshot' : 'latest'
+  const publishTag = publishTagForVersion(version)
   if (hasFlag(flags, 'dry-run') === true) {
     run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
   }


### PR DESCRIPTION
## Summary

- prepares the `0.4.0-dev.23` release plan with the `dev` npm dist-tag
- keeps the DevTools republish aligned with the release channel so `0.4.0-dev.23` is published under the `dev` tag, not `snapshot`

## Rationale

This exercises the PR-driven release path for a dev release before the branch migration work. The DevTools package is repackaged from the public artifact manifest only; no private DevTools source or internal details are included in this PR.

## Verification

- `CI=1 devenv tasks run release:stable:dryrun --mode before --no-tui`
- `CI=1 LIVESTORE_RELEASE_VERSION=0.4.0-dev.23 devenv tasks run release:devtools-artifact:repack-dryrun --mode before --no-tui`
- direct DevTools dry-run confirmed npm would publish `@livestore/devtools-vite@0.4.0-dev.23` with tag `dev`
- `CI=1 oxlint scripts/src/commands/devtools-artifact.ts`
- `devenv` `ts:build` completed during shell setup; direct `bun scripts/src/mono.ts ts` hit a local `@parcel/watcher` native-loader issue before TypeScript proper

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-04-26-genie-snapshot-version/tmp/livestore-changesets-flow/tmp/livestore-dev-release-23 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->