### PR TITLE
Preserve CODEOWNERS and harden ruleset drift guard

### DIFF
--- a/.changeset/empty-ruleset-guard-ci.md
+++ b/.changeset/empty-ruleset-guard-ci.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. This only makes the repository ruleset drift guard independent from the Bun-backed mono CLI in CI.

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -12,7 +12,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": true,
         "require_last_push_approval": false,
@@ -89,11 +89,5 @@
       "type": "deletion"
     }
   ],
-  "bypass_actors": [
-    {
-      "actor_id": 4,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    }
-  ]
+  "bypass_actors": []
 }

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -22,7 +22,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -91,7 +91,7 @@
   ],
   "bypass_actors": [
     {
-      "actor_id": 5,
+      "actor_id": 4,
       "actor_type": "RepositoryRole",
       "bypass_mode": "always"
     }

--- a/.github/repo-settings.json.genie.ts
+++ b/.github/repo-settings.json.genie.ts
@@ -25,7 +25,7 @@ export default githubRuleset({
     {
       type: 'required_status_checks',
       parameters: {
-        strict_required_status_checks_policy: true,
+        strict_required_status_checks_policy: false,
         do_not_enforce_on_create: false,
         required_status_checks: requiredCIJobs.map((context) => ({ context })),
       },

--- a/.github/repo-settings.json.genie.ts
+++ b/.github/repo-settings.json.genie.ts
@@ -35,7 +35,7 @@ export default githubRuleset({
   ],
   bypass_actors: [
     {
-      actor_id: 5,
+      actor_id: 4,
       actor_type: 'RepositoryRole',
       bypass_mode: 'always',
     },

--- a/.github/repo-settings.json.genie.ts
+++ b/.github/repo-settings.json.genie.ts
@@ -15,7 +15,7 @@ export default githubRuleset({
     {
       type: 'pull_request',
       parameters: {
-        required_approving_review_count: 1,
+        required_approving_review_count: 0,
         dismiss_stale_reviews_on_push: false,
         require_code_owner_review: true,
         require_last_push_approval: false,
@@ -33,11 +33,5 @@ export default githubRuleset({
     { type: 'non_fast_forward' },
     { type: 'deletion' },
   ],
-  bypass_actors: [
-    {
-      actor_id: 4,
-      actor_type: 'RepositoryRole',
-      bypass_mode: 'always',
-    },
-  ],
+  bypass_actors: [],
 })

--- a/devenv.nix
+++ b/devenv.nix
@@ -392,7 +392,7 @@ in
       '
 
       jq "$jq_normalize" "$ruleset_file" > "$tmp_dir/desired.json"
-      gh api "repos/livestorejs/livestore/rulesets/$ruleset_id" | jq "$jq_normalize" > "$tmp_dir/live.json"
+      gh api "repos/livestorejs/livestore/rulesets/$ruleset_id" --jq "$jq_normalize" > "$tmp_dir/live.json"
 
       if [ "$viewer_permission" != "ADMIN" ]; then
         jq 'del(.bypass_actors)' "$tmp_dir/desired.json" > "$tmp_dir/desired.visible.json"

--- a/devenv.nix
+++ b/devenv.nix
@@ -358,7 +358,59 @@ in
       set -euo pipefail
       cd "$DEVENV_ROOT"
 
-      mono github rulesets check
+      ruleset_file=".github/repo-settings.json"
+      ruleset_name="$(jq -r '.name' "$ruleset_file")"
+      ruleset_id="$(gh api repos/livestorejs/livestore/rulesets --jq ".[] | select(.name == \"$ruleset_name\") | .id")"
+
+      if [ -z "$ruleset_id" ]; then
+        echo "No live ruleset found with name '$ruleset_name'" >&2
+        echo "Run 'mono github rulesets sync' with admin permissions to create it." >&2
+        exit 1
+      fi
+
+      tmp_dir="tmp/gh-rulesets-check"
+      mkdir -p "$tmp_dir"
+
+      viewer_permission="$(gh repo view livestorejs/livestore --json viewerPermission --jq '.viewerPermission')"
+
+      jq_normalize='
+        {
+          name,
+          target,
+          enforcement,
+          bypass_actors: (.bypass_actors // []),
+          conditions,
+          rules: [
+            .rules[]
+            | if .type == "pull_request" then
+                .parameters |= (del(.allowed_merge_methods) | del(.required_reviewers))
+              else
+                .
+              end
+          ]
+        }
+      '
+
+      jq "$jq_normalize" "$ruleset_file" > "$tmp_dir/desired.json"
+      gh api "repos/livestorejs/livestore/rulesets/$ruleset_id" | jq "$jq_normalize" > "$tmp_dir/live.json"
+
+      if [ "$viewer_permission" != "ADMIN" ]; then
+        jq 'del(.bypass_actors)' "$tmp_dir/desired.json" > "$tmp_dir/desired.visible.json"
+        jq 'del(.bypass_actors)' "$tmp_dir/live.json" > "$tmp_dir/live.visible.json"
+        mv "$tmp_dir/desired.visible.json" "$tmp_dir/desired.json"
+        mv "$tmp_dir/live.visible.json" "$tmp_dir/live.json"
+      fi
+
+      if ! diff -u <(jq -S . "$tmp_dir/desired.json") <(jq -S . "$tmp_dir/live.json"); then
+        echo "Ruleset '$ruleset_name' drift detected against $ruleset_file." >&2
+        echo "Run 'mono github rulesets sync' with admin permissions to reconcile it." >&2
+        exit 1
+      fi
+
+      echo "Ruleset '$ruleset_name' is in sync with $ruleset_file."
+      if [ "$viewer_permission" != "ADMIN" ]; then
+        echo "Bypass actor visibility requires repository admin permission; skipped bypass_actors comparison."
+      fi
     '';
   };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -208,6 +208,7 @@ in
     })
     # Local task: mono command wrappers for uniform dt interface
     ./nix/devenv-modules/tasks/local/mono-wrappers.nix
+    ./nix/devenv-modules/tasks/local/github-rulesets.nix
   ];
 
   packages = [
@@ -349,68 +350,6 @@ in
       cd "$DEVENV_ROOT"
 
       bun scripts/src/commands/changesets.ts verify-baseline-changelog
-    '';
-  };
-
-  tasks."github:rulesets:check" = {
-    description = "Check live GitHub repository rulesets against generated source files";
-    exec = ''
-      set -euo pipefail
-      cd "$DEVENV_ROOT"
-
-      ruleset_file=".github/repo-settings.json"
-      ruleset_name="$(jq -r '.name' "$ruleset_file")"
-      ruleset_id="$(gh api repos/livestorejs/livestore/rulesets --jq ".[] | select(.name == \"$ruleset_name\") | .id")"
-
-      if [ -z "$ruleset_id" ]; then
-        echo "No live ruleset found with name '$ruleset_name'" >&2
-        echo "Run 'mono github rulesets sync' with admin permissions to create it." >&2
-        exit 1
-      fi
-
-      tmp_dir="tmp/gh-rulesets-check"
-      mkdir -p "$tmp_dir"
-
-      viewer_permission="$(gh repo view livestorejs/livestore --json viewerPermission --jq '.viewerPermission')"
-
-      jq_normalize='
-        {
-          name,
-          target,
-          enforcement,
-          bypass_actors: (.bypass_actors // []),
-          conditions,
-          rules: [
-            .rules[]
-            | if .type == "pull_request" then
-                .parameters |= (del(.allowed_merge_methods) | del(.required_reviewers))
-              else
-                .
-              end
-          ]
-        }
-      '
-
-      jq "$jq_normalize" "$ruleset_file" > "$tmp_dir/desired.json"
-      gh api "repos/livestorejs/livestore/rulesets/$ruleset_id" --jq "$jq_normalize" > "$tmp_dir/live.json"
-
-      if [ "$viewer_permission" != "ADMIN" ]; then
-        jq 'del(.bypass_actors)' "$tmp_dir/desired.json" > "$tmp_dir/desired.visible.json"
-        jq 'del(.bypass_actors)' "$tmp_dir/live.json" > "$tmp_dir/live.visible.json"
-        mv "$tmp_dir/desired.visible.json" "$tmp_dir/desired.json"
-        mv "$tmp_dir/live.visible.json" "$tmp_dir/live.json"
-      fi
-
-      if ! diff -u <(jq -S . "$tmp_dir/desired.json") <(jq -S . "$tmp_dir/live.json"); then
-        echo "Ruleset '$ruleset_name' drift detected against $ruleset_file." >&2
-        echo "Run 'mono github rulesets sync' with admin permissions to reconcile it." >&2
-        exit 1
-      fi
-
-      echo "Ruleset '$ruleset_name' is in sync with $ruleset_file."
-      if [ "$viewer_permission" != "ADMIN" ]; then
-        echo "Bypass actor visibility requires repository admin permission; skipped bypass_actors comparison."
-      fi
     '';
   };
 

--- a/nix/devenv-modules/tasks/local/github-rulesets.nix
+++ b/nix/devenv-modules/tasks/local/github-rulesets.nix
@@ -1,0 +1,64 @@
+{ ... }:
+{
+  tasks."github:rulesets:check" = {
+    description = "Check live GitHub repository rulesets against generated source files";
+    exec = ''
+      set -euo pipefail
+      cd "$DEVENV_ROOT"
+
+      ruleset_file=".github/repo-settings.json"
+      ruleset_name="$(jq -r '.name' "$ruleset_file")"
+      ruleset_id="$(gh api repos/livestorejs/livestore/rulesets --jq ".[] | select(.name == \"$ruleset_name\") | .id")"
+
+      if [ -z "$ruleset_id" ]; then
+        echo "No live ruleset found with name '$ruleset_name'" >&2
+        echo "Run 'mono github rulesets sync' with admin permissions to create it." >&2
+        exit 1
+      fi
+
+      tmp_dir="tmp/gh-rulesets-check"
+      mkdir -p "$tmp_dir"
+
+      viewer_permission="$(gh repo view livestorejs/livestore --json viewerPermission --jq '.viewerPermission')"
+
+      jq_normalize='
+        {
+          name,
+          target,
+          enforcement,
+          bypass_actors: (.bypass_actors // []),
+          conditions,
+          rules: [
+            .rules[]
+            | if .type == "pull_request" then
+                .parameters |= (del(.allowed_merge_methods) | del(.required_reviewers))
+              else
+                .
+              end
+          ]
+        }
+      '
+
+      jq "$jq_normalize" "$ruleset_file" > "$tmp_dir/desired.json"
+      gh api "repos/livestorejs/livestore/rulesets/$ruleset_id" --jq "$jq_normalize" > "$tmp_dir/live.json"
+
+      if [ "$viewer_permission" != "ADMIN" ]; then
+        jq 'del(.bypass_actors)' "$tmp_dir/desired.json" > "$tmp_dir/desired.visible.json"
+        jq 'del(.bypass_actors)' "$tmp_dir/live.json" > "$tmp_dir/live.visible.json"
+        mv "$tmp_dir/desired.visible.json" "$tmp_dir/desired.json"
+        mv "$tmp_dir/live.visible.json" "$tmp_dir/live.json"
+      fi
+
+      if ! diff -u <(jq -S . "$tmp_dir/desired.json") <(jq -S . "$tmp_dir/live.json"); then
+        echo "Ruleset '$ruleset_name' drift detected against $ruleset_file." >&2
+        echo "Run 'mono github rulesets sync' with admin permissions to reconcile it." >&2
+        exit 1
+      fi
+
+      echo "Ruleset '$ruleset_name' is in sync with $ruleset_file."
+      if [ "$viewer_permission" != "ADMIN" ]; then
+        echo "Bypass actor visibility requires repository admin permission; skipped bypass_actors comparison."
+      fi
+    '';
+  };
+}

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -135,6 +135,16 @@ const publishTagForVersion = (version: string) => {
   return 'next'
 }
 
+const isSnapshotVersion = (version: string) => version.includes('-snapshot-')
+
+const packageVersionExists = (packageName: string, version: string) => {
+  const result = spawnSync('npm', ['view', `${packageName}@${version}`, 'version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return result.status === 0
+}
+
 const downloadToFile = async (source: string, target: string, redirects = 0): Promise<void> => {
   if (redirects > 5) throw new Error(`Too many redirects while fetching ${source}`)
 
@@ -439,10 +449,22 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
     run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
   }
   if (hasFlag(flags, 'publish') === true) {
+    const alreadyPublished = isSnapshotVersion(version) === true && packageVersionExists(metadata.packageName, version)
     const publishArgs = ['npm', 'publish', '--tag', publishTag, '--access', 'public']
     if (process.env.GITHUB_ACTIONS === 'true') publishArgs.push('--provenance')
     publishArgs.push(repackedPath)
-    run(publishArgs, { cwd: workDir })
+    if (alreadyPublished === true) {
+      console.warn(`${metadata.packageName}@${version} already published, skipping npm publish`)
+    } else {
+      try {
+        run(publishArgs, { cwd: workDir })
+      } catch (error) {
+        if (isSnapshotVersion(version) === false || packageVersionExists(metadata.packageName, version) === false) {
+          throw error
+        }
+        console.warn(`${metadata.packageName}@${version} became visible after npm publish failed; continuing`)
+      }
+    }
     if (chromeZipPath !== undefined) {
       publishChromeZipReleaseAsset(version, chromeZipPath, workDir)
     }

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -353,18 +353,17 @@ const publishReleasePackages = ({
       const publishArgs = ['pnpm', 'publish', `--tag=${npmTag}`, '--access=public', '--no-git-checks']
       if (isCI === true) publishArgs.push('--provenance')
       if (dryRun === true) publishArgs.push('--dry-run')
+      const versionIsVisible = cmd(`npm view ${pkg}@${version} version`, { stdout: 'pipe', stderr: 'pipe' }).pipe(
+        Effect.provide(cwdLayer),
+        Effect.as(true),
+        Effect.catchTag('CmdError', () => Effect.succeed(false)),
+      )
       yield* cmd(`DT_PASSTHROUGH=1 ${publishArgs.join(' ')}`, { shell: true }).pipe(
         Effect.provide(cwdLayer),
         Effect.catchTag('CmdError', (error) => {
           if (isCI === false || dryRun === true || isSnapshotVersion(version) === false) return Effect.fail(error)
 
-          const alreadyVisible = cmd(`npm view ${pkg}@${version} version`, { stdout: 'pipe', stderr: 'pipe' }).pipe(
-            Effect.provide(cwdLayer),
-            Effect.as(true),
-            Effect.catchTag('CmdError', () => Effect.succeed(false)),
-          )
-
-          return alreadyVisible.pipe(
+          return versionIsVisible.pipe(
             Effect.flatMap((isVisible) => {
               if (isVisible === true) {
                 return Effect.logWarning(
@@ -377,7 +376,20 @@ const publishReleasePackages = ({
                 `Retrying ${pkg}@${version} snapshot publish without provenance after provenance publish failed`,
               ).pipe(
                 Effect.zipRight(
-                  cmd(`DT_PASSTHROUGH=1 ${fallbackArgs.join(' ')}`, { shell: true }).pipe(Effect.provide(cwdLayer)),
+                  cmd(`DT_PASSTHROUGH=1 ${fallbackArgs.join(' ')}`, { shell: true }).pipe(
+                    Effect.provide(cwdLayer),
+                    Effect.catchTag('CmdError', (fallbackError) =>
+                      versionIsVisible.pipe(
+                        Effect.flatMap((isVisibleAfterFallback) =>
+                          isVisibleAfterFallback === true
+                            ? Effect.logWarning(
+                                `${pkg}@${version} became visible after the fallback publish failed; continuing`,
+                              )
+                            : Effect.fail(fallbackError),
+                        ),
+                      ),
+                    ),
+                  ),
                 ),
               )
             }),


### PR DESCRIPTION
**Problem**

The live `main-branch-rules` ruleset was reconciled from `.github/repo-settings.json`, but three gaps remained:

- Write-role `bypass_mode: always` bypassed the entire ruleset, including CODEOWNERS, weakening the intended `@schickling` approval gate for release-sensitive paths.
- Strict required status checks reintroduced the rebase-loop friction once the bypass was removed.
- The `ruleset-drift-check` job on `main` could not verify the live state because Bun segfaulted while booting `mono github rulesets check` on the Linux runner.

**Goal**

Keep the generated ruleset as the source of truth, preserve CODEOWNERS as the review authority for owned paths, avoid requiring general reviews or repeated rebases for ordinary Write-role PRs, and keep CI able to detect future drift without depending on the Bun CLI path.

**Decisions**

The ruleset now uses `required_approving_review_count: 0`, keeps `require_code_owner_review: true`, removes all bypass actors, and sets `strict_required_status_checks_policy: false`. Ordinary paths do not need an approving review, CODEOWNERS paths still require the matching code-owner approval, and Write-role users do not get a bypass checkbox that can skip CODEOWNERS.

Strict status checks are disabled because, without bypass actors, strictness forces every PR back through a full rebase + CI cycle whenever `main` advances. The remaining required checks still run on the PR head; if the project later needs serialized integration with latest `main`, a merge queue is the right mechanism.

The `github:rulesets:check` devenv task now performs the guard with `gh api --jq`, `jq`, and `diff` directly. This keeps the same source of truth and admin/non-admin visibility behavior while avoiding the heavy `mono` bootstrap for repository control-plane validation. The task lives in `nix/devenv-modules/tasks/local/github-rulesets.nix` so `devenv.nix` stays focused on composition.

The `mono github rulesets sync/check/show` command remains available for local/admin workflows.

Snapshot publishing is now idempotent for both the main package publish fallback and the DevTools artifact publish path. CI exposed that retries can see a package version become visible after npm accepts the first publish; those duplicate-version cases now verify visibility and continue instead of failing the PR.

**Verification**

- Regenerated settings: `CI=1 devenv tasks run genie:run --mode before --no-tui`
- Live admin sync now reports `updated_at: 2026-05-07T14:17:35.155+02:00`, `bypass_actors: []`, `current_user_can_bypass: never`, `required_approving_review_count: 0`, `require_code_owner_review: true`, and `strict_required_status_checks_policy: false`.
- Default `schickling-assistant` visibility reports the same non-bypass shape.
- `CI=1 GH_CONFIG_DIR=/home/schickling/.config/gh devenv tasks run github:rulesets:check --mode before --no-tui`
- `CI=1 devenv tasks run github:rulesets:check --mode before --no-tui`
- `CI=1 devenv tasks run check:all --mode before --no-tui`
- `git diff --check`
- Final PR CI for `c928f437c2cb698ace3082cbc745c3b6022de6d4`: https://github.com/livestorejs/livestore/actions/runs/25498967067
- Final manual workflow-dispatch e2e for `ruleset-drift-check`: https://github.com/livestorejs/livestore/actions/runs/25498983418/job/74826292321

**Complexity**

This adds shell comparison logic inside a dedicated local devenv task module, but avoids adding a new dependency and keeps the CI guard on the platform tools it is validating through. The snapshot publish changes add a small idempotency check around already-published versions to make retry behavior match npm's immutable package-version model.

**Concerns**

The non-admin path still cannot detect hidden live `bypass_actors` if GitHub redacts them. Admin `github:rulesets:check` remains the authoritative check for bypass actor drift.

With strict checks disabled, PRs are no longer forced to include the latest `main` before merge. Required PR checks still gate the head commit; semantic integration conflicts should be handled by the merge queue if that becomes a real problem.

**Follow-ups**

None known for the ruleset source/sync path. PR #1218, the original blocked workflow, is merged.

**References**

Refs #1214.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦈 co1-lagoon |
| `agent_session_id` | 05ff9049-5cb6-4b37-9374-1b5847fe2b37 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | livestore-ruleset-drift-guard/schickling/ruleset-guard-bun-fix |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->