### PR TITLE
Gate DevTools repack on LiveStore certification

### DIFF
--- a/.changeset/empty-devtools-release-certification.md
+++ b/.changeset/empty-devtools-release-certification.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. This updates DevTools artifact release gating and certification tests without changing package runtime APIs.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,6 +76,13 @@ It can be triggered by `repository_dispatch` from the artifact-producing system
 or manually with public artifact URLs and a SHA-256 checksum. It verifies the
 manifest and opens a PR that only changes the public artifact metadata.
 
+The manifest separates artifact identity from release certification. The
+artifact-producing workflow may update URLs and checksums, but it must not mark
+the artifact as shippable for a LiveStore release. Repack and publish require a
+schemaVersion 2 certification entry, owned by the LiveStore release process,
+that names the exact LiveStore version, DevTools build id, protocol version, and
+e2e scenarios that passed.
+
 Artifact URLs should point at build-id-only release tags such as
 `devtools-artifact-dt-20260505-398c5feb`. The DevTools implementation version
 may appear in public metadata for traceability, but it is not the artifact
@@ -84,9 +91,11 @@ Chrome ZIP release asset are versioned with the LiveStore release group or
 snapshot version.
 
 Artifact ordering should use artifact metadata such as `artifactVersion` or
-`builtAt`. Runtime compatibility is decided by `devtoolsProtocolVersion`, not by
-matching package versions. The release repack path rejects artifacts whose
-protocol version is unsupported by the LiveStore checkout.
+`builtAt`. Runtime protocol compatibility is decided by
+`devtoolsProtocolVersion`, not by matching package versions. Shipping
+compatibility is decided by the LiveStore-owned certification entry, so stale
+artifacts with broad self-declared compatibility cannot be republished as a new
+LiveStore DevTools package.
 
 The workflow exists so the LiveStore repository can keep release CI
 self-contained while the DevTools source remains outside this repository.

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -202,6 +202,10 @@ jobs:
           fi
 
           mkdir -p release
+          # This workflow only records the public artifact identity. It must not
+          # synthesize LiveStore certification: certification belongs to the LiveStore
+          # release e2e gate, which proves one exact DevTools build against one exact
+          # LiveStore release before repack/publish may run.
           jq -n \
             --arg metadataUrl "$ARTIFACT_METADATA_URL" \
             --arg tarballUrl "$ARTIFACT_TARBALL_URL" \
@@ -209,7 +213,7 @@ jobs:
             --arg chromeZipUrl "${ARTIFACT_CHROME_ZIP_URL:-}" \
             --arg chromeZipSha256 "${ARTIFACT_CHROME_ZIP_SHA256:-}" \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               artifact: {
                 metadataUrl: $metadataUrl,
                 tarballUrl: $tarballUrl,
@@ -250,7 +254,7 @@ jobs:
           body="$(cat <<'BODY'
           Updates the public DevTools artifact manifest from a sanitized artifact release.
 
-          This PR only changes public artifact URLs and checksums. The workflow verifies the tarball before opening the PR.
+          This PR only changes public artifact URLs and checksums. The workflow verifies the tarball before opening the PR; LiveStore release certification is added separately after e2e passes.
           BODY
           )"
 

