### PR TITLE
Bump effect-utils + adopt cachix-via-PATH hermetic install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -285,6 +291,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -533,6 +545,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -778,6 +796,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1021,6 +1045,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1264,6 +1294,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1551,6 +1587,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -1824,6 +1866,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -2202,6 +2250,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -2459,6 +2513,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -2834,6 +2894,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -3205,6 +3271,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -3782,6 +3854,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -78,6 +78,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -362,6 +368,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:
@@ -763,6 +775,12 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
       - name: Enable Cachix cache
         uses: cachix/cachix-action@v17
         with:

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,7 +14,7 @@
     "**/.astro/**",
     "**/.nitro/**",
     "**/.tanstack/**",
-    "**/.direnv/**",
+    "**/.devenv/**",
     "**/tmp/**",
     "**/playwright-report/**",
     "**/test-results/**",

--- a/docs/src/content/_assets/code/.oxlintrc.json
+++ b/docs/src/content/_assets/code/.oxlintrc.json
@@ -14,7 +14,7 @@
     "**/.astro/**",
     "**/.nitro/**",
     "**/.tanstack/**",
-    "**/.direnv/**",
+    "**/.devenv/**",
     "**/tmp/**",
     "**/playwright-report/**",
     "**/test-results/**",

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -229,6 +229,8 @@ export const solidJsx = { jsx: 'preserve' as const, jsxImportSource: 'solid-js' 
 
 import {
   bashShellDefaults,
+  cachixCliBuildStep,
+  cachixStep,
   defaultActionlintConfig,
   dispatchAlignmentStep,
   namespaceRunner as namespaceRunnerBase,
@@ -268,15 +270,11 @@ export const livestoreSetupStepsAfterCheckout = [
     extraConf:
       'extra-substituters = https://cache.nixos.org\nextra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=',
   }),
-  {
-    name: 'Enable Cachix cache',
-    uses: 'cachix/cachix-action@v17',
-    with: {
-      name: 'livestore',
-      authToken: '${{ env.CACHIX_AUTH_TOKEN }}',
-      skipPush: true,
-    },
-  },
+  cachixCliBuildStep,
+  (() => {
+    const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
+    return { ...base, with: { ...base.with, skipPush: true } }
+  })(),
   applyMegarepoLockStep(),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,4 +1,4 @@
 members {
-    effect-utils "overengineeringstudio/effect-utils"
+    effect-utils "overengineeringstudio/effect-utils#main"
     effect "effect-ts/effect"
 }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "8d1810b2c359ae95f245e56329018aab5020f8c0",
-      "pinned": false,
-      "lockedAt": "2026-05-09T01:03:25.757Z"
+      "commit": "acd6c63f5e235e7e5f2710fc62b2231e0ba904a6",
+      "pinned": true,
+      "lockedAt": "2026-05-12T02:51:58.431Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "3585f25110fca7af6aeec3f59c3fc05b20c8d316",
+      "commit": "1a63ec87cd295972b05b51c9b4ad2db9567dc994",
       "pinned": false,
-      "lockedAt": "2026-05-09T01:02:48.989Z"
+      "lockedAt": "2026-05-12T01:57:03.940Z"
     }
   }
 }

--- a/tests/integration/.oxlintrc.json
+++ b/tests/integration/.oxlintrc.json
@@ -14,7 +14,7 @@
     "**/.astro/**",
     "**/.nitro/**",
     "**/.tanstack/**",
-    "**/.direnv/**",
+    "**/.devenv/**",
     "**/tmp/**",
     "**/playwright-report/**",
     "**/test-results/**",

--- a/tests/perf-eventlog/.oxlintrc.json
+++ b/tests/perf-eventlog/.oxlintrc.json
@@ -14,7 +14,7 @@
     "**/.astro/**",
     "**/.nitro/**",
     "**/.tanstack/**",
-    "**/.direnv/**",
+    "**/.devenv/**",
     "**/tmp/**",
     "**/playwright-report/**",
     "**/test-results/**",

--- a/tests/perf/.oxlintrc.json
+++ b/tests/perf/.oxlintrc.json
@@ -14,7 +14,7 @@
     "**/.astro/**",
     "**/.nitro/**",
     "**/.tanstack/**",
-    "**/.direnv/**",
+    "**/.devenv/**",
     "**/tmp/**",
     "**/playwright-report/**",
     "**/test-results/**",


### PR DESCRIPTION
## Summary

Pin effect-utils to overengineeringstudio/effect-utils#652 and include the new `cachixCliBuildStep` before every `cachixStep` in this repo's CI. Each job now builds cachix from nixpkgs and prepends its `/nix/store/.../bin` to `$GITHUB_PATH`; cachix-action short-circuits its built-in installer and the runner's nix profile is never mutated.

Builds on the prior iteration of this PR which routed `genie/repo.ts`'s previously-raw cachix step through the shared `cachixStep` helper.

## Why

cachix-action's default installer (`nix-env -iA cachix -f cachix.org/api/v1/install`):

1. **Breaks on Determinate Nix 3.17+** — legacy `nix-env -iA` removed (`error: unrecognised flag '-i'`).
2. **Mutates a global nix profile** — not hermetic.

Upstream PR: https://github.com/overengineeringstudio/effect-utils/pull/652

## Test plan

- [ ] CI green — confirms cachix is on PATH before cachix-action runs and skips install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🦤 cl2-ibis |
| `agent_session_id` | d035a3bb-7d45-4893-9fa4-ec787212edb4 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.121 |
| `agent_runtime` | Claude Code 2.1.121 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | livestore/schickling-assistant/2026-05-12-cachix-install-modern |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@21f0837 |
</details>
<!-- agent-footer:end -->