### PR TITLE
Make release publish recovery idempotent

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,11 @@ that the exact commit under test can publish snapshot packages and that users
 can create projects from those snapshots. Forked PRs skip jobs that require
 repository secrets or publishing permissions.
 
+Snapshot DevTools Chrome ZIPs are uploaded as short-lived workflow artifacts,
+not GitHub Releases. Public GitHub Releases are reserved for dev/stable release
+versions so the releases page remains a user-facing release history rather than
+a CI snapshot log.
+
 Manual `workflow_dispatch` is used by the release workflow for generated release
 PR branches. GitHub does not recursively trigger PR workflows from branches
 pushed with `GITHUB_TOKEN`, so release automation explicitly dispatches CI for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3183,7 +3183,15 @@ jobs:
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:publish --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:publish --mode before'
         env:
+          LIVESTORE_DEVTOOLS_OUT_DIR: '${{ runner.temp }}/livestore-devtools-snapshot'
           LIVESTORE_RELEASE_VERSION: '0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}'
+      - name: Upload DevTools Chrome snapshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'livestore-devtools-chrome-0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}'
+          path: '${{ runner.temp }}/livestore-devtools-snapshot/livestore-devtools-chrome-0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}.zip'
+          if-no-files-found: error
+          retention-days: 14
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -353,7 +353,20 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
         {
           name: 'Publish DevTools artifact snapshot',
           run: runDevenvTasksBefore('release:devtools-artifact:publish'),
-          env: { LIVESTORE_RELEASE_VERSION: `0.0.0-snapshot-${PR_HEAD_SHA}` },
+          env: {
+            LIVESTORE_DEVTOOLS_OUT_DIR: '${{ runner.temp }}/livestore-devtools-snapshot',
+            LIVESTORE_RELEASE_VERSION: `0.0.0-snapshot-${PR_HEAD_SHA}`,
+          },
+        },
+        {
+          name: 'Upload DevTools Chrome snapshot artifact',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: `livestore-devtools-chrome-0.0.0-snapshot-${PR_HEAD_SHA}`,
+            path: '${{ runner.temp }}/livestore-devtools-snapshot/livestore-devtools-chrome-0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}.zip',
+            'if-no-files-found': 'error',
+            'retention-days': 14,
+          },
         },
       ]),
     },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -748,6 +748,7 @@ jobs:
       contents: write
       id-token: write
     env:
