### PR TITLE
Switch default branch references to main

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -32,7 +32,7 @@
   ],
   "linked": [],
   "access": "public",
-  "baseBranch": "dev",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@livestore/effect-playwright"]
 }

--- a/.changeset/main-branch-defaults.md
+++ b/.changeset/main-branch-defaults.md
@@ -1,0 +1,5 @@
+---
+"@livestore/cli": patch
+---
+
+Default generated project repository links to the `main` branch.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ generated YAML directly. `sync-docs.yml` is currently handwritten.
 
 ## `ci.yml`
 
-Primary validation workflow for pull requests, `dev`/`main` pushes, and manual
+Primary validation workflow for pull requests, `main`/`dev` pushes, and manual
 workflow-dispatch runs.
 
 It runs the normal repository quality gates: linting, Changesets release-intent
@@ -29,7 +29,7 @@ the generated release branch.
 Release orchestration workflow for the PR-driven release process.
 
 Manual dispatch with `mode=create-release-pr` runs Changesets versioning on
-`dev`, writes `release/release-plan.json`, updates package versions and the
+`main`, writes `release/release-plan.json`, updates package versions and the
 lockfile, and opens or updates a draft release PR such as
 `automation/release-0.4.0`. The generated PR is the human review gate. Keep it
 as draft until the release is intentionally ready to publish.
@@ -39,7 +39,7 @@ pipeline files, dry-runs the package publisher and public DevTools artifact
 repack path. This checks the stable release machinery without publishing a
 stable release.
 
-On push to `dev` when `release/release-plan.json` changes, the workflow publishes
+On push to `main` when `release/release-plan.json` changes, the workflow publishes
 the release group and the matching public DevTools artifact package. In normal
 operation this happens when the supervised release PR is merged.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ on:
       - scripts/src/commands/devtools-artifact.ts
       - scripts/src/commands/changesets.ts
   push:
-    branches: [dev]
+    branches: [main]
     paths: [release/release-plan.json]
 
 permissions:
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: main
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
         with:
@@ -321,7 +321,7 @@ jobs:
           body="$(cat <<BODY
           Prepares a LiveStore release group for $LIVESTORE_RELEASE_VERSION from the pending Changesets.
 
-          The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group. The publish job can also be manually dispatched after an operator verifies that the checked-in release plan is still the intended release.
+          The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into main, the same workflow publishes the release group. The publish job can also be manually dispatched after an operator verifies that the checked-in release plan is still the intended release.
 
           ## Rationale
 
@@ -334,7 +334,7 @@ jobs:
           else
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
-              --base dev \
+              --base main \
               --head "$branch" \
               --title "Prepare LiveStore $LIVESTORE_RELEASE_VERSION release" \
               --body "$body"
@@ -464,10 +464,21 @@ jobs:
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
         shell: bash
-      - name: Create synthetic release plan when testing release tooling changes
+      - name: Select release plan for validation
         run: |
           set -euo pipefail
-          if [ -f release/release-plan.json ]; then
+          use_synthetic_plan=false
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            if ! git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -qx 'release/release-plan.json'; then
+              use_synthetic_plan=true
+            fi
+          elif [ ! -f release/release-plan.json ]; then
+            use_synthetic_plan=true
+          fi
+
+          if [ "$use_synthetic_plan" = "false" ]; then
             exit 0
           fi
 

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -53,7 +53,7 @@ export default githubWorkflow({
       paths: releasePlanPaths,
     },
     push: {
-      branches: ['dev'],
+      branches: ['main'],
       paths: ['release/release-plan.json'],
     },
   },
