### PR TITLE
Drop .changeset/ from CODEOWNERS required reviewer gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Release-sensitive repository policy and release automation.
 /.github/ @schickling
-/.changeset/ @schickling
 /release/ @schickling
 /scripts/src/commands/changesets.ts @schickling
 /scripts/src/commands/devtools-artifact.ts @schickling


### PR DESCRIPTION
## Problem

Every PR is asked to include a changeset (see `.changeset/README.md`: *"Every pull request should include a changeset. Use an empty changeset for changes that do not need release notes."*). With `/.changeset/ @schickling` in `.github/CODEOWNERS`, this turns every contributor PR into a code-owner-gated PR — even small fixes that have nothing to do with release policy.

Concrete example: #1212 (a one-line `qrcode-generator` version pin restoration in `@livestore/utils`) is currently blocked on "Waiting on code owner review from schickling" purely because it adds a `.changeset/qrcode-generator-pin.md` file.

The intent of the CODEOWNERS gate (added in `248141bad Document release workflow guardrails`) was to lock down release-sensitive policy — release plans, version source, release scripts, repo settings. Changeset files don't fit that profile: they are the per-PR release-intent ledger, written by every PR author, and folded into `CHANGELOG.md` by maintainers before the next stable release.

## Solution

Remove the `/.changeset/ @schickling` line from `.github/CODEOWNERS`. The remaining gates stay in place:

- `/.github/` — repo policy and workflow generators
- `/release/` — release plan, version source, devtools artifact manifest
- `/scripts/src/commands/changesets.ts`, `release.ts`, `devtools-artifact.ts` — release tooling

## Validation

- `git diff` shows a single-line removal in `.github/CODEOWNERS`.
- The remaining lines still cover the release-policy paths the original commit (`248141bad`) was protecting.

## Related issues

- Unblocks #1212.

## Note

This PR itself touches `/.github/`, so it's still code-owner-gated and needs `@schickling` once. After it merges, future changeset-only PRs won't be.