### PR TITLE
Align release deploy targets

### DIFF
--- a/.changeset/empty-release-deploy-targets.md
+++ b/.changeset/empty-release-deploy-targets.md
@@ -1,0 +1,4 @@
+---
+---
+
+No package release note required for release deployment target guardrails.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ workflow-dispatch runs. `main` is the canonical default and release branch.
 
 It runs the normal repository quality gates: linting, Changesets release-intent
 checks, TypeScript builds, unit tests, integration tests, Playwright tests,
-performance tests, docs/examples builds, snapshot publishing, DevTools artifact
+performance tests, docs/examples builds, dev docs/examples deploys, snapshot publishing, DevTools artifact
 snapshot publishing, and create-example smoke tests.
 
 The snapshot and create-example jobs are intentionally part of CI. They verify
@@ -40,13 +40,16 @@ repack path. This checks the stable release machinery without publishing a
 stable release.
 
 On push to `main` when `release/release-plan.json` changes, the workflow publishes
-the release group and the matching public DevTools artifact package. In normal
-operation this happens when the supervised release PR is merged.
+the release group and the matching public DevTools artifact package. For stable
+`latest` releases it then deploys the production docs, production examples, and
+production docs search index. In normal operation this happens when the
+supervised release PR is merged.
 
 Manual dispatch with `mode=publish-release` reruns the publish job for the
 checked-in release plan. Use it only after confirming the current `main` release
 plan is still the intended release; the publisher is idempotent for already
-published packages.
+published packages, but production deploys still reflect the checked-in release
+state.
 
 The publish job uses the repository `NPM_TOKEN` secret. Snapshot publishing uses
 npm trusted publishing from `ci.yml`; release publishing should move to trusted
@@ -76,7 +79,9 @@ review.
 ## `sync-docs.yml`
 
 Synchronizes documentation Markdown/MDX files from `main` into the Mixedbread
-vector store used by docs search/RAG tooling.
+vector store used by docs search/RAG tooling. Pushes to `main` update the dev
+search index. Manual dispatch can target either `dev` or `prod`; production
+sync is also run by the stable release publish workflow.
 
 It runs on pushes to `main` that touch docs content and can also be dispatched
 manually. It is separate from the docs build/deploy jobs in `ci.yml`: CI verifies

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,6 +14,13 @@ checks, TypeScript builds, unit tests, integration tests, Playwright tests,
 performance tests, docs/examples builds, dev docs/examples deploys, snapshot publishing, DevTools artifact
 snapshot publishing, and create-example smoke tests.
 
+Docs deployment uses `mono docs deploy`. Normal `main` pushes update the dev
+Netlify site, pull requests publish sticky and commit-specific aliases on the
+dev site, and stable release publishing is the only workflow path that updates
+the production docs domain. Use `mono docs deploy --plan` when changing deploy
+routing logic; it prints the resolved site and target without building or
+deploying.
+
 The snapshot and create-example jobs are intentionally part of CI. They verify
 that the exact commit under test can publish snapshot packages and that users
 can create projects from those snapshots. Forked PRs skip jobs that require

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   workflow_dispatch: {}
   pull_request: {}
 

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -84,8 +84,8 @@ export default githubWorkflow({
 
   on: {
     push: {
-      // Only run on pushes to main/dev to keep docs deploys consistent
-      branches: ['main', 'dev'],
+      // Only main is an integration branch. Regular pushes deploy dev docs/examples surfaces.
+      branches: ['main'],
     },
     workflow_dispatch: {},
     pull_request: {},
@@ -369,9 +369,9 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
      * Docs deployment mapping (authoritative, with domains) — handled by `mono docs deploy`:
      * - pull_request (any base): deploy alias on dev docs site (no purge)
      *     example domain: https://<alias>--livestore-docs-dev.netlify.app
-     * - push to dev: deploy to dev docs site as prod
+     * - push to main: deploy to dev docs site as prod
      *     domain: https://dev.docs.livestore.dev
-     * - push to main: deploy to prod docs site as prod
+     * - stable release publish: release.yml deploys prod docs explicitly
      *     domain: https://docs.livestore.dev
      * `mono docs deploy` applies filter="docs" and infers context from GitHub env.
      */
@@ -437,7 +437,7 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
     //     'test-integration-sync-provider',
     //     'test-integration-playwright',
     //   ],
-    //   if: "(github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push'",
+    //   if: "github.ref == 'refs/heads/main' && github.event_name == 'push'",
     //   steps: [dispatchAlignmentStep({ targetRepo: 'schickling/megarepo-all' })],
     // },
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -605,8 +605,16 @@ jobs:
         run: |
           set -euo pipefail
           release_version="$(jq -r '.version' release/release-plan.json)"
+          npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
           : "${release_version:?Missing release version}"
+          : "${npm_tag:?Missing npm tag}"
           echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
+          if [ "$npm_tag" = "latest" ]; then
+            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
+          else
+            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
+          fi
       - name: Dry-run DevTools artifact repack
         run: |
           __nix_gc_retry_helper=$(mktemp)
@@ -1090,6 +1098,243 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:publish:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:publish:no-install --mode before'
+      - name: Deploy production docs
+        if: env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run docs:deploy:prod --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:deploy:prod --mode before'
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      - name: Deploy production examples
+        if: env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run examples:deploy:prod --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run examples:deploy:prod --mode before'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Sync production docs search
+        if: env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'
+        run: |
+          set -euo pipefail
+          : "${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
+          : "${MXBAI_VECTOR_STORE_ID_PROD:?Missing MXBAI_VECTOR_STORE_ID_PROD secret}"
+          pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID_PROD" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
+        env:
+          MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
+          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -204,8 +204,16 @@ jq -n \\
           name: 'Read release plan',
           run: `set -euo pipefail
 release_version="$(jq -r '.version' release/release-plan.json)"
+npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
 : "\${release_version:?Missing release version}"
-echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"`,
+: "\${npm_tag:?Missing npm tag}"
+echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
+if [ "$npm_tag" = "latest" ]; then
+  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
+else
+  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
+fi`,
         },
         {
           name: 'Dry-run DevTools artifact repack',
@@ -248,6 +256,35 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
         {
           name: 'Publish DevTools artifact release',
           run: runDevenvTasksBefore('release:devtools-artifact:publish:no-install'),
+        },
+        {
+          name: 'Deploy production docs',
+          if: "env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'",
+          run: runDevenvTasksBefore('docs:deploy:prod'),
+          env: {
+            NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}',
+          },
+        },
+        {
+          name: 'Deploy production examples',
+          if: "env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'",
+          run: runDevenvTasksBefore('examples:deploy:prod'),
+          env: {
+            CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}',
+            CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}',
+          },
+        },
+        {
+          name: 'Sync production docs search',
+          if: "env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'",
+          run: `set -euo pipefail
+: "\${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
+: "\${MXBAI_VECTOR_STORE_ID_PROD:?Missing MXBAI_VECTOR_STORE_ID_PROD secret}"
+pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID_PROD" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast`,
+          env: {
+            MXBAI_API_KEY: '${{ secrets.MXBAI_API_KEY }}',
+            MXBAI_VECTOR_STORE_ID_PROD: '${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}',
+          },
         },
       ]),
     },

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -2,6 +2,15 @@ name: Sync docs to Mixedbread Vector Store
 
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Docs search target to sync'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - prod
   push:
     branches: [main]
     paths:
