### PR TITLE
fix(adapter-web): log stable Vite DevTools URL

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -43,7 +43,7 @@
     "@livestore/adapter-node": "workspace:^",
     "@livestore/adapter-web": "workspace:^",
     "@livestore/common": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",
     "@livestore/solid": "workspace:^",

--- a/docs/src/content/_assets/code/package.json
+++ b/docs/src/content/_assets/code/package.json
@@ -30,7 +30,7 @@
     "@livestore/adapter-node": "workspace:^",
     "@livestore/adapter-web": "workspace:^",
     "@livestore/devtools-expo": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",
     "@livestore/solid": "workspace:^",

--- a/docs/src/content/docs/building-with-livestore/devtools.mdx
+++ b/docs/src/content/docs/building-with-livestore/devtools.mdx
@@ -34,7 +34,7 @@ Requires the `@livestore/devtools-vite` package to be installed and configured i
 
 <ViteConfigSnippet />
 
-The devtools can be opened in a separate tab (via e.g. `localhost:3000/_livestore/web). You should see the Devtools URL logged in the browser console when running the app.
+The devtools can be opened in a separate tab (via e.g. `localhost:3000/_livestore/web`). You should see the Devtools URL logged in the browser console when running the app.
 
 #### Chrome extension
 

--- a/examples/cf-chat-solid/package.json
+++ b/examples/cf-chat-solid/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "tailwindcss": "4.1.18",

--- a/examples/cf-chat/package.json
+++ b/examples/cf-chat/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",

--- a/examples/web-email-client/package.json
+++ b/examples/web-email-client/package.json
@@ -18,7 +18,7 @@
     "react-error-boundary": "6.1.1"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-linearlite/package.json
+++ b/examples/web-linearlite/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@svgr/plugin-jsx": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0",

--- a/examples/web-multi-store/package.json
+++ b/examples/web-multi-store/package.json
@@ -17,7 +17,7 @@
     "react-error-boundary": "6.1.1"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@types/node": "25.3.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-custom-elements/package.json
+++ b/examples/web-todomvc-custom-elements/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",

--- a/examples/web-todomvc-experimental/package.json
+++ b/examples/web-todomvc-experimental/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-react-router/package.json
+++ b/examples/web-todomvc-react-router/package.json
@@ -17,7 +17,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-script/package.json
+++ b/examples/web-todomvc-script/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "typescript": "5.9.3",
     "vite": "7.3.1",

--- a/examples/web-todomvc-solid/package.json
+++ b/examples/web-todomvc-solid/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "solid-devtools": "^0.34.3",
     "typescript": "5.9.3",

--- a/examples/web-todomvc-svelte/package.json
+++ b/examples/web-todomvc-svelte/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@sveltejs/vite-plugin-svelte": "6.2.1",
     "typescript": "5.9.3",

--- a/examples/web-todomvc-sync-cf/package.json
+++ b/examples/web-todomvc-sync-cf/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-sync-electric/package.json
+++ b/examples/web-todomvc-sync-electric/package.json
@@ -19,7 +19,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tanstack/react-router": "1.145.7",
     "@tanstack/router-devtools": "1.139.14",

--- a/examples/web-todomvc-sync-s2/package.json
+++ b/examples/web-todomvc-sync-s2/package.json
@@ -20,7 +20,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tanstack/react-router": "1.145.7",
     "@tanstack/router-devtools": "1.139.14",

--- a/examples/web-todomvc/package.json
+++ b/examples/web-todomvc/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -52,7 +52,7 @@ export const livestoreOnlyCatalog = {
    * LiveStore republishes DevTools artifacts under the LiveStore release version.
    * The source artifact carries its own metadata for artifact lineage and protocol compatibility.
    */
-  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.24',
+  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.25',
   /** Tanstack router sub-packages not in effect-utils catalog (react-router/react-start/router-plugin are there) */
   '@tanstack/router-core': '1.145.7',
   '@tanstack/history': '1.145.7',

--- a/packages/@livestore/adapter-node/package.json
+++ b/packages/@livestore/adapter-node/package.json
@@ -37,7 +37,7 @@
     "@opentelemetry/api": "1.9.0"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@rollup/plugin-commonjs": "28.0.6",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-terser": "0.4.4",

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
@@ -7,10 +7,12 @@ import { Effect, Stream } from '@livestore/utils/effect'
 import { WebChannelBrowser } from '@livestore/utils/effect/browser'
 import * as Webmesh from '@livestore/webmesh'
 
+const joinUrlPath = (baseUrl: string, path: string) => `${baseUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`
+
 export const logDevtoolsUrl = Effect.fn('@livestore/adapter-web:client-session:devtools:logDevtoolsUrl')(function* ({
-  schema,
-  storeId,
-  clientId,
+  schema: _schema,
+  storeId: _storeId,
+  clientId: _clientId,
   sessionId,
 }: {
   schema: LiveStoreSchema
@@ -27,7 +29,7 @@ export const logDevtoolsUrl = Effect.fn('@livestore/adapter-web:client-session:d
     if (response.ok === true) {
       const text = yield* Effect.promise(() => response.text())
       if (text.includes('<meta name="livestore-devtools" content="true" />') === true) {
-        const url = `${devtoolsBaseUrl}/web/${storeId}/${clientId}/${sessionId}/${schema.devtools.alias}`
+        const url = joinUrlPath(devtoolsBaseUrl, `web#${encodeURIComponent(sessionId)}`)
         yield* Effect.log(`[@livestore/adapter-web] Devtools ready on ${url}`)
       }
 

--- a/packages/@livestore/devtools-expo/package.json
+++ b/packages/@livestore/devtools-expo/package.json
@@ -48,7 +48,7 @@
     "@effect/sql": "^0.51.1",
     "@effect/typeclass": "^0.40.0",
     "@effect/vitest": "^0.29.0",
-    "@livestore/devtools-vite": "^0.4.0-dev.24",
+    "@livestore/devtools-vite": "^0.4.0-dev.25",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/resources": "^2.2.0",
     "@standard-schema/spec": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,8 +300,8 @@ importers:
         specifier: workspace:^
         version: link:../packages/@livestore/common
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/livestore':
         specifier: workspace:^
         version: link:../packages/@livestore/livestore
@@ -529,8 +529,8 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/@livestore/devtools-expo
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/livestore':
         specifier: workspace:^
         version: link:../../../../../packages/@livestore/livestore
@@ -690,8 +690,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -760,8 +760,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1151,8 +1151,8 @@ importers:
         version: 6.1.1(react@19.2.3)
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@tailwindcss/vite':
         specifier: 4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -1284,8 +1284,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1378,8 +1378,8 @@ importers:
         version: 6.1.1(react@19.2.3)
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -1445,8 +1445,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1503,8 +1503,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1576,8 +1576,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1637,8 +1637,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1750,8 +1750,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1799,8 +1799,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1854,8 +1854,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1915,8 +1915,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1982,8 +1982,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -2067,8 +2067,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -2343,8 +2343,8 @@ importers:
         version: 3.21.2
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@rollup/plugin-commonjs':
         specifier: 28.0.6
         version: 28.0.6(rollup@4.49.0)
@@ -2740,8 +2740,8 @@ importers:
         specifier: workspace:^
         version: link:../adapter-node
       '@livestore/devtools-vite':
-        specifier: ^0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: ^0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils':
         specifier: workspace:^
         version: link:../utils
@@ -4524,8 +4524,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/@livestore/common-cf
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/effect-playwright':
         specifier: workspace:^
         version: link:../../packages/@livestore/effect-playwright
@@ -4727,8 +4727,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils-dev':
         specifier: workspace:^
         version: link:../../packages/@livestore/utils-dev
@@ -4957,8 +4957,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -5066,8 +5066,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils-dev':
         specifier: workspace:^
         version: link:../../packages/@livestore/utils-dev
@@ -6905,7 +6905,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@54.0.10':
     resolution: {integrity: sha512-iw9gAnN6+PKWWLIyYmiskY/wzZjuFMctunqGXuC8BGATWgtr/HpzjVqWbcL3KIX/GvEBCCh74Tkckrh+Ylxh5Q==}
@@ -7581,8 +7581,8 @@ packages:
   '@livestore/adapter-web@0.3.1':
     resolution: {integrity: sha512-0ZKTam+C3KeG5qiiTLFOgoMhdUBCENmuaMwxoj7WOtA2c4eKyqIy+P/1zga+az0XqaMJoG5FVszWhWMUMzNjtQ==}
 
-  '@livestore/adapter-web@0.4.0-dev.24':
-    resolution: {integrity: sha512-j4JngwuQt+Q+MFuopqf52U03Z0wn4V7NHvgmih1Ba5zJF+sOvPmmRtRj1SDW98aCNRG3XSlg1Yh+S2yikaZV6w==}
+  '@livestore/adapter-web@0.4.0-dev.25':
+    resolution: {integrity: sha512-IlsKqotB0GmGsTn9fP5NrgpNx1oc+vTnoweaGoImLA4Jty9jGpPfFx8MiKlULXVK0oMRQvBwCzZ5AMeurSDHQg==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7604,8 +7604,8 @@ packages:
       '@standard-schema/spec': ^1.1.0
       effect: 3.21.2
 
-  '@livestore/common-cf@0.4.0-dev.24':
-    resolution: {integrity: sha512-5QPrz/SQDLL+o7O8aDhaevyzIdyJrU1saKiyVak4KScbOoIKiN3sa4VkF3MUKgJeJfUUQdWabxBN+fkrsy6pow==}
+  '@livestore/common-cf@0.4.0-dev.25':
+    resolution: {integrity: sha512-a4d3GpHE1HOJV0DuPGJLKs5+H7YldAIAAMBjBZujAmekPbzuU7jdBT+yJVCZB8UZU1NrUQEfDW2N8n85hLA08g==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7630,8 +7630,8 @@ packages:
   '@livestore/common@0.3.1':
     resolution: {integrity: sha512-D44ia+zVH8EF0TWGUp0GQnCVvCsGKgKD/ryFl+kx607/l7GDUSagNnWkRmMwhhshJSJblQwouhA9fwjDNTBB2g==}
 
-  '@livestore/common@0.4.0-dev.24':
-    resolution: {integrity: sha512-KE1BVVq0z+0qR6HPb+X5gabgZcOYMYY9e3FGeJGdSvbWYQouGNeeZFaEe+2xQkg/HVBTa5cg0tEeWZq7vpWQ3A==}
+  '@livestore/common@0.4.0-dev.25':
+    resolution: {integrity: sha512-nyBpTydGNcerQfizD3Quu7L/grY7JWX9RyVXVv/Ap7rDwjfAZwVa6dYyzLquY2hirYbv6Xb4cVFn72Ms/w8MzA==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7658,16 +7658,16 @@ packages:
     peerDependencies:
       vite: ~6.3.4
 
-  '@livestore/devtools-vite@0.4.0-dev.24':
-    resolution: {integrity: sha512-LaovZMF4yuq3jvEx84WyrpTIXDytnDydCkpgPdNUyckL1V+yKqd9Mbq4eXPlAKl2PX0EcK/RGepR/Ua26WAPDQ==}
+  '@livestore/devtools-vite@0.4.0-dev.25':
+    resolution: {integrity: sha512-Lw+JZYp8T6g4yGkJ0ef57td+upQVYGbhGHOnS/DeulebxY6uQjLgJigsvA8UzMN+BksMc/FsQPLv8+qzOe5AEA==}
     peerDependencies:
       vite: ^7.3.1
 
   '@livestore/devtools-web-common@0.3.1':
     resolution: {integrity: sha512-jU7IvebelTtvSTQ2zKNzSm5qZodwUiPsNsDURsY5Yw0DXpafcfpRobs/WYd+Wd4Q1E4oFaK05hPfWZGbVFdw7Q==}
 
-  '@livestore/devtools-web-common@0.4.0-dev.24':
-    resolution: {integrity: sha512-neWpu9GwHRq872S2U0h2Ib2sdBVZWxSRaGeivLHBHmnSgJVPgeCienEp9qsX+XVPzIAFWr+w9tJkmrt13GGwjA==}
+  '@livestore/devtools-web-common@0.4.0-dev.25':
+    resolution: {integrity: sha512-dEcoDpN4nH8xWG0VVNT9WqDmUt4Nlm0UsSVaNhtUw+XYuRQaNBeLt1h/ARIccdPRzS5V+Sbd9H/8CDlyfOsnSg==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7698,8 +7698,8 @@ packages:
   '@livestore/sqlite-wasm@0.3.1':
     resolution: {integrity: sha512-+JLIwpd2N214LmwlUX6arYnJ5IhvSi4Fn3Jk6E6fNfuUU4tczcL1PtgfIX2IoiPhn9QDG0YJVdJBT6KYi1uMyg==}
 
-  '@livestore/sqlite-wasm@0.4.0-dev.24':
-    resolution: {integrity: sha512-ZS0+o4a2ixduSjW20ecHXz//gUdFpnPotwg/eGqMsDJpcNhFV8CvG6jxJhfL2QY58h290MwUW2rrvLqnYDb8dg==}
+  '@livestore/sqlite-wasm@0.4.0-dev.25':
+    resolution: {integrity: sha512-/yAthKdwfLrbw7eAiV9ebEkMKKetwN49iA7XxfjyeHjfnb/sOFWJq1s6Gw7BV6iMKt1TkuRX427WipdnFq3gpQ==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7744,8 +7744,8 @@ packages:
       '@opentelemetry/resources': ~2.0.0
       effect: 3.21.2
 
-  '@livestore/utils@0.4.0-dev.24':
-    resolution: {integrity: sha512-Z1cyNk1lnhdgPWceo85mc8uawp9AzupQvhuQXzLWsLxz/RNJsD/N4c/BLnBhbSVJCGaTr8SbtLoh8HykLtOTPw==}
+  '@livestore/utils@0.4.0-dev.25':
+    resolution: {integrity: sha512-o9VHADdO6tIa/d7G4oxT6TDzc7I9JfhJW2282ndLoE6MKr8V2oYD34SoBzrfDtl4brjAvGh/cGTO6J1eOByzMQ==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7767,8 +7767,8 @@ packages:
       '@standard-schema/spec': ^1.1.0
       effect: 3.21.2
 
-  '@livestore/wa-sqlite@0.4.0-dev.24':
-    resolution: {integrity: sha512-ot0OnZ+54kIzGeu59Loz+L7C/HtYRlbDw89SgJEA93SlHBZ9Zzm4d6EWmF5v5c5lpwZCpgBU7aa23jJamtYXqw==}
+  '@livestore/wa-sqlite@0.4.0-dev.25':
+    resolution: {integrity: sha512-7nzv8G8gdAWfRDSCKjKv9JCGa/AYJPB1hzVf0/N5oTJNiA28Qc/4JL0R9+OlEoB/UlyUiVY6/l5BhD2yhyHmUA==}
 
   '@livestore/wa-sqlite@1.0.5-dev.2':
     resolution: {integrity: sha512-i7tKFEp0m3+4tGLV9Z5eAr/3RZPuNOyuf4NaQ/ygF2KwzlHc3TnqouPuE2sMH06r3soXIilWYND/x0eT8x6D6Q==}
@@ -7776,8 +7776,8 @@ packages:
   '@livestore/webmesh@0.3.1':
     resolution: {integrity: sha512-JLYFgiOf1r7xqN7SkwdHNZdZ+geQlEdC9rg81DeC839vqqshA5TEhh045dhEkeyVJZqeg44vX5adUX6FOkhTfg==}
 
-  '@livestore/webmesh@0.4.0-dev.24':
-    resolution: {integrity: sha512-Iz6PEKNeqAilaEvaPLkgRrmNv+FmWor8qIyXnCq9jujMG65ghqf++zhpxC5RISkBax71bFXSMzxKX9XmhuGeSw==}
+  '@livestore/webmesh@0.4.0-dev.25':
+    resolution: {integrity: sha512-TGjWLeT7lQG6NrjQqm6QGj2owuAuLBs949wDqtTzAjHupc26GGVVI8/SwPY/uxwUL/xzX8ZMCPgXgXTjL7tmWA==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -21921,7 +21921,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/adapter-web@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/adapter-web@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -21938,17 +21938,17 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/devtools-web-common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/sqlite-wasm': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/devtools-web-common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/sqlite-wasm': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
       effect: 3.21.2
 
-  '@livestore/common-cf@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/common-cf@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@cloudflare/workers-types': 4.20251118.0
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -21966,7 +21966,7 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -21997,7 +21997,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/common@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/common@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22014,8 +22014,8 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -22044,10 +22044,10 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/devtools-vite@0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)':
+  '@livestore/devtools-vite@0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)':
     dependencies:
-      '@livestore/adapter-web': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/adapter-web': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@effect/ai'
@@ -22093,7 +22093,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/devtools-web-common@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/devtools-web-common@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22110,9 +22110,9 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -22193,7 +22193,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/sqlite-wasm@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/sqlite-wasm@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@cloudflare/workers-types': 4.20251118.0
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22211,10 +22211,10 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/common-cf': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/wa-sqlite': 0.4.0-dev.24
+      '@livestore/common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common-cf': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/wa-sqlite': 0.4.0-dev.25
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -22265,7 +22265,7 @@ snapshots:
       nanoid: 5.1.3
       pretty-bytes: 6.1.1
 
-  '@livestore/utils@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/utils@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22290,7 +22290,7 @@ snapshots:
       pretty-bytes: 7.0.1
       qrcode-generator: 2.0.4
 
-  '@livestore/wa-sqlite@0.4.0-dev.24': {}
+  '@livestore/wa-sqlite@0.4.0-dev.25': {}
 
   '@livestore/wa-sqlite@1.0.5-dev.2': {}
 
@@ -22315,7 +22315,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/webmesh@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/webmesh@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22332,7 +22332,7 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -15,7 +15,7 @@
     "@livestore/adapter-web": "workspace:^",
     "@livestore/common": "workspace:^",
     "@livestore/common-cf": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/effect-playwright": "workspace:^",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",

--- a/tests/integration/src/tests/playwright/devtools/web.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/web.play.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 
 import type * as otel from '@opentelemetry/api'
 import type * as PW from '@playwright/test'
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 import * as Playwright from '@livestore/effect-playwright'
 import { OtelLiveHttp } from '@livestore/utils-dev/node'
@@ -125,6 +125,15 @@ const PWLive = Effect.gen(function* () {
 
   return Playwright.browserContextLayer({ persistentContextPath })
 }).pipe(Layer.unwrapEffect)
+
+const waitForLoggedDevtoolsUrl = (page: PW.Page) =>
+  page
+    .waitForEvent('console', {
+      predicate: (message) => message.text().includes('[@livestore/adapter-web] Devtools ready on '),
+      timeout: 10_000,
+    })
+    .then((message) => message.text().match(/Devtools ready on (?<url>http:\/\/[^\s]+)/)?.groups?.url)
+    .then((url) => url ?? Promise.reject(new Error('Could not parse logged LiveStore DevTools URL')))
 
 const runTest =
   <E>(eff: Effect.Effect<void, E, Playwright.BrowserContext | Scope.Scope>) =>
@@ -389,6 +398,62 @@ test(
 
         yield* Effect.sleep(500).pipe(Effect.withSpan('wait-for-otel-flush'))
       }).pipe(Effect.raceFirst(Fiber.joinAll([tab1.pageConsoleFiber, tab1.devtoolsConsoleFiber])))
+    }),
+  ),
+)
+
+test(
+  'logged Vite DevTools URL opens the web session chooser',
+  runTest(
+    Effect.gen(function* () {
+      const { browserContext } = yield* Playwright.BrowserContext
+      browserContext.setDefaultTimeout(10_000)
+
+      const app = yield* Effect.tryPromise(() => browserContext.newPage())
+      const devtools = yield* Effect.tryPromise(() => browserContext.newPage())
+      yield* Effect.addFinalizer(() =>
+        Effect.all(
+          [
+            Effect.tryPromise(() => app.close({ reason: 'test cleanup' })).pipe(Effect.ignore),
+            Effect.tryPromise(() => devtools.close({ reason: 'test cleanup' })).pipe(Effect.ignore),
+          ],
+          { concurrency: 'unbounded' },
+        ),
+      )
+
+      const consoleMessages: string[] = []
+      app.on('console', (message) => consoleMessages.push(message.text()))
+      devtools.on('console', (message) => consoleMessages.push(message.text()))
+
+      yield* Effect.tryPromise(async () => {
+        const baseUrl = `http://localhost:${process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT}`
+        const loggedDevtoolsUrlPromise = waitForLoggedDevtoolsUrl(app)
+
+        await app.goto(`${baseUrl}/devtools/todomvc?sessionId=logged-url&clientId=logged-url&adapter=inmemory`)
+        await app.locator('.new-todo').describe('logged-url:new-todo').waitFor({ timeout: 3000 })
+
+        const loggedDevtoolsUrl = await loggedDevtoolsUrlPromise
+        expect(loggedDevtoolsUrl).toBe(`${baseUrl}/_livestore/web#logged-url`)
+
+        await app.locator('.new-todo').fill('Open the logged DevTools URL')
+        await app.locator('.new-todo').press('Enter')
+        await app.locator('.todo-list li label:text("Open the logged DevTools URL")').waitFor()
+
+        await devtools.goto(loggedDevtoolsUrl)
+
+        await devtools.getByText('Sessions (1)').describe('logged-url-devtools:sessions').waitFor()
+        await devtools
+          .locator('a:text("app-root: logged-url:logged-url (default)")')
+          .describe('logged-url-devtools:session-link')
+          .waitFor()
+
+        const devtoolsText = await devtools.locator('body').innerText()
+        expect(devtoolsText).not.toContain('Loading LiveStore')
+        expect([devtoolsText, ...consoleMessages].join('\n')).not.toMatch(/Version Mismatch|version mismatch/i)
+      })
+
+      yield* shutdownTab(app, { expectStore: false })
+      yield* Effect.sleep(500).pipe(Effect.withSpan('wait-for-otel-flush'))
     }),
   ),
 )

--- a/tests/package-common/package.json
+++ b/tests/package-common/package.json
@@ -31,7 +31,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/utils-dev": "workspace:^",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",

--- a/tests/perf-eventlog/package.json
+++ b/tests/perf-eventlog/package.json
@@ -44,7 +44,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",
     "@playwright/test": "1.59.1",

--- a/tests/sync-provider/package.json
+++ b/tests/sync-provider/package.json
@@ -41,7 +41,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/utils-dev": "workspace:^",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",


### PR DESCRIPTION
**Problem**

The Vite web adapter console log pointed users at a direct DevTools session URL. With the current republished DevTools artifact that URL can remain on `Loading LiveStore...`, and stale `@livestore/devtools-vite` dev pins still referenced `0.4.0-dev.24` while the release group is `0.4.0-dev.25`.

**Goal**

The logged Vite DevTools URL should take users to a stable DevTools entry point that renders the available web sessions without showing the misleading version mismatch/loading failure, and repo-local `@livestore/devtools-vite` pins should match the current release version.

**Decisions**

- Log `/_livestore/web#<sessionId>` instead of the direct `/_livestore/web/<store>/<client>/<session>/<schema>` URL. The mode/session chooser route is the stable route in the current artifact; both the direct route and `?autoconnect` route were observed to stay on `Loading LiveStore...` with the current repacked artifact.
- Keep the DevTools artifact identity separate from the republished LiveStore package version. The source artifact still carries `devtoolsVersion: 0.4.0-dev.22` as lineage metadata, while LiveStore repackages it as `@livestore/devtools-vite@0.4.0-dev.25`.
- Update generated/package pins and the catalog fallback from `0.4.0-dev.24` to `0.4.0-dev.25`; no `.22`/`.24` package pins remain in the checked areas.

**Verification**

- `DT_PASSTHROUGH=1 genie --check`
  - Result: generated files unchanged; setup still prints the existing `core.hooksPath` git-hook warning.
- `CI=1 DT_PASSTHROUGH=1 LIVESTORE_RELEASE_VERSION=0.4.0-dev.25 dt release:devtools-artifact:verify`
  - Result: passed.
- `DT_PASSTHROUGH=1 pnpm --filter @livestore/adapter-web test`
  - Result: passed (`No tests yet`).
- Focused browser regression:
  - `DT_PASSTHROUGH=1 FORCE_PLAYWRIGHT_VIA_CLI=1 PLAYWRIGHT_SUITE=devtools PLAYWRIGHT_HEADLESS=1 LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT=<fixture-port> SPAN_CONTEXT_JSON="{}" pnpm playwright test src/tests/playwright/devtools/web.play.ts -g "logged Vite DevTools URL opens the web session chooser" --reporter=line`
  - Result: `1 passed`.
- `devenv tasks run check:all --mode before --no-tui`
  - Result: did not complete; `mr:lock-sync-check` failed, while format, Genie, oxlint, and `ts:check` completed successfully.
- Manual route probe against the fixture confirmed:
  - `/_livestore/web#<session>` renders `Sessions (1)`.
  - direct session URLs and `?autoconnect` still reach the DevTools bundle but remain on `Loading LiveStore...` with the current artifact.

**Complexity**

No new abstraction. The adapter change is a narrow URL-selection change plus one small path join helper.

**Concerns**

This PR avoids logging the broken direct-connect route, but it does not fix direct-connect inside the external DevTools artifact bundle itself. The current artifact can still get stuck if a user manually constructs the direct route or clicks through to a session.

**Friction & bottlenecks**

- Local devenv setup repeatedly prints `Cowardly refusing to install hooks with core.hooksPath set`; commands continue after setup, but this blocks a clean `check:all` story.
- Running pnpm directly is blocked unless `DT_PASSTHROUGH=1` is set.
- Direct non-devenv Playwright attempts hit missing native runtime libraries, so browser verification was run inside the devenv shell.

**Follow-ups**

- Publish a newer DevTools source artifact whose direct session and autoconnect routes work against the current LiveStore web adapter, then switch the logged URL back to a direct connected experience once the e2e proves it.
- Add an artifact-level browser smoke to the DevTools artifact/repack path so protocol metadata plus package shape is not treated as sufficient runtime compatibility.

**References**

Refs the recent DevTools artifact/versioning work and the `0.4.0-dev.25` release line.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ❄️ co2-frost |
| `agent_session_id` | e9e5f226-7818-40f6-b14c-c34c4a2da475 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | livestore-devtools-e2e-pr/schickling/devtools-e2e-loading-version |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@75f90cf |
</details>
<!-- agent-footer:end -->