### PR TITLE
Fix DevTools protocol compatibility versioning

### DIFF
--- a/.changeset/devtools-protocol-compatibility.md
+++ b/.changeset/devtools-protocol-compatibility.md
@@ -1,0 +1,6 @@
+---
+'@livestore/common': patch
+'@livestore/livestore': patch
+---
+
+Decouple LiveStore DevTools runtime compatibility from package versions by adding an explicit DevTools protocol version to the app and DevTools handshake.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -83,6 +83,11 @@ release identity. When LiveStore republishes the artifact, the npm package and
 Chrome ZIP release asset are versioned with the LiveStore release group or
 snapshot version.
 
+Artifact ordering should use artifact metadata such as `artifactVersion` or
+`builtAt`. Runtime compatibility is decided by `devtoolsProtocolVersion`, not by
+matching package versions. The release repack path rejects artifacts whose
+protocol version is unsupported by the LiveStore checkout.
+
 The workflow exists so the LiveStore repository can keep release CI
 self-contained while the DevTools source remains outside this repository.
 

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -176,21 +176,34 @@ version may appear inside `release-metadata.json` for traceability, but it is
 not the public artifact release identity and it does not decide the LiveStore
 package version.
 
+New artifact metadata should also include a monotonically increasing
+`artifactVersion`, a `devtoolsProtocolVersion`, `builtAt`, and `sourceRevision`.
+`artifactVersion` orders DevTools artifact lineage. `devtoolsProtocolVersion`
+is the runtime compatibility contract between the app and DevTools. LiveStore
+package versions may differ from the source artifact version as long as the
+artifact protocol is supported and `compatibleLivestore` accepts the release
+version.
+
 The LiveStore release workflow only consumes those published artifacts. It must
 not require, copy, log, or publish non-public DevTools source. Artifact
 verification checks the metadata, tarball hash and integrity, package shape, and
 text-like files for common secret or machine-local patterns before repacking.
+Repack validation also rejects artifacts with unsupported DevTools protocol
+versions or incompatible `compatibleLivestore` declarations.
 
 The repacked package writes `dist/release-metadata.json` with both identities:
 
 - `devtoolsArtifact.devtoolsVersion`
 - `devtoolsArtifact.devtoolsBuildId`
+- `devtoolsArtifact.artifactVersion` when provided by the artifact producer
+- `devtoolsArtifact.devtoolsProtocolVersion`
 - `livestoreVersion`
 
 Use `devtoolsArtifact.devtoolsBuildId` to correlate a published LiveStore
 package with the exact public DevTools artifact when investigating failures.
 Use `livestoreVersion` to correlate the republished npm package and GitHub
 Chrome ZIP asset with the LiveStore release group or snapshot.
+Do not use `devtoolsArtifact.devtoolsVersion` for compatibility or ordering.
 
 ## Updating the DevTools artifact manifest
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,7 +43,7 @@
     "@livestore/adapter-node": "workspace:^",
     "@livestore/adapter-web": "workspace:^",
     "@livestore/common": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",
     "@livestore/solid": "workspace:^",

--- a/docs/src/content/_assets/code/package.json
+++ b/docs/src/content/_assets/code/package.json
@@ -30,7 +30,7 @@
     "@livestore/adapter-node": "workspace:^",
     "@livestore/adapter-web": "workspace:^",
     "@livestore/devtools-expo": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",
     "@livestore/solid": "workspace:^",

--- a/examples/cf-chat-solid/package.json
+++ b/examples/cf-chat-solid/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "tailwindcss": "4.1.18",

--- a/examples/cf-chat/package.json
+++ b/examples/cf-chat/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",

--- a/examples/web-email-client/package.json
+++ b/examples/web-email-client/package.json
@@ -18,7 +18,7 @@
     "react-error-boundary": "6.1.1"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-linearlite/package.json
+++ b/examples/web-linearlite/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@svgr/plugin-jsx": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0",

--- a/examples/web-multi-store/package.json
+++ b/examples/web-multi-store/package.json
@@ -17,7 +17,7 @@
     "react-error-boundary": "6.1.1"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@types/node": "25.3.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-custom-elements/package.json
+++ b/examples/web-todomvc-custom-elements/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",

--- a/examples/web-todomvc-experimental/package.json
+++ b/examples/web-todomvc-experimental/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-react-router/package.json
+++ b/examples/web-todomvc-react-router/package.json
@@ -17,7 +17,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-script/package.json
+++ b/examples/web-todomvc-script/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "typescript": "5.9.3",
     "vite": "7.3.1",

--- a/examples/web-todomvc-solid/package.json
+++ b/examples/web-todomvc-solid/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "solid-devtools": "^0.34.3",
     "typescript": "5.9.3",

--- a/examples/web-todomvc-svelte/package.json
+++ b/examples/web-todomvc-svelte/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@sveltejs/vite-plugin-svelte": "6.2.1",
     "typescript": "5.9.3",

--- a/examples/web-todomvc-sync-cf/package.json
+++ b/examples/web-todomvc-sync-cf/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-sync-electric/package.json
+++ b/examples/web-todomvc-sync-electric/package.json
@@ -19,7 +19,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@tanstack/react-router": "1.145.7",
     "@tanstack/router-devtools": "1.139.14",

--- a/examples/web-todomvc-sync-s2/package.json
+++ b/examples/web-todomvc-sync-s2/package.json
@@ -20,7 +20,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@tanstack/react-router": "1.145.7",
     "@tanstack/router-devtools": "1.139.14",

