### PR TITLE
Fix Mixedbread docs sync workflow

### DIFF
--- a/.changeset/empty-mixedbread-store-sync.md
+++ b/.changeset/empty-mixedbread-store-sync.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. This updates docs CI for the current Mixedbread CLI and the new `main` branch release model.

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
           MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
-        run: mxbai vs sync "${MXBAI_VECTOR_STORE_ID}" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
+        run: mxbai store sync "${MXBAI_VECTOR_STORE_ID}" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,8 +11,8 @@
     "astro": "astro",
     "build": "astro check && astro build",
     "dev": "astro dev",
-    "dev:docs:sync": "mxbai vs sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\"  --yes --strategy fast",
-    "dev:docs:sync:dry-run": "mxbai vs sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\" --dry-run",
+    "dev:docs:sync": "mxbai store sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\"  --yes --strategy fast",
+    "dev:docs:sync:dry-run": "mxbai store sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\" --dry-run",
     "preview": "astro preview",
     "start": "astro dev"
   },

--- a/docs/package.json.genie.ts
+++ b/docs/package.json.genie.ts
@@ -99,9 +99,9 @@ export default packageJson(
       build: 'astro check && astro build',
       dev: 'astro dev',
       'dev:docs:sync':
-        'mxbai vs sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md"  --yes --strategy fast',
+        'mxbai store sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md"  --yes --strategy fast',
       'dev:docs:sync:dry-run':
-        'mxbai vs sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md" --dry-run',
+        'mxbai store sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md" --dry-run',
       preview: 'astro preview',
       start: 'astro dev',
     },

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -394,7 +394,19 @@ export const docsCommand = Cli.Command.make('docs').pipe(
                 : branchName === 'main' || branchName === devBranchName
 
           if (prod === true && site === 'livestore-docs' && liveStoreVersion.includes('dev') === true) {
-            return yield* Effect.die('Cannot deploy docs for dev version of LiveStore to prod')
+            yield* Effect.logWarning(
+              `Skipping prod docs deploy for dev version ${liveStoreVersion}; docs were built but prod deploy waits for a stable release version.`,
+            )
+            yield* appendGithubSummaryMarkdown({
+              context: 'docs deploy',
+              markdown: [
+                '## Docs deploy',
+                '',
+                `Skipped production docs deploy for dev version \`${liveStoreVersion}\`.`,
+                '',
+              ].join('\n'),
+            })
+            return
           }
 
           const deployAliasLabel =


### PR DESCRIPTION
## Summary

- update the docs vector-store sync workflow for Mixedbread CLI v2 (`mxbai store sync`)
- update the matching generated docs package scripts
- skip production docs deploy when `main` currently carries a dev prerelease version
- add an empty changeset because this has no package release impact

## Rationale

Two post-merge `main` checks exposed assumptions from the previous branch model. The docs vector-store workflow installs the current `@mixedbread/cli`, where `mxbai vs` has been removed in favor of `mxbai store`. Separately, `main` is now the default branch even while package versions can still be `0.4.0-dev.*`, so docs should still build on `main` but must not deploy dev-version docs to production.

The deploy command now exits successfully with an explicit skip summary for dev prerelease versions, preserving the production guard without making `main` CI red until the supervised stable release.

## Validation

- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:run --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run genie:check --mode before --no-tui`
- `CI=1 oxfmt --check scripts/src/commands/docs.ts docs/package.json.genie.ts docs/package.json .github/workflows/sync-docs.yml .changeset/empty-mixedbread-store-sync.md`
- `CI=1 oxlint scripts/src/commands/docs.ts docs/package.json.genie.ts`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run release:changeset:check-pr --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run ts:build --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run test:unit --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 GITHUB_ACTIONS=true GITHUB_REF_NAME=main GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=livestorejs/livestore GITHUB_RUN_ID=local devenv shell -- scripts/bin/mono docs deploy`
- `bunx @mixedbread/cli store sync --help`

Refs failing post-merge runs:
- docs vector-store sync: https://github.com/livestorejs/livestore/actions/runs/25162777579
- docs deploy on dev version: https://github.com/livestorejs/livestore/actions/runs/25162777573

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌱 co1-alder |
| `agent_session_id` | 6c624c62-4e38-435e-b267-475ef99d9340 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | codex-cli 0.124.0 |
| `agent_runtime` | Codex CLI codex-cli 0.124.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-04-26-genie-snapshot-version/tmp/release-docs-guardrails |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@19cf6f4 |
</details>
<!-- agent-footer:end -->