--- a/.github/workflows/devtools-artifact.yml.genie.ts
+++ b/.github/workflows/devtools-artifact.yml.genie.ts
@@ -97,6 +97,10 @@ if [ -n "\${ARTIFACT_CHROME_ZIP_URL:-}" ] && [ -z "\${ARTIFACT_CHROME_ZIP_SHA256
 fi
 
 mkdir -p release
+# This workflow only records the public artifact identity. It must not
+# synthesize LiveStore certification: certification belongs to the LiveStore
+# release e2e gate, which proves one exact DevTools build against one exact
+# LiveStore release before repack/publish may run.
 jq -n \\
   --arg metadataUrl "$ARTIFACT_METADATA_URL" \\
   --arg tarballUrl "$ARTIFACT_TARBALL_URL" \\
@@ -104,7 +108,7 @@ jq -n \\
   --arg chromeZipUrl "\${ARTIFACT_CHROME_ZIP_URL:-}" \\
   --arg chromeZipSha256 "\${ARTIFACT_CHROME_ZIP_SHA256:-}" \\
   '{
-    schemaVersion: 1,
+    schemaVersion: 2,
     artifact: {
       metadataUrl: $metadataUrl,
       tarballUrl: $tarballUrl,
@@ -149,7 +153,7 @@ title="Update LiveStore DevTools artifact manifest"
 body="$(cat <<'BODY'
 Updates the public DevTools artifact manifest from a sanitized artifact release.
 
-This PR only changes public artifact URLs and checksums. The workflow verifies the tarball before opening the PR.
+This PR only changes public artifact URLs and checksums. The workflow verifies the tarball before opening the PR; LiveStore release certification is added separately after e2e passes.
 BODY
 )"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,9 +491,16 @@ jobs:
           fi
 
           mkdir -p release
+          version="$(jq -r '.version' packages/@livestore/common/package.json)"
+          npm_tag="latest"
+          if [[ "$version" == *"-dev."* ]]; then
+            npm_tag="dev"
+          elif [[ "$version" == *"-"* ]]; then
+            npm_tag="next"
+          fi
           jq -n \
-            --arg version "0.0.0-snapshot-release-workflow-test-${GITHUB_SHA}" \
-            --arg npmTag "next" \
+            --arg version "$version" \
+            --arg npmTag "$npm_tag" \
             '{
               schemaVersion: 1,
               version: $version,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,7 +492,7 @@ jobs:
 
           mkdir -p release
           jq -n \
-            --arg version "0.0.0-release-workflow-test-${GITHUB_SHA}" \
+            --arg version "0.0.0-snapshot-release-workflow-test-${GITHUB_SHA}" \
             --arg npmTag "next" \
             '{
               schemaVersion: 1,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,13 +491,14 @@ jobs:
           fi
 
           mkdir -p release
-          version="$(jq -r '.version' packages/@livestore/common/package.json)"
-          npm_tag="latest"
-          if [[ "$version" == *"-dev."* ]]; then
-            npm_tag="dev"
-          elif [[ "$version" == *"-"* ]]; then
-            npm_tag="next"
-          fi
+          # PRs that touch release machinery but do not carry an actual release plan still
+          # need to exercise package publishing and DevTools repacking. Use a unique,
+          # unpublished prerelease instead of the checked-in package version: current dev
+          # versions can already exist on npm, while snapshot versions intentionally
+          # belong to the separate snapshot publisher.
+          short_sha="${GITHUB_SHA:0:12}"
+          version="0.0.0-ci.release-validation.$short_sha"
+          npm_tag="next"
           jq -n \
             --arg version "$version" \
             --arg npmTag "$npm_tag" \

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -187,9 +187,16 @@ if [ "$use_synthetic_plan" = "false" ]; then
 fi
 
 mkdir -p release
+version="$(jq -r '.version' packages/@livestore/common/package.json)"
+npm_tag="latest"
+if [[ "$version" == *"-dev."* ]]; then
+  npm_tag="dev"
+elif [[ "$version" == *"-"* ]]; then
+  npm_tag="next"
+fi
 jq -n \\
-  --arg version "0.0.0-snapshot-release-workflow-test-\${GITHUB_SHA}" \\
-  --arg npmTag "next" \\
+  --arg version "$version" \\
+  --arg npmTag "$npm_tag" \\
   '{
     schemaVersion: 1,
     version: $version,

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -188,7 +188,7 @@ fi
 
 mkdir -p release
 jq -n \\
-  --arg version "0.0.0-release-workflow-test-\${GITHUB_SHA}" \\
+  --arg version "0.0.0-snapshot-release-workflow-test-\${GITHUB_SHA}" \\
   --arg npmTag "next" \\
   '{
     schemaVersion: 1,

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -187,13 +187,14 @@ if [ "$use_synthetic_plan" = "false" ]; then
 fi
 
 mkdir -p release
-version="$(jq -r '.version' packages/@livestore/common/package.json)"
-npm_tag="latest"
-if [[ "$version" == *"-dev."* ]]; then
-  npm_tag="dev"
-elif [[ "$version" == *"-"* ]]; then
-  npm_tag="next"
-fi
+# PRs that touch release machinery but do not carry an actual release plan still
+# need to exercise package publishing and DevTools repacking. Use a unique,
+# unpublished prerelease instead of the checked-in package version: current dev
+# versions can already exist on npm, while snapshot versions intentionally
+# belong to the separate snapshot publisher.
+short_sha="\${GITHUB_SHA:0:12}"
+version="0.0.0-ci.release-validation.$short_sha"
+npm_tag="next"
 jq -n \\
   --arg version "$version" \\
   --arg npmTag "$npm_tag" \\

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -180,16 +180,22 @@ New artifact metadata should also include a monotonically increasing
 `artifactVersion`, a `devtoolsProtocolVersion`, `builtAt`, and `sourceRevision`.
 `artifactVersion` orders DevTools artifact lineage. `devtoolsProtocolVersion`
 is the runtime compatibility contract between the app and DevTools. LiveStore
-package versions may differ from the source artifact version as long as the
-artifact protocol is supported and `compatibleLivestore` accepts the release
-version.
+package versions may differ from the source artifact version. For dev and
+stable release-channel packages, shipping compatibility is decided by the
+LiveStore-owned certification entry in `release/devtools-artifact.json`, not by
+artifact-owned package versions or broad self-declared compatibility ranges.
 
 The LiveStore release workflow only consumes those published artifacts. It must
 not require, copy, log, or publish non-public DevTools source. Artifact
 verification checks the metadata, tarball hash and integrity, package shape, and
 text-like files for common secret or machine-local patterns before repacking.
 Repack validation also rejects artifacts with unsupported DevTools protocol
-versions or incompatible `compatibleLivestore` declarations.
+versions. For dev and stable release versions, repack also requires a
+schemaVersion 2 manifest certification with `status: passed`, the exact
+LiveStore version, exact DevTools build id, protocol version, and the e2e
+scenarios that passed. CI snapshot packages are per-commit artifacts and cannot
+be pre-certified in the checked-in manifest; they still pass through artifact
+integrity, package-shape, secret-scan, and protocol validation.
 
 The repacked package writes `dist/release-metadata.json` with both identities:
 
@@ -198,6 +204,7 @@ The repacked package writes `dist/release-metadata.json` with both identities:
 - `devtoolsArtifact.artifactVersion` when provided by the artifact producer
 - `devtoolsArtifact.devtoolsProtocolVersion`
 - `livestoreVersion`
+- `livestoreCertification`
 
 Use `devtoolsArtifact.devtoolsBuildId` to correlate a published LiveStore
 package with the exact public DevTools artifact when investigating failures.
@@ -214,7 +221,11 @@ release:
    tarball URLs.
 2. Include the tarball SHA-256 when available.
 3. Run `CI=1 dt release:devtools-artifact:verify`.
-4. Open a PR with only the manifest change unless release tooling also changed.
+4. Run the release e2e scenarios against the exact LiveStore version and
+   DevTools build id.
+5. Add the schemaVersion 2 certification entry only after e2e passes.
+6. Open a PR with only the manifest and certification change unless release
+   tooling also changed.
 
 The release PR will then dry-run the repack using that manifest. When the
 release-plan PR merges to `main`, the publish job repackages and publishes the

--- a/devenv.nix
+++ b/devenv.nix
@@ -79,12 +79,9 @@ let
     : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
     artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
     if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" || -n "''${LIVESTORE_DEVTOOLS_CHROME_ZIP:-}" ]]; then
-      : "''${LIVESTORE_DEVTOOLS_METADATA:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
-      : "''${LIVESTORE_DEVTOOLS_TARBALL:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
-      artifact_args=(--metadata "$LIVESTORE_DEVTOOLS_METADATA" --tarball "$LIVESTORE_DEVTOOLS_TARBALL")
-      if [[ -n "''${LIVESTORE_DEVTOOLS_CHROME_ZIP:-}" ]]; then
-        artifact_args+=(--chrome-zip "$LIVESTORE_DEVTOOLS_CHROME_ZIP")
-      fi
+      echo "release:devtools-artifact repack requires LIVESTORE_DEVTOOLS_MANIFEST so LiveStore-owned certification is available." >&2
+      echo "Use release:devtools-artifact:verify for direct metadata/tarball integrity checks." >&2
+      exit 1
     fi
 
     bun scripts/src/commands/devtools-artifact.ts repack \

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,7 +43,7 @@
     "@livestore/adapter-node": "workspace:^",
     "@livestore/adapter-web": "workspace:^",
     "@livestore/common": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",
     "@livestore/solid": "workspace:^",

--- a/docs/src/content/_assets/code/package.json
+++ b/docs/src/content/_assets/code/package.json
@@ -30,7 +30,7 @@
     "@livestore/adapter-node": "workspace:^",
     "@livestore/adapter-web": "workspace:^",
     "@livestore/devtools-expo": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",
     "@livestore/solid": "workspace:^",

--- a/examples/cf-chat-solid/package.json
+++ b/examples/cf-chat-solid/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "tailwindcss": "4.1.18",

--- a/examples/cf-chat/package.json
+++ b/examples/cf-chat/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",

--- a/examples/web-email-client/package.json
+++ b/examples/web-email-client/package.json
@@ -18,7 +18,7 @@
     "react-error-boundary": "6.1.1"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-linearlite/package.json
+++ b/examples/web-linearlite/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@svgr/plugin-jsx": "^8.1.0",
     "@svgr/plugin-svgo": "^8.1.0",

--- a/examples/web-multi-store/package.json
+++ b/examples/web-multi-store/package.json
@@ -17,7 +17,7 @@
     "react-error-boundary": "6.1.1"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@types/node": "25.3.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-custom-elements/package.json
+++ b/examples/web-todomvc-custom-elements/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tailwindcss/vite": "4.1.18",
     "@types/react": "19.2.7",

--- a/examples/web-todomvc-experimental/package.json
+++ b/examples/web-todomvc-experimental/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-react-router/package.json
+++ b/examples/web-todomvc-react-router/package.json
@@ -17,7 +17,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-script/package.json
+++ b/examples/web-todomvc-script/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "typescript": "5.9.3",
     "vite": "7.3.1",

--- a/examples/web-todomvc-solid/package.json
+++ b/examples/web-todomvc-solid/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "solid-devtools": "^0.34.3",
     "typescript": "5.9.3",

--- a/examples/web-todomvc-svelte/package.json
+++ b/examples/web-todomvc-svelte/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@sveltejs/vite-plugin-svelte": "6.2.1",
     "typescript": "5.9.3",

--- a/examples/web-todomvc-sync-cf/package.json
+++ b/examples/web-todomvc-sync-cf/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/examples/web-todomvc-sync-electric/package.json
+++ b/examples/web-todomvc-sync-electric/package.json
@@ -19,7 +19,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tanstack/react-router": "1.145.7",
     "@tanstack/router-devtools": "1.139.14",

--- a/examples/web-todomvc-sync-s2/package.json
+++ b/examples/web-todomvc-sync-s2/package.json
@@ -20,7 +20,7 @@
     "todomvc-app-css": "2.4.3"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@tanstack/react-router": "1.145.7",
     "@tanstack/router-devtools": "1.139.14",

--- a/examples/web-todomvc/package.json
+++ b/examples/web-todomvc/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.13.12",
     "@cloudflare/workers-types": "4.20251118.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@playwright/test": "1.59.1",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -52,7 +52,7 @@ export const livestoreOnlyCatalog = {
    * LiveStore republishes DevTools artifacts under the LiveStore release version.
    * The source artifact carries its own metadata for artifact lineage and protocol compatibility.
    */
-  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.24',
+  '@livestore/devtools-vite': process.env.LIVESTORE_RELEASE_VERSION ?? '0.4.0-dev.25',
   /** Tanstack router sub-packages not in effect-utils catalog (react-router/react-start/router-plugin are there) */
   '@tanstack/router-core': '1.145.7',
   '@tanstack/history': '1.145.7',

--- a/packages/@livestore/adapter-node/package.json
+++ b/packages/@livestore/adapter-node/package.json
@@ -37,7 +37,7 @@
     "@opentelemetry/api": "1.9.0"
   },
   "devDependencies": {
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@rollup/plugin-commonjs": "28.0.6",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-terser": "0.4.4",

--- a/packages/@livestore/devtools-expo/package.json
+++ b/packages/@livestore/devtools-expo/package.json
@@ -48,7 +48,7 @@
     "@effect/sql": "^0.51.1",
     "@effect/typeclass": "^0.40.0",
     "@effect/vitest": "^0.29.0",
-    "@livestore/devtools-vite": "^0.4.0-dev.24",
+    "@livestore/devtools-vite": "^0.4.0-dev.25",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/resources": "^2.2.0",
     "@standard-schema/spec": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,8 +300,8 @@ importers:
         specifier: workspace:^
         version: link:../packages/@livestore/common
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/livestore':
         specifier: workspace:^
         version: link:../packages/@livestore/livestore
@@ -529,8 +529,8 @@ importers:
         specifier: workspace:^
         version: link:../../../../../packages/@livestore/devtools-expo
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/livestore':
         specifier: workspace:^
         version: link:../../../../../packages/@livestore/livestore
@@ -690,8 +690,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -760,8 +760,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1151,8 +1151,8 @@ importers:
         version: 6.1.1(react@19.2.3)
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@tailwindcss/vite':
         specifier: 4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -1284,8 +1284,8 @@ importers:
         specifier: 1.13.12
         version: 1.13.12(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20251008.0)(wrangler@4.42.2(@cloudflare/workers-types@4.20251118.0))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1378,8 +1378,8 @@ importers:
         version: 6.1.1(react@19.2.3)
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -1445,8 +1445,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1503,8 +1503,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1576,8 +1576,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1637,8 +1637,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1750,8 +1750,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1799,8 +1799,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1854,8 +1854,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1915,8 +1915,8 @@ importers:
         specifier: 4.20251118.0
         version: 4.20251118.0
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -1982,8 +1982,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -2067,8 +2067,8 @@ importers:
         version: 2.4.3
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -2343,8 +2343,8 @@ importers:
         version: 3.21.2
     devDependencies:
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@rollup/plugin-commonjs':
         specifier: 28.0.6
         version: 28.0.6(rollup@4.49.0)
@@ -2740,8 +2740,8 @@ importers:
         specifier: workspace:^
         version: link:../adapter-node
       '@livestore/devtools-vite':
-        specifier: ^0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: ^0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils':
         specifier: workspace:^
         version: link:../utils
@@ -4524,8 +4524,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/@livestore/common-cf
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/effect-playwright':
         specifier: workspace:^
         version: link:../../packages/@livestore/effect-playwright
@@ -4727,8 +4727,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils-dev':
         specifier: workspace:^
         version: link:../../packages/@livestore/utils-dev
@@ -4957,8 +4957,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -5066,8 +5066,8 @@ importers:
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       '@livestore/devtools-vite':
-        specifier: 0.4.0-dev.24
-        version: 0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)
+        specifier: 0.4.0-dev.25
+        version: 0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)
       '@livestore/utils-dev':
         specifier: workspace:^
         version: link:../../packages/@livestore/utils-dev
