### PR TITLE
Automate DevTools certification in release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,7 @@ jobs:
             .changeset \
             package.json \
             pnpm-lock.yaml \
+            release/devtools-artifact.json \
             release/release-plan.json \
             release/version.json \
             docs/package.json \

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -116,6 +116,7 @@ git add \\
   .changeset \\
   package.json \\
   pnpm-lock.yaml \\
+  release/devtools-artifact.json \\
   release/release-plan.json \\
   release/version.json \\
   docs/package.json \\

--- a/contributor-docs/release-workflows.md
+++ b/contributor-docs/release-workflows.md
@@ -105,6 +105,13 @@ generator also syncs standalone examples and other non-workspace consumers to
 the exact release version. This keeps `pnpm install --lockfile-only` validating
 the same package graph that the release will publish.
 
+The release PR generator also updates the LiveStore-owned DevTools artifact
+certification in `release/devtools-artifact.json` to the generated release
+version and stages that manifest in the release PR. This keeps the checked-in
+release data self-contained: the DevTools artifact identity remains the
+artifact build id, while the LiveStore package version is assigned by release
+automation and then validated by CI before auto-merge.
+
 Release plans are validated against the npm dist-tag before dry-run or publish:
 
 - `latest` only accepts stable versions such as `0.4.0`.
@@ -193,9 +200,13 @@ Repack validation also rejects artifacts with unsupported DevTools protocol
 versions. For dev and stable release versions, repack also requires a
 schemaVersion 2 manifest certification with `status: passed`, the exact
 LiveStore version, exact DevTools build id, protocol version, and the e2e
-scenarios that passed. CI snapshot packages are per-commit artifacts and cannot
-be pre-certified in the checked-in manifest; they still pass through artifact
-integrity, package-shape, secret-scan, and protocol validation.
+scenarios that passed. The release PR generator rewrites only the
+`livestoreVersion` and evidence text for an already-passed certification so the
+manifest matches the generated release plan; it does not change the DevTools
+artifact build, protocol, or scenario list. CI snapshot packages are per-commit
+artifacts and cannot be pre-certified in the checked-in manifest; they still
+pass through artifact integrity, package-shape, secret-scan, and protocol
+validation.
 
 The repacked package writes `dist/release-metadata.json` with both identities:
 
@@ -221,13 +232,14 @@ release:
    tarball URLs.
 2. Include the tarball SHA-256 when available.
 3. Run `CI=1 dt release:devtools-artifact:verify`.
-4. Run the release e2e scenarios against the exact LiveStore version and
+4. Run the release e2e scenarios against the current LiveStore branch and
    DevTools build id.
 5. Add the schemaVersion 2 certification entry only after e2e passes.
 6. Open a PR with only the manifest and certification change unless release
    tooling also changed.
 
-The release PR will then dry-run the repack using that manifest. When the
+The release PR generator will assign that passed certification to the generated
+release version and dry-run the repack using the resulting manifest. When the
 release-plan PR merges to `main`, the publish job repackages and publishes the
 artifact as `@livestore/devtools-vite@<livestore-version>`.
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -332,6 +332,7 @@ in
       DT_PASSTHROUGH=1 pnpm exec changeset version
       bun scripts/src/commands/changesets.ts restore-prerelease-changesets
       bun scripts/src/commands/changesets.ts sync-version-source
+      bun scripts/src/commands/changesets.ts sync-devtools-artifact-certification
       DT_PASSTHROUGH=1 genie
       bun scripts/src/commands/changesets.ts sync-standalone-consumers
       DT_PASSTHROUGH=1 pnpm install --lockfile-only --no-frozen-lockfile

