### PR TITLE
chore: collapse duplicate devenv ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ scripts/.completions
 # locally downloaded S2 CLI
 .infra/s2/
 
-.devenv
 .devenv*
 .pre-commit-config.yaml
 


### PR DESCRIPTION
## Summary
- collapse the shadowed `.devenv` ignore entry into the existing `.devenv*` pattern

## Validation
- inspected `.gitignore` for duplicate devenv ignore entries

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏝️ co2-cove |
| `agent_session_id` | 0da77e12-f53f-475f-b53a-e0bccf9eaa25 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.125.0 |
| `agent_runtime` | Codex CLI 0.125.0 |
| `agent_model` | unknown |
| `worktree` | livestore-devenv-ignore-cleanup/schickling/2026-05-12-devenv-ignore-cleanup |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@21f0837 |
</details>
<!-- agent-footer:end -->