@@ -6905,7 +6905,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@54.0.10':
     resolution: {integrity: sha512-iw9gAnN6+PKWWLIyYmiskY/wzZjuFMctunqGXuC8BGATWgtr/HpzjVqWbcL3KIX/GvEBCCh74Tkckrh+Ylxh5Q==}
@@ -7581,8 +7581,8 @@ packages:
   '@livestore/adapter-web@0.3.1':
     resolution: {integrity: sha512-0ZKTam+C3KeG5qiiTLFOgoMhdUBCENmuaMwxoj7WOtA2c4eKyqIy+P/1zga+az0XqaMJoG5FVszWhWMUMzNjtQ==}
 
-  '@livestore/adapter-web@0.4.0-dev.24':
-    resolution: {integrity: sha512-j4JngwuQt+Q+MFuopqf52U03Z0wn4V7NHvgmih1Ba5zJF+sOvPmmRtRj1SDW98aCNRG3XSlg1Yh+S2yikaZV6w==}
+  '@livestore/adapter-web@0.4.0-dev.25':
+    resolution: {integrity: sha512-IlsKqotB0GmGsTn9fP5NrgpNx1oc+vTnoweaGoImLA4Jty9jGpPfFx8MiKlULXVK0oMRQvBwCzZ5AMeurSDHQg==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7604,8 +7604,8 @@ packages:
       '@standard-schema/spec': ^1.1.0
       effect: 3.21.2
 
-  '@livestore/common-cf@0.4.0-dev.24':
-    resolution: {integrity: sha512-5QPrz/SQDLL+o7O8aDhaevyzIdyJrU1saKiyVak4KScbOoIKiN3sa4VkF3MUKgJeJfUUQdWabxBN+fkrsy6pow==}
+  '@livestore/common-cf@0.4.0-dev.25':
+    resolution: {integrity: sha512-a4d3GpHE1HOJV0DuPGJLKs5+H7YldAIAAMBjBZujAmekPbzuU7jdBT+yJVCZB8UZU1NrUQEfDW2N8n85hLA08g==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7630,8 +7630,8 @@ packages:
   '@livestore/common@0.3.1':
     resolution: {integrity: sha512-D44ia+zVH8EF0TWGUp0GQnCVvCsGKgKD/ryFl+kx607/l7GDUSagNnWkRmMwhhshJSJblQwouhA9fwjDNTBB2g==}
 
-  '@livestore/common@0.4.0-dev.24':
-    resolution: {integrity: sha512-KE1BVVq0z+0qR6HPb+X5gabgZcOYMYY9e3FGeJGdSvbWYQouGNeeZFaEe+2xQkg/HVBTa5cg0tEeWZq7vpWQ3A==}
+  '@livestore/common@0.4.0-dev.25':
+    resolution: {integrity: sha512-nyBpTydGNcerQfizD3Quu7L/grY7JWX9RyVXVv/Ap7rDwjfAZwVa6dYyzLquY2hirYbv6Xb4cVFn72Ms/w8MzA==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7658,16 +7658,16 @@ packages:
     peerDependencies:
       vite: ~6.3.4
 
-  '@livestore/devtools-vite@0.4.0-dev.24':
-    resolution: {integrity: sha512-LaovZMF4yuq3jvEx84WyrpTIXDytnDydCkpgPdNUyckL1V+yKqd9Mbq4eXPlAKl2PX0EcK/RGepR/Ua26WAPDQ==}
+  '@livestore/devtools-vite@0.4.0-dev.25':
+    resolution: {integrity: sha512-Lw+JZYp8T6g4yGkJ0ef57td+upQVYGbhGHOnS/DeulebxY6uQjLgJigsvA8UzMN+BksMc/FsQPLv8+qzOe5AEA==}
     peerDependencies:
       vite: ^7.3.1
 
   '@livestore/devtools-web-common@0.3.1':
     resolution: {integrity: sha512-jU7IvebelTtvSTQ2zKNzSm5qZodwUiPsNsDURsY5Yw0DXpafcfpRobs/WYd+Wd4Q1E4oFaK05hPfWZGbVFdw7Q==}
 
-  '@livestore/devtools-web-common@0.4.0-dev.24':
-    resolution: {integrity: sha512-neWpu9GwHRq872S2U0h2Ib2sdBVZWxSRaGeivLHBHmnSgJVPgeCienEp9qsX+XVPzIAFWr+w9tJkmrt13GGwjA==}
+  '@livestore/devtools-web-common@0.4.0-dev.25':
+    resolution: {integrity: sha512-dEcoDpN4nH8xWG0VVNT9WqDmUt4Nlm0UsSVaNhtUw+XYuRQaNBeLt1h/ARIccdPRzS5V+Sbd9H/8CDlyfOsnSg==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7698,8 +7698,8 @@ packages:
   '@livestore/sqlite-wasm@0.3.1':
     resolution: {integrity: sha512-+JLIwpd2N214LmwlUX6arYnJ5IhvSi4Fn3Jk6E6fNfuUU4tczcL1PtgfIX2IoiPhn9QDG0YJVdJBT6KYi1uMyg==}
 
-  '@livestore/sqlite-wasm@0.4.0-dev.24':
-    resolution: {integrity: sha512-ZS0+o4a2ixduSjW20ecHXz//gUdFpnPotwg/eGqMsDJpcNhFV8CvG6jxJhfL2QY58h290MwUW2rrvLqnYDb8dg==}
+  '@livestore/sqlite-wasm@0.4.0-dev.25':
+    resolution: {integrity: sha512-/yAthKdwfLrbw7eAiV9ebEkMKKetwN49iA7XxfjyeHjfnb/sOFWJq1s6Gw7BV6iMKt1TkuRX427WipdnFq3gpQ==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7744,8 +7744,8 @@ packages:
       '@opentelemetry/resources': ~2.0.0
       effect: 3.21.2
 
-  '@livestore/utils@0.4.0-dev.24':
-    resolution: {integrity: sha512-Z1cyNk1lnhdgPWceo85mc8uawp9AzupQvhuQXzLWsLxz/RNJsD/N4c/BLnBhbSVJCGaTr8SbtLoh8HykLtOTPw==}
+  '@livestore/utils@0.4.0-dev.25':
+    resolution: {integrity: sha512-o9VHADdO6tIa/d7G4oxT6TDzc7I9JfhJW2282ndLoE6MKr8V2oYD34SoBzrfDtl4brjAvGh/cGTO6J1eOByzMQ==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -7767,8 +7767,8 @@ packages:
       '@standard-schema/spec': ^1.1.0
       effect: 3.21.2
 
-  '@livestore/wa-sqlite@0.4.0-dev.24':
-    resolution: {integrity: sha512-ot0OnZ+54kIzGeu59Loz+L7C/HtYRlbDw89SgJEA93SlHBZ9Zzm4d6EWmF5v5c5lpwZCpgBU7aa23jJamtYXqw==}
+  '@livestore/wa-sqlite@0.4.0-dev.25':
+    resolution: {integrity: sha512-7nzv8G8gdAWfRDSCKjKv9JCGa/AYJPB1hzVf0/N5oTJNiA28Qc/4JL0R9+OlEoB/UlyUiVY6/l5BhD2yhyHmUA==}
 
   '@livestore/wa-sqlite@1.0.5-dev.2':
     resolution: {integrity: sha512-i7tKFEp0m3+4tGLV9Z5eAr/3RZPuNOyuf4NaQ/ygF2KwzlHc3TnqouPuE2sMH06r3soXIilWYND/x0eT8x6D6Q==}
@@ -7776,8 +7776,8 @@ packages:
   '@livestore/webmesh@0.3.1':
     resolution: {integrity: sha512-JLYFgiOf1r7xqN7SkwdHNZdZ+geQlEdC9rg81DeC839vqqshA5TEhh045dhEkeyVJZqeg44vX5adUX6FOkhTfg==}
 
-  '@livestore/webmesh@0.4.0-dev.24':
-    resolution: {integrity: sha512-Iz6PEKNeqAilaEvaPLkgRrmNv+FmWor8qIyXnCq9jujMG65ghqf++zhpxC5RISkBax71bFXSMzxKX9XmhuGeSw==}
+  '@livestore/webmesh@0.4.0-dev.25':
+    resolution: {integrity: sha512-TGjWLeT7lQG6NrjQqm6QGj2owuAuLBs949wDqtTzAjHupc26GGVVI8/SwPY/uxwUL/xzX8ZMCPgXgXTjL7tmWA==}
     peerDependencies:
       '@effect/ai': ^0.35.0
       '@effect/cli': 0.75.1
@@ -21921,7 +21921,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/adapter-web@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/adapter-web@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -21938,17 +21938,17 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/devtools-web-common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/sqlite-wasm': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/devtools-web-common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/sqlite-wasm': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
       effect: 3.21.2
 
-  '@livestore/common-cf@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/common-cf@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@cloudflare/workers-types': 4.20251118.0
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -21966,7 +21966,7 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -21997,7 +21997,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/common@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/common@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22014,8 +22014,8 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -22044,10 +22044,10 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/devtools-vite@0.4.0-dev.24(5a277068ab2fc267bf897432879ebba0)':
+  '@livestore/devtools-vite@0.4.0-dev.25(5a277068ab2fc267bf897432879ebba0)':
     dependencies:
-      '@livestore/adapter-web': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/adapter-web': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@effect/ai'
@@ -22093,7 +22093,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/devtools-web-common@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/devtools-web-common@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22110,9 +22110,9 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/webmesh': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/webmesh': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -22193,7 +22193,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/sqlite-wasm@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/sqlite-wasm@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@cloudflare/workers-types': 4.20251118.0
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22211,10 +22211,10 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/common': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/common-cf': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
-      '@livestore/wa-sqlite': 0.4.0-dev.24
+      '@livestore/common': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/common-cf': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/wa-sqlite': 0.4.0-dev.25
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0
@@ -22265,7 +22265,7 @@ snapshots:
       nanoid: 5.1.3
       pretty-bytes: 6.1.1
 
-  '@livestore/utils@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/utils@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22290,7 +22290,7 @@ snapshots:
       pretty-bytes: 7.0.1
       qrcode-generator: 2.0.4
 
-  '@livestore/wa-sqlite@0.4.0-dev.24': {}
+  '@livestore/wa-sqlite@0.4.0-dev.25': {}
 
   '@livestore/wa-sqlite@1.0.5-dev.2': {}
 
@@ -22315,7 +22315,7 @@ snapshots:
       - '@opentelemetry/resources'
       - effect
 
-  '@livestore/webmesh@0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)':
+  '@livestore/webmesh@0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)':
     dependencies:
       '@effect/ai': 0.35.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -22332,7 +22332,7 @@ snapshots:
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/typeclass': 0.40.0(effect@3.21.2)
       '@effect/vitest': 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@livestore/utils': 0.4.0-dev.24(10159e6faafba03ca68ac1a223e3d717)
+      '@livestore/utils': 0.4.0-dev.25(10159e6faafba03ca68ac1a223e3d717)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@standard-schema/spec': 1.1.0

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,10 +1,22 @@
 {
   "schemaVersion": 2,
   "artifact": {
-    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260505-398c5feb/release-metadata.json",
-    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260505-398c5feb/livestore-devtools-vite.tgz",
-    "sha256": "6c5fb9ddc7d8c3cc55b5e04f67064dd65aa20b6a6a1eb89a5651cd74642ad83f",
-    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260505-398c5feb/livestore-devtools-chrome.zip",
-    "chromeZipSha256": "92505c851d29276a3ee00230bfd2c395af41545ab70ff396ef4c40a8f6dd2077"
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/livestore-devtools-vite.tgz",
+    "sha256": "1e766d5b1e0226c3c70c29c0dff24ee4da0ff8593b813c4b5fd29e852696f3f0",
+    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/livestore-devtools-chrome.zip",
+    "chromeZipSha256": "f1feead7eb67f620a119ce92d35f84238274128cc480e3a851f1cc20785e2ed2"
+  },
+  "certification": {
+    "livestoreVersion": "0.4.0-dev.25",
+    "devtoolsBuildId": "dt-20260513-27179788",
+    "devtoolsProtocolVersion": 1,
+    "status": "passed",
+    "testSuite": "tests/integration/src/tests/playwright/devtools",
+    "scenarios": [
+      "direct web session loads and stays connected past heartbeat window",
+      "node adapter session loads through Vite and stays connected past 35 seconds"
+    ],
+    "evidence": "Verified locally on 2026-05-13 against exact artifact tarball from https://github.com/livestorejs/livestore-devtools-artifacts/releases/tag/devtools-artifact-dt-20260513-27179788."
   }
 }

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "artifact": {
     "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260505-398c5feb/release-metadata.json",
     "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260505-398c5feb/livestore-devtools-vite.tgz",

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 
 import {
   assertCertifiedDevtoolsArtifactForLivestore,
+  containsForbiddenPattern,
   type ArtifactManifest,
   type ArtifactMetadata,
+  forbiddenPatterns,
 } from './devtools-artifact.ts'
 
 const metadata: ArtifactMetadata = {
@@ -144,5 +146,16 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
         version: '0.4.0-dev.25',
       }),
     ).toThrow(/missing scenarios/)
+  })
+})
+
+describe('artifact forbidden text patterns', () => {
+  const containsForbiddenText = (content: string) =>
+    forbiddenPatterns.some((pattern) => containsForbiddenPattern(content, pattern))
+
+  it('allows Emscripten virtual home paths but rejects host home paths', () => {
+    expect(containsForbiddenText('HOME: "/home/web_user"')).toBe(false)
+    expect(containsForbiddenText('source: "/home/alice/project/src/file.ts"')).toBe(true)
+    expect(containsForbiddenText('source: "/Users/alice/project/src/file.ts"')).toBe(true)
   })
 })

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertCertifiedDevtoolsArtifactForLivestore,
+  type ArtifactManifest,
+  type ArtifactMetadata,
+} from './devtools-artifact.ts'
+
+const metadata: ArtifactMetadata = {
+  schemaVersion: 1,
+  artifactName: 'livestore-devtools-vite',
+  packageName: '@livestore/devtools-vite',
+  devtoolsBuildId: 'dt-test-build',
+  devtoolsProtocolVersion: 1,
+  files: {
+    tarball: {
+      name: 'livestore-devtools-vite.tgz',
+      sha256: 'tarball-sha',
+      integrity: 'tarball-integrity',
+    },
+  },
+}
+
+const manifest = (
+  overrides: Partial<NonNullable<Extract<ArtifactManifest, { schemaVersion: 2 }>['certification']>> = {},
+) =>
+  ({
+    schemaVersion: 2,
+    artifact: {
+      metadataUrl: 'release-metadata.json',
+      tarballUrl: 'livestore-devtools-vite.tgz',
+    },
+    certification: {
+      livestoreVersion: '0.4.0-dev.25',
+      devtoolsBuildId: 'dt-test-build',
+      devtoolsProtocolVersion: 1,
+      status: 'passed',
+      testSuite: 'devtools-direct-connect-e2e',
+      scenarios: ['direct-url-connects-and-stays-connected'],
+      ...overrides,
+    },
+  }) satisfies ArtifactManifest
+
+describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
+  it('accepts an exact LiveStore-owned certification', () => {
+    expect(
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest(),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toMatchObject({ livestoreVersion: '0.4.0-dev.25', devtoolsBuildId: 'dt-test-build' })
+  })
+
+  it('rejects direct repack inputs without a checked-in certification manifest', () => {
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: undefined,
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/requires --manifest/)
+  })
+
+  it('rejects legacy manifests that only describe the artifact pointer', () => {
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: {
+          schemaVersion: 1,
+          artifact: {
+            metadataUrl: 'release-metadata.json',
+            tarballUrl: 'livestore-devtools-vite.tgz',
+          },
+        },
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/schemaVersion 2/)
+  })
+
+  it('rejects missing or non-passing certification', () => {
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: { schemaVersion: 2, artifact: { metadataUrl: 'release-metadata.json', tarballUrl: 'devtools.tgz' } },
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/certification entry/)
+
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest({ status: 'pending' }),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/expected passed/)
+  })
+
+  it('allows CI snapshot repack through the artifact and protocol gates without release certification', () => {
+    expect(
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: { schemaVersion: 2, artifact: { metadataUrl: 'release-metadata.json', tarballUrl: 'devtools.tgz' } },
+        metadata,
+        version: '0.0.0-snapshot-abc123',
+      }),
+    ).toMatchObject({
+      livestoreVersion: '0.0.0-snapshot-abc123',
+      status: 'ci-snapshot',
+      testSuite: 'artifact-integrity-and-protocol-gate',
+    })
+  })
+
+  it('rejects certification for a different LiveStore release or DevTools build', () => {
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest({ livestoreVersion: '0.4.0-dev.24' }),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/not release 0\.4\.0-dev\.25/)
+
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest({ devtoolsBuildId: 'dt-other-build' }),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/does not match metadata build/)
+  })
+
+  it('rejects certification for a different protocol or incomplete test evidence', () => {
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest({ devtoolsProtocolVersion: 2 }),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/does not match metadata protocol/)
+
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest({ scenarios: [] }),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/missing scenarios/)
+  })
+})

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -112,6 +112,21 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
     })
   })
 