@@ -19,18 +28,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.0.0-rc.5
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-
-      - name: Install Mixedbread CLI
-        run: npm i -g @mixedbread/cli
 
       - name: Sync vector store
         shell: bash
         working-directory: ./docs
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
-          MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
-        run: mxbai store sync "${MXBAI_VECTOR_STORE_ID}" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
+          MXBAI_VECTOR_STORE_ID_DEV: ${{ secrets.MXBAI_VECTOR_STORE_ID_DEV }}
+          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
+          MXBAI_VECTOR_STORE_ID_LEGACY: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
+          SYNC_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'dev' }}
+        run: |
+          set -euo pipefail
+          : "${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
+
+          if [ "$SYNC_TARGET" = "prod" ]; then
+            vector_store_id="${MXBAI_VECTOR_STORE_ID_PROD:-}"
+          else
+            vector_store_id="${MXBAI_VECTOR_STORE_ID_DEV:-${MXBAI_VECTOR_STORE_ID_LEGACY:-}}"
+          fi
+
+          : "${vector_store_id:?Missing Mixedbread vector store id for target ${SYNC_TARGET}}"
+          pnpm dlx @mixedbread/cli@2.3.2 store sync "$vector_store_id" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast

--- a/contributor-docs/examples-cloudflare.md
+++ b/contributor-docs/examples-cloudflare.md
@@ -4,9 +4,9 @@ LiveStore examples ship via Cloudflare Workers using the `mono examples deploy` 
 
 ## Branch Behaviour
 
-- `main` → builds production artifacts and deploys the Worker named `example-<slug>`, served at `https://example-<slug>.livestore.workers.dev`.
-- `dev` → deploys `example-<slug>-dev`, served at `https://example-<slug>-dev.livestore.workers.dev`.
-- Any other branch → builds the shared preview Worker named `example-<slug>-preview`, available at `https://example-<slug>-preview.livestore.workers.dev`. Use `--prod` to force a production publish when working on a feature branch.
+- `main` → deploys the dev Worker named `example-<slug>-dev`, served at `https://example-<slug>-dev.livestore.workers.dev`.
+- Pull requests and feature branches → build the shared preview Worker named `example-<slug>-preview`, available at `https://example-<slug>-preview.livestore.workers.dev`.
+- Stable release publishing → passes `--prod`, deploys the Worker named `example-<slug>`, and serves it at `https://example-<slug>.livestore.workers.dev`.
 
 The script uses the directory name inside `/examples` as the `<slug>` (for example `web-todomvc`).
 
