### PR TITLE
fix(react): scope `useRcResource` cache by `Store`

### DIFF
--- a/.changeset/fix-usercresource-stale-after-store-replace.md
+++ b/.changeset/fix-usercresource-stale-after-store-replace.md
@@ -1,0 +1,5 @@
+---
+"@livestore/react": patch
+---
+
+Fix `useQuery` returning stale results after the underlying `Store` is disposed and recreated with the same `(storeId, clientId, sessionId)`. The `useRcResource` cache is now scoped per `Store` instance via a `WeakMap`, so a replaced store gets a fresh bucket and previously cached `LiveQuery` instances become GC-eligible (#1186).

--- a/packages/@livestore/react/src/useQuery.test.tsx
+++ b/packages/@livestore/react/src/useQuery.test.tsx
@@ -1,17 +1,19 @@
+/** biome-ignore-all lint/a11y: test */
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { provideOtel } from '@livestore/common'
+import * as LiveStore from '@livestore/livestore'
+import { createStore, queryDb, StoreInternalsSymbol, signal } from '@livestore/livestore'
+import { RG } from '@livestore/livestore/internal/testing-utils'
+import { Effect, Schema } from '@livestore/utils/effect'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
 import * as ReactTesting from '@testing-library/react'
 import React from 'react'
 import * as ReactWindow from 'react-window'
 import { expect } from 'vitest'
 
-/** biome-ignore-all lint/a11y: test */
-import * as LiveStore from '@livestore/livestore'
-import { queryDb, StoreInternalsSymbol, signal } from '@livestore/livestore'
-import { RG } from '@livestore/livestore/internal/testing-utils'
-import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Effect, Schema } from '@livestore/utils/effect'
-
-import { events, makeTodoMvcReact, tables } from './__tests__/fixture.tsx'
+import { events, makeTodoMvcReact, schema, tables } from './__tests__/fixture.tsx'
 import { __resetUseRcResourceCache } from './useRcResource.ts'
+import { withReactApi } from './useStore.ts'
 
 Vitest.describe.each([{ strictMode: true }, { strictMode: false }] as const)(
   'useQuery (strictMode=%s)',
@@ -210,6 +212,39 @@ Vitest.describe.each([{ strictMode: true }, { strictMode: false }] as const)(
         })
 
         expect(result.current).toEqual(['t1'])
+      }),
+    )
+
+    Vitest.scopedLive('derives a fresh LiveQuery per Store instance', () =>
+      Effect.gen(function* () {
+        const makeStore = () =>
+          createStore({
+            schema,
+            storeId: 'reset-test',
+            adapter: makeInMemoryAdapter({ clientId: 'stable-client', sessionId: 'stable-session' }),
+            debug: { instanceId: 'test' },
+          }).pipe(provideOtel({}))
+
+        const storeA = withReactApi(yield* makeStore())
+        const storeB = withReactApi(yield* makeStore())
+
+        const allTodos$ = queryDb({ query: `select * from todos`, schema: Schema.Array(tables.todos.rowSchema) })
+
+        const MaybeStrictMode = strictMode === true ? React.StrictMode : React.Fragment
+        const wrapper = ({ children }: any) => <MaybeStrictMode>{children}</MaybeStrictMode>
+
+        storeA.commit(events.todoCreated({ id: 't1', text: 'buy milk', completed: false }))
+
+        const { result, rerender } = ReactTesting.renderHook(
+          ({ store }: { store: typeof storeA }) => store.useQuery(allTodos$).length,
+          { wrapper, initialProps: { store: storeA } },
+        )
+
+        expect(result.current).toBe(1)
+
+        rerender({ store: storeB })
+
+        expect(result.current).toBe(0)
       }),
     )
 

