### PR TITLE
Scope changeset checks to public package files

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -9,9 +9,13 @@ files record PR-level release intent and semver impact; maintainers fold that
 information into `CHANGELOG.md` using the existing changelog guide before a
 stable release.
 
-Every pull request should include a changeset. Use an empty changeset for
-changes that do not need release notes:
+Pull requests that change files in the public LiveStore package graph should
+include a changeset. Use an empty changeset for public package changes that do
+not need release notes:
 
 ```bash
 pnpm exec changeset add --empty
 ```
+
+Infrastructure, documentation, and release-control-plane changes that do not
+touch public package files do not need a changeset.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
           retention-days: 14
   ruleset-drift-check:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    if: (github.event_name == 'workflow_dispatch' && !startsWith(github.ref_name, 'automation/release-')) || github.ref == 'refs/heads/main'
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -125,7 +125,7 @@ export default githubWorkflow({
     }),
 
     'ruleset-drift-check': standardCIJob({
-      if: "github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'",
+      if: "(github.event_name == 'workflow_dispatch' && !startsWith(github.ref_name, 'automation/release-')) || github.ref == 'refs/heads/main'",
       steps: [
         ...livestoreSetupSteps,
         {

--- a/contributor-docs/changelog-guide.md
+++ b/contributor-docs/changelog-guide.md
@@ -33,7 +33,7 @@ The changelog should meet the goals of an application developer as follows:
 ## Active Release Workflow
 
 1. Add a changeset for every public package change. Use an empty changeset only
-   when the change has no release-note impact.
+   when a public package change intentionally has no release-note impact.
 2. Keep an "Upcoming" (or next-version) section at the top of the changelog.
 3. Fold release-impacting changesets into the upcoming section as features,
    fixes, or documentation updates land.

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -16,7 +16,8 @@ generated release notes replace it. Maintainers fold PR-level changeset
 information into the handcrafted changelog structure before cutting a stable
 release.
 
-Every PR must include one of:
+Every PR that touches files in the public LiveStore package graph must include
+one of:
 
 - A regular `.changeset/*.md` file for release-impacting changes.
 - An empty changeset for changes that do not need release notes.
@@ -25,6 +26,11 @@ Every PR must include one of:
 pnpm exec changeset
 pnpm exec changeset add --empty
 ```
+
+The PR changeset check derives that package graph from the public `@livestore/*`
+workspace packages. Infrastructure, documentation, generated workflow, and
+release-control-plane changes that do not touch those package directories do
+not need an empty changeset.
 
 The baseline `.changeset/livestore-0-4-0-baseline.md` mirrors the existing
 handcrafted `CHANGELOG.md` 0.4.0 unreleased section. Keep both in sync until the

--- a/scripts/src/commands/changesets.ts
+++ b/scripts/src/commands/changesets.ts
@@ -74,6 +74,8 @@ const publicLivestorePackages = () =>
     })
     .sort((left, right) => left.name.localeCompare(right.name))
 
+const fileIsWithinDir = (file: string, dir: string) => file === dir || file.startsWith(`${dir}/`)
+
 const changedFiles = (base: string) => {
   const result = spawnSync('git', ['diff', '--name-only', `${base}...HEAD`], {
     encoding: 'utf8',
@@ -88,6 +90,14 @@ const changedFiles = (base: string) => {
 
 const isChangesetMarkdown = (file: string) =>
   file.startsWith('.changeset/') && file.endsWith('.md') && path.basename(file) !== 'README.md'
+
+const changedPublicPackageFiles = (files: ReadonlyArray<string>) => {
+  const packages = publicLivestorePackages()
+  return files.flatMap((file) => {
+    const pkg = packages.find((candidate) => fileIsWithinDir(file, candidate.dir))
+    return pkg === undefined ? [] : [{ file, packageName: pkg.name }]
+  })
+}
 
 const isPrereleaseNpmTag = (npmTag: string) => npmTag !== 'latest'
 
@@ -104,11 +114,18 @@ const checkPr = (flags: Map<string, string | true>) => {
     return
   }
 
+  const packageFiles = changedPublicPackageFiles(files)
+  if (packageFiles.length === 0) {
+    console.log('This PR does not change files in the public LiveStore package graph; no changeset required.')
+    return
+  }
+
   throw new Error(
     [
-      'This PR does not add or modify a changeset.',
+      'This PR changes public LiveStore package files but does not add or modify a changeset.',
+      ...packageFiles.map(({ file, packageName }) => `- ${packageName}: ${file}`),
       'Run `pnpm exec changeset` for a release-impacting change.',
-      'Run `pnpm exec changeset add --empty` when the package change does not need release notes.',
+      'Run `pnpm exec changeset add --empty` when the package change intentionally does not need release notes.',
     ].join('\n'),
   )
 }


### PR DESCRIPTION
**Problem**

Generated `automation/release-*` branches run `ci.yml` through `workflow_dispatch` as part of release PR validation. That previously also ran `ruleset-drift-check`, even though repository ruleset reconciliation is a main-branch control-plane guard and not release payload validation.

The same PR exposed that our changeset enforcement was too blunt: workflow/docs/release-control-plane PRs had to add empty `.changeset/*.md` files even when they did not touch public package files.

**Goal**

Keep ruleset drift validation on `main` and on explicit manual runs, while preventing generated release branches from being blocked by repository control-plane checks.

Require changesets for public LiveStore package graph changes, without forcing empty changesets for infrastructure, documentation, or workflow-only changes.

**Decisions**

`ruleset-drift-check` still runs for pushes to `main` and normal manual workflow dispatches. It now skips only manual dispatches where `github.ref_name` starts with `automation/release-`, matching the release branch naming convention used by the release workflow.

`release:changeset:check-pr` now classifies changed files against the public `@livestore/*` package directories. A PR with no `.changeset/*.md` passes only when it does not touch that public package graph. If it does touch public package files, the check fails and prints the affected package/file list.

The empty changeset that was originally added for this workflow-only PR has been removed from the final diff.

**Verification**

- `CI=1 devenv tasks run release:changeset:check-pr lint:check:format --mode before --no-tui --show-output`
  - printed: `This PR does not change files in the public LiveStore package graph; no changeset required.`
- `CI=1 devenv tasks run lint:check:genie --mode before --no-tui --show-output`
- Throwaway worktree experiment: committed a change under `packages/@livestore/common/package.json` without a changeset; `release:changeset:check-pr` failed and reported `@livestore/common: packages/@livestore/common/package.json`.
- Previous release-branch validation passed separately: https://github.com/livestorejs/livestore/actions/runs/25473404402
- Previous release-branch CI failure was isolated to `ruleset-drift-check` on workflow-dispatched `automation/release-0.4.0-dev.24`: https://github.com/livestorejs/livestore/actions/runs/25473403899

**Complexity**

This adds a small package-path classifier to the existing changeset command. It avoids maintaining broad path allowlists and keeps the enforcement tied to the actual public package graph.

**Concerns**

This intentionally treats root-level dependency, CI, docs, and release-control-plane changes as not requiring a changeset unless they also touch public package files. Those surfaces still need their own CI/release validation, but they should not create package release notes by default.

The release-branch skip relies on generated release branches continuing to use the `automation/release-` prefix. That prefix is already part of the release workflow contract.

**Follow-ups**

After this lands, regenerate the `0.4.0-dev.24` release PR from `main` so the release branch picks up the corrected workflow condition.

**References**

Refs #1220.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏹 co2-yew |
| `agent_session_id` | f4dc0e19-c065-4ef6-88a5-3ccd141697ea |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | livestore-dev-release-main/schickling/2026-05-07-skip-ruleset-check-release-branches |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->