### PR TITLE
Add manual release publish dispatch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,6 +43,15 @@ On push to `dev` when `release/release-plan.json` changes, the workflow publishe
 the release group and the matching public DevTools artifact package. In normal
 operation this happens when the supervised release PR is merged.
 
+Manual dispatch with `mode=publish-release` reruns the publish job for the
+checked-in release plan. Use it only after confirming the current `dev` release
+plan is still the intended release; the publisher is idempotent for already
+published packages.
+
+The publish job uses the repository `NPM_TOKEN` secret. Snapshot publishing uses
+npm trusted publishing from `ci.yml`; stable/dev release publishing should move
+to trusted publishing too once `release.yml` is authorized for the npm packages.
+
 ## `devtools-artifact.yml`
 
 Maintains `release/devtools-artifact.json`, the public manifest that tells the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         required: true
         default: create-release-pr
         type: choice
-        options: [create-release-pr, validate-release-plan]
+        options: [create-release-pr, validate-release-plan, publish-release]
   pull_request:
     paths:
       - .github/workflows/release.yml
@@ -321,7 +321,7 @@ jobs:
           body="$(cat <<BODY
           Prepares a LiveStore release group for $LIVESTORE_RELEASE_VERSION from the pending Changesets.
 
-          The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group.
+          The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group. The publish job can also be manually dispatched after an operator verifies that the checked-in release plan is still the intended release.
 
           ## Rationale
 
@@ -723,11 +723,13 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
   publish-release:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-release')
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -45,7 +45,7 @@ export default githubWorkflow({
           required: true,
           default: 'create-release-pr',
           type: 'choice',
-          options: ['create-release-pr', 'validate-release-plan'],
+          options: ['create-release-pr', 'validate-release-plan', 'publish-release'],
         },
       },
     },
@@ -135,7 +135,7 @@ fi
 body="$(cat <<BODY
 Prepares a LiveStore release group for $LIVESTORE_RELEASE_VERSION from the pending Changesets.
 
-The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group.
+The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group. The publish job can also be manually dispatched after an operator verifies that the checked-in release plan is still the intended release.
 
 ## Rationale
 
@@ -204,11 +204,14 @@ echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"`,
     },
 
     'publish-release': {
-      if: "github.event_name == 'push'",
+      if: "github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-release')",
       'runs-on': 'ubuntu-24.04',
       permissions: {
         contents: 'read',
         'id-token': 'write',
+      },
+      env: {
+        NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}',
       },
       defaults: bashShellDefaults,
       steps: withNixDiagnosticsOnFailure([


### PR DESCRIPTION
Adds an explicit `publish-release` workflow dispatch mode for the Release workflow, wires the publish job to the repository `NPM_TOKEN` secret, and documents when to use the recovery path.

This is a recovery path for an already-reviewed release plan: if a publish job fails after the plan has merged, an operator can rerun the publish job from the checked-in plan after verifying that `dev` still contains the intended release. The package publisher is already idempotent via `--allow-existing`, so retrying can resume after a partial publish.

## Rationale

The normal path remains PR-driven: create a release PR, validate it, and publish on merge. The manual publish mode avoids needing a synthetic/no-op release-plan change just to retry the same release from CI, while still keeping the checked-in release plan as the source of truth.

Snapshot publishing currently works through npm trusted publishing from `ci.yml`. Release publishing should move to trusted publishing too once `release.yml` is authorized for the npm packages; until then the existing `NPM_TOKEN` secret keeps the release path CI-driven and auditable.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | megarepo-all/schickling/2026-04-26-livestore-release |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->