### PR TITLE
chore: smoke-test self-merge on non-CODEOWNERS path

### DIFF
--- a/.changeset/empty-self-merge-smoke-test.md
+++ b/.changeset/empty-self-merge-smoke-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Smoke-tests self-merge behavior on a non-CODEOWNERS path under the current ruleset configuration (`required_approving_review_count: 0`, `require_code_owner_review: true`, `bypass_actors: []`).


### PR DESCRIPTION
## Problem

After the recent ruleset reconfiguration (`required_approving_review_count: 0`, `require_code_owner_review: true`, `bypass_actors: []`), we want empirical confirmation that:

1. A write-role author can merge a PR touching only non-CODEOWNERS paths without any approval and without invoking a bypass affordance.
2. CI status checks remain enforced (PR can't merge until they pass).

## Solution

Adds an empty changeset under `.changeset/` (a path that is not code-owned per `.github/CODEOWNERS`). The change has no functional or release-note impact — it exists solely to exercise the merge gate.

## Validation

Expected post-CI state for an authenticated `@IGassmann` view:

- No "Merging is blocked" banner.
- No "Merge without waiting for requirements to be met (bypass rules)" checkbox.
- Standard merge button enabled.
- `gh pr view` reports `mergeStateStatus: CLEAN` (or comparable non-`BLOCKED` state).

If any of those don't match, the ruleset behavior diverges from intent and we'll bring evidence back to #1214 / #1223.

## Follow-up

The empty changeset file is safe to leave on `main` (it has no release impact). If we want to drop it post-test, a follow-up one-line PR removes it.