### PR TITLE
Detect repository ruleset drift before it blocks merges

### DIFF
--- a/.changeset/empty-ruleset-drift-guard.md
+++ b/.changeset/empty-ruleset-drift-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. This only adds repository ruleset drift detection.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,254 @@ jobs:
           path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
+  ruleset-drift-check:
+    runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+        run: |
+          EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '::error::megarepo.lock missing members["effect-utils"].commit'
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf 'MEGAREPO_STORE=%s
+          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+          fi
+
+          nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
+        shell: bash
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          if [ -z "${DEVENV_REV:-}" ]; then
+            DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          fi
+
+          resolve_devenv() {
+            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
+        shell: bash
+      - name: Check repository ruleset drift
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run github:rulesets:check --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run github:rulesets:check --mode before'
+        env:
+          GH_TOKEN: ${{ secrets.LIVESTORE_RULESET_ADMIN_TOKEN || github.token }}
+      - name: Save pnpm state
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Upload Nix diagnostics artifact
+        if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14
   type-check:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -124,6 +124,20 @@ export default githubWorkflow({
       ],
     }),
 
+    'ruleset-drift-check': standardCIJob({
+      if: "github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'",
+      steps: [
+        ...livestoreSetupSteps,
+        {
+          name: 'Check repository ruleset drift',
+          run: runDevenvTasksBefore('github:rulesets:check'),
+          env: {
+            GH_TOKEN: '${{ secrets.LIVESTORE_RULESET_ADMIN_TOKEN || github.token }}',
+          },
+        },
+      ],
+    }),
+
     'type-check': standardCIJob({
       // TODO(oep-1n3.9): Switch back to patched tsc once Effect diagnostics backlog is addressed.
       steps: [...livestoreSetupSteps, { name: 'Run type-check', run: runDevenvTasksBefore('ts:build') }],

--- a/devenv.nix
+++ b/devenv.nix
@@ -351,6 +351,16 @@ in
     '';
   };
 
+  tasks."github:rulesets:check" = {
+    description = "Check live GitHub repository rulesets against generated source files";
+    exec = ''
+      set -euo pipefail
+      cd "$DEVENV_ROOT"
+
+      mono github rulesets check
+    '';
+  };
+
   # NOTE: check:quick is provided by effect-utils taskModules.check.
 
   git-hooks.enable = true;

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -153,6 +153,10 @@ const formatValue = (value: TJsonValue) => JSON.stringify(value)
 
 const isBypassActorsDiff = (diff: string) => diff.startsWith('$.bypass_actors')
 
+const isGitHubExpandedDefaultDiff = (diff: string) =>
+  diff === '$.rules.0.parameters.allowed_merge_methods: desired null, live ["merge","squash","rebase"]' ||
+  diff === '$.rules.0.parameters.required_reviewers: desired null, live []'
+
 const collectDiffs = (
   desired: TJsonValue,
   live: TJsonValue,
@@ -176,7 +180,9 @@ const collectDiffs = (
       return [`${formatPath(pathParts)}: desired ${formatValue(desired)}, live ${formatValue(live)}`]
     }
 
-    const keys = Object.keys(desired).toSorted((a, b) => a.localeCompare(b))
+    const keys = Array.from(new Set([...Object.keys(desired), ...Object.keys(live)])).toSorted((a, b) =>
+      a.localeCompare(b),
+    )
     return keys.flatMap((key) => collectDiffs(desired[key] ?? null, live[key] ?? null, [...pathParts, key]))
   }
 
@@ -240,7 +246,9 @@ const checkRulesetsCommand = Cli.Command.make(
 
     const live = yield* getRulesetDetails(existing.id).pipe(Effect.map(normalizeRuleset))
     const viewerPermission = yield* getViewerPermission
-    const allDiffs = collectDiffs(body as TJsonValue, live as TJsonValue)
+    const allDiffs = collectDiffs(body as TJsonValue, live as TJsonValue).filter(
+      (diff) => isGitHubExpandedDefaultDiff(diff) === false,
+    )
     const diffs =
       viewerPermission === 'ADMIN' ? allDiffs : allDiffs.filter((diff) => isBypassActorsDiff(diff) === false)
 

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -53,6 +53,38 @@ interface TExistingRuleset {
   enforcement: string
 }
 
+const ManagedRulesetSchema = Schema.Struct({
+  name: Schema.String,
+  target: Schema.Literal('branch', 'tag'),
+  enforcement: Schema.Literal('disabled', 'active', 'evaluate'),
+  bypass_actors: Schema.optional(Schema.NullOr(RulesetRequestBody.fields.bypass_actors)),
+  conditions: RulesetRequestBody.fields.conditions,
+  rules: RulesetRequestBody.fields.rules,
+})
+
+const normalizeRuleset = (ruleset: typeof ManagedRulesetSchema.Type): TRulesetRequestBody => ({
+  name: ruleset.name,
+  target: ruleset.target,
+  enforcement: ruleset.enforcement,
+  bypass_actors: ruleset.bypass_actors ?? [],
+  conditions: ruleset.conditions,
+  rules: ruleset.rules,
+})
+
+const getViewerPermission = Effect.gen(function* () {
+  const response = yield* cmdText(['gh', 'repo', 'view', `${OWNER}/${REPO}`, '--json', 'viewerPermission'], {
+    stderr: 'pipe',
+  }).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+
+  const ViewerPermissionSchema = Schema.parseJson(
+    Schema.Struct({
+      viewerPermission: Schema.String,
+    }),
+  )
+  const parsed = yield* Schema.decode(ViewerPermissionSchema)(response)
+  return parsed.viewerPermission
+})
+
 const getRulesetByName = (name: string) =>
   Effect.gen(function* () {
     const response = yield* cmdText(['gh', 'api', `repos/${OWNER}/${REPO}/rulesets`, '--jq', '.'], {
@@ -70,6 +102,16 @@ const getRulesetByName = (name: string) =>
     )
     const rulesets = yield* Schema.decode(ExistingRulesetSchema)(response)
     return rulesets.find((ruleset) => ruleset.name === name) ?? null
+  })
+
+const getRulesetDetails = (rulesetId: number) =>
+  Effect.gen(function* () {
+    const details = yield* cmdText(['gh', 'api', `repos/${OWNER}/${REPO}/rulesets/${rulesetId}`, '--jq', '.'], {
+      stderr: 'pipe',
+    }).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+
+    const parser = Schema.parseJson(ManagedRulesetSchema)
+    return yield* Schema.decode(parser)(details)
   })
 
 const writeRulesetBodyToTmp = (body: TRulesetRequestBody) =>
@@ -100,6 +142,47 @@ const updateRuleset = (rulesetId: number, body: TRulesetRequestBody) =>
     }).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
   })
 
