### PR TITLE
fix: canonicalize event args in equality comparator

### DIFF
--- a/.changeset/fix-sync-args-undefined-key-mismatch.md
+++ b/.changeset/fix-sync-args-undefined-key-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Fix sync hash mismatch when event args use `Schema.UndefinedOr` or loose `Schema.optional` and the field is omitted at commit time. The local pending event encoded as `{ ..., flag: undefined }` no longer compares unequal to the same event JSON-roundtripped through the sync provider as `{ ... }`. Without this fix, the merge falsely took the rebase path and state-dependent materializers re-ran on already-mutated state, surfacing as `MaterializerHashMismatchError` (#1217).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -455,6 +455,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Prevent `store.subscribe` reentrancy crashes by restoring the reactive debug context after nested commits (#577, #656)
 - Fix `subscribe` with `skipInitialRun` to properly register reactive dependencies while suppressing the initial callback (#847)
 - Fix event equality check failing when args key order differs, which caused duplicate events when syncing with backends that reorder JSON keys (e.g. PostgreSQL `jsonb`) (#1160)
+- Fix event equality check failing when args use `Schema.UndefinedOr` or loose `Schema.optional` and the field is omitted at commit time, which caused the sync merge to falsely take the rebase path and trigger `MaterializerHashMismatchError` for state-dependent materializers ([#1217](https://github.com/livestorejs/livestore/issues/1217))
 
 ##### TypeScript & Build
 

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
 
-import { Option } from '@livestore/utils/effect'
+import { Option, Schema } from '@livestore/utils/effect'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 
 import * as EventSequenceNumber from '../EventSequenceNumber/mod.ts'
@@ -93,5 +93,47 @@ Vitest.describe('isEqualEncoded', () => {
     const a = { ...makeEncodedEvent({ id: 'abc' }), name: 'eventA' }
     const b = { ...makeEncodedEvent({ id: 'abc' }), name: 'eventB' }
     expect(isEqualEncoded(a, b)).toBe(false)
+  })
+
+  // Regression tests for the hash-mismatch bug: locally-encoded events with
+  // `Schema.UndefinedOr` (or loose `Schema.optional`) fields end up with shape
+  // `{ ..., flag: undefined }`. JSON wire transport drops the key, producing
+  // `{ ... }`. Without canonicalization at the encode boundary, the two forms
+  // compare unequal here, and the sync merge falsely takes the rebase path —
+  // which then surfaces as `MaterializerHashMismatchError` when materializers
+  // are state-dependent.
+  Vitest.it('should consider events with undefined-valued and missing keys as equal', () => {
+    const a = makeEncodedEvent({ id: 'abc', flag: undefined })
+    const b = makeEncodedEvent({ id: 'abc' })
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should consider events with nested undefined-valued and missing keys as equal', () => {
+    const a = makeEncodedEvent({ outer: { x: 1, y: undefined } })
+    const b = makeEncodedEvent({ outer: { x: 1 } })
+    expect(isEqualEncoded(a, b)).toBe(true)
+  })
+
+  Vitest.it('should consider Effect Schema UndefinedOr-encoded args equal to their JSON-roundtripped form', () => {
+    const argsSchema = Schema.Struct({
+      id: Schema.String,
+      flag: Schema.UndefinedOr(Schema.Boolean),
+    })
+    // Effect Schema's Struct encoder materializes the omitted `flag` field as
+    // `{ ..., flag: undefined }` — the local pending event's shape.
+    const localArgs = Schema.encodeUnknownSync(argsSchema)({ id: 'abc' } as any)
+    // JSON.parse(JSON.stringify(...)) is exactly what the sync wire transport does.
+    const wireArgs = JSON.parse(JSON.stringify(localArgs))
+    expect(isEqualEncoded(makeEncodedEvent(localArgs), makeEncodedEvent(wireArgs))).toBe(true)
+  })
+
+  Vitest.it('should consider Effect Schema loose-optional encoded args equal to their JSON-roundtripped form', () => {
+    const argsSchema = Schema.Struct({
+      id: Schema.String,
+      label: Schema.optional(Schema.String),
+    })
+    const localArgs = Schema.encodeUnknownSync(argsSchema)({ id: 'abc', label: undefined } as any)
+    const wireArgs = JSON.parse(JSON.stringify(localArgs))
+    expect(isEqualEncoded(makeEncodedEvent(localArgs), makeEncodedEvent(wireArgs))).toBe(true)
   })
 })

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -95,13 +95,6 @@ Vitest.describe('isEqualEncoded', () => {
     expect(isEqualEncoded(a, b)).toBe(false)
   })
 
-  // Regression tests for the hash-mismatch bug: locally-encoded events with
-  // `Schema.UndefinedOr` (or loose `Schema.optional`) fields end up with shape
-  // `{ ..., flag: undefined }`. JSON wire transport drops the key, producing
-  // `{ ... }`. Without canonicalization at the encode boundary, the two forms
-  // compare unequal here, and the sync merge falsely takes the rebase path —
-  // which then surfaces as `MaterializerHashMismatchError` when materializers
-  // are state-dependent.
   Vitest.it('should consider events with undefined-valued and missing keys as equal', () => {
     const a = makeEncodedEvent({ id: 'abc', flag: undefined })
     const b = makeEncodedEvent({ id: 'abc' })
@@ -119,10 +112,7 @@ Vitest.describe('isEqualEncoded', () => {
       id: Schema.String,
       flag: Schema.UndefinedOr(Schema.Boolean),
     })
-    // Effect Schema's Struct encoder materializes the omitted `flag` field as
-    // `{ ..., flag: undefined }` — the local pending event's shape.
     const localArgs = Schema.encodeUnknownSync(argsSchema)({ id: 'abc' } as any)
-    // JSON.parse(JSON.stringify(...)) is exactly what the sync wire transport does.
     const wireArgs = JSON.parse(JSON.stringify(localArgs))
     expect(isEqualEncoded(makeEncodedEvent(localArgs), makeEncodedEvent(wireArgs))).toBe(true)
   })

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
@@ -187,6 +187,14 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
 /**
  * Structural equality check for client events. Compares seqNum (global + client),
  * name, clientId, sessionId, and args. The `meta` field is ignored.
+ *
+ * Args are compared in their JSON-canonical form: locally-encoded events with
+ * `Schema.UndefinedOr` (or loose `Schema.optional`) fields produce
+ * `{ ..., flag: undefined }`, but JSON wire transport drops the key. Without
+ * canonicalizing, the local pending event compares unequal to its
+ * wire-roundtripped counterpart and the sync merge falsely takes the rebase
+ * path, surfacing as `MaterializerHashMismatchError` for state-dependent
+ * materializers.
  */
 export const isEqualEncoded = (a: Encoded, b: Encoded) =>
   a.seqNum.global === b.seqNum.global &&
@@ -194,7 +202,10 @@ export const isEqualEncoded = (a: Encoded, b: Encoded) =>
   a.name === b.name &&
   a.clientId === b.clientId &&
   a.sessionId === b.sessionId &&
-  deepEqual(a.args, b.args) // TODO use schema equality here
+  deepEqual(canonicalizeArgs(a.args), canonicalizeArgs(b.args)) // TODO use schema equality here
+
+const canonicalizeArgs = (args: unknown): unknown =>
+  args === undefined ? args : JSON.parse(JSON.stringify(args))
 
 /**
  * Creates an Effect Schema union for all event types in a schema (with composite sequence numbers).

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -1,5 +1,5 @@
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Cause, Effect, Exit } from '@livestore/utils/effect'
+import { Cause, Effect, Exit, Schema } from '@livestore/utils/effect'
 import { assert, expect } from 'vitest'
 
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
@@ -370,6 +370,59 @@ Vitest.describe('syncstate', () => {
           )
           assert(Exit.isFailure(exit))
           expect(Cause.isDie(exit.cause)).toBe(true)
+        }),
+      )
+
+      // Regression for hash-mismatch bug: when an event-def schema uses
+      // `Schema.UndefinedOr` (or loose `Schema.optional`) and the optional
+      // field is omitted at commit time, Effect Schema's encoder produces
+      // `{ ..., flag: undefined }` while JSON wire transport drops the key.
+      // The local pending event and the same event JSON-roundtripped through
+      // the sync provider therefore have different `Object.keys`. `deepEqual`
+      // returns false for the pair, and merge falsely takes the rebase path.
+      // For state-dependent materializers, the rebase rerun produces different
+      // SQL bind values and surfaces as `MaterializerHashMismatchError`.
+      Vitest.it.effect('should advance (not rebase) when pending event has undefined-valued key dropped by JSON wire round-trip', () =>
+        Effect.gen(function* () {
+          const argsSchema = Schema.Struct({
+            id: Schema.String,
+            flag: Schema.UndefinedOr(Schema.Boolean),
+          })
+          // Local pending shape: Effect Schema adds `flag` back as undefined.
+          const localArgs = Schema.encodeUnknownSync(argsSchema)({ id: 'abc' } as any)
+          // Wire shape: JSON.parse(JSON.stringify(...)) strips the undefined-valued key.
+          const wireArgs = JSON.parse(JSON.stringify(localArgs))
+
+          const localPending = new TestEvent({
+            seqNum: e1_0.seqNum,
+            parentSeqNum: e1_0.parentSeqNum,
+            name: e1_0.name,
+            args: localArgs,
+            clientId: e1_0.clientId,
+            sessionId: e1_0.sessionId,
+          })
+          const fromUpstream = new TestEvent({
+            seqNum: e1_0.seqNum,
+            parentSeqNum: e1_0.parentSeqNum,
+            name: e1_0.name,
+            args: wireArgs,
+            clientId: e1_0.clientId,
+            sessionId: e1_0.sessionId,
+          })
+
+          const syncState = new SyncState.SyncState({
+            pending: [localPending],
+            upstreamHead: EventSequenceNumber.Client.ROOT,
+            localHead: localPending.seqNum,
+          })
+          const result = yield* merge({
+            syncState,
+            payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [fromUpstream] }),
+          })
+
+          expectAdvance(result)
+          expect(result.confirmedEvents).toHaveLength(1)
+          expect(result.newSyncState.pending).toHaveLength(0)
         }),
       )
     })

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -373,24 +373,13 @@ Vitest.describe('syncstate', () => {
         }),
       )
 
-      // Regression for hash-mismatch bug: when an event-def schema uses
-      // `Schema.UndefinedOr` (or loose `Schema.optional`) and the optional
-      // field is omitted at commit time, Effect Schema's encoder produces
-      // `{ ..., flag: undefined }` while JSON wire transport drops the key.
-      // The local pending event and the same event JSON-roundtripped through
-      // the sync provider therefore have different `Object.keys`. `deepEqual`
-      // returns false for the pair, and merge falsely takes the rebase path.
-      // For state-dependent materializers, the rebase rerun produces different
-      // SQL bind values and surfaces as `MaterializerHashMismatchError`.
       Vitest.it.effect('should advance (not rebase) when pending event has undefined-valued key dropped by JSON wire round-trip', () =>
         Effect.gen(function* () {
           const argsSchema = Schema.Struct({
             id: Schema.String,
             flag: Schema.UndefinedOr(Schema.Boolean),
           })
-          // Local pending shape: Effect Schema adds `flag` back as undefined.
           const localArgs = Schema.encodeUnknownSync(argsSchema)({ id: 'abc' } as any)
-          // Wire shape: JSON.parse(JSON.stringify(...)) strips the undefined-valued key.
           const wireArgs = JSON.parse(JSON.stringify(localArgs))
 
           const localPending = new TestEvent({


### PR DESCRIPTION
## Problem

Locally-encoded events with `Schema.UndefinedOr` (or loose `Schema.optional`) fields produce args of shape `{ ..., flag: undefined }`, while JSON wire transport drops the `undefined`-valued key. The current `isEqualEncoded` comparator used `deepEqual` on the args directly, which counts keys via `Object.keys` and treats the two forms as unequal. Sync merge therefore falsely took the rebase path when an event came back from the sync provider, and state-dependent materializers re-ran on already-mutated state — surfacing as `MaterializerHashMismatchError`.

The bug regressed in #1161, which replaced `JSON.stringify(a.args) === JSON.stringify(b.args)` with `deepEqual(a.args, b.args)` to fix a key-order bug. The earlier form masked this asymmetry because both sides were stringified through `JSON.stringify`, which drops `undefined` symmetrically.

A community-supplied reproduction with a Cloudflare Durable Object sync server: https://github.com/Fuzzyma/livestore-hash-missmatch.

Closes #1217.

## Solution

Canonicalize both args through `JSON.parse(JSON.stringify(...))` before `deepEqual` in `isEqualEncoded`. The local pending event and the same event after a wire round-trip therefore reduce to the same canonical form regardless of how the event reached the comparator.

```ts
export const isEqualEncoded = (a: Encoded, b: Encoded) =>
  a.seqNum.global === b.seqNum.global &&
  a.seqNum.client === b.seqNum.client &&
  a.name === b.name &&
  a.clientId === b.clientId &&
  a.sessionId === b.sessionId &&
  deepEqual(canonicalizeArgs(a.args), canonicalizeArgs(b.args)) // TODO use schema equality here

const canonicalizeArgs = (args: unknown): unknown =>
  args === undefined ? args : JSON.parse(JSON.stringify(args))
```

This composes correctly with #1161's key-order fix: `deepEqual` is order-independent (uses `Object.keys` for membership, not positional comparison), and the JSON round-trip canonicalizes the *value-level* shape — not the string form — so it doesn't reintroduce the order sensitivity that #1161 fixed. The existing key-order regression tests at `client.test.ts:50-60` still pass.

## Trade-offs

- **Per-comparison cost.** A `JSON.parse(JSON.stringify(...))` runs on each arg pair during merge. For typical event args this is a few microseconds; for high-throughput sync workloads, gating in dev mode and constraining event-def schemas at the type level (`Schema.JsonValue` upper bound) is a follow-up worth considering.
- **Coverage.** This addresses the entire JSON-wire/in-memory impedance mismatch class (undefined keys, `NaN` → null, sparse-array holes, `Date` instances coerced via `toJSON`). Anything the wire would change collapses to the same canonical form on both sides.
- **Schema-equality follow-up.** Effect's `Schema.equivalence` derived from the encoded schema would be the more idiomatic fix, but its current behavior is asymmetric across schema variants (works for `UndefinedOr`, fails for loose `optional`), and treats missing-vs-present-with-true-value as equivalent for `UndefinedOr` — i.e. it's a *broader* bug than what we have now. The `// TODO use schema equality here` comment is preserved to track this when Effect Schema's equivalence semantics are tightened.

## Validation

- New regression tests added that fail on `main`:
  - `client.test.ts`: 4 tests on `isEqualEncoded` covering the direct undefined-vs-missing pair, nested objects, and full Effect Schema round-trips for both `Schema.UndefinedOr` and loose `Schema.optional`.
  - `syncstate.test.ts`: 1 integration test reproducing the production symptom (`expected 'rebase' to be 'advance'`).
- Full common-package suite (`pnpx vitest run` in `packages/@livestore/common`): **252 tests pass.**
- `dt lint:full:fix` clean.
- #1161's key-order regression tests (`should consider events with different key order in args as equal` and the nested variant) still pass — the fix doesn't reintroduce that bug.

## Test plan

- [x] Regression tests added in `client.test.ts` and `syncstate.test.ts`
- [x] `vitest run` for `@livestore/common` — all 252 tests pass
- [x] `dt lint:full:fix` — clean
- [x] CI green