@@ -85,7 +85,7 @@ export default githubWorkflow({
           name: 'Checkout',
           uses: 'actions/checkout@v4',
           with: {
-            ref: 'dev',
+            ref: 'main',
           },
         },
         ...livestoreSetupSteps.slice(1),
@@ -135,7 +135,7 @@ fi
 body="$(cat <<BODY
 Prepares a LiveStore release group for $LIVESTORE_RELEASE_VERSION from the pending Changesets.
 
-The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into dev, the same workflow publishes the release group. The publish job can also be manually dispatched after an operator verifies that the checked-in release plan is still the intended release.
+The release workflow dry-runs the npm publish for the LiveStore packages and the public DevTools artifact repack on this PR. After merge into main, the same workflow publishes the release group. The publish job can also be manually dispatched after an operator verifies that the checked-in release plan is still the intended release.
 
 ## Rationale
 
@@ -148,7 +148,7 @@ if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
 else
   gh pr create \\
     --repo "$GITHUB_REPOSITORY" \\
-    --base dev \\
+    --base main \\
     --head "$branch" \\
     --title "Prepare LiveStore $LIVESTORE_RELEASE_VERSION release" \\
     --body "$body"
@@ -169,9 +169,20 @@ gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$branch" \\
       steps: withNixDiagnosticsOnFailure([
         ...livestoreSetupSteps,
         {
-          name: 'Create synthetic release plan when testing release tooling changes',
+          name: 'Select release plan for validation',
           run: `set -euo pipefail
-if [ -f release/release-plan.json ]; then
+use_synthetic_plan=false
+
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+  git fetch origin "\${{ github.base_ref }}" --depth=1
+  if ! git diff --name-only "origin/\${{ github.base_ref }}...HEAD" | grep -qx 'release/release-plan.json'; then
+    use_synthetic_plan=true
+  fi
+elif [ ! -f release/release-plan.json ]; then
+  use_synthetic_plan=true
+fi
+
+if [ "$use_synthetic_plan" = "false" ]; then
   exit 0
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Use GitHub issues or an issue checklist for non-trivial work.
 
 ## Git
 
-- The default branch of this repository is `dev`.
+- The default branch of this repository is `main`.
 - Before committing, run `dt lint:full:fix` to auto-fix most linting errors. Make sure there are no type check/lint errors.
 
 ### Branch Naming Conventions

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -76,12 +76,12 @@ The preferred flow is:
 
 1. Ensure pending changesets and `CHANGELOG.md` agree on the intended release
    contents.
-2. Run the `Release` workflow manually from `dev` with the intended npm tag.
+2. Run the `Release` workflow manually from `main` with the intended npm tag.
    The workflow consumes changesets, syncs `release/version.json`, regenerates
    Genie-managed manifests, refreshes the lockfile, and opens or updates the
    release-plan PR.
 3. Review the release-plan PR and wait for CI to pass.
-4. Merge the release-plan PR into `dev`.
+4. Merge the release-plan PR into `main`.
 5. Let the push-triggered `Release` workflow publish the release group.
 
 The release-plan PR validates the exact work that will run after merge:
@@ -90,7 +90,7 @@ The release-plan PR validates the exact work that will run after merge:
 - `release:devtools-artifact:repack-dryrun:no-install` verifies and repacks the
   public DevTools artifact for the same LiveStore version without publishing it.
 
-After merge to `dev`, the push-triggered workflow runs:
+After merge to `main`, the push-triggered workflow runs:
 
 - `release:stable:publish`
 - `release:devtools-artifact:publish:no-install`
@@ -155,7 +155,7 @@ release:
 4. Open a PR with only the manifest change unless release tooling also changed.
 
 The release PR will then dry-run the repack using that manifest. When the
-release-plan PR merges to `dev`, the publish job repackages and publishes the
+release-plan PR merges to `main`, the publish job repackages and publishes the
 artifact as `@livestore/devtools-vite@<livestore-version>`.
 
 ## Safety rules

--- a/devenv.nix
+++ b/devenv.nix
@@ -300,7 +300,7 @@ in
       set -euo pipefail
       cd "$DEVENV_ROOT"
 
-      bun scripts/src/commands/changesets.ts check-pr --base "''${CHANGESET_BASE_REF:-origin/dev}"
+      bun scripts/src/commands/changesets.ts check-pr --base "''${CHANGESET_BASE_REF:-origin/main}"
     '';
   };
 
@@ -310,7 +310,7 @@ in
       set -euo pipefail
       cd "$DEVENV_ROOT"
 
-      DT_PASSTHROUGH=1 pnpm exec changeset status --since "''${CHANGESET_BASE_REF:-origin/dev}"
+      DT_PASSTHROUGH=1 pnpm exec changeset status --since "''${CHANGESET_BASE_REF:-origin/main}"
     '';
     after = [ "pnpm:install" ];
   };

--- a/docs/src/content/docs/building-with-livestore/events.mdx
+++ b/docs/src/content/docs/building-with-livestore/events.mdx
@@ -226,7 +226,7 @@ On the client, sequence numbers are expanded to track additional information for
 
 Events can be represented as strings like `e5` (global event 5), `e5.1` (client-local event), or `e5r1` (after a rebase).
 
-For the full type definitions, see [`LiveStoreEvent`](https://github.com/livestorejs/livestore/tree/dev/packages/@livestore/common/src/schema/LiveStoreEvent) and [`EventSequenceNumber`](https://github.com/livestorejs/livestore/tree/dev/packages/@livestore/common/src/schema/EventSequenceNumber).
+For the full type definitions, see [`LiveStoreEvent`](https://github.com/livestorejs/livestore/tree/main/packages/@livestore/common/src/schema/LiveStoreEvent) and [`EventSequenceNumber`](https://github.com/livestorejs/livestore/tree/main/packages/@livestore/common/src/schema/EventSequenceNumber).
 
 ### Event type namespaces
 

--- a/docs/src/content/docs/building-with-livestore/tools/cli.mdx
+++ b/docs/src/content/docs/building-with-livestore/tools/cli.mdx
@@ -38,7 +38,7 @@ livestore new-project
 livestore new-project --example web-todomvc my-project
 
 # Use specific branch
-livestore new-project --branch dev
+livestore new-project --branch main
 ```
 
 ### `livestore mcp`

--- a/docs/src/content/docs/patterns/list-ordering.mdx
+++ b/docs/src/content/docs/patterns/list-ordering.mdx
@@ -87,7 +87,7 @@ Since fractional index values maintain lexicographic ordering, you can use simpl
 
 ## Real-World Example
 
-The [web-linearlite example](https://github.com/livestorejs/livestore/tree/dev/examples/web-linearlite) demonstrates fractional indexing for Kanban board ordering. It shows:
+The [web-linearlite example](https://github.com/livestorejs/livestore/tree/main/examples/web-linearlite) demonstrates fractional indexing for Kanban board ordering. It shows:
 - Schema definition with `kanbanorder` column
 - Creating issues with proper ordering
 - Drag-and-drop reordering across columns

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -41,7 +41,7 @@ There are many ways to contribute to LiveStore.
 - Monorepo setup changes
 - Changes to the docs site/setup
 
-**Note:** For significant changes to public APIs or core architecture, consider writing an [RFC (Request for Comments)](https://github.com/livestorejs/livestore/tree/dev/contributor-docs/rfcs) first to gather feedback before implementation.
+**Note:** For significant changes to public APIs or core architecture, consider writing an [RFC (Request for Comments)](https://github.com/livestorejs/livestore/tree/main/contributor-docs/rfcs) first to gather feedback before implementation.
 
 ### Out of scope (for now)
 

--- a/docs/src/content/docs/sustainable-open-source/contributing/monorepo.mdx
+++ b/docs/src/content/docs/sustainable-open-source/contributing/monorepo.mdx
@@ -152,7 +152,7 @@ Most-used tasks:
   example workflows
 
 Release workflows are documented in
-[`contributor-docs/release-workflows.md`](https://github.com/livestorejs/livestore/blob/dev/contributor-docs/release-workflows.md).
+[`contributor-docs/release-workflows.md`](https://github.com/livestorejs/livestore/blob/main/contributor-docs/release-workflows.md).
 
 ## Tasks to run before committing
 
@@ -214,7 +214,7 @@ export VITE_OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
   edit the `.genie.ts` and run `dt genie:run` (or let the pre-commit hook run
   it) rather than editing generated `package.json` files directly.
 - For updating dependencies across the monorepo, see
-  [`contributor-docs/dependency-management.md`](https://github.com/livestorejs/livestore/blob/dev/contributor-docs/dependency-management.md)
+  [`contributor-docs/dependency-management.md`](https://github.com/livestorejs/livestore/blob/main/contributor-docs/dependency-management.md)
   (catalog policy, peer-dep handling, validation).
 
 ### Notes on external dependencies
@@ -241,7 +241,7 @@ The following packages need to be updated with extra care:
 #### Updating dependencies
 
 See
-[dependency-management.md](https://github.com/livestorejs/livestore/blob/dev/contributor-docs/dependency-management.md)
+[dependency-management.md](https://github.com/livestorejs/livestore/blob/main/contributor-docs/dependency-management.md)
 for the full workflow.
 
 ### Notes on monorepo structure

--- a/docs/src/content/docs/tutorial/1-setup-starter-project.mdx
+++ b/docs/src/content/docs/tutorial/1-setup-starter-project.mdx
@@ -10,7 +10,7 @@ import StateAndUiDiagram from '../../_assets/diagrams/tutorial-chapter-1-1-state
 
 ## Set up a starter project with React, Vite & Tailwind
 
-We have prepared a [starter project](https://github.com/livestorejs/livestore/tree/dev/examples/tutorial-starter) for you that you can use as a starting point for the tutorial. Download it via the following command:
+We have prepared a [starter project](https://github.com/livestorejs/livestore/tree/main/examples/tutorial-starter) for you that you can use as a starting point for the tutorial. Download it via the following command:
 
 <Tabs syncKey="package-manager">
 

--- a/packages/@livestore/cli/src/commands/new-project.ts
+++ b/packages/@livestore/cli/src/commands/new-project.ts
@@ -222,7 +222,7 @@ export const createCommand = Cli.Command.make(
       Cli.Options.withAlias('commit'),
       Cli.Options.withAlias('branch'),
       Cli.Options.withAlias('tag'),
-      Cli.Options.withDefault('dev'),
+      Cli.Options.withDefault('main'),
       Cli.Options.withDescription(
         'The name of the commit/branch/tag to fetch examples from. Pull requests refs must be fully-formed (e.g., `refs/pull/123/merge`).',
       ),

--- a/scripts/src/commands/changesets.ts
+++ b/scripts/src/commands/changesets.ts
@@ -81,7 +81,7 @@ const checkPr = (flags: Map<string, string | true>) => {
     return
   }
 
-  const base = readFlag(flags, 'base') ?? process.env.CHANGESET_BASE_REF ?? 'origin/dev'
+  const base = readFlag(flags, 'base') ?? process.env.CHANGESET_BASE_REF ?? 'origin/main'
   const files = changedFiles(base)
   const publicPackageDirs = publicLivestorePackages().map((pkg) => `${pkg.dir}/`)
   const packageFilesChanged = files.some((file) => publicPackageDirs.some((dir) => file.startsWith(dir)))

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -107,7 +107,7 @@ const syncRulesetsCommand = Cli.Command.make(
   {
     branch: Cli.Options.choice('branch', ['dev', 'main'] as const).pipe(
       Cli.Options.withDescription('Ruleset variant to sync from generated repo-settings file'),
-      Cli.Options.withDefault('dev'),
+      Cli.Options.withDefault('main'),
     ),
     dryRun: Cli.Options.boolean('dry-run').pipe(Cli.Options.withDefault(false)),
   },
@@ -140,7 +140,7 @@ const showRulesetsCommand = Cli.Command.make(
   {
     branch: Cli.Options.choice('branch', ['dev', 'main'] as const).pipe(
       Cli.Options.withDescription('Ruleset variant to show'),
-      Cli.Options.withDefault('dev'),
+      Cli.Options.withDefault('main'),
     ),
   },
   Effect.fn(function* ({ branch }) {


### PR DESCRIPTION
Prepares LiveStore to use `main` as the default branch again.

This updates release workflow targets, Changesets baseline defaults, contributor docs, CLI starter defaults, generated workflow YAML, and public docs links from `dev` to `main`. The branch still targets `dev` so we can land the migration under the current default branch first; after merge, `main` can be updated to the same commit and then selected as the GitHub default branch.

The PR also includes a small patch changeset for the CLI starter default-branch behavior, so the release-intent check continues to model package-facing changes explicitly. PR release validation now uses a synthetic unpublished plan unless the PR itself changes `release/release-plan.json`; this keeps release-tooling PRs testable after the currently checked-in plan has already been published.

## Rationale

With PR-driven release planning and explicit release publishing, `dev` no longer needs to encode “next unreleased work”. Using `main` as the default branch aligns with ecosystem conventions and removes special-case branch handling from release automation and documentation.

## Verification

- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:run --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:check --mode before --no-tui`
- `CI=1 oxlint .github/workflows/release.yml.genie.ts scripts/src/commands/changesets.ts scripts/src/commands/github.ts packages/@livestore/cli/src/commands/new-project.ts`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run ts:build --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run release:changeset:check-pr --mode before`
- Synthetic `release/release-plan.json` + `CI=1 DT_PASSTHROUGH=1 devenv tasks run release:stable:dryrun --mode before --no-tui`

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-04-26-genie-snapshot-version/tmp/livestore-main-migration-fresh |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->