+type TJsonValue = null | boolean | number | string | ReadonlyArray<TJsonValue> | { readonly [key: string]: TJsonValue }
+
+const isJsonObject = (value: TJsonValue): value is { readonly [key: string]: TJsonValue } =>
+  typeof value === 'object' && value !== null && Array.isArray(value) === false
+
+const formatPath = (pathParts: ReadonlyArray<string>) => (pathParts.length === 0 ? '$' : `$.${pathParts.join('.')}`)
+
+const formatValue = (value: TJsonValue) => JSON.stringify(value)
+
+const isBypassActorsDiff = (diff: string) => diff.startsWith('$.bypass_actors')
+
+const collectDiffs = (
+  desired: TJsonValue,
+  live: TJsonValue,
+  pathParts: ReadonlyArray<string> = [],
+): ReadonlyArray<string> => {
+  if (Object.is(desired, live) === true) return []
+
+  if (Array.isArray(desired) === true || Array.isArray(live) === true) {
+    if (Array.isArray(desired) === false || Array.isArray(live) === false) {
+      return [`${formatPath(pathParts)}: desired ${formatValue(desired)}, live ${formatValue(live)}`]
+    }
+
+    const maxLength = Math.max(desired.length, live.length)
+    return Array.from({ length: maxLength }).flatMap((_, index) =>
+      collectDiffs(desired[index] ?? null, live[index] ?? null, [...pathParts, String(index)]),
+    )
+  }
+
+  if (isJsonObject(desired) === true || isJsonObject(live) === true) {
+    if (isJsonObject(desired) === false || isJsonObject(live) === false) {
+      return [`${formatPath(pathParts)}: desired ${formatValue(desired)}, live ${formatValue(live)}`]
+    }
+
+    const keys = Object.keys(desired).toSorted((a, b) => a.localeCompare(b))
+    return keys.flatMap((key) => collectDiffs(desired[key] ?? null, live[key] ?? null, [...pathParts, key]))
+  }
+
+  return [`${formatPath(pathParts)}: desired ${formatValue(desired)}, live ${formatValue(live)}`]
+}
+
 const syncRulesetsCommand = Cli.Command.make(
   'sync',
   {
@@ -110,12 +193,22 @@ const syncRulesetsCommand = Cli.Command.make(
 
     const body = yield* loadRulesetBody()
     const existing = yield* getRulesetByName(body.name)
+    const live = existing === null ? null : yield* getRulesetDetails(existing.id).pipe(Effect.map(normalizeRuleset))
+    const diffs = live === null ? [] : collectDiffs(body as TJsonValue, live as TJsonValue)
 
     if (dryRun === true) {
       console.log(`Ruleset file: ${getRulesetFilePath()}`)
       console.log(`Ruleset name: ${body.name}`)
       console.log(`Existing: ${existing !== null ? `yes (id: ${existing.id})` : 'no'}`)
       console.log(`Action: ${existing !== null ? 'update' : 'create'}`)
+      if (existing !== null) {
+        if (diffs.length === 0) {
+          console.log('Drift: none')
+        } else {
+          console.log('Drift:')
+          for (const diff of diffs) console.log(`- ${diff}`)
+        }
+      }
       return
     }
 
@@ -128,6 +221,43 @@ const syncRulesetsCommand = Cli.Command.make(
     }
   }),
 ).pipe(Cli.Command.withDescription('Create or update repository ruleset from generated repo-settings file'))
