### PR TITLE
Configure npm token for release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -853,6 +853,12 @@ jobs:
           release_version="$(jq -r '.version' release/release-plan.json)"
           : "${release_version:?Missing release version}"
           echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+      - name: Configure npm token fallback
+        run: |
+          set -euo pipefail
+          : "${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
+          printf '%s\n' "always-auth=true" > "$HOME/.npmrc"
+          printf '%s\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"
       - name: Publish stable package release
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -224,6 +224,13 @@ release_version="$(jq -r '.version' release/release-plan.json)"
 echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"`,
         },
         {
+          name: 'Configure npm token fallback',
+          run: `set -euo pipefail
+: "\${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
+printf '%s\\n' "always-auth=true" > "$HOME/.npmrc"
+printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"`,
+        },
+        {
           name: 'Publish stable package release',
           run: runDevenvTasksBefore('release:stable:publish'),
         },


### PR DESCRIPTION
Fixes the release publish retry after `0.4.0-dev.23` failed before any packages were published.

The workflow already exposes `NPM_TOKEN` as `NODE_AUTH_TOKEN`, but pnpm was only attempting npm trusted publishing/OIDC and never had an npm token config entry. The publish step therefore failed on the first scoped package with npm 404.

This adds an ephemeral `$HOME/.npmrc` in the publish job only, failing fast if the secret is missing. The token is not checked in and the step does not print it.

## Rationale

This keeps the current long-term direction intact: release publishing should eventually use npm trusted publishing for `release.yml`, but the CI job needs a reliable token fallback until npm is configured for that workflow file. The fix is scoped to the release publish job and does not affect snapshot publishing or PR dry-runs.

## Verification

- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:run --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:check --mode before --no-tui`
- `CI=1 oxlint .github/workflows/release.yml.genie.ts`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-04-26-genie-snapshot-version/tmp/livestore-release-auth |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->