### PR TITLE
fix(devenv): prepend only /usr/bin to PATH on macOS

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -413,12 +413,14 @@ in
     export PATH="$WORKSPACE_ROOT/scripts/bin:$WORKSPACE_ROOT/scripts/node_modules/.bin:$PATH"
 
     if [ "$(uname)" = "Darwin" ]; then
-      # Append (not prepend) Apple's tool dirs so Xcode-only commands
-      # (xcrun, xcodebuild, xcode-select) remain discoverable for Expo/iOS
-      # builds without shadowing Nix-store binaries. Prepending /bin pulled
-      # in Bash 3.2, which breaks devenv task scripts that expand empty
-      # arrays under `set -u` (e.g. effect-utils' run_pnpm_install).
-      export PATH="$PATH:/usr/bin:/bin"
+      # Prepend /usr/bin so Apple's xcrun/xcodebuild/xcode-select win for
+      # Expo/iOS native builds — the Nix `xcbuild` shim's xcrun is incomplete
+      # and breaks pod install / Expo prebuild. Do NOT prepend /bin: that
+      # would put Bash 3.2 ahead of the Nix bash, and devenv task bodies
+      # (e.g. effect-utils' run_pnpm_install) trip on empty array expansion
+      # under `set -u` in Bash 3.2. /usr/bin/bash doesn't exist on macOS,
+      # so prepending only /usr/bin keeps Nix bash in front.
+      export PATH="/usr/bin:$PATH"
       unset DEVELOPER_DIR
     fi
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -413,7 +413,12 @@ in
     export PATH="$WORKSPACE_ROOT/scripts/bin:$WORKSPACE_ROOT/scripts/node_modules/.bin:$PATH"
 
     if [ "$(uname)" = "Darwin" ]; then
-      export PATH="/usr/bin:/bin:$PATH"
+      # Append (not prepend) Apple's tool dirs so Xcode-only commands
+      # (xcrun, xcodebuild, xcode-select) remain discoverable for Expo/iOS
+      # builds without shadowing Nix-store binaries. Prepending /bin pulled
+      # in Bash 3.2, which breaks devenv task scripts that expand empty
+      # arrays under `set -u` (e.g. effect-utils' run_pnpm_install).
+      export PATH="$PATH:/usr/bin:/bin"
       unset DEVELOPER_DIR
     fi
 


### PR DESCRIPTION
## Problem

`devenv shell` on macOS aborted on `pnpm:install`:

```
└ ✗ ts:build failed
  └ ✗ pnpm:install failed → bash: line 109: extra_install_args[@]: unbound variable
```

Two layers combined:

1. `enterShell` prepended `/usr/bin:/bin` to `PATH` on Darwin (intent: Xcode tooling for Expo/iOS — `unset DEVELOPER_DIR` and the `# Expo / iOS quirks` comment in the original commit `3c76cd1ac`). Side-effect: `bash` resolved to `/bin/bash` 3.2 instead of the Nix bash 5.x.
2. effect-utils' `trace.nix` runs every task body via `otel-span run … -- bash -c <body>` (active because `(effectUtils.devenvModules.otel { mode = "local"; })` is enabled). With Bash 3.2 in front, `pnpm.nix`'s `run_pnpm_install` (which does `local extra_install_args=("$@")` then expands `"${extra_install_args[@]}"`) trips on empty-array expansion under `set -u`. Bash 3.2 reports it as unbound; Bash 4.4+ does not.

```
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ /bin/bash -c 'set -u; a=("$@"); echo "${a[@]}"' --
/bin/bash: a[@]: unbound variable
```

## Solution

Prepend `/usr/bin` only — not `/bin` — to `PATH` on Darwin.

- `/usr/bin/xcrun`, `/usr/bin/xcodebuild`, `/usr/bin/xcode-select` exist there, so Expo/iOS tooling still wins over the incomplete Nix `xcbuild` shim. (Confirmed: an earlier draft that appended both dirs regressed `xcrun --version` from `72` to `1 (xcbuild)`.)
- `/usr/bin/bash` does not exist on macOS, so the Nix bash stays in front and task bodies run on Bash 5.x.
- `/bin` is left out of PATH entirely; shebang-resolved `/bin/sh` / `/bin/bash` callers continue to work via absolute path.

## Validation

Inside `devenv shell` on macOS 25.4 / Apple silicon:

| Tool | Resolves to | Notes |
| --- | --- | --- |
| `bash` | `/nix/store/…bash-interactive-5.3p9/bin/bash` | GNU bash 5.3.9 |
| `xcrun` | `/usr/bin/xcrun` | version 72 |
| `xcodebuild` | `/usr/bin/xcodebuild` | Xcode 26.4.1 |
| `xcode-select` | `/usr/bin/xcode-select` | `/Applications/Xcode.app/Contents/Developer` |

Tasks:

- `dt pnpm:install` → exit 0 (was failing pre-fix)
- `dt ts:build` → exit 0 (was failing pre-fix transitively via `pnpm:install`)

## Test plan

- [x] `devenv shell` enters cleanly on macOS; `pnpm:install` and `ts:build` complete.
- [x] `xcrun --version` / `xcodebuild -version` still resolve to Apple tools (Expo/iOS path intact).
- [x] Linux devenv shell unaffected (change is scoped to `if [ "$(uname)" = "Darwin" ]`; verified by inspection — only the Darwin block was edited).