+
+const checkRulesetsCommand = Cli.Command.make(
+  'check',
+  {},
+  Effect.fn(function* () {
+    yield* cmdText('gh --version', { stderr: 'pipe' }).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+
+    const body = yield* loadRulesetBody()
+    const existing = yield* getRulesetByName(body.name)
+
+    if (existing === null) {
+      console.error(`No live ruleset found with name '${body.name}'`)
+      console.error("Run 'mono github rulesets sync' to create one.")
+      process.exitCode = 1
+      return
+    }
+
+    const live = yield* getRulesetDetails(existing.id).pipe(Effect.map(normalizeRuleset))
+    const viewerPermission = yield* getViewerPermission
+    const allDiffs = collectDiffs(body as TJsonValue, live as TJsonValue)
+    const diffs =
+      viewerPermission === 'ADMIN' ? allDiffs : allDiffs.filter((diff) => isBypassActorsDiff(diff) === false)
+
+    if (diffs.length === 0) {
+      console.log(`Ruleset '${body.name}' is in sync with ${getRulesetFilePath()}.`)
+      if (viewerPermission !== 'ADMIN' && allDiffs.some(isBypassActorsDiff) === true) {
+        console.log('Bypass actor visibility requires repository admin permission; skipped bypass_actors comparison.')
+      }
+      return
+    }
+
+    console.error(`Ruleset '${body.name}' drift detected against ${getRulesetFilePath()}:`)
+    for (const diff of diffs) console.error(`- ${diff}`)
+    console.error("Run 'mono github rulesets sync' with admin permissions to reconcile it.")
+    process.exitCode = 1
+  }),
+).pipe(Cli.Command.withDescription('Check whether the live GitHub ruleset matches the generated source file'))
 
 const showRulesetsCommand = Cli.Command.make(
   'show',
@@ -148,13 +278,9 @@ const showRulesetsCommand = Cli.Command.make(
     console.log(`ID: ${existing.id}`)
     console.log(`Enforcement: ${existing.enforcement}`)
 
-    const details = yield* cmdText(['gh', 'api', `repos/${OWNER}/${REPO}/rulesets/${existing.id}`, '--jq', '.'], {
-      stderr: 'pipe',
-    }).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
-
     console.log('\nFull details:')
-    const parsed = yield* Schema.decode(Schema.parseJson(Schema.Unknown))(details)
-    console.dir(parsed, { depth: null })
+    const details = yield* getRulesetDetails(existing.id)
+    console.dir(details, { depth: null })
   }),
 ).pipe(Cli.Command.withDescription('Show current ruleset configuration'))
 
