### PR TITLE
Restore qrcode-generator to 2.0.4 after Genie migration downgrade

### DIFF
--- a/genie/external.ts
+++ b/genie/external.ts
@@ -102,7 +102,7 @@ export const livestoreOnlyCatalog = {
   'monaco-editor': '0.34.1',
   nanoid: '5.0.9',
   'pretty-bytes': '7.0.1',
-  'qrcode-generator': '1.4.4',
+  'qrcode-generator': '2.0.4',
   '@iarna/toml': '3.0.0',
   '@graphql-typed-document-node/core': '3.2.0',
   'astro-expressive-code': '0.41.5',

--- a/packages/@livestore/utils/package.json
+++ b/packages/@livestore/utils/package.json
@@ -78,7 +78,7 @@
     "@standard-schema/spec": "1.1.0",
     "nanoid": "5.0.9",
     "pretty-bytes": "7.0.1",
-    "qrcode-generator": "1.4.4"
+    "qrcode-generator": "2.0.4"
   },
   "devDependencies": {
     "@effect/ai": "0.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3858,8 +3858,8 @@ importers:
         specifier: 7.0.1
         version: 7.0.1
       qrcode-generator:
-        specifier: 1.4.4
-        version: 1.4.4
+        specifier: 2.0.4
+        version: 2.0.4
     devDependencies:
       '@effect/ai':
         specifier: 0.35.0
@@ -16289,9 +16289,6 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
-
-  qrcode-generator@1.4.4:
-    resolution: {integrity: sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw==}
 
   qrcode-generator@2.0.4:
     resolution: {integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==}
@@ -33702,8 +33699,6 @@ snapshots:
       - utf-8-validate
 
   pure-rand@6.1.0: {}
-
-  qrcode-generator@1.4.4: {}
 
   qrcode-generator@2.0.4: {}
 


### PR DESCRIPTION
## Problem

`@livestore/utils` shipped in `v0.4.0-dev.23` with `qrcode-generator@1.4.4`, but `v0.4.0-dev.22` had `2.0.4`. The downgrade broke the QR helpers for consumers — confirmed by a community report and reproducible by pinning `2.0.4` back. `@livestore/utils/src/qr.ts` is written against the 2.x API (the docstring even links the 2.0.4 type definitions on unpkg), so the downgrade is an API-level break.

Tracing the regression: commit `b054174b9` (*"refactor: migrate to genie for self-contained packages"*, 2026-01-27) introduced the Genie catalog and seeded `livestoreOnlyCatalog` with `'qrcode-generator': '1.4.4'`, then re-materialized `packages/@livestore/utils/package.json` from `2.0.4` → `1.4.4`. The catalog has stayed at `1.4.4` ever since. There's no upstream signal that justified `1.4.4`:

- npm's `latest` dist-tag for `qrcode-generator` is `2.0.4`.
- `qrcode-generator` does not appear in the effect-utils base catalog (it's in `livestoreOnlyCatalog` precisely because effect-utils doesn't carry it).

It looks like a hand-typed value at migration time. It only surfaced in a release because the next release (dev.23) didn't ship until ~3 months after the migration commit.

## Solution

- Bump the catalog entry in `genie/external.ts` from `1.4.4` to `2.0.4`.
- Re-materialize `packages/@livestore/utils/package.json` to match (the only manifest pulling `qrcode-generator` from the catalog).
- Refresh `pnpm-lock.yaml` (the prior `qrcode-generator@1.4.4` entries drop out cleanly; only `2.0.4` remains).
- Add a `patch` changeset for `@livestore/utils`.

## Validation

- Verified the lockfile no longer references `qrcode-generator@1.4.4` and `@livestore/utils` resolves `2.0.4` (`grep qrcode-generator pnpm-lock.yaml`).
- Could not run the full `genie` regen locally because `devenv shell` currently fails with a Nix oxc-config fixed-output hash mismatch (`specified: sha256-PBEEB/… got: sha256-lFQ/…`). The manual `package.json` edit produces the same bytes Genie would write from the catalog, so CI's Genie coverage check should be a no-op.
- No tests added — this is a version pin restoration; the `qr.ts` callers are exercised by their existing test suite.

## Related issues

- Reported in community feedback on the `v0.4.0-dev.23` release. (No issue filed yet — happy to open one for tracking if reviewers want.)

## Follow-up (not in this PR)

The same `v0.4.0-dev.23` release is missing the `livestore-devtools-chrome-0.4.0-dev.23.zip` asset that all prior releases had. That zip was historically uploaded by hand (uploader was always `schickling` for dev.20–22); the new automated release flow does not build or attach it, and the Chrome extension source isn't in this repo. That's a separate fix and likely needs a maintainer decision on the build/upload pipeline.