@@ -26,7 +26,7 @@ The script uses the directory name inside `/examples` as the `<slug>` (for examp
 ```bash
 direnv exec . mono examples deploy              # build + deploy all configured examples
 direnv exec . mono examples deploy --example-filter web-
-direnv exec . mono examples deploy --prod       # force a prod push regardless of branch
+direnv exec . mono examples deploy --prod       # stable release versions only
 ```
 
 The command builds examples in parallel (three at a time) and retries Worker uploads twice. Preview Workers are accessible exclusively via their Workers.dev host names.

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -101,6 +101,12 @@ After merge to `main`, the push-triggered workflow runs:
 
 - `release:stable:publish`
 - `release:devtools-artifact:publish:no-install`
+- For stable `latest` releases only: `docs:deploy:prod`,
+  `examples:deploy:prod`, and the production docs search sync.
+
+Normal CI deploys docs/examples to the dev surfaces. Production docs, examples,
+and search are only updated by an explicit stable release publish so regular
+`main` integration work cannot accidentally update the public latest surfaces.
 
 ## Local stable release checks
 
@@ -168,6 +174,8 @@ artifact as `@livestore/devtools-vite@<livestore-version>`.
 ## Safety rules
 
 - `main` is the only canonical release branch. Do not cut releases from `dev`.
+- Do not use `--prod` docs/examples deploys for snapshots or prereleases. The
+  deploy commands reject non-stable LiveStore versions.
 - Do not add non-public DevTools source, internal paths, credentials, or local
   machine details to this repository.
 - Do not paste secrets into release plans, PR descriptions, workflow inputs, or

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -35,11 +35,11 @@ const branch = getBranchName()
 const domain =
   process.env.DEPLOY_PRIME_URL !== undefined
     ? new URL(process.env.DEPLOY_PRIME_URL).hostname
-    : process.env.NODE_ENV === 'production'
-      ? branch === 'main'
-        ? 'docs.livestore.dev'
-        : 'dev.docs.livestore.dev'
-      : `localhost:${port}`
+    : process.env.LIVESTORE_DOCS_SITE_URL !== undefined
+      ? new URL(process.env.LIVESTORE_DOCS_SITE_URL).hostname
+      : process.env.NODE_ENV === 'production'
+        ? 'dev.docs.livestore.dev'
+        : `localhost:${port}`
 
 const site = `https://${domain}`
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "build": "astro check && astro build",
     "dev": "astro dev",
     "dev:docs:sync": "mxbai store sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\"  --yes --strategy fast",
+    "prod:docs:sync": "mxbai store sync \"livestore-docs\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\" --yes --strategy fast",
     "dev:docs:sync:dry-run": "mxbai store sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\" --dry-run",
     "preview": "astro preview",
     "start": "astro dev"
@@ -53,7 +54,7 @@
     "@local/astro-tldraw": "workspace:^",
     "@local/astro-twoslash-code": "workspace:^",
     "@local/shared": "workspace:^",
-    "@mixedbread/cli": "1.2.1",
+    "@mixedbread/cli": "2.3.2",
     "@mixedbread/sdk": "0.28.1",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",

--- a/docs/package.json.genie.ts
+++ b/docs/package.json.genie.ts
@@ -55,7 +55,7 @@ const runtimeDeps = catalog.compose({
       '@astrojs/netlify': '6.5.9',
       '@astrojs/react': '4.3.0',
       '@astrojs/starlight-tailwind': '4.0.1',
-      '@mixedbread/cli': '1.2.1',
+      '@mixedbread/cli': '2.3.2',
       '@mixedbread/sdk': '0.28.1',
       '@tailwindcss/vite': '4.1.18',
       'astro-d2': '0.8.1',
@@ -100,6 +100,8 @@ export default packageJson(
       dev: 'astro dev',
       'dev:docs:sync':
         'mxbai store sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md"  --yes --strategy fast',
+      'prod:docs:sync':
+        'mxbai store sync "livestore-docs" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast',
       'dev:docs:sync:dry-run':
         'mxbai store sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md" --dry-run',
       preview: 'astro preview',

--- a/docs/src/content/docs/getting-started/expo.mdx
+++ b/docs/src/content/docs/getting-started/expo.mdx
@@ -29,7 +29,7 @@ export const SNIPPETS = {
   listTodos: ListTodosSnippet,
 }
 
-{/* We're adjusting the package to use the dev version on the dev branch */}
+{/* We're adjusting package versions when the docs are built from a dev prerelease */}
 export const manualInstallDepsStr = [
   '@livestore/devtools-expo' + versionNpmSuffix,
   '@livestore/adapter-expo' + versionNpmSuffix,

--- a/docs/src/content/docs/getting-started/react-web.mdx
+++ b/docs/src/content/docs/getting-started/react-web.mdx
@@ -30,7 +30,7 @@ export const SNIPPETS = {
   worker: WorkerSnippet,
 }
 
-{/* We're adjusting the package to use the dev version on the dev branch */}
+{/* We're adjusting package versions when the docs are built from a dev prerelease */}
 export const manualInstallDepsStr = [
   '@livestore/livestore' + versionNpmSuffix,
   '@livestore/wa-sqlite' + versionNpmSuffix,

--- a/docs/src/content/docs/getting-started/vue.mdx
+++ b/docs/src/content/docs/getting-started/vue.mdx
@@ -16,7 +16,7 @@ import AppSnippet from '../../_assets/code/getting-started/vue/app.vue?snippet'
 import CommitEventsSnippet from '../../_assets/code/getting-started/vue/commit-events.vue?snippet'
 import QueriesSnippet from '../../_assets/code/getting-started/vue/queries.vue?snippet'
 
-{/* We're adjusting the package to use the dev version on the dev branch */}
+{/* We're adjusting package versions when the docs are built from a dev prerelease */}
 export const manualInstallDepsStr = [
   '@livestore/livestore' + versionNpmSuffix,
   '@livestore/wa-sqlite' + versionNpmSuffix,

--- a/docs/src/content/docs/sustainable-open-source/contributing/docs.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/docs.md
@@ -93,8 +93,8 @@ For snippet guidelines, see: `/contributor-docs/docs/snippets.md`
 
 ## Deploying the docs
 
-- Run `direnv exec . mono docs deploy` to build and deploy the documentation to the dev domain (`https://dev.docs.livestore.dev`).
-- Passing `--prod` targets the production domain (`https://docs.livestore.dev`) when you are on `main` (otherwise the command deploys using a branch alias).
+- Run `direnv exec . mono docs deploy` to deploy the already-built documentation to the dev Netlify site. On `main`, this updates the dev domain (`https://dev.docs.livestore.dev`); on pull requests and feature branches, it uses a branch alias on the dev site.
+- Passing `--prod` targets the production domain (`https://docs.livestore.dev`) and is only allowed for stable LiveStore release versions.
 - Use `--site=<slug>` if you need to override the default Netlify site name.
 - Add `--purge-cdn` when you need to invalidate Netlify's CDN cache after deploying; this ensures new edge handlers or content-negotiation changes take effect immediately.
-- CI automatically builds and deploys the docs: `main` updates `https://docs.livestore.dev`, `dev` updates `https://dev.docs.livestore.dev`, and feature branches publish to the dev domain behind a branch alias.
+- CI automatically builds and deploys the docs: normal `main` pushes update `https://dev.docs.livestore.dev`, pull requests publish aliases on the dev site, and the release workflow updates `https://docs.livestore.dev` only after publishing a stable release.

--- a/docs/src/content/docs/sustainable-open-source/contributing/docs.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/docs.md
@@ -96,5 +96,6 @@ For snippet guidelines, see: `/contributor-docs/docs/snippets.md`
 - Run `direnv exec . mono docs deploy` to deploy the already-built documentation to the dev Netlify site. On `main`, this updates the dev domain (`https://dev.docs.livestore.dev`); on pull requests and feature branches, it uses a branch alias on the dev site.
 - Passing `--prod` targets the production domain (`https://docs.livestore.dev`) and is only allowed for stable LiveStore release versions.
 - Use `--site=<slug>` if you need to override the default Netlify site name.
+- Use `--plan` to print the resolved deploy target without building or deploying. This is the safest way to verify whether a CI event would update the dev site, create PR aliases, or target the production site before running a live deploy.
 - Add `--purge-cdn` when you need to invalidate Netlify's CDN cache after deploying; this ensures new edge handlers or content-negotiation changes take effect immediately.
 - CI automatically builds and deploys the docs: normal `main` pushes update `https://dev.docs.livestore.dev`, pull requests publish aliases on the dev site, and the release workflow updates `https://docs.livestore.dev` only after publishing a stable release.

--- a/docs/src/data/data.ts
+++ b/docs/src/data/data.ts
@@ -29,7 +29,7 @@ export const makeTiged = (example: string, approach: 'bunx' | 'pnpm dlx' | 'npx'
 
 export const makeCreate = (example: string, approach: 'bunx' | 'pnpm dlx' | 'npx' | 'yarn dlx') => {
   const branch = getBranchName()
-  const branchFlag = branch !== 'dev' ? ` --branch ${branch}` : ''
+  const branchFlag = branch !== 'main' ? ` --branch ${branch}` : ''
   const packageName = `@livestore/cli${npmTagSuffix}`
   return `${approach} ${packageName} create --example ${example}${branchFlag} livestore-app`
 }

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -224,6 +224,11 @@ in
       exec = "mono docs deploy";
     };
 
+    "docs:deploy:prod" = {
+      description = "Build and deploy production docs";
+      exec = "mono docs deploy --prod --build --purge-cdn";
+    };
+
     "docs:build:phase:snippets" = {
       description = "Build docs snippets (CI phase)";
       exec = ''
@@ -287,6 +292,11 @@ in
     "examples:deploy" = {
       description = "Deploy examples to Cloudflare";
       exec = "mono examples deploy";
+    };
+
+    "examples:deploy:prod" = {
+      description = "Deploy examples to production Cloudflare Workers";
+      exec = "mono examples deploy --prod";
     };
 
     "examples:install" = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
         specifier: workspace:^
         version: link:../packages/@local/shared
       '@mixedbread/cli':
-        specifier: 1.2.1
-        version: 1.2.1(@types/node@25.3.3)
+        specifier: 2.3.2
+        version: 2.3.2
       '@mixedbread/sdk':
         specifier: 0.28.1
         version: 0.28.1
@@ -5980,6 +5980,12 @@ packages:
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
+
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
     engines: {node: '>=18.0.0'}
@@ -7494,10 +7500,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.15':
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
-    engines: {node: '>=18'}
-
   '@internationalized/date@3.12.0':
     resolution: {integrity: sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==}
 
@@ -7701,17 +7703,17 @@ packages:
   '@mermaid-js/parser@1.0.1':
     resolution: {integrity: sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==}
 
-  '@mixedbread/cli@1.2.1':
-    resolution: {integrity: sha512-IrDO4zG6i1Lf6b1vjohvd1xXmoIpJv+USZj9LVH0Bft6J4vbqgPD1yAiSazrNPSzLIKavLtAkh6uRUzI2wpHEA==}
+  '@mixedbread/cli@2.3.2':
+    resolution: {integrity: sha512-WlZJ3QYTX1yhmNc+tr7di+N4kK0OGPEYO5jPTs9KEwSZCDOHohQ6A2A8URytQd67Fn+N6FGrtXoDq+mnvM5Gpw==}
     engines: {node: '>=20'}
-    hasBin: true
-
-  '@mixedbread/sdk@0.26.0':
-    resolution: {integrity: sha512-B0Un0thpz4UKN69QVmgdVsCIgiz+jR4V+nxuCOgdm/P0Iie1NctqY092VQ/iobY/FSMzhHJofXij086y/9E5rg==}
     hasBin: true
 
   '@mixedbread/sdk@0.28.1':
     resolution: {integrity: sha512-+YMo8VoxnKS91WCG127fRmY1vM6Wj/AB7hIbruNRJa0gDwqhhUXwu+pSq7iKT1omqjaTz69giceB6bEVHIC/5g==}
+    hasBin: true
+
+  '@mixedbread/sdk@0.57.1':
+    resolution: {integrity: sha512-lMczeYXD2yhUomNseQURN/Wzm4aa5olu21s8/aoGbuLnxNMXEllAJatkvJvZUCdtw2hx0XW/Gfrjy6BMwlbpgQ==}
     hasBin: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
@@ -11729,10 +11731,6 @@ packages:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
   cli-progress@3.12.0:
     resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
     engines: {node: '>=4'}
@@ -11744,10 +11742,6 @@ packages:
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
-
-  cli-width@4.1.0:
-    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
-    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -11859,6 +11853,10 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -13166,8 +13164,17 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -13896,10 +13903,6 @@ packages:
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
-  inquirer@9.3.8:
-    resolution: {integrity: sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==}
-    engines: {node: '>=18'}
-
   internal-ip@6.2.0:
     resolution: {integrity: sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==}
     engines: {node: '>=10'}
@@ -14044,10 +14047,6 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
-  is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
-
   is-ip@3.1.0:
     resolution: {integrity: sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==}
     engines: {node: '>=8'}
@@ -14158,10 +14157,6 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
 
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
@@ -14767,10 +14762,6 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
-  log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
-    engines: {node: '>=18'}
-
   log-update@4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
     engines: {node: '>=10'}
@@ -15266,10 +15257,6 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -15398,10 +15385,6 @@ packages:
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
-  mute-stream@1.0.0:
-    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   mv@2.1.1:
     resolution: {integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==}
@@ -15687,10 +15670,6 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
-
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -15723,10 +15702,6 @@ packages:
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
-
-  ora@8.2.0:
-    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
-    engines: {node: '>=18'}
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
@@ -15769,6 +15744,10 @@ packages:
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
+
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
 
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
@@ -16862,10 +16841,6 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
@@ -16939,10 +16914,6 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
-  run-async@3.0.0:
-    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
-    engines: {node: '>=0.12.0'}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -16959,9 +16930,6 @@ packages:
       react-server-dom-webpack: '>=19.3.0-canary-4fdf7cf2-20251003 <20.0.0'
       vite: ^6.2.6 || 7.x
       wrangler: ^4.35.0
-
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -17359,10 +17327,6 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
-    engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -18934,10 +18898,6 @@ packages:
     resolution: {integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==}
     engines: {node: '>=18.19'}
 
-  yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
-
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
@@ -20225,6 +20185,18 @@ snapshots:
   '@chevrotain/types@11.1.2': {}
 
   '@chevrotain/utils@11.1.2': {}
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
@@ -21782,8 +21754,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.3
 
-  '@inquirer/figures@1.0.15': {}
-
   '@internationalized/date@3.12.0':
     dependencies:
       '@swc/helpers': 0.5.20
@@ -22448,29 +22418,26 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@mixedbread/cli@1.2.1(@types/node@25.3.3)':
+  '@mixedbread/cli@2.3.2':
     dependencies:
-      '@mixedbread/sdk': 0.26.0
+      '@clack/prompts': 1.2.0
+      '@mixedbread/sdk': 0.57.1
       '@pnpm/tabtab': 0.5.4
       chalk: 5.6.2
       cli-table3: 0.6.5
-      commander: 12.1.0
-      dotenv: 16.6.1
-      glob: 10.5.0
-      inquirer: 9.3.8(@types/node@25.3.3)
+      commander: 14.0.3
+      glob: 13.0.6
       mime-types: 3.0.2
       minimatch: 10.2.5
-      ora: 8.2.0
-      p-limit: 6.2.0
-      yaml: 2.8.1
+      p-limit: 7.3.0
+      yaml: 2.8.3
       zod: 4.3.6
     transitivePeerDependencies:
-      - '@types/node'
       - supports-color
 
-  '@mixedbread/sdk@0.26.0': {}
-
   '@mixedbread/sdk@0.28.1': {}
+
+  '@mixedbread/sdk@0.57.1': {}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -28035,10 +28002,6 @@ snapshots:
     dependencies:
       restore-cursor: 3.1.0
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
   cli-progress@3.12.0:
     dependencies:
       string-width: 4.2.3
@@ -28050,8 +28013,6 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
-
-  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -28159,6 +28120,8 @@ snapshots:
   commander@11.1.0: {}
 
   commander@12.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -29807,7 +29770,17 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fastq@1.20.1:
     dependencies:
@@ -30711,23 +30684,6 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
-  inquirer@9.3.8(@types/node@25.3.3):
-    dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@25.3.3)
-      '@inquirer/figures': 1.0.15
-      ansi-escapes: 4.3.2
-      cli-width: 4.1.0
-      mute-stream: 1.0.0
-      ora: 5.4.1
-      run-async: 3.0.0
-      rxjs: 7.8.2
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
-    transitivePeerDependencies:
-      - '@types/node'
-
   internal-ip@6.2.0:
     dependencies:
       default-gateway: 6.0.3
@@ -30898,8 +30854,6 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
-  is-interactive@2.0.0: {}
-
   is-ip@3.1.0:
     dependencies:
       ip-regex: 4.3.0
@@ -30984,8 +30938,6 @@ snapshots:
       which-typed-array: 1.1.20
 
   is-unicode-supported@0.1.0: {}
-
-  is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
 
@@ -31613,11 +31565,6 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-
-  log-symbols@6.0.0:
-    dependencies:
-      chalk: 5.6.2
-      is-unicode-supported: 1.3.0
 
   log-update@4.0.0:
     dependencies:
@@ -32640,8 +32587,6 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mimic-function@5.0.1: {}
-
   min-indent@1.0.1: {}
 
   mini-svg-data-uri@1.4.4: {}
@@ -32779,8 +32724,6 @@ snapshots:
   multipasta@0.2.7: {}
 
   mute-stream@0.0.8: {}
-
-  mute-stream@1.0.0: {}
 
   mv@2.1.1:
     dependencies:
@@ -33023,10 +32966,6 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.5:
@@ -33087,18 +33026,6 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
-  ora@8.2.0:
-    dependencies:
-      chalk: 5.6.2
-      cli-cursor: 5.0.0
-      cli-spinners: 2.9.2
-      is-interactive: 2.0.0
-      is-unicode-supported: 2.1.0
-      log-symbols: 6.0.0
-      stdin-discarder: 0.2.2
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   orderedmap@2.1.1: {}
 
   outdent@0.5.0: {}
@@ -33136,6 +33063,10 @@ snapshots:
       yocto-queue: 1.2.2
 
   p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 
@@ -34586,11 +34517,6 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   restructure@3.0.2: {}
 
   retext-latin@4.0.0:
@@ -34686,8 +34612,6 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
-  run-async@3.0.0: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -34747,10 +34671,6 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
-
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -35313,8 +35233,6 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
-
-  stdin-discarder@0.2.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -37100,8 +37018,6 @@ snapshots:
   yocto-spinner@0.2.3:
     dependencies:
       yoctocolors: 2.1.2
-
-  yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
 

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -310,9 +310,14 @@ export const docsCommand = Cli.Command.make('docs').pipe(
           Cli.Options.optional,
           Cli.Options.withDescription('Build the docs before deploying (split flow)'),
         ),
+        plan: Cli.Options.boolean('plan').pipe(
+          Cli.Options.withDefault(false),
+          Cli.Options.optional,
+          Cli.Options.withDescription('Print the resolved deploy plan without building or deploying'),
+        ),
       },
       Effect.fn(
-        function* ({ prod: prodOption, alias: aliasOption, site: siteOption, purgeCdn, build: buildOption }) {
+        function* ({ prod: prodOption, alias: aliasOption, site: siteOption, purgeCdn, build: buildOption, plan }) {
           const branchName = yield* Effect.gen(function* () {
             if (isGithubAction === true) {
               const branchFromEnv = process.env.GITHUB_HEAD_REF ?? process.env.GITHUB_REF_NAME
@@ -411,8 +416,37 @@ export const docsCommand = Cli.Command.make('docs').pipe(
 
           // Split mode: build first only when requested via --build
           const shouldBuild = buildOption._tag === 'Some' && buildOption.value === true
+          const docsSiteUrl = site === DOCS_PROD_SITE ? DOCS_PROD_URL : DOCS_DEV_URL
+
+          const shouldPrintPlan = plan._tag === 'Some' && plan.value === true
+
+          if (shouldPrintPlan === true) {
+            console.log(
+              JSON.stringify(
+                {
+                  branchName,
+                  isPr,
+                  liveStoreVersion,
+                  site,
+                  siteUrl: docsSiteUrl,
+                  build: shouldBuild,
+                  deployTarget:
+                    prAliases !== undefined
+                      ? { _tag: 'pr-aliases', ...prAliases }
+                      : prod === true
+                        ? { _tag: 'prod' }
+                        : { _tag: 'alias', alias: branchAlias },
+                  purgeCdn,
+                },
+                null,
+                2,
+              ),
+            )
+            return
+          }
+
           if (shouldBuild === true) {
-            process.env.LIVESTORE_DOCS_SITE_URL = site === DOCS_PROD_SITE ? DOCS_PROD_URL : DOCS_DEV_URL
+            process.env.LIVESTORE_DOCS_SITE_URL = docsSiteUrl
             yield* docsBuildCommand.handler({ apiDocs: true, clean: false, skipDeps: false })
           }
 

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -8,6 +8,14 @@ import { Cli, getFreePort } from '@livestore/utils/node'
 import { buildDiagrams, watchDiagrams } from '@local/astro-tldraw'
 import { buildSnippets, createSnippetsCommand } from '@local/astro-twoslash-code'
 
+import {
+  assertProductionDeployAllowed,
+  DOCS_DEV_SITE,
+  DOCS_DEV_URL,
+  DOCS_PROD_SITE,
+  DOCS_PROD_URL,
+  isPrimaryIntegrationBranch,
+} from '../shared/deploy-target.ts'
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../shared/misc.ts'
 import { deployToNetlify, purgeNetlifyCdn } from '../shared/netlify.ts'
 import { exportMarkdownCommand } from './docs-export.ts'
@@ -323,16 +331,16 @@ export const docsCommand = Cli.Command.make('docs').pipe(
 
           yield* Effect.log(`Branch name: "${branchName}"`)
 
-          const devBranchName = 'dev'
+          const isPr = isGithubAction && process.env.GITHUB_EVENT_NAME === 'pull_request'
+          const explicitProd = prodOption._tag === 'Some' && prodOption.value === true
 
           const site =
-            siteOption._tag === 'Some'
-              ? siteOption.value
-              : branchName === 'main'
-                ? 'livestore-docs' // Prod site
-                : 'livestore-docs-dev' // Dev site
+            siteOption._tag === 'Some' ? siteOption.value : explicitProd === true ? DOCS_PROD_SITE : DOCS_DEV_SITE
 
-          const isPr = isGithubAction && process.env.GITHUB_EVENT_NAME === 'pull_request'
+          if (explicitProd === true) {
+            yield* Effect.sync(() => assertProductionDeployAllowed(liveStoreVersion))
+          }
+
           const prNumber = (() => {
             const ref = process.env.GITHUB_REF
             if (typeof ref === 'string') {
@@ -387,27 +395,11 @@ export const docsCommand = Cli.Command.make('docs').pipe(
                 : undefined
 
           const prod =
-            prodOption._tag === 'Some' && prodOption.value === true // TODO clean up when Effect CLI boolean flag is fixed
-              ? prodOption.value
+            explicitProd === true // TODO clean up when Effect CLI boolean flag is fixed
+              ? true
               : isPr === true
                 ? false
-                : branchName === 'main' || branchName === devBranchName
-
-          if (prod === true && site === 'livestore-docs' && liveStoreVersion.includes('dev') === true) {
-            yield* Effect.logWarning(
-              `Skipping prod docs deploy for dev version ${liveStoreVersion}; docs were built but prod deploy waits for a stable release version.`,
-            )
-            yield* appendGithubSummaryMarkdown({
-              context: 'docs deploy',
-              markdown: [
-                '## Docs deploy',
-                '',
-                `Skipped production docs deploy for dev version \`${liveStoreVersion}\`.`,
-                '',
-              ].join('\n'),
-            })
-            return
-          }
+                : site === DOCS_DEV_SITE && isPrimaryIntegrationBranch(branchName)
 
           const deployAliasLabel =
             prAliases !== undefined
@@ -420,6 +412,7 @@ export const docsCommand = Cli.Command.make('docs').pipe(
           // Split mode: build first only when requested via --build
           const shouldBuild = buildOption._tag === 'Some' && buildOption.value === true
           if (shouldBuild === true) {
+            process.env.LIVESTORE_DOCS_SITE_URL = site === DOCS_PROD_SITE ? DOCS_PROD_URL : DOCS_DEV_URL
             yield* docsBuildCommand.handler({ apiDocs: true, clean: false, skipDeps: false })
           }
 
@@ -432,19 +425,19 @@ export const docsCommand = Cli.Command.make('docs').pipe(
           const { stickyDeploy, commitDeploy } = yield* Effect.gen(function* () {
             if (prAliases !== undefined) {
               /** PR deploy: first create sticky alias, then commit-specific alias */
-              const stickyDeploy: NetlifyDeploySummary = yield* deployToNetlify({
+              const stickyPrDeploy: NetlifyDeploySummary = yield* deployToNetlify({
                 site,
                 target: { _tag: 'alias', alias: prAliases.stickyAlias },
                 message: buildMessage(contextLabelFor(false, prAliases.stickyAlias)),
               }).pipe(docsWorkspaceCwd)
 
-              const commitDeploy: NetlifyDeploySummary = yield* deployToNetlify({
+              const commitPrDeploy: NetlifyDeploySummary = yield* deployToNetlify({
                 site,
                 target: { _tag: 'alias', alias: prAliases.commitAlias },
                 message: buildMessage(contextLabelFor(false, prAliases.commitAlias)),
               }).pipe(docsWorkspaceCwd)
 
-              return { stickyDeploy, commitDeploy }
+              return { stickyDeploy: stickyPrDeploy, commitDeploy: commitPrDeploy }
             } else {
               /** Non-PR deploy: single deploy with prod or branch alias */
               const deploy: NetlifyDeploySummary = yield* deployToNetlify({

--- a/scripts/src/commands/examples/deploy-examples.ts
+++ b/scripts/src/commands/examples/deploy-examples.ts
@@ -1,5 +1,6 @@
 import process from 'node:process'
 
+import { liveStoreVersion } from '@livestore/common'
 import { cmd, cmdText, LivestoreWorkspace } from '@livestore/utils-dev/node'
 import { Effect, FileSystem, Layer, Logger, LogLevel, Option, Schema } from '@livestore/utils/effect'
 import { Cli, PlatformNode } from '@livestore/utils/node'
@@ -16,6 +17,11 @@ import {
   resolveWorkerName,
   resolveWorkersSubdomain,
 } from '../../shared/cloudflare.ts'
+import {
+  assertProductionDeployAllowed,
+  isPrimaryIntegrationBranch,
+  type DeploymentKind,
+} from '../../shared/deploy-target.ts'
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../../shared/misc.ts'
 
 export class ScriptError extends Schema.TaggedError<ScriptError>()('ScriptError', {
@@ -143,8 +149,6 @@ export const runExampleTests = (examples: ReadonlyArray<string>, options: { skip
     }
   })
 
-const DEV_BRANCH_NAME = 'dev'
-
 interface DeploymentSummary {
   example: string
   workerName: string
@@ -205,13 +209,11 @@ const determineDeploymentKind = ({
   prod: boolean
   branchName: string
 }): CloudflareEnvironmentKind => {
-  const normalizedBranch = branchName.toLowerCase()
-
-  if (prod === true || normalizedBranch === 'main') {
+  if (prod === true) {
     return 'prod'
   }
 
-  if (normalizedBranch === DEV_BRANCH_NAME) {
+  if (isPrimaryIntegrationBranch(branchName) === true) {
     return 'dev'
   }
 
@@ -222,6 +224,9 @@ const formatDomain = (domain: { domain: string; name: string }) =>
   domain.name === '@' ? domain.domain : `${domain.name}.${domain.domain}`
 
 const deploymentKindLabel = (kind: CloudflareEnvironmentKind) => kind
+
+const deploymentKindDescription = (kind: DeploymentKind) =>
+  kind === 'prod' ? 'to production' : kind === 'dev' ? 'to dev' : 'to preview'
 
 /**
  * Build + deploy a single example, returning a summary that can be rendered in the CLI table.
@@ -295,6 +300,11 @@ export const command = Cli.Command.make(
     const { branchName } = yield* getBranchInfo
     console.log(`Deploy branch: ${branchName}`)
 
+    const requestedProd = prod === true
+    if (requestedProd === true) {
+      yield* Effect.sync(() => assertProductionDeployAllowed(liveStoreVersion))
+    }
+
     const filteredExamples = cloudflareExamples.filter((example) =>
       Option.isSome(exampleFilter) === true ? example.slug.includes(exampleFilter.value) : true,
     )
@@ -310,8 +320,11 @@ export const command = Cli.Command.make(
     }
 
     const workersSubdomain = yield* resolveWorkersSubdomain
+    const deploymentKind = determineDeploymentKind({ prod: requestedProd, branchName })
     console.log(
-      `Deploying${prod === true ? ' (to prod)' : ''}: ${filteredExamples.map((example) => example.slug).join(', ')} using ${workersSubdomain}.workers.dev`,
+      `Deploying (${deploymentKindDescription(deploymentKind)}): ${filteredExamples
+        .map((example) => example.slug)
+        .join(', ')} using ${workersSubdomain}.workers.dev`,
     )
 
     const results = yield* Effect.forEach(
@@ -319,7 +332,7 @@ export const command = Cli.Command.make(
       (example) =>
         deployExample({
           exampleSlug: example.slug,
-          prod,
+          prod: requestedProd,
           branchName,
           workersSubdomain,
         }),

--- a/scripts/src/shared/deploy-target.ts
+++ b/scripts/src/shared/deploy-target.ts
@@ -1,0 +1,29 @@
+import semver from 'semver'
+
+export const MAIN_BRANCH_NAME = 'main'
+export const LEGACY_DEV_BRANCH_NAME = 'dev'
+
+export const DOCS_PROD_SITE = 'livestore-docs'
+export const DOCS_DEV_SITE = 'livestore-docs-dev'
+export const DOCS_PROD_URL = 'https://docs.livestore.dev'
+export const DOCS_DEV_URL = 'https://dev.docs.livestore.dev'
+
+export type DeploymentKind = 'prod' | 'dev' | 'preview'
+
+export const isStableReleaseVersion = (version: string): boolean => {
+  const validVersion = semver.valid(version)
+  return validVersion !== null && semver.prerelease(validVersion) === null && version.includes('-snapshot-') === false
+}
+
+export const assertProductionDeployAllowed = (version: string): void => {
+  if (isStableReleaseVersion(version) === false) {
+    throw new Error(
+      `Production deploys require a stable LiveStore release version. Got ${version}. Use the default dev deploy for snapshots and prereleases.`,
+    )
+  }
+}
+
+export const isPrimaryIntegrationBranch = (branchName: string): boolean => {
+  const normalizedBranch = branchName.toLowerCase()
+  return normalizedBranch === MAIN_BRANCH_NAME || normalizedBranch === LEGACY_DEV_BRANCH_NAME
+}


### PR DESCRIPTION
Aligns the docs/examples/search deployment policy with the new main-based release flow.

## Changes

- Makes normal `main` CI deploy docs and examples to the dev surfaces only.
- Adds explicit stable-release production deploy steps to `release.yml` for docs, examples, and docs search.
- Adds shared deploy target guards so `--prod` docs/examples deploys reject snapshots and prereleases.
- Adds `mono docs deploy --plan` so maintainers can verify docs deploy routing without building or deploying.
- Updates sync-docs so pushes update the dev vector store and manual dispatch can target dev or prod.
- Refreshes contributor workflow docs for the new dev-by-default, prod-on-stable-release model.

## Rationale

Branch names should no longer decide whether public production surfaces are updated. `main` is now the integration branch, so routine merges should keep the dev docs/examples current while production only moves as part of an explicit stable release publish. This keeps the old dev/prod docs split without bringing back a long-lived `dev` branch.

`--plan` is intentionally part of the CLI rather than a one-off shell script because deploy routing is now release-critical behavior. It gives us a stable, non-mutating way to exercise PR aliases, dev-site production deploys, prod-site alias smoke tests, and forbidden production deploy inputs before touching Netlify.

## Validation

Local:

- `DT_PASSTHROUGH=1 devenv tasks run ts:build --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run lint:check --mode before --no-tui`
- `CI=1 DT_PASSTHROUGH=1 devenv tasks run test:unit --mode before --no-tui`
- `tmp/actionlint-bin/actionlint .github/workflows/sync-docs.yml`
- Deploy guard experiment: `0.4.0-dev.23` and snapshot versions are blocked for production deploys, `0.4.0` is accepted.

Docs deploy plan matrix:

- PR event resolves to `livestore-docs-dev` with sticky and commit-specific PR aliases.
- `main` push resolves to the production deploy target of `livestore-docs-dev`, i.e. `https://dev.docs.livestore.dev`.
- Prod-site smoke with `--site livestore-docs --alias release-smoke-<sha> --build --plan` resolves to an alias deploy on the production Netlify site without updating `https://docs.livestore.dev`.
- `mono docs deploy --prod --plan` rejects the current dev version before any build or deploy.

CI on latest head `5c7ebaad8803d5ca0be17870eebc34d181d206ce`:

- `ci.yml` is green, including docs deploy, examples deploy, snapshot publish, and create-example smoke tests.
- `release.yml` validation is green; publish jobs are skipped on PRs as intended.
- Snapshot packages exist on npm for both `@livestore/livestore` and `@livestore/devtools-vite` at `0.0.0-snapshot-5c7ebaad8803d5ca0be17870eebc34d181d206ce`.

## Notes

The generated repository ruleset source already targets `main` with code owner reviews and current required checks. Applying that ruleset live still requires repository ruleset admin permission; the assistant account receives `404` from the GitHub ruleset update/delete endpoints.