+      GH_TOKEN: ${{ github.token }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     defaults:
       run:

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -230,6 +230,7 @@ fi`,
         'id-token': 'write',
       },
       env: {
+        GH_TOKEN: '${{ github.token }}',
         NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}',
       },
       defaults: bashShellDefaults,

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -126,6 +126,12 @@ After merge to `main`, the push-triggered workflow runs:
 - For stable `latest` releases only: `docs:deploy:prod`,
   `examples:deploy:prod`, and the production docs search sync.
 
+CI snapshot publishing still republishes the public DevTools npm package for
+the exact snapshot version. Snapshot Chrome ZIPs are retained as workflow
+artifacts for short-term debugging; they are not published as GitHub Releases.
+GitHub Releases are reserved for dev and stable release versions that users may
+need to download directly.
+
 Normal CI deploys docs/examples to the dev surfaces. Production docs, examples,
 and search are only updated by an explicit stable release publish so regular
 `main` integration work cannot accidentally update the public latest surfaces.

--- a/devenv.nix
+++ b/devenv.nix
@@ -90,6 +90,7 @@ let
     bun scripts/src/commands/devtools-artifact.ts repack \
       "''${artifact_args[@]}" \
       --version "$LIVESTORE_RELEASE_VERSION" \
+      --out-dir "''${LIVESTORE_DEVTOOLS_OUT_DIR:-$(mktemp -d)}" \
       ${publishFlag}
   '';
 

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -121,6 +121,16 @@ const runCapture = (command: ReadonlyArray<string>, options: { readonly cwd?: st
   return result.stdout
 }
 
+const runCaptureOptional = (command: ReadonlyArray<string>, options: { readonly cwd?: string } = {}) => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    cwd: options.cwd,
+    env: process.env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return result.status === 0 ? result.stdout.trim() : undefined
+}
+
 const sha256 = (file: string) => createHash('sha256').update(readFileSync(file)).digest('hex')
 const integrity = (file: string) => `sha512-${createHash('sha512').update(readFileSync(file)).digest('base64')}`
 
@@ -137,13 +147,8 @@ const publishTagForVersion = (version: string) => {
 
 const isSnapshotVersion = (version: string) => version.includes('-snapshot-')
 
-const packageVersionExists = (packageName: string, version: string) => {
-  const result = spawnSync('npm', ['view', `${packageName}@${version}`, 'version'], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
-  return result.status === 0
-}
+const packageVersionExists = (packageName: string, version: string) =>
+  runCaptureOptional(['npm', 'view', `${packageName}@${version}`, 'version']) === version
 
 const downloadToFile = async (source: string, target: string, redirects = 0): Promise<void> => {
   if (redirects > 5) throw new Error(`Too many redirects while fetching ${source}`)
@@ -376,11 +381,15 @@ const verifyArtifact = async (flags: Map<string, string | true>) => {
   return { metadata, tarballPath, chromeZipPath, workDir }
 }
 
-const publishChromeZipReleaseAsset = (version: string, chromeZipPath: string, workDir: string) => {
-  const repo = process.env.GITHUB_REPOSITORY ?? 'livestorejs/livestore'
-  const tag = `v${version}`
+const materializeChromeZipAsset = (version: string, chromeZipPath: string, workDir: string) => {
   const assetPath = path.join(workDir, `livestore-devtools-chrome-${version}.zip`)
   writeFileSync(assetPath, readFileSync(chromeZipPath))
+  return assetPath
+}
+
+const publishChromeZipReleaseAsset = (version: string, assetPath: string) => {
+  const repo = process.env.GITHUB_REPOSITORY ?? 'livestorejs/livestore'
+  const tag = `v${version}`
 
   const releaseExists = spawnSync('gh', ['release', 'view', tag, '--repo', repo], {
     encoding: 'utf8',
@@ -449,7 +458,7 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
     run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
   }
   if (hasFlag(flags, 'publish') === true) {
-    const alreadyPublished = isSnapshotVersion(version) === true && packageVersionExists(metadata.packageName, version)
+    const alreadyPublished = packageVersionExists(metadata.packageName, version)
     const publishArgs = ['npm', 'publish', '--tag', publishTag, '--access', 'public']
     if (process.env.GITHUB_ACTIONS === 'true') publishArgs.push('--provenance')
     publishArgs.push(repackedPath)
@@ -459,14 +468,19 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
       try {
         run(publishArgs, { cwd: workDir })
       } catch (error) {
-        if (isSnapshotVersion(version) === false || packageVersionExists(metadata.packageName, version) === false) {
+        if (packageVersionExists(metadata.packageName, version) === false) {
           throw error
         }
         console.warn(`${metadata.packageName}@${version} became visible after npm publish failed; continuing`)
       }
     }
     if (chromeZipPath !== undefined) {
-      publishChromeZipReleaseAsset(version, chromeZipPath, workDir)
+      const chromeZipAssetPath = materializeChromeZipAsset(version, chromeZipPath, workDir)
+      if (isSnapshotVersion(version) === true) {
+        console.log(`Snapshot Chrome zip prepared for workflow artifact upload: ${chromeZipAssetPath}`)
+      } else {
+        publishChromeZipReleaseAsset(version, chromeZipAssetPath)
+      }
     }
   }
 


### PR DESCRIPTION
**Problem**

The `0.4.0-dev.24` post-merge release publish reached the DevTools artifact publish step, published `@livestore/devtools-vite@0.4.0-dev.24`, then failed while creating the GitHub release because the publish job did not expose `GH_TOKEN` to the `gh release` commands.

CI snapshot DevTools publishing also created public GitHub Releases such as `v0.0.0-snapshot-<sha>`, which made the releases page read like a CI log instead of a user-facing release history.

**Goal**

Make release publish recovery safe to rerun and reserve public GitHub Releases for dev/stable release versions users may download directly.

**Decisions**

- Pass `GH_TOKEN` from `github.token` in the `publish-release` job, matching the snapshot publisher and standalone DevTools artifact workflow.
- Make DevTools artifact publishing idempotent for already-published npm versions. A rerun now skips npm publish when `@livestore/devtools-vite@<version>` is already visible, then continues to upload the Chrome zip release asset.
- For `0.0.0-snapshot-*`, skip GitHub Release creation/upload for the Chrome zip.
- Upload snapshot Chrome zips as short-lived workflow artifacts with 14-day retention.
- Keep package contents and artifact privacy checks unchanged.

**Verification**

- `CI=1 devenv tasks run genie:run --mode before --no-tui --show-output`
- `CI=1 devenv tasks run lint:check:genie lint:check:format --mode before --no-tui --show-output`
- `CI=1 devenv tasks run ts:build --mode before --no-tui --show-output`
- Confirmed `@livestore/common@0.4.0-dev.24` and `@livestore/devtools-vite@0.4.0-dev.24` are already visible on npm with the `dev` dist-tag.
- Deleted all existing GitHub Releases matching `^v0\.0\.0-snapshot-[0-9a-f]{40}$` with release tag cleanup, including additional releases produced by pre-fix in-flight runs during this PR.
- Verified no remaining GitHub Releases or remote tags matching `v0.0.0-snapshot-*` after the successful PR snapshot publish job.
- PR CI run `25500050089`: `publish-snapshot-version` succeeded, including `Publish DevTools artifact snapshot` and `Upload DevTools Chrome snapshot artifact`.
- Verified workflow artifact `livestore-devtools-chrome-0.0.0-snapshot-0f218bcd51e93f733ad8d69fb337fa1515c5583e` exists on run `25500050089`.
- Failure being recovered: https://github.com/livestorejs/livestore/actions/runs/25494779901

**Complexity**

Small policy split: dev/stable versions keep public GitHub release assets; snapshots keep npm snapshots plus temporary workflow artifacts.

**Concerns**

Existing external links to deleted snapshot GitHub release assets will no longer resolve. The npm snapshot packages remain the supported CI snapshot contract.

**Friction & bottlenecks**

GitHub branch protection only counted PR-attached checks, so the release PR had to run a real pull_request CI cycle in addition to the workflow-dispatch validation.

**Follow-ups**

After this merges, rerun the `Release` workflow on `main` in `publish-release` mode to recover the partially completed `0.4.0-dev.24` release and attach the dev Chrome zip.

**References**

Refs https://github.com/livestorejs/livestore/pull/1220

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏹 co2-yew |
| `agent_session_id` | f4dc0e19-c065-4ef6-88a5-3ccd141697ea |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | livestore-dev-release-main/schickling/2026-05-07-fix-release-publish-token |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->