@@ -162,7 +288,7 @@ export const githubCommand = Cli.Command.make('github').pipe(
   Cli.Command.withSubcommands([
     Cli.Command.make('rulesets').pipe(
       Cli.Command.withDescription('Manage repository rulesets from generated repo-settings files'),
-      Cli.Command.withSubcommands([syncRulesetsCommand, showRulesetsCommand]),
+      Cli.Command.withSubcommands([syncRulesetsCommand, checkRulesetsCommand, showRulesetsCommand]),
     ),
   ]),
 )


### PR DESCRIPTION
## Problem

The live `main-branch-rules` ruleset drifted from the checked-in repository settings and silently dropped the Write-role bypass. That blocked maintainer self-merge until an admin manually resynced the ruleset.

## Goal

Make ruleset drift visible from normal repo tooling and CI before it turns into another merge-policy surprise.

## Decisions

- Add a read-only `mono github rulesets check` command instead of adding an automatic writer. Ruleset writes require admin credentials, so detection is the safer default path.
- Extend `sync --dry-run` to print concrete field-level drift, so maintainers can see what an admin sync would change.
- Skip `bypass_actors` comparison for non-admin viewers because GitHub hides bypass actors from non-admin tokens. The CI job uses `LIVESTORE_RULESET_ADMIN_TOKEN` when available and falls back to the default token for the rest of the ruleset surface.
- Run the CI drift check only on `main` pushes and manual dispatches, not PRs, because ruleset-source changes cannot be reflected in live GitHub until after merge.

## Verification

- `devenv tasks run github:rulesets:check --mode before --no-tui`
- `GH_CONFIG_DIR=/home/schickling/.config/gh devenv tasks run github:rulesets:check --mode before --no-tui`
- `devenv tasks run check:all --mode before --no-tui`
- `devenv tasks run genie:run --mode before --no-tui`
- `git diff --check`

## Complexity

Adds a small structural JSON diff helper inside the existing GitHub ruleset command. No new dependency.

## Concerns

The fallback CI token cannot verify `bypass_actors`; full bypass verification needs `LIVESTORE_RULESET_ADMIN_TOKEN` configured.

## Friction & bottlenecks

The first attempt was made from an older dev-derived worktree, which would have produced an oversized PR against `main`. I moved the PR work to a clean `origin/main` worktree before committing.

## Follow-ups

Configure `LIVESTORE_RULESET_ADMIN_TOKEN` if we want CI to verify bypass actors instead of only the non-sensitive ruleset fields.

## References

Refs #1214

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐙 co1-atoll |
| `agent_session_id` | 1b85f913-611c-475b-b619-8d079d6612a5 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | livestore-ruleset-drift-guard/schickling/ruleset-drift-guard |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->