--- a/scripts/src/commands/changesets.ts
+++ b/scripts/src/commands/changesets.ts
@@ -8,6 +8,7 @@ const usage = `Usage:
   bun scripts/src/commands/changesets.ts check-pr [--base <ref>]
   bun scripts/src/commands/changesets.ts restore-prerelease-changesets
   bun scripts/src/commands/changesets.ts sync-version-source
+  bun scripts/src/commands/changesets.ts sync-devtools-artifact-certification
   bun scripts/src/commands/changesets.ts sync-standalone-consumers
   bun scripts/src/commands/changesets.ts write-release-plan [--npm-tag <tag>]
   bun scripts/src/commands/changesets.ts assert-fixed-versions
@@ -256,6 +257,59 @@ const syncVersionSource = () => {
   console.log(`Synced release/version.json to ${version}`)
 }
 
+type DevtoolsArtifactManifest = {
+  readonly schemaVersion?: number
+  readonly artifact?: {
+    readonly metadataUrl?: string
+  }
+  readonly certification?: {
+    readonly livestoreVersion?: string
+    readonly status?: string
+    readonly testSuite?: string
+    readonly evidence?: string
+  }
+}
+
+const syncDevtoolsArtifactCertification = () => {
+  const file = 'release/devtools-artifact.json'
+  if (existsSync(file) === false) {
+    console.log('No release/devtools-artifact.json to sync')
+    return
+  }
+
+  const version = readReleaseVersion()
+  const manifest = readJson<DevtoolsArtifactManifest>(file)
+  if (manifest.schemaVersion !== 2 || manifest.certification === undefined) {
+    console.log('DevTools artifact manifest has no LiveStore-owned certification to sync')
+    return
+  }
+  if (manifest.certification.status !== 'passed') {
+    console.log(`DevTools artifact certification is ${manifest.certification.status}; leaving it unchanged`)
+    return
+  }
+  if (manifest.certification.livestoreVersion === version) {
+    console.log(`DevTools artifact certification already targets ${version}`)
+    return
+  }
+
+  // The artifact build stays the same; the release PR only assigns it to the
+  // generated LiveStore release-group version. Release PR CI must still pass
+  // before auto-merge, and publish re-runs the same repack gate from main.
+  const nextManifest = {
+    ...manifest,
+    certification: {
+      ...manifest.certification,
+      livestoreVersion: version,
+      evidence:
+        `Release automation assigned this passed DevTools artifact certification to LiveStore ${version}. ` +
+        `The release PR must pass CI, including ${manifest.certification.testSuite ?? 'the DevTools repack gate'}, ` +
+        `before auto-merge. Artifact metadata: ${manifest.artifact?.metadataUrl ?? file}.`,
+    },
+  }
+  writeJson(file, nextManifest)
+  console.log(`Synced DevTools artifact certification to ${version}`)
+}
+
 const writeReleasePlan = (flags: Map<string, string | true>) => {
   const version = readReleaseVersion()
   const npmTag = readFlag(flags, 'npm-tag') ?? process.env.LIVESTORE_NPM_TAG ?? 'latest'
@@ -303,6 +357,7 @@ const main = () => {
   if (command === 'check-pr') return checkPr(flags)
   if (command === 'restore-prerelease-changesets') return restorePrereleaseChangesets()
   if (command === 'sync-version-source') return syncVersionSource()
+  if (command === 'sync-devtools-artifact-certification') return syncDevtoolsArtifactCertification()
   if (command === 'sync-standalone-consumers') return syncStandaloneConsumers()
   if (command === 'write-release-plan') return writeReleasePlan(flags)
   if (command === 'assert-fixed-versions') return assertFixedVersions()


### PR DESCRIPTION
## Problem

The dev release flow still had one manual step after the DevTools artifact certification work: the release PR generator computed the next LiveStore version, but `release/devtools-artifact.json` stayed certified for the previous release version. Operators had to patch the certification manually before the DevTools repack gate could pass.

## Goal

Release PR creation should produce a complete, self-contained release data change for the next dev or stable release, including a DevTools artifact certification whose `livestoreVersion` matches the generated release plan.

## Decisions

- Added `sync-devtools-artifact-certification` to the Changesets release helper and wired it into `release:changeset:version` immediately after `release/version.json` is generated.
- The helper only rewrites an existing schema v2 certification with `status: passed`; pending or failed certifications are left unchanged so the flow still fails closed.
- The helper updates only the assigned LiveStore release version and evidence text. It does not change the DevTools build id, protocol version, scenario list, metadata URL, or tarball identity.
- The release PR workflow now stages `release/devtools-artifact.json`, so the generated branch includes the automated certification update.

## Verification

- `pnpm install --frozen-lockfile`
- `bun scripts/src/commands/changesets.ts sync-devtools-artifact-certification` -> confirmed current manifest is already certified for `0.4.0-dev.26`.
- Temp fixture with `release/version.json = 0.4.0-dev.99` -> command rewrote certification to `0.4.0-dev.99` while preserving `status: passed` and `devtoolsBuildId: dt-20260513-27179788`.
- Disposable release-flow worktree running the real pre-sync sequence (`changeset version`, restore prerelease changesets, sync version source, sync DevTools certification) with `LIVESTORE_NPM_TAG=dev` -> produced `releaseVersion: 0.4.0-dev.27` and `certifiedVersion: 0.4.0-dev.27`.
- `bun scripts/src/commands/devtools-artifact.ts repack --manifest release/devtools-artifact.json --version 0.4.0-dev.26 --dry-run --out-dir /tmp/livestore-release-automation-repack` -> dry-run package `@livestore/devtools-vite@0.4.0-dev.26`, sha256 `7d716bb1ac5ce6f379b50361afac1e704728c70016eb5cd844433ef52258461c`.
- `bun --check scripts/src/commands/changesets.ts`
- `git diff --check`
- GitHub Release `validate-release-plan` run 25803056660 passed, including `Dry-run stable package publish` and `Dry-run DevTools artifact repack`.
- GitHub CI run 25803056683 passed, including lint, type-check, unit tests, DevTools Playwright, docs/examples, snapshot publish, and generated example builds.

`devenv tasks run lint:check:format --mode before` and a full `devenv tasks run release:changeset:version --mode before` attempt both hung after lock validation in this checkout, before running the relevant command body. The direct release helper commands above cover the changed behavior; CI should still run the generated workflow checks.

## Complexity

Small local release-helper command. The extra branch exists to keep the release contract explicit and fail-closed rather than hiding version assignment inside the repack command.

## Concerns

The release PR generator now auto-assigns the latest passed DevTools certification to the generated LiveStore release version. That is intentional because LiveStore releases much more frequently than DevTools artifacts, but it relies on release PR CI and branch protection to reject incompatible LiveStore changes before auto-merge.

## Friction & bottlenecks

The local `devenv tasks run ... --mode before` wrapper repeatedly hung immediately after lock validation in this worktree. Direct `bun` commands and repack validation were usable.

## Follow-ups

None for the release automation itself. The existing local devenv task-wrapper hang is separate tooling friction.

## References

Refs #1237
Refs #1239

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ❄️ co2-frost |
| `agent_session_id` | e9e5f226-7818-40f6-b14c-c34c4a2da475 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | livestore-release-automation/schickling/automate-devtools-release-cert |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@75f90cf |
</details>
<!-- agent-footer:end -->