--- a/examples/web-todomvc/package.json
+++ b/examples/web-todomvc/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -49,11 +49,10 @@ export const livestoreWorkspaceCatalog = {
 /** LiveStore-only versions not provided by effect-utils base catalog. */
 export const livestoreOnlyCatalog = {
   /**
-   * Snapshot releases pin every `@livestore/*` package — including the
-   * externally-published `devtools-vite` from overeng — to the same
-   * `LIVESTORE_RELEASE_VERSION`. Default to the dev tag for normal builds.
+   * LiveStore republishes DevTools artifacts under the LiveStore release version.
+   * The source artifact carries its own metadata for artifact lineage and protocol compatibility.
    */
-  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.22',
+  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.24',
   /** Tanstack router sub-packages not in effect-utils catalog (react-router/react-start/router-plugin are there) */
   '@tanstack/router-core': '1.145.7',
   '@tanstack/history': '1.145.7',

--- a/packages/@livestore/adapter-node/package.json
+++ b/packages/@livestore/adapter-node/package.json
@@ -37,7 +37,7 @@
     "@opentelemetry/api": "1.9.0"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@rollup/plugin-commonjs": "28.0.6",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-terser": "0.4.4",

--- a/packages/@livestore/common/src/devtools/devtools-compatibility.test.ts
+++ b/packages/@livestore/common/src/devtools/devtools-compatibility.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { isDevtoolsProtocolVersionSupported, resolveDevtoolsProtocolVersion } from '../version.ts'
+
+describe('DevTools protocol compatibility', () => {
+  it('treats legacy pings without a protocol version as protocol 1', () => {
+    expect(resolveDevtoolsProtocolVersion(undefined)).toBe(1)
+    expect(isDevtoolsProtocolVersionSupported(undefined, [1])).toBe(true)
+  })
+
+  it('accepts supported protocol versions independent of package version', () => {
+    expect(isDevtoolsProtocolVersionSupported(1, [1])).toBe(true)
+  })
+
+  it('rejects unsupported protocol versions', () => {
+    expect(isDevtoolsProtocolVersionSupported(2, [1])).toBe(false)
+  })
+})

--- a/packages/@livestore/common/src/devtools/devtools-messages-client-session.ts
+++ b/packages/@livestore/common/src/devtools/devtools-messages-client-session.ts
@@ -103,19 +103,25 @@ export class LiveQueriesRes extends LSDClientSessionReqResMessage('LSD.ClientSes
   subscriptionId: Schema.String,
 }) {}
 
-export class Ping extends LSDClientSessionReqResMessage('LSD.ClientSession.Ping', {}) {}
+export class Ping extends LSDClientSessionReqResMessage('LSD.ClientSession.Ping', {
+  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+}) {}
 
-export class Pong extends LSDClientSessionReqResMessage('LSD.ClientSession.Pong', {}) {}
+export class Pong extends LSDClientSessionReqResMessage('LSD.ClientSession.Pong', {
+  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+}) {}
 
 /**
- * Sent by the app when DevTools version doesn't match.
- * Contains the app's actual version so DevTools can display a meaningful error.
+ * Sent by the app when the DevTools protocol isn't compatible.
+ * Contains package versions for display and protocol versions for the actual compatibility decision.
  */
 export class VersionMismatch extends LSDClientSessionReqResMessage('LSD.ClientSession.VersionMismatch', {
   /** The version running in the app */
   appVersion: Schema.String,
   /** The version that was sent by DevTools (that caused the mismatch) */
   receivedVersion: Schema.String,
+  appDevtoolsProtocolVersion: Schema.Number,
+  receivedDevtoolsProtocolVersion: Schema.optional(Schema.Number),
 }) {}
 
 export class Disconnect extends LSDClientSessionChannelMessage('LSD.ClientSession.Disconnect', {}) {}

--- a/packages/@livestore/common/src/devtools/devtools-messages-common.ts
+++ b/packages/@livestore/common/src/devtools/devtools-messages-common.ts
@@ -6,10 +6,8 @@ export const requestId = Schema.String
 export const clientId = Schema.String
 export const sessionId = Schema.String
 /**
- * Version field for devtools messages.
- * Uses Schema.String to accept messages from any version (backwards/forwards compatible).
- * Version checking happens at the application layer after message parsing succeeds,
- * allowing DevTools to respond with a proper VersionMismatch error instead of silent rejection.
+ * Display/package version field for DevTools messages.
+ * Compatibility is decided by the optional DevTools protocol version carried by handshake messages.
  */
 export const liveStoreVersion = Schema.String
 

--- a/packages/@livestore/common/src/devtools/devtools-messages-leader.ts
+++ b/packages/@livestore/common/src/devtools/devtools-messages-leader.ts
@@ -107,19 +107,25 @@ export class EventlogRes extends LSDReqResMessage('LSD.Leader.EventlogRes', {
   eventlog: Transferable.Uint8Array as Schema.Schema<Uint8Array<ArrayBuffer>>,
 }) {}
 
-export class Ping extends LSDReqResMessage('LSD.Leader.Ping', {}) {}
+export class Ping extends LSDReqResMessage('LSD.Leader.Ping', {
+  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+}) {}
 
-export class Pong extends LSDReqResMessage('LSD.Leader.Pong', {}) {}
+export class Pong extends LSDReqResMessage('LSD.Leader.Pong', {
+  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+}) {}
 
 /**
- * Sent by the app when DevTools version doesn't match.
- * Contains the app's actual version so DevTools can display a meaningful error.
+ * Sent by the app when the DevTools protocol isn't compatible.
+ * Contains package versions for display and protocol versions for the actual compatibility decision.
  */
 export class VersionMismatch extends LSDReqResMessage('LSD.Leader.VersionMismatch', {
   /** The version running in the app */
   appVersion: Schema.String,
   /** The version that was sent by DevTools (that caused the mismatch) */
   receivedVersion: Schema.String,
+  appDevtoolsProtocolVersion: Schema.Number,
+  receivedDevtoolsProtocolVersion: Schema.optional(Schema.Number),
 }) {}
 
 export class Disconnect extends LSDReqResMessage('LSD.Leader.Disconnect', {}) {}

--- a/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
+++ b/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
@@ -1,7 +1,15 @@
 import { Effect, FiberMap, Option, Stream, SubscriptionRef } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 
-import { Devtools, IntentionalShutdownCause, liveStoreVersion, UnknownError } from '../index.ts'
+import {
+  Devtools,
+  devtoolsProtocolVersion,
+  IntentionalShutdownCause,
+  isDevtoolsProtocolVersionSupported,
+  liveStoreVersion,
+  resolveDevtoolsProtocolVersion,
+  UnknownError,
+} from '../index.ts'
 import { SystemTables } from '../schema/mod.ts'
 import type { DevtoolsOptions, PersistenceInfoPair } from './types.ts'
 import { LeaderThreadCtx } from './types.ts'
@@ -166,18 +174,19 @@ const listenToDevtools = ({
 
           switch (decodedEvent._tag) {
             case 'LSD.Leader.Ping': {
-              // Check version mismatch and respond with VersionMismatch if versions don't match
-              if (decodedEvent.liveStoreVersion !== liveStoreVersion) {
+              if (isDevtoolsProtocolVersionSupported(decodedEvent.devtoolsProtocolVersion) === false) {
                 yield* sendMessage(
                   Devtools.Leader.VersionMismatch.make({
                     ...reqPayload,
                     appVersion: liveStoreVersion,
                     receivedVersion: decodedEvent.liveStoreVersion,
+                    appDevtoolsProtocolVersion: devtoolsProtocolVersion,
+                    receivedDevtoolsProtocolVersion: resolveDevtoolsProtocolVersion(decodedEvent.devtoolsProtocolVersion),
                   }),
                 )
                 return
               }
-              yield* sendMessage(Devtools.Leader.Pong.make({ ...reqPayload }))
+              yield* sendMessage(Devtools.Leader.Pong.make({ ...reqPayload, devtoolsProtocolVersion }))
               return
             }
             case 'LSD.Leader.SnapshotReq': {
@@ -352,10 +361,10 @@ const listenToDevtools = ({
               return
             }
             case 'LSD.Leader.SyncHistoryUnsubscribe': {
-              const { requestId } = decodedEvent
-              console.log('LSD.SyncHistoryUnsubscribe', requestId)
+              const unsubscribeRequestId = decodedEvent.requestId
+              console.log('LSD.SyncHistoryUnsubscribe', unsubscribeRequestId)
 
-              yield* FiberMap.remove(subscriptionFiberMap, requestId)
+              yield* FiberMap.remove(subscriptionFiberMap, unsubscribeRequestId)
 
               return
             }
@@ -408,9 +417,9 @@ const listenToDevtools = ({
               return
             }
             case 'LSD.Leader.NetworkStatusUnsubscribe': {
-              const { requestId } = decodedEvent
+              const unsubscribeRequestId = decodedEvent.requestId
 
-              yield* FiberMap.remove(subscriptionFiberMap, requestId)
+              yield* FiberMap.remove(subscriptionFiberMap, unsubscribeRequestId)
 
               return
             }

--- a/packages/@livestore/common/src/version.ts
+++ b/packages/@livestore/common/src/version.ts
@@ -1,12 +1,23 @@
 import pkg from '../package.json' with { type: 'json' }
 
 /**
- * Current LiveStore version used for DevTools version compatibility checks.
+ * Current LiveStore package version used for display, release assets, and install guidance.
  *
- * Can be overridden at runtime via `globalThis.__LIVESTORE_VERSION_OVERRIDE__` for testing purposes.
- * This allows Playwright tests to simulate version mismatch scenarios without rebuilding.
+ * Can be overridden at runtime via `globalThis.__LIVESTORE_VERSION_OVERRIDE__` for testing display-only version values.
  */
 export const liveStoreVersion: string = (globalThis as any).__LIVESTORE_VERSION_OVERRIDE__ ?? pkg.version
+
+export const devtoolsProtocolVersion: number =
+  (globalThis as any).__LIVESTORE_DEVTOOLS_PROTOCOL_VERSION_OVERRIDE__ ?? 1
+
+export const supportedDevtoolsProtocolVersions: ReadonlyArray<number> = [devtoolsProtocolVersion]
+
+export const resolveDevtoolsProtocolVersion = (version: number | undefined): number => version ?? 1
+
+export const isDevtoolsProtocolVersionSupported = (
+  version: number | undefined,
+  supportedVersions: ReadonlyArray<number> = supportedDevtoolsProtocolVersions,
+): boolean => supportedVersions.includes(resolveDevtoolsProtocolVersion(version))
 
 /**
  * CRITICAL: Increment this version whenever you modify client-side EVENTLOG table schemas.

--- a/packages/@livestore/devtools-expo/package.json
+++ b/packages/@livestore/devtools-expo/package.json
@@ -48,7 +48,7 @@
     "@effect/sql": "^0.51.1",
     "@effect/typeclass": "^0.40.0",
     "@effect/vitest": "^0.29.0",
-    "@livestore/devtools-vite": "^0.4.0-dev.22",
+    "@livestore/devtools-vite": "^0.4.0-dev.24",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/resources": "^2.2.0",
     "@standard-schema/spec": "^1.1.0",

--- a/packages/@livestore/livestore/src/store/devtools.ts
+++ b/packages/@livestore/livestore/src/store/devtools.ts
@@ -1,5 +1,12 @@
 import type { DebugInfo, SyncState } from '@livestore/common'
-import { Devtools, liveStoreVersion, UnknownError } from '@livestore/common'
+import {
+  Devtools,
+  devtoolsProtocolVersion,
+  isDevtoolsProtocolVersionSupported,
+  liveStoreVersion,
+  resolveDevtoolsProtocolVersion,
+  UnknownError,
+} from '@livestore/common'
 import { throttle } from '@livestore/utils'
 import type { WebChannel } from '@livestore/utils/effect'
 import { Effect, Stream } from '@livestore/utils/effect'
@@ -316,8 +323,7 @@ export const connectDevtoolsToStore = Effect.fn('LSD.devtools.connectStoreToDevt
           break
         }
         case 'LSD.ClientSession.Ping': {
-          // Check version mismatch and respond with VersionMismatch if versions don't match
-          if (decodedMessage.liveStoreVersion !== liveStoreVersion) {
+          if (isDevtoolsProtocolVersionSupported(decodedMessage.devtoolsProtocolVersion) === false) {
             sendToDevtools(
               Devtools.ClientSession.VersionMismatch.make({
                 requestId,
@@ -326,11 +332,21 @@ export const connectDevtoolsToStore = Effect.fn('LSD.devtools.connectStoreToDevt
                 liveStoreVersion,
                 appVersion: liveStoreVersion,
                 receivedVersion: decodedMessage.liveStoreVersion,
+                appDevtoolsProtocolVersion: devtoolsProtocolVersion,
+                receivedDevtoolsProtocolVersion: resolveDevtoolsProtocolVersion(decodedMessage.devtoolsProtocolVersion),
               }),
             )
             break
           }
-          sendToDevtools(Devtools.ClientSession.Pong.make({ requestId, clientId, sessionId, liveStoreVersion }))
+          sendToDevtools(
+            Devtools.ClientSession.Pong.make({
+              requestId,
+              clientId,
+              sessionId,
+              liveStoreVersion,
+              devtoolsProtocolVersion,
+            }),
+          )
           break
         }
         default: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,8 +300,8 @@ importers:
         specifier: workspace:^
         version: link:../packages/@livestore/common
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@livestore/livestore':
         specifier: workspace:^
         version: link:../packages/@livestore/livestore
@@ -529,8 +529,8 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/@livestore/devtools-expo
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@livestore/livestore':
         specifier: workspace:^
         version: link:../../../../../packages/@livestore/livestore
@@ -690,8 +690,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -760,8 +760,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1151,8 +1151,8 @@ importers:
         version: 6.1.1(react@19.2.3)
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@tailwindcss/vite':
         specifier: 4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -1284,8 +1284,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1378,8 +1378,8 @@ importers:
         version: 6.1.1(react@19.2.3)
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -1445,8 +1445,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1503,8 +1503,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1576,8 +1576,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1637,8 +1637,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1750,8 +1750,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1799,8 +1799,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1854,8 +1854,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1915,8 +1915,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1982,8 +1982,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -2067,8 +2067,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -2343,8 +2343,8 @@ importers:
         version: 3.21.2
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@rollup/plugin-commonjs':
         specifier: 28.0.6
         version: 28.0.6(rollup@4.49.0)
@@ -2740,8 +2740,8 @@ importers:
         specifier: workspace:^
         version: link:../adapter-node
       '@livestore/devtools-vite':
-        specifier: ^0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: ^0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils':
         specifier: workspace:^
         version: link:../utils
@@ -4524,8 +4524,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/@livestore/common-cf
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@livestore/effect-playwright':
         specifier: workspace:^
         version: link:../../packages/@livestore/effect-playwright
@@ -4727,8 +4727,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils-dev':
         specifier: workspace:^
         version: link:../../packages/@livestore/utils-dev
@@ -4957,8 +4957,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -5066,8 +5066,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.22
-        version: 0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)
+        specifier: 0.4.0-dev.24
+        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils-dev':
         specifier: workspace:^
         version: link:../../packages/@livestore/utils-dev
@@ -6905,7 +6905,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@54.0.10':
     resolution: {integrity: sha512-iw9gAnN6+PKWWLIyYmiskY/wzZjuFMctunqGXuC8BGATWgtr/HpzjVqWbcL3KIX/GvEBCCh74Tkckrh+Ylxh5Q==}
@@ -7581,33 +7581,113 @@ packages:
   '@livestore/adapter-web@0.3.1':
     resolution: {integrity: sha512-0ZKTam+C3KeG5qiiTLFOgoMhdUBCENmuaMwxoj7WOtA2c4eKyqIy+P/1zga+az0XqaMJoG5FVszWhWMUMzNjtQ==}
 
-  '@livestore/adapter-web@0.4.0-dev.22':
-    resolution: {integrity: sha512-TXr+LCQYiijr3H5aDzmHjCH0OFBC2l4jnuSZm47Gjk7nFW7oba+kRNuLRjy5/T84H64+WBEvUemuiKBcQQkwOg==}
+  '@livestore/adapter-web@0.4.0-dev.24':
+    resolution: {integrity: sha512-j4JngwuQt+Q+MFuopqf52U03Z0wn4V7NHvgmih1Ba5zJF+sOvPmmRtRj1SDW98aCNRG3XSlg1Yh+S2yikaZV6w==}
+    peerDependencies:
+      '@effect/ai': ^0.35.0
+      '@effect/cli': 0.75.1
+      '@effect/cluster': ^0.58.2
+      '@effect/experimental': 0.60.0
+      '@effect/opentelemetry': 0.63.0
+      '@effect/platform': 0.96.1
+      '@effect/platform-browser': 0.76.0
+      '@effect/platform-bun': 0.89.0
+      '@effect/platform-node': 0.106.0
+      '@effect/printer': 0.49.0
+      '@effect/printer-ansi': 0.49.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
+      '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: 3.21.2
 
-  '@livestore/common-cf@0.4.0-dev.22':
-    resolution: {integrity: sha512-eWHeOpQ4Lwa39WpgHGPZvDCTo5Muf6qHO0SKklOibUDGxhb7yCX3qcV/cOH7cwiFU6FTZI6cZr7PMUYlSwr5UQ==}
+  '@livestore/common-cf@0.4.0-dev.24':
+    resolution: {integrity: sha512-5QPrz/SQDLL+o7O8aDhaevyzIdyJrU1saKiyVak4KScbOoIKiN3sa4VkF3MUKgJeJfUUQdWabxBN+fkrsy6pow==}
+    peerDependencies:
+      '@effect/ai': ^0.35.0
+      '@effect/cli': 0.75.1
+      '@effect/cluster': ^0.58.2
+      '@effect/experimental': 0.60.0
+      '@effect/opentelemetry': 0.63.0
+      '@effect/platform': 0.96.1
+      '@effect/platform-browser': 0.76.0
+      '@effect/platform-bun': 0.89.0
+      '@effect/platform-node': 0.106.0
+      '@effect/printer': 0.49.0
+      '@effect/printer-ansi': 0.49.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
+      '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: 3.21.2
 
   '@livestore/common@0.3.1':
     resolution: {integrity: sha512-D44ia+zVH8EF0TWGUp0GQnCVvCsGKgKD/ryFl+kx607/l7GDUSagNnWkRmMwhhshJSJblQwouhA9fwjDNTBB2g==}
 
-  '@livestore/common@0.4.0-dev.22':
-    resolution: {integrity: sha512-ybtwS2eTZ/RaO0Jdtuu2tcRxr36Vz9lsOoHtFLagflaiB5+emC9W4d73++ideOBP6BM+gfi9PpiKTNeFZ1lLtg==}
+  '@livestore/common@0.4.0-dev.24':
+    resolution: {integrity: sha512-KE1BVVq0z+0qR6HPb+X5gabgZcOYMYY9e3FGeJGdSvbWYQouGNeeZFaEe+2xQkg/HVBTa5cg0tEeWZq7vpWQ3A==}
+    peerDependencies:
+      '@effect/ai': ^0.35.0
+      '@effect/cli': 0.75.1
+      '@effect/cluster': ^0.58.2
+      '@effect/experimental': 0.60.0
+      '@effect/opentelemetry': 0.63.0
+      '@effect/platform': 0.96.1
+      '@effect/platform-browser': 0.76.0
+      '@effect/platform-bun': 0.89.0
+      '@effect/platform-node': 0.106.0
+      '@effect/printer': 0.49.0
+      '@effect/printer-ansi': 0.49.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
+      '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: 3.21.2
 
   '@livestore/devtools-vite@0.3.1':
     resolution: {integrity: sha512-7d4dxI1jkNtMRNxfnj7WVFIg+z5+M1FxTCUw4XrtHYeJGd7qy3GOJ/75D0lU12OQ7EbY/qSVnoU7++SkSEjMFA==}
     peerDependencies:
       vite: ~6.3.4
 
-  '@livestore/devtools-vite@0.4.0-dev.22':
-    resolution: {integrity: sha512-J+hKbCPmdXGNW5Y6JK3ia0bHXzEi0zIRXP6xJATm77arCCmIYU2SrQanK4s/9oAGfx3VARONupYCtC+a+JNbsQ==}
+  '@livestore/devtools-vite@0.4.0-dev.24':
+    resolution: {integrity: sha512-LaovZMF4yuq3jvEx84WyrpTIXDytnDydCkpgPdNUyckL1V+yKqd9Mbq4eXPlAKl2PX0EcK/RGepR/Ua26WAPDQ==}
     peerDependencies:
-      vite: ^7.2.4
+      vite: ^7.3.1
 
   '@livestore/devtools-web-common@0.3.1':
     resolution: {integrity: sha512-jU7IvebelTtvSTQ2zKNzSm5qZodwUiPsNsDURsY5Yw0DXpafcfpRobs/WYd+Wd4Q1E4oFaK05hPfWZGbVFdw7Q==}
 
-  '@livestore/devtools-web-common@0.4.0-dev.22':
-    resolution: {integrity: sha512-EXlFKrrsmjlrcRrowheGsXk7uoF+ab4LeMaGYp2Uoo62nLVH0D8Q8zMbbzojnYhZHs6SHDaqAmQE430G+HUfgA==}
+  '@livestore/devtools-web-common@0.4.0-dev.24':
+    resolution: {integrity: sha512-neWpu9GwHRq872S2U0h2Ib2sdBVZWxSRaGeivLHBHmnSgJVPgeCienEp9qsX+XVPzIAFWr+w9tJkmrt13GGwjA==}
+    peerDependencies:
+      '@effect/ai': ^0.35.0
+      '@effect/cli': 0.75.1
+      '@effect/cluster': ^0.58.2
+      '@effect/experimental': 0.60.0
+      '@effect/opentelemetry': 0.63.0
+      '@effect/platform': 0.96.1
+      '@effect/platform-browser': 0.76.0
+      '@effect/platform-bun': 0.89.0
+      '@effect/platform-node': 0.106.0
+      '@effect/printer': 0.49.0
+      '@effect/printer-ansi': 0.49.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
+      '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: 3.21.2
 
   '@livestore/livestore@0.3.1':
     resolution: {integrity: sha512-imw1JK5i82yTmSC4PRoZ1gUiG39jasR49c5TPQI/MCIFSbgqcKS0x1IPoB8js6tlPoVm+iH7p4JTAQKYC2q3Pg==}
@@ -7618,8 +7698,28 @@ packages:
   '@livestore/sqlite-wasm@0.3.1':
     resolution: {integrity: sha512-+JLIwpd2N214LmwlUX6arYnJ5IhvSi4Fn3Jk6E6fNfuUU4tczcL1PtgfIX2IoiPhn9QDG0YJVdJBT6KYi1uMyg==}
 
-  '@livestore/sqlite-wasm@0.4.0-dev.22':
-    resolution: {integrity: sha512-ZdhwguqJbEjPqem2rYfI6mdrnMLFmbLtgWAwLNFQRmiSiY4F20i7y/c3tFbHTJUDYoQwWmvunLRL8GYDHtCXzA==}
+  '@livestore/sqlite-wasm@0.4.0-dev.24':
+    resolution: {integrity: sha512-ZS0+o4a2ixduSjW20ecHXz//gUdFpnPotwg/eGqMsDJpcNhFV8CvG6jxJhfL2QY58h290MwUW2rrvLqnYDb8dg==}
+    peerDependencies:
+      '@effect/ai': ^0.35.0
+      '@effect/cli': 0.75.1
+      '@effect/cluster': ^0.58.2
+      '@effect/experimental': 0.60.0
+      '@effect/opentelemetry': 0.63.0
+      '@effect/platform': 0.96.1
+      '@effect/platform-browser': 0.76.0
+      '@effect/platform-bun': 0.89.0
+      '@effect/platform-node': 0.106.0
+      '@effect/printer': 0.49.0
+      '@effect/printer-ansi': 0.49.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
+      '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: 3.21.2
 
   '@livestore/sync-cf@0.3.1':
     resolution: {integrity: sha512-Vopen/K5/MRr4va/3u19cGLFslJs/fqtr5C2MhEOy080uYcClEWUDxyHh/Oec9wx4ZsbC0WKfTiUVN48DjHo/A==}
@@ -7644,12 +7744,12 @@ packages:
       '@opentelemetry/resources': ~2.0.0
       effect: 3.21.2
 
-  '@livestore/utils@0.4.0-dev.22':
-    resolution: {integrity: sha512-5eDFievmIQA9A/KpqNYbfm5hyLahHHyzl4dlkeEe26EefF2cxF5/7EH2Bt5fMzsDgIyAc4WNgxSXtZRp74TftQ==}
+  '@livestore/utils@0.4.0-dev.24':
+    resolution: {integrity: sha512-Z1cyNk1lnhdgPWceo85mc8uawp9AzupQvhuQXzLWsLxz/RNJsD/N4c/BLnBhbSVJCGaTr8SbtLoh8HykLtOTPw==}
     peerDependencies:
-      '@effect/ai': ^0.29.0
+      '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
-      '@effect/cluster': ^0.50.6
+      '@effect/cluster': ^0.58.2
       '@effect/experimental': 0.60.0
       '@effect/opentelemetry': 0.63.0
       '@effect/platform': 0.96.1
@@ -7658,15 +7758,17 @@ packages:
       '@effect/platform-node': 0.106.0
       '@effect/printer': 0.49.0
       '@effect/printer-ansi': 0.49.0
-      '@effect/rpc': ^0.71.1
-      '@effect/sql': ^0.46.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
       '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
       '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/resources': ^2.0.1
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
       effect: 3.21.2
 
-  '@livestore/wa-sqlite@0.4.0-dev.22':
-    resolution: {integrity: sha512-+Q4JP2SiXRI+CUYQa33KeyWdeUtRJbrSXbJ0acIRNJmnXSdHWA9N1XHZOCtkoR2BY7XCA29/uh3coNklsQOYtA==}
+  '@livestore/wa-sqlite@0.4.0-dev.24':
+    resolution: {integrity: sha512-ot0OnZ+54kIzGeu59Loz+L7C/HtYRlbDw89SgJEA93SlHBZ9Zzm4d6EWmF5v5c5lpwZCpgBU7aa23jJamtYXqw==}
 
   '@livestore/wa-sqlite@1.0.5-dev.2':
     resolution: {integrity: sha512-i7tKFEp0m3+4tGLV9Z5eAr/3RZPuNOyuf4NaQ/ygF2KwzlHc3TnqouPuE2sMH06r3soXIilWYND/x0eT8x6D6Q==}
@@ -7674,8 +7776,28 @@ packages:
   '@livestore/webmesh@0.3.1':
     resolution: {integrity: sha512-JLYFgiOf1r7xqN7SkwdHNZdZ+geQlEdC9rg81DeC839vqqshA5TEhh045dhEkeyVJZqeg44vX5adUX6FOkhTfg==}
 
-  '@livestore/webmesh@0.4.0-dev.22':
-    resolution: {integrity: sha512-HlLKupNlq7MNTFmIYBXPX/n+jOpI5cyx5Sbpsj/acCVaqSaeq1tOdIpn6LNBzTR1uv4bkbEb2XUYIxxsvY4e9g==}
+  '@livestore/webmesh@0.4.0-dev.24':
+    resolution: {integrity: sha512-Iz6PEKNeqAilaEvaPLkgRrmNv+FmWor8qIyXnCq9jujMG65ghqf++zhpxC5RISkBax71bFXSMzxKX9XmhuGeSw==}
+    peerDependencies:
+      '@effect/ai': ^0.35.0
+      '@effect/cli': 0.75.1
+      '@effect/cluster': ^0.58.2
+      '@effect/experimental': 0.60.0
+      '@effect/opentelemetry': 0.63.0
+      '@effect/platform': 0.96.1
+      '@effect/platform-browser': 0.76.0
+      '@effect/platform-bun': 0.89.0
+      '@effect/platform-node': 0.106.0
+      '@effect/printer': 0.49.0
+      '@effect/printer-ansi': 0.49.0
+      '@effect/rpc': ^0.75.1
+      '@effect/sql': ^0.51.1
+      '@effect/typeclass': 0.40.0
+      '@effect/vitest': ^0.29.0
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/resources': ^2.2.0
+      '@standard-schema/spec': ^1.1.0
+      effect: 3.21.2
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -15390,11 +15512,6 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-
   nanoid@5.1.7:
     resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
     engines: {node: ^18 || >=20}
@@ -21804,55 +21921,56 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/adapter-web@0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)':
+  '@livestore/adapter-web@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
-      '@livestore/common': 0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)
-      '@livestore/devtools-web-common': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/sqlite-wasm': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/webmesh': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
+      '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.0)(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-browser': 0.76.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-bun': 0.89.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/devtools-web-common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/sqlite-wasm': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - '@effect/ai'
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/resources'
-      - effect
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      effect: 3.21.2
 
-  '@livestore/common-cf@0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)':
+  '@livestore/common-cf@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@cloudflare/workers-types': 4.20251118.0
-      '@livestore/common': 0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-    transitivePeerDependencies:
-      - '@effect/ai'
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/api'
-      - '@opentelemetry/resources'
-      - effect
+      '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.0)(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-browser': 0.76.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-bun': 0.89.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      effect: 3.21.2
 
   '@livestore/common@0.3.1(ce2bcadb83c7125be54ec47dd4ce6301)':
     dependencies:
@@ -21879,28 +21997,29 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/common@0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)':
+  '@livestore/common@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/webmesh': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
+      '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.0)(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-browser': 0.76.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-bun': 0.89.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
-    transitivePeerDependencies:
-      - '@effect/ai'
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/resources'
-      - effect
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      effect: 3.21.2
 
   '@livestore/devtools-vite@0.3.1(5b3920c49d61edd87c884ba49580a2cc)':
     dependencies:
@@ -21925,10 +22044,10 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/devtools-vite@0.4.0-dev.22(8d22fcfc6cd2670eb3a4ebb76d042427)':
+  '@livestore/devtools-vite@0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)':
     dependencies:
-      '@livestore/adapter-web': 0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
+      '@livestore/adapter-web': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
       vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@effect/ai'
@@ -21945,8 +22064,10 @@ snapshots:
       - '@effect/rpc'
       - '@effect/sql'
       - '@effect/typeclass'
+      - '@effect/vitest'
       - '@opentelemetry/api'
       - '@opentelemetry/resources'
+      - '@standard-schema/spec'
       - effect
 
   '@livestore/devtools-web-common@0.3.1(f5236e16fa75f9cfb04823aba7144054)':
@@ -21972,29 +22093,30 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/devtools-web-common@0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)':
+  '@livestore/devtools-web-common@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
-      '@livestore/common': 0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/webmesh': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-    transitivePeerDependencies:
-      - '@effect/ai'
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/api'
-      - '@opentelemetry/resources'
-      - effect
+      '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.0)(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-browser': 0.76.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-bun': 0.89.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      effect: 3.21.2
 
   '@livestore/livestore@0.3.1(ce2bcadb83c7125be54ec47dd4ce6301)':
     dependencies:
@@ -22071,31 +22193,32 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/sqlite-wasm@0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)':
+  '@livestore/sqlite-wasm@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@cloudflare/workers-types': 4.20251118.0
-      '@livestore/common': 0.4.0-dev.22(9f90f947adb02087b2f0be67cb801e8a)
-      '@livestore/common-cf': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-      '@livestore/wa-sqlite': 0.4.0-dev.22
-    transitivePeerDependencies:
-      - '@effect/ai'
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/api'
-      - '@opentelemetry/resources'
-      - effect
+      '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.0)(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-browser': 0.76.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-bun': 0.89.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common-cf': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/wa-sqlite': 0.4.0-dev.24
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      effect: 3.21.2
 
   '@livestore/sync-cf@0.3.1(f5236e16fa75f9cfb04823aba7144054)':
     dependencies:
@@ -22142,7 +22265,7 @@ snapshots:
       nanoid: 5.1.3
       pretty-bytes: 6.1.1
 
-  '@livestore/utils@0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)':
+  '@livestore/utils@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22158,15 +22281,16 @@ snapshots:
       '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       effect: 3.21.2
-      nanoid: 5.1.5
+      nanoid: 5.0.9
       pretty-bytes: 7.0.1
       qrcode-generator: 2.0.4
 
-  '@livestore/wa-sqlite@0.4.0-dev.22': {}
+  '@livestore/wa-sqlite@0.4.0-dev.24': {}
 
   '@livestore/wa-sqlite@1.0.5-dev.2': {}
 
@@ -22191,27 +22315,28 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/webmesh@0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)':
+  '@livestore/webmesh@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
-      '@livestore/utils': 0.4.0-dev.22(02654c5ae230a40f0daf886b151269b0)
-    transitivePeerDependencies:
-      - '@effect/ai'
-      - '@effect/cli'
-      - '@effect/cluster'
-      - '@effect/experimental'
-      - '@effect/opentelemetry'
-      - '@effect/platform'
-      - '@effect/platform-browser'
-      - '@effect/platform-bun'
-      - '@effect/platform-node'
-      - '@effect/printer'
-      - '@effect/printer-ansi'
-      - '@effect/rpc'
-      - '@effect/sql'
-      - '@effect/typeclass'
-      - '@opentelemetry/api'
-      - '@opentelemetry/resources'
-      - effect
+      '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/opentelemetry': 0.63.0(@effect/platform@0.96.1(effect@3.21.2))(@opentelemetry/api@1.9.0)(@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-node@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-web@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.40.0)(effect@3.21.2)
+      '@effect/platform': 0.96.1(effect@3.21.2)
+      '@effect/platform-browser': 0.76.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-bun': 0.89.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.40.0(effect@3.21.2)
+      '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@standard-schema/spec': 1.1.0
+      effect: 3.21.2
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -32533,8 +32658,6 @@ snapshots:
   nanoid@5.0.9: {}
 
   nanoid@5.1.3: {}
-
-  nanoid@5.1.5: {}
 
   nanoid@5.1.7: {}
 

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -17,6 +17,10 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { pipeline } from 'node:stream/promises'
 
+import semver from 'semver'
+
+import { supportedDevtoolsProtocolVersions } from '@livestore/common'
+
 type CompatibleLivestore =
   | { readonly kind: 'range'; readonly range: string }
   | { readonly kind: 'snapshot'; readonly gitSha: string; readonly version: string }
@@ -27,6 +31,10 @@ type ArtifactMetadata = {
   readonly packageName: '@livestore/devtools-vite'
   readonly devtoolsVersion: string
   readonly devtoolsBuildId: string
+  readonly artifactVersion?: number
+  readonly devtoolsProtocolVersion?: number
+  readonly builtAt?: string
+  readonly sourceRevision?: string
   readonly compatibleLivestore: CompatibleLivestore
   readonly files: {
     readonly tarball: {
@@ -133,6 +141,12 @@ const runCaptureOptional = (command: ReadonlyArray<string>, options: { readonly 
 
 const sha256 = (file: string) => createHash('sha256').update(readFileSync(file)).digest('hex')
 const integrity = (file: string) => `sha512-${createHash('sha512').update(readFileSync(file)).digest('base64')}`
+const devtoolsProtocolVersionForArtifact = (metadata: ArtifactMetadata) => metadata.devtoolsProtocolVersion ?? 1
+
+const normalizeArtifactMetadata = (metadata: ArtifactMetadata): ArtifactMetadata => ({
+  ...metadata,
+  devtoolsProtocolVersion: devtoolsProtocolVersionForArtifact(metadata),
+})
 
 const publishTagForVersion = (version: string) => {
   const prerelease = version.split('-')[1]
@@ -255,10 +269,41 @@ const forbiddenPatternName = (pattern: string | RegExp) => (typeof pattern === '
 const containsForbiddenPattern = (content: string, pattern: string | RegExp) =>
   typeof pattern === 'string' ? content.includes(pattern) : pattern.test(content)
 
+const assertSupportedDevtoolsProtocol = (metadata: ArtifactMetadata) => {
+  const protocolVersion = devtoolsProtocolVersionForArtifact(metadata)
+  if (supportedDevtoolsProtocolVersions.includes(protocolVersion) === false) {
+    throw new Error(
+      `Unsupported DevTools protocol version ${protocolVersion}; supported versions: ${supportedDevtoolsProtocolVersions.join(', ')}`,
+    )
+  }
+}
+
+const assertCompatibleLivestoreVersion = (metadata: ArtifactMetadata, version: string) => {
+  const compatibility = metadata.compatibleLivestore
+
+  switch (compatibility.kind) {
+    case 'range': {
+      const validVersion = semver.valid(version)
+      if (validVersion === null) throw new Error(`Invalid LiveStore release version: ${version}`)
+      if (semver.satisfies(validVersion, compatibility.range, { includePrerelease: true }) === false) {
+        throw new Error(`LiveStore ${version} does not satisfy DevTools artifact range ${compatibility.range}`)
+      }
+      return
+    }
+    case 'snapshot': {
+      if (version !== compatibility.version) {
+        throw new Error(`LiveStore ${version} does not match DevTools artifact snapshot ${compatibility.version}`)
+      }
+      return
+    }
+  }
+}
+
 const assertMetadata = (metadata: ArtifactMetadata, tarballPath: string, chromeZipPath: string | undefined) => {
   if (metadata.schemaVersion !== 1) throw new Error('Unsupported metadata schemaVersion')
   if (metadata.artifactName !== 'livestore-devtools-vite') throw new Error('Unexpected artifactName')
   if (metadata.packageName !== '@livestore/devtools-vite') throw new Error('Unexpected packageName')
+  assertSupportedDevtoolsProtocol(metadata)
   if (metadata.files.tarball.sha256 !== sha256(tarballPath)) throw new Error('Tarball SHA-256 mismatch')
   if (metadata.files.tarball.integrity !== integrity(tarballPath)) throw new Error('Tarball integrity mismatch')
   if (metadata.files.chromeZip !== undefined) {
@@ -410,6 +455,7 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
   if (version === undefined) throw new Error('--version is required')
 
   const { metadata, tarballPath, chromeZipPath, workDir } = await verifyArtifact(flags)
+  assertCompatibleLivestoreVersion(metadata, version)
   const unpackDir = path.join(workDir, 'package-src')
   rmSync(unpackDir, { recursive: true, force: true })
   mkdirSync(unpackDir, { recursive: true })
@@ -439,9 +485,10 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
     vite: '*',
   }
   writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)
+
   writeFileSync(
     path.join(packageDir, 'dist/release-metadata.json'),
-    `${JSON.stringify({ schemaVersion: 1, devtoolsArtifact: metadata, livestoreVersion: version }, null, 2)}\n`,
+    `${JSON.stringify({ schemaVersion: 1, devtoolsArtifact: normalizeArtifactMetadata(metadata), livestoreVersion: version }, null, 2)}\n`,
   )
 
   const packedJson = runCapture(['npm', 'pack', '--json', '--pack-destination', workDir], {

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -15,7 +15,7 @@
     "@livestore/adapter-web": "workspace:^",
     "@livestore/common": "workspace:^",
     "@livestore/common-cf": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@livestore/effect-playwright": "workspace:^",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",

--- a/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
@@ -23,7 +23,7 @@ import type * as PW from '@playwright/test'
 import { expect, test } from '@playwright/test'
 
 import { downloadChromeExtension } from '../../../../scripts/download-chrome-extension.ts'
-import { checkDevtoolsState, checkVersionMismatchOverlay } from './shared.ts'
+import { checkDevtoolsState, checkProtocolMismatchOverlay } from './shared.ts'
 
 export class TestError extends Schema.TaggedError<TestError>()('TestError', {
   message: Schema.String,
@@ -35,9 +35,13 @@ type AdapterKind = 'persisted' | 'inmemory'
 
 /**
  * Creates a tab pair with an app page and a DevTools page (browser extension).
- * @param appVersionOverride - Optional version override to inject via globalThis.__LIVESTORE_VERSION_OVERRIDE__ for testing version mismatch scenarios.
  */
-const makeTabPair = (url: string, tabName: string, adapter: AdapterKind, options?: { appVersionOverride?: string }) =>
+const makeTabPair = (
+  url: string,
+  tabName: string,
+  adapter: AdapterKind,
+  options?: { appVersionOverride?: string; appDevtoolsProtocolVersionOverride?: number },
+) =>
   Effect.gen(function* () {
     const { browserContext } = yield* Playwright.BrowserContext
 
@@ -62,10 +66,17 @@ const makeTabPair = (url: string, tabName: string, adapter: AdapterKind, options
         .filter(isUnused)
         .find((p) => p.url() === 'about:blank') ?? (yield* newPage)
 
-    // Inject version override before page loads (for version mismatch testing)
+    // Inject display version override before page loads for compatibility overlay assertions.
     if (options?.appVersionOverride !== undefined) {
       yield* Effect.tryPromise(() =>
         page.addInitScript(`globalThis.__LIVESTORE_VERSION_OVERRIDE__ = '${options.appVersionOverride}';`),
+      )
+    }
+    if (options?.appDevtoolsProtocolVersionOverride !== undefined) {
+      yield* Effect.tryPromise(() =>
+        page.addInitScript(
+          `globalThis.__LIVESTORE_DEVTOOLS_PROTOCOL_VERSION_OVERRIDE__ = ${options.appDevtoolsProtocolVersionOverride};`,
+        ),
       )
     }
 
@@ -167,7 +178,7 @@ const runTest =
   }
 
 const getExtensionPath = Effect.gen(function* () {
-  const fs = yield* FileSystem.FileSystem
+  const fileSystem = yield* FileSystem.FileSystem
 
   const extensionPathFromEnv = process.env.LIVESTORE_DEVTOOLS_CHROME_DIST_PATH
   if (extensionPathFromEnv !== undefined) {
@@ -176,17 +187,17 @@ const getExtensionPath = Effect.gen(function* () {
   }
 
   const defaultExtensionPath = LIVESTORE_DEVTOOLS_CHROME_DIST_PATH
-  if ((yield* fs.exists(defaultExtensionPath)) === false) {
+  if ((yield* fileSystem.exists(defaultExtensionPath)) === false) {
     yield* Effect.logInfo(`Downloading Chrome extension to ${defaultExtensionPath}`)
     yield* downloadChromeExtension({ targetDir: defaultExtensionPath })
   }
   return defaultExtensionPath
 }).pipe(
-  Effect.tap((path) =>
+  Effect.tap((extensionPath) =>
     Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem
-      if ((yield* fs.exists(path)) === false) {
-        return yield* new TestError({ message: `Chrome extension not found at ${path}` })
+      const fileSystem = yield* FileSystem.FileSystem
+      if ((yield* fileSystem.exists(extensionPath)) === false) {
+        return yield* new TestError({ message: `Chrome extension not found at ${extensionPath}` })
       }
     }),
   ),
@@ -470,28 +481,27 @@ test(
 )
 
 test(
-  'version mismatch overlay',
+  'protocol mismatch overlay',
   runTest(
     Effect.gen(function* () {
       const fakeAppVersion = '0.0.0-fake-version'
 
       const tab1 = yield* makeTabPair(
         `http://localhost:${process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT}/devtools/todomvc`,
-        'tab-version-mismatch',
+        'tab-protocol-mismatch',
         'inmemory',
-        { appVersionOverride: fakeAppVersion },
+        { appDevtoolsProtocolVersionOverride: 999, appVersionOverride: fakeAppVersion },
       )
 
       yield* Effect.tryPromise(async () => {
         // Wait for the app to load
-        const el = tab1.page.locator('.new-todo').describe('tab-version-mismatch:new-todo')
+        const el = tab1.page.locator('.new-todo').describe('tab-protocol-mismatch:new-todo')
         await el.waitFor({ timeout: 10_000 })
 
-        // The browser extension auto-connects to the session, so we just need to wait for the mismatch overlay
-        // Check version mismatch overlay is displayed in the LiveStore DevTools frame
-        await checkVersionMismatchOverlay({
+        // The browser extension auto-connects to the session, so wait for the compatibility overlay.
+        await checkProtocolMismatchOverlay({
           devtools: tab1.liveStoreDevtools,
-          label: 'devtools-version-mismatch',
+          label: 'devtools-protocol-mismatch',
           expect: {
             devtoolsVersion: '0.4', // Partial match for the real DevTools version
             appVersion: fakeAppVersion,

--- a/tests/integration/src/tests/playwright/devtools/shared.ts
+++ b/tests/integration/src/tests/playwright/devtools/shared.ts
@@ -2,9 +2,9 @@ import type * as PW from '@playwright/test'
 import { expect } from '@playwright/test'
 
 /**
- * Checks that the version mismatch overlay is displayed with correct content.
+ * Checks that the DevTools compatibility overlay is displayed with correct content.
  */
-export const checkVersionMismatchOverlay = async (options: {
+export const checkProtocolMismatchOverlay = async (options: {
   devtools: PW.Frame | PW.Page
   label: string
   expect: {
@@ -13,24 +13,26 @@ export const checkVersionMismatchOverlay = async (options: {
   }
 }) => {
   const overlay = options.devtools.locator('[data-testid="version-mismatch-overlay"]')
-  await overlay.describe(`${options.label}:version-mismatch-overlay`).waitFor({ state: 'attached', timeout: 5000 })
+  await overlay.describe(`${options.label}:protocol-mismatch-overlay`).waitFor({ state: 'attached', timeout: 5000 })
 
-  // Check for version mismatch text
   await expect(
     options.devtools
       .getByText('Version Mismatch', { exact: false })
-      .describe(`${options.label}:version-mismatch-title`),
+      .describe(`${options.label}:protocol-mismatch-title`),
   ).toBeVisible()
 
-  // Check that the versions are displayed
   await expect(
     options.devtools
-      .getByText(options.expect.devtoolsVersion, { exact: false })
+      .locator('code')
+      .filter({ hasText: options.expect.devtoolsVersion })
       .describe(`${options.label}:devtools-version`),
   ).toBeVisible()
 
   await expect(
-    options.devtools.getByText(options.expect.appVersion, { exact: false }).describe(`${options.label}:app-version`),
+    options.devtools
+      .locator('code')
+      .filter({ hasText: options.expect.appVersion })
+      .describe(`${options.label}:app-version`),
   ).toBeVisible()
 }
 

--- a/tests/integration/src/tests/playwright/devtools/web.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/web.play.ts
@@ -12,7 +12,7 @@ import { OtelLiveHttp } from '@livestore/utils-dev/node'
 import type { Scope } from '@livestore/utils/effect'
 import { Effect, Fiber, Layer, Logger, OtelTracer, Schema, Tracer } from '@livestore/utils/effect'
 
-import { checkDevtoolsState, checkVersionMismatchOverlay } from './shared.ts'
+import { checkDevtoolsState, checkProtocolMismatchOverlay } from './shared.ts'
 
 const usedPages = new Set<PW.Page>()
 
@@ -20,9 +20,13 @@ type AdapterKind = 'persisted' | 'inmemory'
 
 /**
  * Creates a tab pair with an app page and a DevTools page.
- * @param appVersionOverride - Optional version override to inject via globalThis.__LIVESTORE_VERSION_OVERRIDE__ for testing version mismatch scenarios.
  */
-const makeTabPair = (url: string, tabName: string, adapter: AdapterKind, options?: { appVersionOverride?: string }) =>
+const makeTabPair = (
+  url: string,
+  tabName: string,
+  adapter: AdapterKind,
+  options?: { appVersionOverride?: string; appDevtoolsProtocolVersionOverride?: number },
+) =>
   Effect.gen(function* () {
     const { browserContext } = yield* Playwright.BrowserContext
 
@@ -57,10 +61,17 @@ const makeTabPair = (url: string, tabName: string, adapter: AdapterKind, options
       await page.pause()
     })
 
-    // Inject version override before page loads (for version mismatch testing)
+    // Inject display version override before page loads for compatibility overlay assertions.
     if (options?.appVersionOverride !== undefined) {
       yield* Effect.tryPromise(() =>
         page.addInitScript(`globalThis.__LIVESTORE_VERSION_OVERRIDE__ = '${options.appVersionOverride}';`),
+      )
+    }
+    if (options?.appDevtoolsProtocolVersionOverride !== undefined) {
+      yield* Effect.tryPromise(() =>
+        page.addInitScript(
+          `globalThis.__LIVESTORE_DEVTOOLS_PROTOCOL_VERSION_OVERRIDE__ = ${options.appDevtoolsProtocolVersionOverride};`,
+        ),
       )
     }
 
@@ -78,8 +89,8 @@ const makeTabPair = (url: string, tabName: string, adapter: AdapterKind, options
       page.goto(`${url}/devtools/todomvc?sessionId=${tabName}&clientId=${tabName}&adapter=${adapter}`),
     )
 
-    // Skip OTel span linking when testing version mismatch (app may not initialize properly)
-    if (options?.appVersionOverride == null) {
+    // Skip OTel span linking when testing DevTools protocol mismatch (app may not initialize properly)
+    if (options?.appDevtoolsProtocolVersionOverride == null) {
       const rootSpanContext = yield* Effect.tryPromise(() =>
         page
           .waitForFunction('window.__debugLiveStore?.default !== undefined')
@@ -311,52 +322,62 @@ const runTest =
   }
 })
 
-const shutdownTab = Effect.fn('shutdown-tab')(function* (tab: PW.Page) {
+const shutdownTab = Effect.fn('shutdown-tab')(function* (tab: PW.Page, options?: { expectStore?: boolean }) {
   // yield* Playwright.withPage(() => tab.pause())
   yield* Effect.sleep(1000)
   yield* Playwright.withPage(() => tab.evaluate('console.log(window.__debugLiveStore)'))
-  yield* Playwright.withPage(() => tab.evaluate('window.__debugLiveStore.default.shutdown()'), {
-    label: 'shutdown',
-  }).pipe(Effect.timeout(1000))
 
-  yield* Playwright.withPage(() => tab.getByText('LiveStore Shutdown').waitFor())
+  const didShutdown = yield* Playwright.withPage(
+    () =>
+      tab.evaluate(() => {
+        const store = (window as any).__debugLiveStore?.default
+        if (store === undefined) return false
+
+        store.shutdown()
+        return true
+      }),
+    { label: 'shutdown' },
+  ).pipe(Effect.timeout(1000))
+
+  if (didShutdown === false && options?.expectStore !== false) {
+    yield* Effect.dieMessage('Expected LiveStore debug store to be available for shutdown')
+  }
+
+  if (didShutdown === true) {
+    yield* Playwright.withPage(() => tab.getByText('LiveStore Shutdown').waitFor())
+  }
 })
 
 test(
-  'version mismatch overlay',
+  'protocol mismatch overlay',
   runTest(
     Effect.gen(function* () {
       const fakeAppVersion = '0.0.0-fake-version'
+      const tabName = 'tab-protocol-mismatch'
 
       const tab1 = yield* makeTabPair(
         `http://localhost:${process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT}`,
-        'tab-version-mismatch',
+        tabName,
         'inmemory',
-        { appVersionOverride: fakeAppVersion },
+        { appDevtoolsProtocolVersionOverride: 999, appVersionOverride: fakeAppVersion },
       )
 
       yield* Effect.gen(function* () {
         yield* Effect.tryPromise(async () => {
           // Wait for the app to load
-          const el = tab1.page.locator('.new-todo').describe('tab-version-mismatch:new-todo')
+          const el = tab1.page.locator('.new-todo').describe('tab-protocol-mismatch:new-todo')
           await el.waitFor({ timeout: 3000 })
 
           // Click on the session in devtools to connect
-          const tabChannelId = await tab1.page.evaluate<string>(
-            `window.__debugLiveStore.default.clientId + ':' + window.__debugLiveStore.default.sessionId`,
-          )
-          await tab1.devtools.locator(`a:text("${tabChannelId}")`).describe('devtools:click-session').click()
+          await tab1.devtools.locator(`a:text("${tabName}:${tabName}")`).describe('devtools:click-session').click()
 
-          // Get the DevTools version (the real version since DevTools isn't overridden)
           const devtoolsVersion = await tab1.devtools.evaluate<string>(() => {
-            // The devtools bundles the same liveStoreVersion constant
             return (window as any).__LIVESTORE_DEVTOOLS_VERSION__ ?? 'unknown'
           })
 
-          // Check version mismatch overlay is displayed
-          await checkVersionMismatchOverlay({
+          await checkProtocolMismatchOverlay({
             devtools: tab1.devtools,
-            label: 'devtools-version-mismatch',
+            label: 'devtools-protocol-mismatch',
             expect: {
               devtoolsVersion: devtoolsVersion !== 'unknown' ? devtoolsVersion : '0.4', // Partial match
               appVersion: fakeAppVersion,
@@ -364,7 +385,7 @@ test(
           })
         })
 
-        yield* shutdownTab(tab1.page)
+        yield* shutdownTab(tab1.page, { expectStore: false })
 
         yield* Effect.sleep(500).pipe(Effect.withSpan('wait-for-otel-flush'))
       }).pipe(Effect.raceFirst(Fiber.joinAll([tab1.pageConsoleFiber, tab1.devtoolsConsoleFiber])))

--- a/tests/package-common/package.json
+++ b/tests/package-common/package.json
@@ -31,7 +31,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@livestore/utils-dev": "workspace:^",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",

--- a/tests/perf-eventlog/package.json
+++ b/tests/perf-eventlog/package.json
@@ -44,7 +44,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",
     "@playwright/test": "1.59.1",

--- a/tests/sync-provider/package.json
+++ b/tests/sync-provider/package.json
@@ -41,7 +41,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.22",
+    "@livestore/devtools-vite": "0.4.0-dev.24",
     "@livestore/utils-dev": "workspace:^",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",


### PR DESCRIPTION
**Problem**

DevTools artifact compatibility was coupled to package/display versions. That made a republished DevTools package such as `@livestore/devtools-vite@0.4.0-dev.24` look incompatible when the bundled DevTools artifact identified itself with an older source version.

**Goal**

Make runtime DevTools compatibility depend on an explicit protocol version, preserve package versions as release/display identity, and remove stale `dev.22` package pins from the workspace.

**Decisions**

- Add `devtoolsProtocolVersion` and `supportedDevtoolsProtocolVersions` in `@livestore/common`, with omitted protocol values resolving to protocol `1` for current/legacy artifacts.
- Keep the existing `VersionMismatch` message tag for compatibility with currently shipped DevTools, but populate it from protocol checks instead of package-version equality.
- Preserve `devtoolsVersion` in artifact metadata as source/artifact identity. Repacking now normalizes `devtoolsProtocolVersion` and does not rewrite bundled DevTools version strings.
- Update package manifests, generated fallbacks, and lockfile from `@livestore/devtools-vite@0.4.0-dev.22` to `0.4.0-dev.24`.
- Add a changeset for the runtime protocol-compatibility behavior.

**Verification**

- `git diff --check` passed.
- `pnpm --filter @livestore/common exec vitest run src/devtools/devtools-compatibility.test.ts` -> 1 file / 3 tests passed.
- `bun scripts/src/commands/devtools-artifact.ts verify --manifest release/devtools-artifact.json` -> verified build `dt-20260505-398c5feb`.
- Focused Playwright E2E: `pnpm --filter @local/tests-integration exec playwright test src/tests/playwright/devtools/web.play.ts --grep 'protocol mismatch overlay'` -> 1 passed.
- Changed-file `oxlint --import-plugin --deny-warnings ...` passed.
- `pnpm exec changeset status --since origin/main` passed and reports patch bumps for `@livestore/common` and `@livestore/livestore`.
- CI on head `0c4d48059441f2d638408b9efd5b6ebbe1ca014c`: `lint`, `type-check`, `changeset-check`, and the DevTools artifact manifest check are green; remaining long-running matrix jobs are still in progress at the time of this update.

**Complexity**

This adds one small compatibility abstraction: a numeric DevTools protocol version shared by app-side handlers, message schemas, tests, and artifact validation. That is the needed boundary between runtime compatibility and release/display identity.

**Concerns**

- The DevTools artifact UI copy is updated in the paired Overeng artifact-source PR; this PR only changes the LiveStore runtime/repack side.
- The paired Overeng PR is temporarily pinned to this PR branch and must be retargeted back to LiveStore main after this PR lands.

**Friction & bottlenecks**

- Full local `devenv tasks run lint:full:with-megarepo-check` stalled after lock validation in this environment, so changed-file lint plus CI lint were used as the authoritative lint proof.
- Full DevTools Playwright automation is expensive locally; I ran the focused protocol mismatch E2E and rely on CI for the full matrix.

**Follow-ups**

- After merge, repin the Overeng artifact-source PR from this branch back to LiveStore main.
- Prepare the next dev release from main once the protocol stack has landed.

**References**

- Stacked with Overeng PR https://github.com/overengineeringstudio/overeng/pull/189.
- Refs the reported `@livestore/devtools-vite@0.4.0-dev.24` / bundled older artifact mismatch.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ❄️ co2-frost |
| `agent_session_id` | e9e5f226-7818-40f6-b14c-c34c4a2da475 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/devtools-protocol-compat |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@75f90cf |
</details>
<!-- agent-footer:end -->