+  it('allows synthetic CI release validation repack without exact release certification', () => {
+    expect(
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest(),
+        metadata,
+        version: '0.0.0-ci.release-validation.abc123',
+      }),
+    ).toMatchObject({
+      livestoreVersion: '0.0.0-ci.release-validation.abc123',
+      status: 'ci-release-validation',
+      testSuite: 'artifact-integrity-and-protocol-gate',
+      scenarios: ['ci-release-validation-repack'],
+    })
+  })
+
   it('rejects certification for a different LiveStore release or DevTools build', () => {
     expect(() =>
       assertCertifiedDevtoolsArtifactForLivestore({

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -66,13 +66,13 @@ type DevtoolsArtifactCertification = {
   readonly evidence?: string
 }
 
-type DevtoolsArtifactCiSnapshotCertification = {
+type DevtoolsArtifactEphemeralCertification = {
   readonly livestoreVersion: string
   readonly devtoolsBuildId: string
   readonly devtoolsProtocolVersion: number
-  readonly status: 'ci-snapshot'
+  readonly status: 'ci-snapshot' | 'ci-release-validation'
   readonly testSuite: 'artifact-integrity-and-protocol-gate'
-  readonly scenarios: ReadonlyArray<'ci-snapshot-repack'>
+  readonly scenarios: ReadonlyArray<'ci-snapshot-repack' | 'ci-release-validation-repack'>
 }
 
 type ArtifactManifestV1 = {
@@ -187,6 +187,8 @@ const publishTagForVersion = (version: string) => {
 }
 
 const isSnapshotVersion = (version: string) => version.includes('-snapshot-')
+
+const isCiReleaseValidationVersion = (version: string) => version.includes('-ci.release-validation.')
 
 const packageVersionExists = (packageName: string, version: string) =>
   runCaptureOptional(['npm', 'view', `${packageName}@${version}`, 'version']) === version
@@ -332,23 +334,26 @@ export const assertCertifiedDevtoolsArtifactForLivestore = ({
     )
   }
 
+  // Ephemeral CI versions cannot be pre-certified in a checked-in manifest:
+  // snapshot versions are produced by the snapshot publisher, and
+  // ci.release-validation versions are synthetic PR-only release-plan probes.
+  // They still require the LiveStore-owned manifest pointer and pass through
+  // artifact checksums, package-shape audit, secret scan, and protocol
+  // validation; dev/stable release-channel packages below fail closed unless
+  // LiveStore records an exact passed e2e certification.
+  if (isSnapshotVersion(version) === true || isCiReleaseValidationVersion(version) === true) {
+    return {
+      livestoreVersion: version,
+      devtoolsBuildId: metadata.devtoolsBuildId,
+      devtoolsProtocolVersion: protocolVersion,
+      status: isSnapshotVersion(version) === true ? 'ci-snapshot' : 'ci-release-validation',
+      testSuite: 'artifact-integrity-and-protocol-gate',
+      scenarios: isSnapshotVersion(version) === true ? ['ci-snapshot-repack'] : ['ci-release-validation-repack'],
+    } satisfies DevtoolsArtifactEphemeralCertification
+  }
+
   const certification = manifest.certification
   if (certification === undefined) {
-    // Snapshot packages are per-commit CI artifacts whose version contains the
-    // PR/head SHA, so they cannot be pre-certified in a checked-in manifest.
-    // They still pass through artifact checksums, package-shape audit, secret
-    // scan, and protocol validation; dev/stable release-channel packages below
-    // fail closed unless LiveStore records an exact passed e2e certification.
-    if (isSnapshotVersion(version) === true) {
-      return {
-        livestoreVersion: version,
-        devtoolsBuildId: metadata.devtoolsBuildId,
-        devtoolsProtocolVersion: protocolVersion,
-        status: 'ci-snapshot',
-        testSuite: 'artifact-integrity-and-protocol-gate',
-        scenarios: ['ci-snapshot-repack'],
-      } satisfies DevtoolsArtifactCiSnapshotCertification
-    }
     throw new Error('DevTools repack requires a LiveStore-owned certification entry in the artifact manifest')
   }
   if (certification.status !== 'passed') {

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -283,8 +283,10 @@ const prepareInputs = async (flags: Map<string, string | true>) => {
   return { workDir, metadata, metadataPath, tarballPath, chromeZipPath, manifest }
 }
 
-const forbiddenPatterns: ReadonlyArray<string | RegExp> = [
-  '/home/',
+export const forbiddenPatterns: ReadonlyArray<string | RegExp> = [
+  // Reject real host home paths without blocking Emscripten's browser-only
+  // virtual filesystem defaults such as /home/web_user.
+  /\/home\/(?!web_user(?:\/|["'`]|$))[A-Za-z0-9._-]+\//,
   '/Users/',
   'op://',
   /npm_[A-Za-z0-9]{20,}/,
@@ -296,7 +298,7 @@ const forbiddenPatterns: ReadonlyArray<string | RegExp> = [
 
 const forbiddenPatternName = (pattern: string | RegExp) => (typeof pattern === 'string' ? pattern : pattern.source)
 
-const containsForbiddenPattern = (content: string, pattern: string | RegExp) =>
+export const containsForbiddenPattern = (content: string, pattern: string | RegExp) =>
   typeof pattern === 'string' ? content.includes(pattern) : pattern.test(content)
 
 const assertSupportedDevtoolsProtocol = (metadata: ArtifactMetadata) => {

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -17,25 +17,23 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { pipeline } from 'node:stream/promises'
 
-import semver from 'semver'
-
 import { supportedDevtoolsProtocolVersions } from '@livestore/common'
 
 type CompatibleLivestore =
   | { readonly kind: 'range'; readonly range: string }
   | { readonly kind: 'snapshot'; readonly gitSha: string; readonly version: string }
 
-type ArtifactMetadata = {
+export type ArtifactMetadata = {
   readonly schemaVersion: 1
   readonly artifactName: 'livestore-devtools-vite'
   readonly packageName: '@livestore/devtools-vite'
-  readonly devtoolsVersion: string
+  readonly devtoolsVersion?: string
   readonly devtoolsBuildId: string
   readonly artifactVersion?: number
   readonly devtoolsProtocolVersion?: number
   readonly builtAt?: string
   readonly sourceRevision?: string
-  readonly compatibleLivestore: CompatibleLivestore
+  readonly compatibleLivestore?: CompatibleLivestore
   readonly files: {
     readonly tarball: {
       readonly name: string
@@ -50,23 +48,52 @@ type ArtifactMetadata = {
   }
 }
 
-type ArtifactManifest = {
-  readonly schemaVersion: 1
-  readonly artifact: {
-    readonly metadataUrl: string
-    readonly tarballUrl: string
-    readonly sha256?: string
-    readonly chromeZipUrl?: string
-    readonly chromeZipSha256?: string
-  }
+type ArtifactSource = {
+  readonly metadataUrl: string
+  readonly tarballUrl: string
+  readonly sha256?: string
+  readonly chromeZipUrl?: string
+  readonly chromeZipSha256?: string
 }
+
+type DevtoolsArtifactCertification = {
+  readonly livestoreVersion: string
+  readonly devtoolsBuildId: string
+  readonly devtoolsProtocolVersion: number
+  readonly status: 'pending' | 'passed' | 'failed'
+  readonly testSuite: string
+  readonly scenarios: ReadonlyArray<string>
+  readonly evidence?: string
+}
+
+type DevtoolsArtifactCiSnapshotCertification = {
+  readonly livestoreVersion: string
+  readonly devtoolsBuildId: string
+  readonly devtoolsProtocolVersion: number
+  readonly status: 'ci-snapshot'
+  readonly testSuite: 'artifact-integrity-and-protocol-gate'
+  readonly scenarios: ReadonlyArray<'ci-snapshot-repack'>
+}
+
+type ArtifactManifestV1 = {
+  readonly schemaVersion: 1
+  readonly artifact: ArtifactSource
+}
+
+type ArtifactManifestV2 = {
+  readonly schemaVersion: 2
+  readonly artifact: ArtifactSource
+  readonly certification?: DevtoolsArtifactCertification
+}
+
+export type ArtifactManifest = ArtifactManifestV1 | ArtifactManifestV2
 
 const usage = `Usage:
   bun scripts/src/commands/devtools-artifact.ts verify (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>)
-  bun scripts/src/commands/devtools-artifact.ts repack (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>) --version <version> [--dry-run|--publish]
+  bun scripts/src/commands/devtools-artifact.ts repack --manifest <file> --version <version> [--dry-run|--publish]
 
 Options:
-  --manifest <file>        Checked-in public artifact manifest
+  --manifest <file>        Checked-in public artifact manifest. Repack requires schemaVersion 2 with passed certification.
   --metadata <url-or-file>  Public release-metadata.json URL or local path
   --tarball <url-or-file>   Public artifact tarball URL or local path
   --chrome-zip <url-or-file> Public Chrome extension ZIP URL or local path
@@ -204,6 +231,7 @@ const fetchToFile = async (source: string, target: string) => {
 
 const prepareInputs = async (flags: Map<string, string | true>) => {
   const manifestSource = readFlag(flags, 'manifest')
+  let manifest: ArtifactManifest | undefined
   let metadataSource = readFlag(flags, 'metadata')
   let tarballSource = readFlag(flags, 'tarball')
   let chromeZipSource = readFlag(flags, 'chrome-zip')
@@ -214,8 +242,10 @@ const prepareInputs = async (flags: Map<string, string | true>) => {
     if (metadataSource !== undefined || tarballSource !== undefined || chromeZipSource !== undefined) {
       throw new Error('--manifest cannot be combined with --metadata, --tarball, or --chrome-zip')
     }
-    const manifest = JSON.parse(readFileSync(path.resolve(manifestSource), 'utf8')) as ArtifactManifest
-    if (manifest.schemaVersion !== 1) throw new Error('Unsupported artifact manifest schemaVersion')
+    manifest = JSON.parse(readFileSync(path.resolve(manifestSource), 'utf8')) as ArtifactManifest
+    if (manifest.schemaVersion !== 1 && manifest.schemaVersion !== 2) {
+      throw new Error('Unsupported artifact manifest schemaVersion')
+    }
     metadataSource = manifest.artifact.metadataUrl
     tarballSource = manifest.artifact.tarballUrl
     chromeZipSource = manifest.artifact.chromeZipUrl
@@ -250,7 +280,7 @@ const prepareInputs = async (flags: Map<string, string | true>) => {
   }
 
   const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as ArtifactMetadata
-  return { workDir, metadata, metadataPath, tarballPath, chromeZipPath }
+  return { workDir, metadata, metadataPath, tarballPath, chromeZipPath, manifest }
 }
 
 const forbiddenPatterns: ReadonlyArray<string | RegExp> = [
@@ -278,25 +308,71 @@ const assertSupportedDevtoolsProtocol = (metadata: ArtifactMetadata) => {
   }
 }
 
-const assertCompatibleLivestoreVersion = (metadata: ArtifactMetadata, version: string) => {
-  const compatibility = metadata.compatibleLivestore
+export const assertCertifiedDevtoolsArtifactForLivestore = ({
+  manifest,
+  metadata,
+  version,
+}: {
+  readonly manifest: ArtifactManifest | undefined
+  readonly metadata: ArtifactMetadata
+  readonly version: string
+}) => {
+  const protocolVersion = devtoolsProtocolVersionForArtifact(metadata)
 
-  switch (compatibility.kind) {
-    case 'range': {
-      const validVersion = semver.valid(version)
-      if (validVersion === null) throw new Error(`Invalid LiveStore release version: ${version}`)
-      if (semver.satisfies(validVersion, compatibility.range, { includePrerelease: true }) === false) {
-        throw new Error(`LiveStore ${version} does not satisfy DevTools artifact range ${compatibility.range}`)
-      }
-      return
-    }
-    case 'snapshot': {
-      if (version !== compatibility.version) {
-        throw new Error(`LiveStore ${version} does not match DevTools artifact snapshot ${compatibility.version}`)
-      }
-      return
-    }
+  if (manifest === undefined) {
+    throw new Error(
+      'DevTools repack requires --manifest because LiveStore-owned certification is checked in release/devtools-artifact.json',
+    )
   }
+  if (manifest.schemaVersion !== 2) {
+    throw new Error(
+      'DevTools repack requires release/devtools-artifact.json schemaVersion 2 with LiveStore-owned certification',
+    )
+  }
+
+  const certification = manifest.certification
+  if (certification === undefined) {
+    // Snapshot packages are per-commit CI artifacts whose version contains the
+    // PR/head SHA, so they cannot be pre-certified in a checked-in manifest.
+    // They still pass through artifact checksums, package-shape audit, secret
+    // scan, and protocol validation; dev/stable release-channel packages below
+    // fail closed unless LiveStore records an exact passed e2e certification.
+    if (isSnapshotVersion(version) === true) {
+      return {
+        livestoreVersion: version,
+        devtoolsBuildId: metadata.devtoolsBuildId,
+        devtoolsProtocolVersion: protocolVersion,
+        status: 'ci-snapshot',
+        testSuite: 'artifact-integrity-and-protocol-gate',
+        scenarios: ['ci-snapshot-repack'],
+      } satisfies DevtoolsArtifactCiSnapshotCertification
+    }
+    throw new Error('DevTools repack requires a LiveStore-owned certification entry in the artifact manifest')
+  }
+  if (certification.status !== 'passed') {
+    throw new Error(`DevTools artifact certification is ${certification.status}; expected passed`)
+  }
+  if (certification.livestoreVersion !== version) {
+    throw new Error(
+      `DevTools artifact is certified for LiveStore ${certification.livestoreVersion}, not release ${version}`,
+    )
+  }
+  if (certification.devtoolsBuildId !== metadata.devtoolsBuildId) {
+    throw new Error(
+      `DevTools artifact certification build ${certification.devtoolsBuildId} does not match metadata build ${metadata.devtoolsBuildId}`,
+    )
+  }
+
+  if (certification.devtoolsProtocolVersion !== protocolVersion) {
+    throw new Error(
+      `DevTools artifact certification protocol ${certification.devtoolsProtocolVersion} does not match metadata protocol ${protocolVersion}`,
+    )
+  }
+  if (certification.testSuite.trim().length === 0)
+    throw new Error('DevTools artifact certification is missing testSuite')
+  if (certification.scenarios.length === 0) throw new Error('DevTools artifact certification is missing scenarios')
+
+  return certification
 }
 
 const assertMetadata = (metadata: ArtifactMetadata, tarballPath: string, chromeZipPath: string | undefined) => {
@@ -415,7 +491,7 @@ const assertNoForbiddenZipText = async (chromeZipPath: string) => {
 }
 
 const verifyArtifact = async (flags: Map<string, string | true>) => {
-  const { metadata, tarballPath, chromeZipPath, workDir } = await prepareInputs(flags)
+  const { metadata, tarballPath, chromeZipPath, workDir, manifest } = await prepareInputs(flags)
   assertMetadata(metadata, tarballPath, chromeZipPath)
   assertTarballEntries(tarballPath)
   await assertNoForbiddenText(tarballPath)
@@ -423,7 +499,7 @@ const verifyArtifact = async (flags: Map<string, string | true>) => {
     assertChromeZipEntries(chromeZipPath)
     await assertNoForbiddenZipText(chromeZipPath)
   }
-  return { metadata, tarballPath, chromeZipPath, workDir }
+  return { metadata, tarballPath, chromeZipPath, workDir, manifest }
 }
 
 const materializeChromeZipAsset = (version: string, chromeZipPath: string, workDir: string) => {
@@ -454,8 +530,14 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
   const version = readFlag(flags, 'version')
   if (version === undefined) throw new Error('--version is required')
 
-  const { metadata, tarballPath, chromeZipPath, workDir } = await verifyArtifact(flags)
-  assertCompatibleLivestoreVersion(metadata, version)
+  const { metadata, tarballPath, chromeZipPath, workDir, manifest } = await verifyArtifact(flags)
+  // The public DevTools artifact describes what was built; it does not decide which
+  // LiveStore releases may ship it. LiveStore releases much more frequently than
+  // DevTools artifacts, so repack/publish requires this repo to certify the exact
+  // build id and protocol against the exact release version after the release e2e
+  // suite has passed. This prevents stale artifacts with broad compatibility
+  // metadata, such as "*", from being republished as if they were current.
+  const livestoreCertification = assertCertifiedDevtoolsArtifactForLivestore({ manifest, metadata, version })
   const unpackDir = path.join(workDir, 'package-src')
   rmSync(unpackDir, { recursive: true, force: true })
   mkdirSync(unpackDir, { recursive: true })
@@ -488,7 +570,16 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
 
   writeFileSync(
     path.join(packageDir, 'dist/release-metadata.json'),
-    `${JSON.stringify({ schemaVersion: 1, devtoolsArtifact: normalizeArtifactMetadata(metadata), livestoreVersion: version }, null, 2)}\n`,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        devtoolsArtifact: normalizeArtifactMetadata(metadata),
+        livestoreVersion: version,
+        livestoreCertification,
+      },
+      null,
+      2,
+    )}\n`,
   )
 
   const packedJson = runCapture(['npm', 'pack', '--json', '--pack-destination', workDir], {
@@ -552,7 +643,9 @@ const main = async () => {
   throw new Error(`Unknown command: ${command}\n\n${usage}`)
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error)
-  process.exit(1)
-})
+if (import.meta.main === true) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -15,7 +15,7 @@
     "@livestore/adapter-web": "workspace:^",
     "@livestore/common": "workspace:^",
     "@livestore/common-cf": "workspace:^",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/effect-playwright": "workspace:^",
     "@livestore/livestore": "workspace:^",
     "@livestore/react": "workspace:^",

--- a/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
@@ -21,6 +21,8 @@ import process from 'node:process'
 
 import { expect, test } from '@playwright/test'
 
+import { checkConnectionRemainsActive } from './shared.ts'
+
 const FIXTURE_DIR = path.join(import.meta.dirname, '../fixtures/devtools/node-adapter-timeout')
 const TIMEOUT_WAIT_MS = 35_000 // 35 seconds, to exceed the 30 second timeout
 
@@ -206,105 +208,12 @@ test.describe('Node adapter devtools timeout', () => {
     const initialState = await page.locator('text=todo').first().isVisible()
     console.log('Initial state - todo table visible:', initialState)
 
-    // Now wait for 35 seconds to exceed the 30 second timeout
-    console.log(`Waiting ${TIMEOUT_WAIT_MS / 1000} seconds to test timeout...`)
-    await page.waitForTimeout(TIMEOUT_WAIT_MS)
+    console.log(`Watching connection for ${TIMEOUT_WAIT_MS / 1000} seconds...`)
+    await checkConnectionRemainsActive({ devtools: page, label: 'node-devtools', durationMs: TIMEOUT_WAIT_MS })
 
-    // After waiting, check if the connection is still active or if we see the error
-    const connectionLostVisible = await page.locator('text=Connection to app lost').isVisible()
-    const reloadButtonVisible = await page.locator('button:has-text("Reload")').isVisible()
+    const databaseTabStillVisible = await page.locator('text=Database').isVisible()
+    const tablesStillVisible = await page.locator('text=Tables').isVisible()
 
-    if (connectionLostVisible === true || reloadButtonVisible === true) {
-      // This is the bug - the connection should NOT be lost
-      console.error('BUG REPRODUCED: Connection to app was lost after 30 seconds')
-
-      // Take a screenshot for debugging
-      await page.screenshot({ path: 'devtools-timeout-error.png' })
-
-      // Fail the test to indicate the bug exists
-      expect(connectionLostVisible, 'Connection should NOT be lost after 30 seconds').toBe(false)
-    } else {
-      // Connection is still active - this is the expected behavior
-      console.log('Connection is still active after 30+ seconds')
-
-      // Verify we can still see the database content
-      const databaseTabStillVisible = await page.locator('text=Database').isVisible()
-      const tablesStillVisible = await page.locator('text=Tables').isVisible()
-      const todoTableStillVisible = await page.locator('text=todo').first().isVisible()
-
-      console.log('Database tab visible:', databaseTabStillVisible)
-      console.log('Tables visible:', tablesStillVisible)
-      console.log('Todo table visible:', todoTableStillVisible)
-
-      expect(databaseTabStillVisible === true || tablesStillVisible === true).toBe(true)
-    }
-  })
-
-  test('should detect the 30 second timeout bug (expected to fail)', async ({ page }) => {
-    /**
-     * This test is designed to reliably reproduce and detect the timeout bug.
-     * It explicitly waits for the "Connection to app lost" message.
-     *
-     * When the bug is fixed, this test should be updated to expect no timeout.
-     */
-    test.setTimeout(90_000)
-
-    const devtoolsUrl = `http://localhost:${devtoolsPort}/_livestore/node?autoconnect`
-
-    // Retry navigation a few times in case Vite is still warming up
-    let navigationSuccess = false
-    for (let attempt = 0; attempt < 3 && navigationSuccess === false; attempt++) {
-      try {
-        await page.goto(devtoolsUrl, { timeout: 15_000 })
-        navigationSuccess = true
-      } catch (_err) {
-        console.log(`Navigation attempt ${attempt + 1} failed, retrying...`)
-        await page.waitForTimeout(2000)
-      }
-    }
-
-    if (navigationSuccess === false) {
-      throw new Error('Failed to navigate to devtools after 3 attempts')
-    }
-
-    // Wait for devtools to load - with ?autoconnect, it may auto-connect to the first session
-    await Promise.race([
-      page.waitForSelector('text=Sessions', { timeout: 15_000 }),
-      page.waitForSelector('text=Database', { timeout: 15_000 }),
-      page.waitForSelector('text=Tables', { timeout: 15_000 }),
-    ])
-
-    // Check if we need to click on a session link (if not auto-connected)
-    const sessionLink = page
-      .locator('a')
-      .filter({ hasText: /test-store/ })
-      .first()
-    if ((await sessionLink.isVisible({ timeout: 1000 }).catch(() => false)) === true) {
-      await sessionLink.click()
-    }
-
-    // Wait for connection
-    await page.waitForSelector('text=Database', { timeout: 10_000 }).catch(() => {
-      return page.waitForSelector('text=Tables', { timeout: 5_000 })
-    })
-
-    console.log('Connected to devtools, waiting for timeout bug to manifest...')
-
-    // Wait for the "Connection to app lost" message to appear
-    // This should appear after ~30 seconds if the bug exists
-    try {
-      await page.waitForSelector('text=Connection to app lost', { timeout: 40_000 })
-      console.log('BUG DETECTED: Connection to app lost message appeared')
-
-      // Take a screenshot of the bug
-      await page.screenshot({ path: 'devtools-timeout-bug-detected.png' })
-
-      // The bug exists - this test passes when the bug is present
-      expect(true).toBe(true)
-    } catch {
-      console.log('No timeout detected - the bug may have been fixed')
-      // If we don't see the timeout error, it means the bug might be fixed
-      // or the timeout is longer than expected
-    }
+    expect(databaseTabStillVisible === true || tablesStillVisible === true).toBe(true)
   })
 })

--- a/tests/integration/src/tests/playwright/devtools/shared.ts
+++ b/tests/integration/src/tests/playwright/devtools/shared.ts
@@ -1,5 +1,5 @@
 import type * as PW from '@playwright/test'
-import { expect } from '@playwright/test'
+import { errors, expect } from '@playwright/test'
 
 /**
  * Checks that the DevTools compatibility overlay is displayed with correct content.
@@ -34,6 +34,30 @@ export const checkProtocolMismatchOverlay = async (options: {
       .filter({ hasText: options.expect.appVersion })
       .describe(`${options.label}:app-version`),
   ).toBeVisible()
+}
+
+export const checkConnectionRemainsActive = async (options: {
+  devtools: PW.Frame | PW.Page
+  label: string
+  durationMs: number
+}) => {
+  await expect(
+    options.devtools
+      .getByText('Connection to app lost', { exact: false })
+      .describe(`${options.label}:connection-lost`),
+  ).not.toBeVisible()
+
+  try {
+    await options.devtools
+      .getByText('Connection to app lost', { exact: false })
+      .describe(`${options.label}:connection-lost-during-watch`)
+      .waitFor({ state: 'visible', timeout: options.durationMs })
+  } catch (error) {
+    if (error instanceof errors.TimeoutError) return
+    throw error
+  }
+
+  throw new Error(`DevTools lost its app connection during ${options.label}`)
 }
 
 const checkDevtoolsState_ = async (options: {

--- a/tests/integration/src/tests/playwright/devtools/web.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/web.play.ts
@@ -12,7 +12,7 @@ import { OtelLiveHttp } from '@livestore/utils-dev/node'
 import type { Scope } from '@livestore/utils/effect'
 import { Effect, Fiber, Layer, Logger, OtelTracer, Schema, Tracer } from '@livestore/utils/effect'
 
-import { checkDevtoolsState, checkProtocolMismatchOverlay } from './shared.ts'
+import { checkConnectionRemainsActive, checkDevtoolsState, checkProtocolMismatchOverlay } from './shared.ts'
 
 const usedPages = new Set<PW.Page>()
 
@@ -25,7 +25,12 @@ const makeTabPair = (
   url: string,
   tabName: string,
   adapter: AdapterKind,
-  options?: { appVersionOverride?: string; appDevtoolsProtocolVersionOverride?: number },
+  options?: {
+    appVersionOverride?: string
+    appDevtoolsProtocolVersionOverride?: number
+    devtoolsRoute?: 'session-list' | 'direct-session'
+    skipOtelSpanLink?: boolean
+  },
 ) =>
   Effect.gen(function* () {
     const { browserContext } = yield* Playwright.BrowserContext
@@ -90,7 +95,7 @@ const makeTabPair = (
     )
 
     // Skip OTel span linking when testing DevTools protocol mismatch (app may not initialize properly)
-    if (options?.appDevtoolsProtocolVersionOverride == null) {
+    if (options?.appDevtoolsProtocolVersionOverride == null && options?.skipOtelSpanLink !== true) {
       const rootSpanContext = yield* Effect.tryPromise(() =>
         page
           .waitForFunction('window.__debugLiveStore?.default !== undefined')
@@ -113,7 +118,12 @@ const makeTabPair = (
       shouldEvaluateArgs: false,
     }).pipe(Effect.forkScoped)
 
-    yield* Effect.tryPromise(() => devtools.goto(`${url}/_livestore/web#${tabName}`))
+    const devtoolsRoute =
+      options?.devtoolsRoute === 'direct-session'
+        ? `/_livestore/web/app-root/${tabName}/${tabName}/default`
+        : `/_livestore/web#${tabName}`
+
+    yield* Effect.tryPromise(() => devtools.goto(`${url}${devtoolsRoute}`))
 
     usedPages.add(devtools)
 
@@ -321,6 +331,43 @@ const runTest =
     )
   }
 })
+
+test(
+  'direct web session stays connected past heartbeat window',
+  runTest(
+    Effect.gen(function* () {
+      const tab1 = yield* makeTabPair(
+        `http://localhost:${process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT}`,
+        'tab-direct-session',
+        'inmemory',
+        { devtoolsRoute: 'direct-session', skipOtelSpanLink: true },
+      )
+
+      yield* Effect.gen(function* () {
+        yield* Effect.tryPromise(async () => {
+          await checkDevtoolsState({
+            devtools: tab1.devtools,
+            label: 'devtools-direct-session',
+            expect: { leader: true, alreadyLoaded: false, tables: ['uiState (1)', 'todos (0)'] },
+          })
+
+          // The web direct transport previously reused one Ping request id. The app
+          // dedupes request ids, so the second heartbeat was ignored and this page
+          // reported "Connection to app lost" after roughly 15 seconds.
+          await checkConnectionRemainsActive({
+            devtools: tab1.devtools,
+            label: 'devtools-direct-session',
+            durationMs: 22_000,
+          })
+        })
+
+        yield* shutdownTab(tab1.page, { expectStore: false })
+
+        yield* Effect.sleep(500).pipe(Effect.withSpan('wait-for-otel-flush'))
+      }).pipe(Effect.raceFirst(Fiber.joinAll([tab1.pageConsoleFiber, tab1.devtoolsConsoleFiber])))
+    }),
+  ),
+)
 
 const shutdownTab = Effect.fn('shutdown-tab')(function* (tab: PW.Page, options?: { expectStore?: boolean }) {
   // yield* Playwright.withPage(() => tab.pause())

--- a/tests/package-common/package.json
+++ b/tests/package-common/package.json
@@ -31,7 +31,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/utils-dev": "workspace:^",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",

--- a/tests/perf-eventlog/package.json
+++ b/tests/perf-eventlog/package.json
@@ -44,7 +44,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",
     "@playwright/test": "1.59.1",

--- a/tests/sync-provider/package.json
+++ b/tests/sync-provider/package.json
@@ -41,7 +41,7 @@
     "@effect/sql": "0.51.1",
     "@effect/typeclass": "0.40.0",
     "@effect/vitest": "0.29.0",
-    "@livestore/devtools-vite": "0.4.0-dev.24",
+    "@livestore/devtools-vite": "0.4.0-dev.25",
     "@livestore/utils-dev": "workspace:^",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "2.2.0",


### PR DESCRIPTION
**Problem**

DevTools artifact metadata could imply LiveStore compatibility even though LiveStore releases more frequently than DevTools artifacts. That let a stale artifact be repacked as a newer `@livestore/devtools-vite` release and contributed to the reported direct DevTools disconnect after load.

**Goal**

Make LiveStore own release-channel DevTools certification: raw artifacts describe build identity and checksums, while LiveStore repack/publish requires exact checked-in certification for the LiveStore version, DevTools build id, protocol version, and e2e scenarios.

**Decisions**

- Added schema v2 `release/devtools-artifact.json` with LiveStore-owned certification.
- Release-channel repack now requires the checked-in manifest and exact `status: passed` certification; direct metadata/tarball repack is rejected.
- Raw artifact metadata no longer needs misleading `devtoolsVersion` / `compatibleLivestore` shipping semantics. The fixed published artifact uses `devtoolsBuildId: dt-20260513-27179788`, `artifactVersion: 2`, `devtoolsProtocolVersion: 1`, and `sourceRevision`.
- Snapshot and synthetic CI validation versions remain allowed without exact e2e certification, but only as ephemeral CI paths after manifest, checksum, package-shape, leak-scan, and protocol gates.
- Added DevTools liveness certification coverage for direct web and node-adapter sessions so the Discord “connection to app lost” regression is tested past the heartbeat window.

**Verification**

GitHub CI is green on `7aacddca3`, including:

- `validate-release-plan` passed.
- `test-integration-playwright (devtools)` passed.
- `publish-snapshot-version` passed.
- `update-manifest-pr`, `lint`, `type-check`, unit/integration suites, docs, examples, and perf jobs passed.

Local verification included:

- DevTools artifact verify against the published fixed artifact manifest passed.
- Release repack dry-run for certified `0.4.0-dev.25` passed and packed `@livestore/devtools-vite@0.4.0-dev.25` with npm tag `dev`.
- Exact published tarball was overlaid into the integration test package; direct web stayed connected past the heartbeat window and node adapter stayed connected past 35s.
- Synthetic release validation package dry-run passed with `0.0.0-ci.release-validation.<sha>` / `next`.
- Synthetic DevTools repack dry-run passed with the same CI-only version.
- `scripts/src/commands/devtools-artifact.test.ts` passed: 9 tests.
- `devenv tasks run genie:run --mode before --no-tui`, `devenv tasks run lint:check:format --mode before --no-tui`, `lint:check:oxlint`, `ts:check`, and `git diff --check` passed.

**Complexity**

Adds one small certification contract and keeps compatibility checks at the release owner boundary. That is intentional: artifact producers can publish build identity, but LiveStore decides what ships with each LiveStore release.

**Concerns**

PR #1198 overlaps release/package version files, `release/devtools-artifact.json`, and the DevTools artifact workflows. This PR is based on current `main`; merge ordering with #1198 should be handled deliberately.

**Friction & Bottlenecks**

Local `check:all` exposed a megarepo task edge: after applying pinned member worktrees with `--worktree-mode commit`, `mr status --all` is clean, but `mr:lock-sync-check` still fails locally because `mr lock --dry-run --all` skips pinned detached member worktrees as “not synced to source ref main.” The equivalent GitHub CI gates are green.

**Follow-Ups**

- No Overeng PR was opened, per request. The fixed Overeng source branch is pushed and the raw artifact was published from commit `27179788da08fa19a4cc34ff8159369ea1c615ad`.
- Effect-utils PRs remain owned by other agents.

**References**

Refs the Discord reports about DevTools version identity mismatch and direct DevTools showing `connection to app lost` after load.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ❄️ co2-frost |
| `agent_session_id` | e9e5f226-7818-40f6-b14c-c34c4a2da475 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | livestore-devtools-direct-pr/schickling/devtools-direct-connect-e2e |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@75f90cf |
</details>
<!-- agent-footer:end -->