--- a/packages/@livestore/react/src/useQuery.ts
+++ b/packages/@livestore/react/src/useQuery.ts
@@ -82,6 +82,7 @@ export const useQueryRef = <TQueryable extends Queryable<any>>(
   const stackInfo = React.useMemo(() => captureStackInfo(), [])
 
   const { queryRcRef, span, otelContext } = useRcResource(
+    store,
     rcRefKey,
     () =>
       createQueryResource(store, normalized, stackInfo, {
@@ -134,6 +135,7 @@ export const useQueryRef = <TQueryable extends Queryable<any>>(
   }, [stackInfo, query$, setValue, store, valueRef, otelContext, span, options?.otelSpanName])
 
   useRcResource(
+    store,
     rcRefKey,
     () => ({ queryRcRef, span }),
     ({ queryRcRef, span }) => {

--- a/packages/@livestore/react/src/useRcResource.test.tsx
+++ b/packages/@livestore/react/src/useRcResource.test.tsx
@@ -12,10 +12,13 @@ describe.each([{ strictMode: true }, { strictMode: false }])('useRcResource (str
   const wrapper = strictMode === true ? React.StrictMode : React.Fragment
 
   it('should create a stateful entity using make and call cleanup on unmount', () => {
+    const scope = {}
     const makeSpy = vi.fn(() => Symbol('statefulResource'))
     const cleanupSpy = vi.fn()
 
-    const { result, unmount } = ReactTesting.renderHook(() => useRcResource('key-1', makeSpy, cleanupSpy), { wrapper })
+    const { result, unmount } = ReactTesting.renderHook(() => useRcResource(scope, 'key-1', makeSpy, cleanupSpy), {
+      wrapper,
+    })
 
     expect(makeSpy).toHaveBeenCalledTimes(1)
     expect(result.current).toBeDefined()
@@ -26,11 +29,12 @@ describe.each([{ strictMode: true }, { strictMode: false }])('useRcResource (str
   })
 
   it('should reuse the same entity when the key remains unchanged', () => {
+    const scope = {}
     const makeSpy = vi.fn(() => Symbol('statefulResource'))
     const cleanupSpy = vi.fn()
 
     const { result, rerender, unmount } = ReactTesting.renderHook(
-      ({ key }) => useRcResource(key, makeSpy, cleanupSpy),
+      ({ key }) => useRcResource(scope, key, makeSpy, cleanupSpy),
       { initialProps: { key: 'consistent-key' }, wrapper },
     )
 
@@ -48,11 +52,12 @@ describe.each([{ strictMode: true }, { strictMode: false }])('useRcResource (str
   })
 
   it('should dispose the previous instance when the key changes', () => {
+    const scope = {}
     const makeSpy = vi.fn(() => Symbol('statefulResource'))
     const cleanupSpy = vi.fn()
 
     const { result, rerender, unmount } = ReactTesting.renderHook(
-      ({ key }) => useRcResource(key, makeSpy, cleanupSpy),
+      ({ key }) => useRcResource(scope, key, makeSpy, cleanupSpy),
       { initialProps: { key: 'a' }, wrapper },
     )
 
@@ -71,18 +76,18 @@ describe.each([{ strictMode: true }, { strictMode: false }])('useRcResource (str
   })
 
   it('should not dispose the entity until all consumers unmount', () => {
+    const scope = {}
     const makeSpy = vi.fn(() => Symbol('statefulResource'))
     const cleanupSpy = vi.fn()
 
-    // Simulate two consumers using the same key independently.
-    const { unmount: unmount1 } = ReactTesting.renderHook(() => useRcResource('shared-key', makeSpy, cleanupSpy), {
-      wrapper,
-    })
+    // Simulate two consumers using the same (scope, key) pair independently.
+    const { unmount: unmount1 } = ReactTesting.renderHook(
+      () => useRcResource(scope, 'shared-key', makeSpy, cleanupSpy),
+      { wrapper },
+    )
     const { unmount: unmount2, result } = ReactTesting.renderHook(
-      () => useRcResource('shared-key', makeSpy, cleanupSpy),
-      {
-        wrapper,
-      },
+      () => useRcResource(scope, 'shared-key', makeSpy, cleanupSpy),
+      { wrapper },
     )
 
     expect(result.current).toBeDefined()
@@ -98,10 +103,11 @@ describe.each([{ strictMode: true }, { strictMode: false }])('useRcResource (str
   })
 
   it('should handle rapid key changes correctly', () => {
+    const scope = {}
     const makeSpy = vi.fn(() => Symbol('statefulResource'))
     const cleanupSpy = vi.fn()
 
-    const { rerender, unmount } = ReactTesting.renderHook(({ key }) => useRcResource(key, makeSpy, cleanupSpy), {
+    const { rerender, unmount } = ReactTesting.renderHook(({ key }) => useRcResource(scope, key, makeSpy, cleanupSpy), {
       initialProps: { key: '1' },
       wrapper,
     })
@@ -119,49 +125,99 @@ describe.each([{ strictMode: true }, { strictMode: false }])('useRcResource (str
     // Unmounting the final consumer disposes the key '3' instance.
     expect(cleanupSpy).toHaveBeenCalledTimes(3)
   })
+
+  it('should isolate entities created with the same key but different scopes', () => {
+    const scopeA = { tag: 'A' }
+    const scopeB = { tag: 'B' }
+    const makeSpy = vi.fn(() => Symbol('statefulResource'))
+    const cleanupSpy = vi.fn()
+
+    const { result: resultA } = ReactTesting.renderHook(
+      () => useRcResource(scopeA, 'shared-key', makeSpy, cleanupSpy),
+      { wrapper },
+    )
+    const { result: resultB } = ReactTesting.renderHook(
+      () => useRcResource(scopeB, 'shared-key', makeSpy, cleanupSpy),
+      { wrapper },
+    )
+
+    expect(resultA.current).not.toBe(resultB.current)
+    expect(makeSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should dispose the previous entity when the scope changes (key unchanged)', () => {
+    const scopeA = { tag: 'A' }
+    const scopeB = { tag: 'B' }
+    const makeSpy = vi.fn(() => Symbol('statefulResource'))
+    const cleanupSpy = vi.fn()
+
+    const { result, rerender, unmount } = ReactTesting.renderHook(
+      ({ scope }) => useRcResource(scope, 'k', makeSpy, cleanupSpy),
+      { initialProps: { scope: scopeA }, wrapper },
+    )
+
+    const instanceA = result.current
+    expect(makeSpy).toHaveBeenCalledTimes(1)
+
+    rerender({ scope: scopeB })
+    const instanceB = result.current
+
+    expect(instanceA).not.toBe(instanceB)
+    expect(makeSpy).toHaveBeenCalledTimes(2)
+    // The scopeA entry's last consumer left when we switched scopes → cleaned up.
+    expect(cleanupSpy).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(cleanupSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not reuse a cached entity after the scope is replaced', () => {
+    const makeSpy = vi.fn(() => Symbol('statefulResource'))
+    const cleanupSpy = vi.fn()
+
+    const scope1 = {}
+    const { result: result1, unmount: unmount1 } = ReactTesting.renderHook(
+      () => useRcResource(scope1, 'k', makeSpy, cleanupSpy),
+      { wrapper },
+    )
+    const instance1 = result1.current
+    unmount1()
+    expect(cleanupSpy).toHaveBeenCalledTimes(1)
+
+    // Fresh scope, same string key — must NOT reuse the (already-disposed) entry.
+    const scope2 = {}
+    const { result: result2, unmount: unmount2 } = ReactTesting.renderHook(
+      () => useRcResource(scope2, 'k', makeSpy, cleanupSpy),
+      { wrapper },
+    )
+
+    expect(result2.current).not.toBe(instance1)
+    expect(makeSpy).toHaveBeenCalledTimes(2)
+
+    unmount2()
+    expect(cleanupSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('should share the entity across components within the same scope', () => {
+    const scope = {}
+    const makeSpy = vi.fn(() => Symbol('statefulResource'))
+    const cleanupSpy = vi.fn()
+
+    const { result: r1, unmount: unmount1 } = ReactTesting.renderHook(
+      () => useRcResource(scope, 'k', makeSpy, cleanupSpy),
+      { wrapper },
+    )
+    const { result: r2, unmount: unmount2 } = ReactTesting.renderHook(
+      () => useRcResource(scope, 'k', makeSpy, cleanupSpy),
+      { wrapper },
+    )
+
+    expect(r1.current).toBe(r2.current)
+    expect(makeSpy).toHaveBeenCalledTimes(1)
+
+    unmount1()
+    expect(cleanupSpy).not.toHaveBeenCalled()
+    unmount2()
+    expect(cleanupSpy).toHaveBeenCalledTimes(1)
+  })
 })
-
-// This code was useful to better understand the hook behaviour with and without strict mode
-// describe('debug', () => {
-//  const useStrictTest = (key: string) => {
-//   const id = React.useId()
-//   console.log(key, 'id', id)
-
-//   const x = React.useMemo(() => {
-//     console.log('useMemo', key)
-//     return 'hi' + key
-//   }, [key])
-
-//   React.useEffect(() => {
-//     console.log('useEffect', key)
-//     return () => {
-//       console.log('unmount', key)
-//     }
-//   }, [])
-
-//   return x
-// }
-
-//   it('strict mode component', () => {
-//     console.log('strict mode component')
-//     const Root = () => {
-//       useStrictTest('a')
-//       return null
-//     }
-//     const { unmount } = ReactTesting.render(
-//       <React.StrictMode>
-//         <Root />
-//       </React.StrictMode>,
-//     )
-
-//     unmount()
-//   })
-
-//   it('strict mode hook', () => {
-//     console.log('strict mode hook')
-//     const wrapper: React.FC<{ children: React.ReactNode }> = React.StrictMode
-//     const { unmount } = ReactTesting.renderHook(() => useStrictTest('b'), { wrapper })
-
-//     unmount()
-//   })
-// })

--- a/packages/@livestore/react/src/useRcResource.ts
+++ b/packages/@livestore/react/src/useRcResource.ts
@@ -25,10 +25,10 @@ import * as React from 'react'
  * - Upon component unmount, the reference count is decremented, leading to disposal (via the `dispose` function)
  *   if the reference count drops to zero. An unmount is either detected via React's `useEffect` callback or
  *   in the useMemo hook when the key changes.
- * 
+ *
  * Why this is needed in LiveStore:
  * Let's first take a look at the "trivial implementation":
- * 
+ *
  * ```ts
  * const useSimpleResource = <T>(create: () => T, dispose: (resource: T) => void) => {
  *     const val = React.useMemo(() => create(), [create])
@@ -42,7 +42,7 @@ import * as React from 'react'
  *     return val
  * }
  * ```
- * 
+ *
  * LiveStore uses this hook to create LiveQuery instances which are stateful and must not be leaked.
  * The simple implementation above would leak the LiveQuery instance if the component is unmounted or props change.
  *
@@ -72,12 +72,14 @@ import * as React from 'react'
  * @returns The stateful entity corresponding to the provided key.
  */
 export const useRcResource = <T>(
+  scope: object,
   key: string,
   create: () => T,
   dispose: (resource: NoInfer<T>) => void,
   _options?: { debugPrint?: (resource: NoInfer<T>) => ReadonlyArray<any> },
 ): T => {
   const keyRef = React.useRef<string | undefined>(undefined)
+  const scopeRef = React.useRef<object | undefined>(undefined)
   const didDisposeInMemo = React.useRef(false)
   const createRef = React.useRef(create)
   const disposeRef = React.useRef(dispose)
@@ -85,79 +87,72 @@ export const useRcResource = <T>(
   createRef.current = create
   disposeRef.current = dispose
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Dependency is deliberately limited to `key` to avoid unintended re-creations.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Dependencies are deliberately limited to `scope` and `key` to avoid unintended re-creations.
   const resource = React.useMemo(() => {
-    // console.debug('useMemo', key)
+    const bucket = getBucket(scope)
+
     if (didDisposeInMemo.current === true) {
-      // console.debug('useMemo', key, 'skip')
-      const cachedItem = cache.get(key)
+      const cachedItem = bucket.get(key)
       if (cachedItem !== undefined && cachedItem._tag === 'active') {
         return cachedItem.resource
       }
     }
 
-    // Check if the key has changed (or is undefined)
-    if (keyRef.current !== undefined && keyRef.current !== key) {
-      // If the key has changed, decrement the reference on the previous key
+    // Check if the (scope, key) pair has changed (or is undefined)
+    if (keyRef.current !== undefined && (keyRef.current !== key || scopeRef.current !== scope)) {
       const previousKey = keyRef.current
-      const cachedItemForPreviousKey = cache.get(previousKey)
+      // scopeRef.current is set together with keyRef.current below, so it's defined here.
+      const previousBucket = getBucket(scopeRef.current!)
+      const cachedItemForPreviousKey = previousBucket.get(previousKey)
       if (cachedItemForPreviousKey !== undefined && cachedItemForPreviousKey._tag === 'active') {
-        // previousKeyRef.current = previousKey
         cachedItemForPreviousKey.rc--
-
-        // console.debug('useMemo', key, 'rc--', previousKey, cachedItemForPreviousKey.rc)
 
         if (cachedItemForPreviousKey.rc === 0) {
           // Clean up the stateful resource if no longer referenced
           disposeRef.current(cachedItemForPreviousKey.resource)
-          cache.set(previousKey, { _tag: 'destroyed' })
+          previousBucket.set(previousKey, { _tag: 'destroyed' })
           didDisposeInMemo.current = true
         }
       }
     }
 
-    const cachedItem = cache.get(key)
+    const cachedItem = bucket.get(key)
     if (cachedItem !== undefined && cachedItem._tag === 'active') {
       // In React Strict Mode, the `useMemo` hook is called multiple times,
       // so we only increment the reference from the first call for this component.
       cachedItem.rc++
-      // console.debug('rc++', cachedItem.rc, ...(_options?.debugPrint?.(cachedItem.resource) ?? []))
-
       return cachedItem.resource
     }
 
     // Create a new stateful resource if not cached
     const resource = createRef.current()
-    cache.set(key, { _tag: 'active', rc: 1, resource })
+    bucket.set(key, { _tag: 'active', rc: 1, resource })
     return resource
-  }, [key])
+  }, [scope, key])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We assume the `dispose` function is stable and won't change across renders
   React.useEffect(() => {
     return () => {
       if (didDisposeInMemo.current === true) {
-        // console.debug('unmount', keyRef.current, 'skip')
         didDisposeInMemo.current = false
         return
       }
 
-      // console.debug('unmount', keyRef.current)
-      const cachedItem = cache.get(key)
-      // If the stateful resource is already cleaned up, do nothing.
+      const bucket = getBucket(scope)
+      const cachedItem = bucket.get(key)
       if (cachedItem === undefined || cachedItem._tag === 'destroyed') return
 
       cachedItem.rc--
 
-      // console.debug('rc--', cachedItem.rc, ...(_options?.debugPrint?.(cachedItem.resource) ?? []))
-
       if (cachedItem.rc === 0) {
         disposeRef.current(cachedItem.resource)
-        cache.delete(key)
+        bucket.delete(key)
       }
     }
-  }, [key])
+  }, [scope, key])
 
   keyRef.current = key
+  scopeRef.current = scope
 
   return resource
 }
@@ -166,8 +161,7 @@ export const useRcResource = <T>(
 // we are using this cache to avoid starting multiple queries/spans for the same component.
 // This is somewhat against some recommended React best practices, but it should be fine in our case below.
 // Please definitely open an issue if you see or run into any problems with this approach!
-const cache = new Map<
-  string,
+type Entry =
   | {
       _tag: 'active'
       rc: number
@@ -176,8 +170,23 @@ const cache = new Map<
   | {
       _tag: 'destroyed'
     }
->()
+
+type Bucket = Map<string, Entry>
+
+// Per-scope buckets. Keying by the scope object (e.g. a Store instance) ensures that
+// when the scope is replaced (store dispose/recreate), the new scope gets a fresh bucket
+// and stale entries from the disposed scope become GC-eligible. See issue #1186.
+let scopedBuckets = new WeakMap<object, Bucket>()
+
+const getBucket = (scope: object): Bucket => {
+  let bucket = scopedBuckets.get(scope)
+  if (bucket === undefined) {
+    bucket = new Map()
+    scopedBuckets.set(scope, bucket)
+  }
+  return bucket
+}
 
 export const __resetUseRcResourceCache = () => {
-  cache.clear()
+  scopedBuckets = new WeakMap()
 }


### PR DESCRIPTION
## Problem

When a `StoreRegistry` is replaced — e.g. a logout/login flow swapping in a fresh registry — `useQuery` keeps returning rows from the *disposed* store. Direct `store.query(...)` against the new store returns the correct (empty) result, but the hook does not.

Two things conspire:

1. `computeRcRefKey` builds the cache key from `storeId_clientId_sessionId`. Apps that use a stable identity triple (adapter-expo's static `sessionId`, adapter-web's `sessionStorage`-based `sessionId`, or any persisted clientId) produce identical keys across the two store instances.
2. React preserves the component fiber across the Suspense transition that `useStore` triggers when the new store loads. `useRcResource`'s `useMemo([key])` therefore never re-runs, so the component keeps reading the `LiveQuery` bound to the old, disposed store.

Closes #1186.

## Solution

Scope the `useRcResource` cache by `Store` identity instead of by an identity-string key.

- Cache is now `WeakMap<object, Map<innerKey, Entry>>`. A fresh `Store` reference gets a fresh bucket; stale entries from disposed stores become GC-eligible automatically.
- `useRcResource` takes a required `scope: object` parameter. Making it required (no unscoped fallback bucket) prevents callers from silently landing in a shared global cache and reintroducing the original footgun.
- `useQuery` passes the `store` as scope at both `useRcResource` call sites.
- `scope` is added to the `useMemo` / `useEffect` dependency arrays, and the previous-key disposal path handles cross-scope transitions.

## Validation

Added unit coverage in `useRcResource.test.tsx`:

- different scopes with the same key stay isolated
- changing scope disposes the previous entry
- a fresh scope after dispose does not reuse the prior entry (direct #1186 repro)
- cross-component sharing within a single scope still works

Plus a `useQuery` regression test (`'rebinds the LiveQuery when the store reference changes'`) that creates two `Store` instances with identical `(storeId, clientId, sessionId)`, commits into the first, swaps to the second, and asserts the hook reads `0` rather than the stale `1`.

## Related issues

- Closes #1186