### PR TITLE
Document and lock down release workflows

### DIFF
--- a/.changeset/empty-release-docs-guardrails.md
+++ b/.changeset/empty-release-docs-guardrails.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. This updates release workflow documentation and guardrails.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Release-sensitive repository policy and release automation.
+/.github/ @schickling
+/.changeset/ @schickling
+/release/ @schickling
+/scripts/src/commands/changesets.ts @schickling
+/scripts/src/commands/devtools-artifact.ts @schickling
+/scripts/src/commands/release.ts @schickling
+

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -14,7 +14,7 @@
       "parameters": {
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
-        "require_code_owner_review": false,
+        "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true
       }

--- a/.github/repo-settings.json.genie.ts
+++ b/.github/repo-settings.json.genie.ts
@@ -17,7 +17,7 @@ export default githubRuleset({
       parameters: {
         required_approving_review_count: 1,
         dismiss_stale_reviews_on_push: false,
-        require_code_owner_review: false,
+        require_code_owner_review: true,
         require_last_push_approval: false,
         required_review_thread_resolution: true,
       },

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,8 +6,8 @@ generated YAML directly. `sync-docs.yml` is currently handwritten.
 
 ## `ci.yml`
 
-Primary validation workflow for pull requests, `main`/`dev` pushes, and manual
-workflow-dispatch runs.
+Primary validation workflow for pull requests, `main` pushes, and manual
+workflow-dispatch runs. `main` is the canonical default and release branch.
 
 It runs the normal repository quality gates: linting, Changesets release-intent
 checks, TypeScript builds, unit tests, integration tests, Playwright tests,
@@ -44,13 +44,13 @@ the release group and the matching public DevTools artifact package. In normal
 operation this happens when the supervised release PR is merged.
 
 Manual dispatch with `mode=publish-release` reruns the publish job for the
-checked-in release plan. Use it only after confirming the current `dev` release
+checked-in release plan. Use it only after confirming the current `main` release
 plan is still the intended release; the publisher is idempotent for already
 published packages.
 
 The publish job uses the repository `NPM_TOKEN` secret. Snapshot publishing uses
-npm trusted publishing from `ci.yml`; stable/dev release publishing should move
-to trusted publishing too once `release.yml` is authorized for the npm packages.
+npm trusted publishing from `ci.yml`; release publishing should move to trusted
+publishing too once `release.yml` is authorized for the npm packages.
 
 ## `devtools-artifact.yml`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2583,6 +2583,8 @@ jobs:
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-24.04
     needs: [test-unit, test-integration-node-sync, test-integration-sync-provider, test-integration-playwright]
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     defaults:
       run:
         shell: bash
@@ -2700,6 +2702,12 @@ jobs:
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
         shell: bash
+      - name: Configure npm token fallback
+        run: |
+          set -euo pipefail
+          : "${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
+          printf '%s\n' "always-auth=true" > "$HOME/.npmrc"
+          printf '%s\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"
       - name: Publish snapshot version
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -301,7 +301,8 @@ done`,
     /**
      * Publish job runs on GitHub-hosted runner (not Namespace) because npm OIDC
      * trusted publishing with --provenance requires sigstore, which only supports
-     * GitHub-hosted runners.
+     * GitHub-hosted runners. We still configure the npm token fallback to avoid
+     * interactive auth if trusted publishing is unavailable for a package.
      */
     'publish-snapshot-version': {
       if: IS_NOT_FORK,
@@ -312,9 +313,19 @@ done`,
         'test-integration-sync-provider',
         'test-integration-playwright',
       ],
+      env: {
+        NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}',
+      },
       defaults: bashShellDefaults,
       steps: withNixDiagnosticsOnFailure([
         ...livestoreSetupSteps,
+        {
+          name: 'Configure npm token fallback',
+          run: `set -euo pipefail
+: "\${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
+printf '%s\\n' "always-auth=true" > "$HOME/.npmrc"
+printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"`,
+        },
         {
           name: 'Publish snapshot version',
           run: runDevenvTasksBefore('release:snapshot:git-sha'),

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -7,7 +7,7 @@ and validate a release-plan PR.
 
 ## Release intent
 
-Changesets are the release-intent ledger for public LiveStore package changes.
+Changesets are the release-intent ledger for LiveStore pull requests.
 The public `@livestore/*` packages are configured as a fixed Changesets group,
 so any accepted changeset bumps the whole LiveStore release group together.
 
@@ -16,11 +16,10 @@ generated release notes replace it. Maintainers fold PR-level changeset
 information into the handcrafted changelog structure before cutting a stable
 release.
 
-PRs that change public package files must include one of:
+Every PR must include one of:
 
 - A regular `.changeset/*.md` file for release-impacting changes.
-- An empty changeset for package-affecting changes that do not need release
-  notes.
+- An empty changeset for changes that do not need release notes.
 
 ```bash
 pnpm exec changeset
@@ -83,6 +82,14 @@ The preferred flow is:
 3. Review the release-plan PR and wait for CI to pass.
 4. Merge the release-plan PR into `main`.
 5. Let the push-triggered `Release` workflow publish the release group.
+
+Release plans are validated against the npm dist-tag before dry-run or publish:
+
+- `latest` only accepts stable versions such as `0.4.0`.
+- `dev` only accepts dev prereleases such as `0.4.0-dev.24`.
+- Other non-`latest` tags only accept prerelease versions.
+- `snapshot` is reserved for CI snapshot publishing and cannot be used through
+  `release.yml`.
 
 The release-plan PR validates the exact work that will run after merge:
 
@@ -160,6 +167,7 @@ artifact as `@livestore/devtools-vite@<livestore-version>`.
 
 ## Safety rules
 
+- `main` is the only canonical release branch. Do not cut releases from `dev`.
 - Do not add non-public DevTools source, internal paths, credentials, or local
   machine details to this repository.
 - Do not paste secrets into release plans, PR descriptions, workflow inputs, or
@@ -178,3 +186,5 @@ artifact as `@livestore/devtools-vite@<livestore-version>`.
 - Do not publish patch, minor, or major releases while testing this Changesets
   integration. Use snapshots and non-`latest` prerelease tags until the final
   supervised release.
+- Release-sensitive files are code-owned and should be reviewed by a maintainer:
+  `.github/`, `.changeset/`, `release/`, and release command scripts.

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -60,6 +60,22 @@ Please get in touch if you'd like to discuss any of these topics!
 
 - Please include a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) for how to reproduce the bug.
 
+## Pull requests
+
+Every pull request must include a changeset. Use a normal changeset for
+user-visible or package-affecting changes, and use an empty changeset for
+changes that do not need release notes:
+
+```bash
+pnpm exec changeset
+pnpm exec changeset add --empty
+```
+
+See [`.changeset/README.md`](https://github.com/livestorejs/livestore/tree/main/.changeset#readme)
+for the short contributor-facing rule and
+[`contributor-docs/release-workflows.md`](https://github.com/livestorejs/livestore/blob/main/contributor-docs/release-workflows.md)
+for the maintainer release workflow.
+
 ## Guiding principles {#guiding-principles}
 
 - Keep it as simple as possible

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -324,7 +324,7 @@ in
           echo "Error: GIT_SHA is required"
           exit 1
         fi
-        mono release snapshot --git-sha="$GIT_SHA"
+        mono release snapshot --git-sha="$GIT_SHA" --yes
       '';
       after = [ "setup:strict" ];
     };

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -48,6 +48,36 @@ const validateReleaseVersion = (version: string) =>
     ),
   )
 
+const validateReleasePlan = (plan: TReleasePlan) =>
+  validateReleaseVersion(plan.version).pipe(
+    Effect.flatMap((validVersion) =>
+      Effect.sync(() => {
+        const prerelease = semver.prerelease(validVersion)
+
+        if (plan.npmTag === 'snapshot') {
+          throw new Error('The npm tag "snapshot" is reserved for CI snapshot publishing')
+        }
+
+        if (plan.npmTag === 'latest' && prerelease !== null) {
+          throw new Error(`The npm tag "latest" requires a stable version, got ${validVersion}`)
+        }
+
+        if (plan.npmTag === 'dev') {
+          if (prerelease?.[0] !== 'dev') {
+            throw new Error(`The npm tag "dev" requires a dev prerelease version, got ${validVersion}`)
+          }
+          return validVersion
+        }
+
+        if (plan.npmTag !== 'latest' && prerelease === null) {
+          throw new Error(`The npm tag "${plan.npmTag}" requires a prerelease version, got ${validVersion}`)
+        }
+
+        return validVersion
+      }),
+    ),
+  )
+
 const releasePlanPath = (cwd: string) => `${cwd}/release/release-plan.json`
 
 const readReleasePlan = (cwd: string, planPath: string) =>
@@ -56,13 +86,13 @@ const readReleasePlan = (cwd: string, planPath: string) =>
     const absolutePlanPath = planPath.startsWith('/') === true ? planPath : `${cwd}/${planPath}`
     const content = yield* fsEffect.readFileString(absolutePlanPath)
     const plan = yield* Schema.decodeUnknown(ReleasePlan)(JSON.parse(content))
-    yield* validateReleaseVersion(plan.version)
+    yield* validateReleasePlan(plan)
     return plan
   })
 
 const writeReleasePlan = (cwd: string, plan: TReleasePlan) =>
   Effect.gen(function* () {
-    yield* validateReleaseVersion(plan.version)
+    yield* validateReleasePlan(plan)
     const fsEffect = yield* FileSystem.FileSystem
     yield* fsEffect.makeDirectory(`${cwd}/release`, { recursive: true })
     yield* fsEffect.writeFileString(releasePlanPath(cwd), `${JSON.stringify(plan, null, 2)}\n`)


### PR DESCRIPTION
## Summary

- documents the `main`-based release workflow for contributors and maintainers
- adds CODEOWNERS for release-sensitive paths
- updates generated repo settings to require code-owner review
- validates release-plan version/tag combinations before dry-run or publish
- configures CI snapshot publishing with the same npm token fallback as release publishing
- records no release impact with an empty changeset

## Rationale

The release pipeline now uses PR-driven release plans, fixed-group Changesets, and public DevTools artifact repacking. The docs should make the normal operator path obvious, and the automation should reject common wrong release flows before any publish step runs. CODEOWNERS plus the repo ruleset keeps changes to workflow, changeset, release manifest, and release command surfaces under maintainer review.

The release-plan guardrails intentionally allow:

- `latest` with stable versions, e.g. `0.4.0`
- `dev` with dev prereleases, e.g. `0.4.0-dev.24`
- other non-`latest` tags only with prerelease versions

They reject `snapshot` in `release.yml`; snapshots stay in CI snapshot publishing.

Snapshot publishing still runs on GitHub-hosted runners so provenance can work, but now also writes an npm token `.npmrc` before publish. This matches the stable/dev publish path and avoids unauthenticated interactive npm/pnpm behavior if trusted publishing is unavailable for a package.

## Validation

- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:run --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:check --mode before --no-tui`
- `CI=1 oxlint .github/repo-settings.json.genie.ts scripts/src/commands/release.ts`
- `CI=1 oxfmt --check .github/repo-settings.json.genie.ts scripts/src/commands/release.ts .github/workflows/README.md contributor-docs/release-workflows.md docs/src/content/docs/sustainable-open-source/contributing/info.md`
- `CI=1 oxlint .github/workflows/ci.yml.genie.ts`
- `CI=1 oxfmt --check .github/workflows/ci.yml.genie.ts nix/devenv-modules/tasks/local/mono-wrappers.nix .github/workflows/ci.yml`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run release:changeset:check-pr --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run ts:build --mode before --no-tui`
- release-plan guardrail experiment: accepted `0.4.0-dev.24`/`dev` and `0.4.0`/`latest`; rejected prerelease/`latest`, stable/`dev`, and `snapshot` tag

## Follow-up after merge

- sync `main-branch-rules` from `.github/repo-settings.json` so code-owner review is active
- delete the stale live `dev-branch-rules` ruleset from GitHub settings; this account gets `404` on the admin ruleset delete endpoint

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | megarepo-all/schickling/2026-04-26-livestore-release |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->