### PR TITLE
Harden DevTools artifact release certification

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,6 +98,9 @@ artifact-producing workflow may update URLs and checksums, but it must not mark
 the artifact as shippable for a LiveStore release. Release validation produces
 an ephemeral release-candidate certification after exact-artifact liveness
 passes; repack and publish require that CI proof for release-channel versions.
+The exact-artifact liveness gate disables DevTools license enforcement
+explicitly via `LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false`; relying on a
+maintainer's local sponsor activation would make the gate non-hermetic.
 
 This workflow must not become a hidden prerequisite for ordinary LiveStore
 releases. It is used when the selected DevTools artifact changes. Release PRs

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -51,6 +51,14 @@ pipeline files, dry-runs the package publisher and public DevTools artifact
 repack path. This checks the stable release machinery without publishing a
 stable release.
 
+DevTools artifact validation must preserve release cadence independence:
+LiveStore releases are expected to happen more often than DevTools releases.
+A normal LiveStore release must be able to ship with the already selected
+DevTools artifact without checking out, building, or publishing from the
+`overeng` repository. The release gate should re-verify the pinned artifact
+against the LiveStore release candidate and require a new DevTools artifact only
+when compatibility actually fails or DevTools itself changes.
+
 On push to `main` when `release/release-plan.json` changes, the workflow publishes
 the release group and the matching public DevTools artifact package. For stable
 `latest` releases it then deploys the production docs, production examples, and
@@ -85,12 +93,16 @@ It can be triggered by `repository_dispatch` from the artifact-producing system
 or manually with public artifact URLs and a SHA-256 checksum. It verifies the
 manifest and opens a PR that only changes the public artifact metadata.
 
-The manifest separates artifact identity from release certification. The
+The manifest records artifact identity, not release certification. The
 artifact-producing workflow may update URLs and checksums, but it must not mark
-the artifact as shippable for a LiveStore release. Repack and publish require a
-schemaVersion 2 certification entry, owned by the LiveStore release process,
-that names the exact LiveStore version, DevTools build id, protocol version, and
-e2e scenarios that passed.
+the artifact as shippable for a LiveStore release. Release validation produces
+an ephemeral release-candidate certification after exact-artifact liveness
+passes; repack and publish require that CI proof for release-channel versions.
+
+This workflow must not become a hidden prerequisite for ordinary LiveStore
+releases. It is used when the selected DevTools artifact changes. Release PRs
+that only change LiveStore should consume the checked-in artifact pointer and
+prove compatibility in LiveStore CI.
 
 Artifact URLs should point at build-id-only release tags such as
 `devtools-artifact-dt-20260505-398c5feb`. The DevTools implementation version
@@ -102,12 +114,15 @@ snapshot version.
 Artifact ordering should use artifact metadata such as `artifactVersion` or
 `builtAt`. Runtime protocol compatibility is decided by
 `devtoolsProtocolVersion`, not by matching package versions. Shipping
-compatibility is decided by the LiveStore-owned certification entry, so stale
-artifacts with broad self-declared compatibility cannot be republished as a new
-LiveStore DevTools package.
+compatibility is decided by LiveStore release CI, so stale artifacts with broad
+self-declared compatibility cannot be republished as a new LiveStore DevTools
+package.
 
 The workflow exists so the LiveStore repository can keep release CI
 self-contained while the DevTools source remains outside this repository.
+
+See [../../context/devtools-artifact-release/spec.md](../../context/devtools-artifact-release/spec.md)
+for the release-scenario contract and certification model.
 
 ## `auto-review.yml`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2933,6 +2933,8 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      npm_snapshot_published: ${{ steps.publish-snapshot.outcome == 'success' && '1' || '0' }}
     needs: [test-unit, test-integration-node-sync, test-integration-sync-provider, test-integration-playwright]
     env:
       GH_TOKEN: ${{ github.token }}
@@ -3063,7 +3065,8 @@ jobs:
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
         shell: bash
-      - name: Publish snapshot version
+      - id: publish-snapshot
+        name: Publish snapshot version
         run: |
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
@@ -4717,7 +4720,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
   build-example-create:
-    if: github.event.pull_request.head.repo.fork != true
+    if: github.event.pull_request.head.repo.fork != true && needs.publish-snapshot-version.outputs.npm_snapshot_published == '1'
     needs: publish-snapshot-version
     strategy:
       matrix:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -326,6 +326,9 @@ done`,
         contents: 'write',
         'id-token': 'write',
       },
+      outputs: {
+        npm_snapshot_published: "${{ steps.publish-snapshot.outcome == 'success' && '1' || '0' }}",
+      },
       needs: [
         'test-unit',
         'test-integration-node-sync',
@@ -339,6 +342,7 @@ done`,
       steps: withNixDiagnosticsOnFailure([
         ...livestoreSetupSteps,
         {
+          id: 'publish-snapshot',
           name: 'Publish snapshot version',
           run: runDevenvTasksBefore('release:snapshot:git-sha'),
           env: { GIT_SHA: PR_HEAD_SHA },
@@ -471,7 +475,7 @@ done`,
     // },
 
     'build-example-create': {
-      if: IS_NOT_FORK,
+      if: `${IS_NOT_FORK} && needs.publish-snapshot-version.outputs.npm_snapshot_published == '1'`,
       needs: 'publish-snapshot-version',
       strategy: {
         matrix: {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -650,6 +650,116 @@ jobs:
           else
             echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
           fi
+      - name: Certify DevTools artifact liveness
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:certify-liveness:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:certify-liveness:no-install --mode before'
       - name: Dry-run DevTools artifact repack
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1041,8 +1041,12 @@ jobs:
         run: |
           set -euo pipefail
           : "${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
-          printf '%s\n' "always-auth=true" > "$HOME/.npmrc"
-          printf '%s\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"
+          npmrc="$HOME/.npmrc"
+          printf '%s\n' "always-auth=true" > "$npmrc"
+          printf '%s\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$npmrc"
+          printf '%s\n' "NPM_CONFIG_USERCONFIG=$npmrc" >> "$GITHUB_ENV"
+          printf '%s\n' "NPM_CONFIG_REGISTRY=https://registry.npmjs.org/" >> "$GITHUB_ENV"
+          NPM_CONFIG_USERCONFIG="$npmrc" NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ npm whoami >/dev/null
       - name: Publish stable package release
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -760,6 +760,15 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:certify-liveness:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:certify-liveness:no-install --mode before'
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: 'devtools-certification-playwright-artifacts-${{ github.job }}'
+          path: |
+            tests/integration/playwright-report/
+            tests/integration/test-results/devtools/
+          retention-days: 30
+          if-no-files-found: ignore
       - name: Dry-run DevTools artifact repack
         run: |
           __nix_gc_retry_helper=$(mktemp)
@@ -1254,6 +1263,15 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:certify-liveness:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:certify-liveness:no-install --mode before'
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: 'devtools-certification-playwright-artifacts-${{ github.job }}'
+          path: |
+            tests/integration/playwright-report/
+            tests/integration/test-results/devtools/
+          retention-days: 30
+          if-no-files-found: ignore
       - name: Publish DevTools artifact release
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1144,6 +1144,116 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run release:stable:publish --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:stable:publish --mode before'
+      - name: Certify DevTools artifact liveness
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:certify-liveness:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:certify-liveness:no-install --mode before'
       - name: Publish DevTools artifact release
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -14,6 +14,18 @@ const withNixDiagnosticsOnFailure = (steps: unknown[]) => [
   nixDiagnosticsArtifactStep(),
 ]
 
+const devtoolsCertificationArtifactsStep = {
+  uses: 'actions/upload-artifact@v4',
+  if: '${{ !cancelled() }}',
+  with: {
+    name: 'devtools-certification-playwright-artifacts-${{ github.job }}',
+    path: `tests/integration/playwright-report/
+tests/integration/test-results/devtools/`,
+    'retention-days': 30,
+    'if-no-files-found': 'ignore',
+  },
+}
+
 const releasePlanPaths = [
   '.github/workflows/release.yml',
   '.github/workflows/release.yml.genie.ts',
@@ -234,6 +246,7 @@ fi`,
           name: 'Certify DevTools artifact liveness',
           run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
         },
+        devtoolsCertificationArtifactsStep,
         {
           name: 'Dry-run DevTools artifact repack',
           run: runDevenvTasksBefore('release:devtools-artifact:repack-dryrun:no-install'),
@@ -277,6 +290,7 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
           name: 'Certify DevTools artifact liveness',
           run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
         },
+        devtoolsCertificationArtifactsStep,
         {
           name: 'Publish DevTools artifact release',
           run: runDevenvTasksBefore('release:devtools-artifact:publish:no-install'),

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -231,6 +231,10 @@ else
 fi`,
         },
         {
+          name: 'Certify DevTools artifact liveness',
+          run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
+        },
+        {
           name: 'Dry-run DevTools artifact repack',
           run: runDevenvTasksBefore('release:devtools-artifact:repack-dryrun:no-install'),
         },

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -274,6 +274,10 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
           run: runDevenvTasksBefore('release:stable:publish'),
         },
         {
+          name: 'Certify DevTools artifact liveness',
+          run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
+        },
+        {
           name: 'Publish DevTools artifact release',
           run: runDevenvTasksBefore('release:devtools-artifact:publish:no-install'),
         },

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -279,8 +279,12 @@ echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"`,
           name: 'Configure npm token fallback',
           run: `set -euo pipefail
 : "\${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
-printf '%s\\n' "always-auth=true" > "$HOME/.npmrc"
-printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"`,
+npmrc="$HOME/.npmrc"
+printf '%s\\n' "always-auth=true" > "$npmrc"
+printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$npmrc"
+printf '%s\\n' "NPM_CONFIG_USERCONFIG=$npmrc" >> "$GITHUB_ENV"
+printf '%s\\n' "NPM_CONFIG_REGISTRY=https://registry.npmjs.org/" >> "$GITHUB_ENV"
+NPM_CONFIG_USERCONFIG="$npmrc" NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ npm whoami >/dev/null`,
         },
         {
           name: 'Publish stable package release',

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ packages/@livestore/livestore/docs
 # Task context files (agent work tracking, not part of codebase)
 /tasks/
 .claude/settings.local.json
+
+# Ephemeral release-candidate proof produced by DevTools artifact liveness CI
+/release/devtools-artifact.certification.json

--- a/context/devtools-artifact-release/spec.md
+++ b/context/devtools-artifact-release/spec.md
@@ -118,6 +118,13 @@ workspace build. The Node adapter scenario must replace every workspace
 transitive package under `@livestore/adapter-node`; replacing only the test
 package's top-level `node_modules` entry is not sufficient proof.
 
+The liveness scenarios must also be independent of developer-machine sponsor
+activation state. Public DevTools artifacts enforce the sponsor/license gate by
+default, but release certification runs with the explicit
+`LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false` test override so CI verifies
+connectivity and protocol compatibility rather than a maintainer's local
+license cache.
+
 ## Simplification
 
 The durable state is intentionally limited to immutable artifact identity:

--- a/context/devtools-artifact-release/spec.md
+++ b/context/devtools-artifact-release/spec.md
@@ -1,0 +1,143 @@
+This document specifies the LiveStore DevTools artifact release contract. It is a spec-only VRS document for the release subsystem and is constrained by the workflow documentation in [../../.github/workflows/README.md](../../.github/workflows/README.md).
+
+## Status
+
+Active.
+
+## Scope
+
+This spec defines:
+
+- how LiveStore releases consume DevTools artifacts
+- when `overeng` is required
+- which release scenarios must remain supported
+- the simpler long-term certification model
+
+This spec does not define:
+
+- DevTools runtime protocol semantics
+- npm package publishing credentials
+- Chrome Web Store publication
+
+## Release Boundary
+
+```
+overeng source
+  -> DevTools artifact producer
+  -> immutable public artifact
+  -> release/devtools-artifact.json
+  -> LiveStore release CI
+  -> @livestore/devtools-vite + Chrome ZIP repack
+```
+
+`overeng` owns DevTools source and artifact production. LiveStore owns the
+release decision for artifacts shipped under LiveStore versions.
+
+The checked-in artifact pointer is long-lived state. Compatibility proof is
+release-candidate state.
+
+## Cadence Invariant
+
+LiveStore releases must not require `overeng` work when the selected DevTools
+artifact is still compatible.
+
+This invariant is intentional because LiveStore releases happen more often than
+DevTools releases. A normal LiveStore release should download the pinned
+artifact, verify its integrity, run release-candidate compatibility checks, and
+publish the repacked DevTools package if those checks pass.
+
+`overeng` is required only when:
+
+- DevTools source changes
+- the selected artifact fails LiveStore release-candidate compatibility checks
+- the artifact metadata or packaging contract changes
+- a coupled LiveStore and DevTools protocol change is intentional
+
+## Release Scenarios
+
+| Scenario | Requires `overeng`? | Expected behavior |
+| --- | --- | --- |
+| LiveStore release with unchanged DevTools | No | LiveStore CI re-verifies the pinned artifact against the release candidate. |
+| LiveStore patch release | No | The pinned artifact is reused if the compatibility gate passes. |
+| DevTools-only artifact refresh | Yes | `overeng` builds and publishes a new immutable artifact, then LiveStore reviews the manifest update. |
+| Coupled LiveStore and DevTools change | Yes | A new artifact is produced for the LiveStore change and LiveStore CI verifies that exact pairing. |
+| Existing artifact fails compatibility | Usually yes | Release blocks until LiveStore preserves compatibility or a new DevTools artifact is produced. |
+| CI snapshot release | No | Snapshot repack may use ephemeral CI certification because snapshot versions cannot be checked in ahead of time. |
+
+## Certification Model
+
+The release model does not store LiveStore-version-specific certification as
+durable repository state.
+
+Durable state:
+
+```json
+{
+  "artifact": {
+    "metadataUrl": "...",
+    "tarballUrl": "...",
+    "sha256": "...",
+    "chromeZipUrl": "...",
+    "chromeZipSha256": "..."
+  }
+}
+```
+
+Ephemeral CI proof:
+
+```json
+{
+  "livestoreVersion": "0.4.0-dev.27",
+  "devtoolsBuildId": "dt-...",
+  "devtoolsProtocolVersion": 1,
+  "scenarios": [
+    "direct web session loads and stays connected past heartbeat window",
+    "node adapter session loads through Vite and stays connected past heartbeat window"
+  ],
+  "ciRunUrl": "https://github.com/livestorejs/livestore/actions/runs/..."
+}
+```
+
+Release publish should depend on the CI proof for the release candidate, not on
+manual certification text committed to the manifest.
+
+## Compatibility Gate
+
+LiveStore release CI must verify:
+
+- artifact checksums match the manifest
+- metadata declares a supported DevTools protocol version
+- repacked package shape is valid
+- the artifact does not leak source, sourcemaps, credentials, or local paths
+- direct web session liveness survives the heartbeat window
+- node adapter direct-route liveness survives the heartbeat window
+
+The liveness scenarios must use the exact downloaded artifact, not a local
+workspace build.
+
+## Simplification
+
+The durable state is intentionally limited to immutable artifact identity:
+
+1. keep only immutable artifact identity in `release/devtools-artifact.json`
+2. run compatibility certification during LiveStore release validation
+3. publish only from the same release candidate that passed certification
+4. require `overeng` only to produce or replace artifacts
+
+This preserves the original safety property without making every LiveStore
+release a DevTools release.
+
+## Documentation Contract
+
+LiveStore docs must document consumer behavior and release scenarios.
+
+`overeng` docs must document producer behavior:
+
+- how DevTools artifacts are built
+- how artifact metadata is generated
+- how artifact checksums are produced
+- how a LiveStore manifest update is requested
+- how to debug producer-side certification failures
+
+Docs must be updated whenever the release boundary, artifact schema, or required
+compatibility scenarios change.

--- a/context/devtools-artifact-release/spec.md
+++ b/context/devtools-artifact-release/spec.md
@@ -113,7 +113,10 @@ LiveStore release CI must verify:
 - node adapter direct-route liveness survives the heartbeat window
 
 The liveness scenarios must use the exact downloaded artifact, not a local
-workspace build.
+workspace build. The Node adapter scenario must replace every workspace
+`@livestore/devtools-vite` resolution path used by the fixture, including the
+transitive package under `@livestore/adapter-node`; replacing only the test
+package's top-level `node_modules` entry is not sufficient proof.
 
 ## Simplification
 

--- a/context/devtools-artifact-release/spec.md
+++ b/context/devtools-artifact-release/spec.md
@@ -91,8 +91,7 @@ Ephemeral CI proof:
   "devtoolsBuildId": "dt-...",
   "devtoolsProtocolVersion": 1,
   "scenarios": [
-    "direct web session loads and stays connected past heartbeat window",
-    "node adapter session loads through Vite and stays connected past heartbeat window"
+    "node adapter session loads through Vite and stays connected past 35 seconds"
   ],
   "ciRunUrl": "https://github.com/livestorejs/livestore/actions/runs/..."
 }
@@ -109,16 +108,20 @@ LiveStore release CI must verify:
 - metadata declares a supported DevTools protocol version
 - repacked package shape is valid
 - the artifact does not leak source, sourcemaps, credentials, or local paths
-- direct web session liveness survives the heartbeat window
 - node adapter direct-route liveness survives the heartbeat window
 
-The liveness scenarios must use the exact downloaded artifact, not a local
-workspace build. The Node adapter scenario must replace every workspace
+The release artifact liveness scenario must use the exact downloaded artifact,
+not a local workspace build. The Node adapter scenario must replace every workspace
 `@livestore/devtools-vite` resolution path used by the fixture, including the
 transitive package under `@livestore/adapter-node`; replacing only the test
 package's top-level `node_modules` entry is not sufficient proof.
 
-The liveness scenarios must also be independent of developer-machine sponsor
+Direct web session liveness is still required in the normal Playwright DevTools
+suite, but it is not claimed as exact-artifact release proof because it does not
+exercise the repacked `@livestore/devtools-vite` artifact selected by the
+LiveStore manifest.
+
+The liveness scenario must also be independent of developer-machine sponsor
 activation state. Public DevTools artifacts enforce the sponsor/license gate by
 default, but release certification runs with the explicit
 `LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false` test override so CI verifies

--- a/devenv.nix
+++ b/devenv.nix
@@ -91,6 +91,55 @@ let
       ${publishFlag}
   '';
 
+  devtoolsArtifactCertifyLivenessExec = ''
+    set -euo pipefail
+    cd "$DEVENV_ROOT"
+
+    : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
+
+    out_dir="''${LIVESTORE_DEVTOOLS_OUT_DIR:-$(mktemp -d)}"
+    mkdir -p "$out_dir"
+    export LIVESTORE_DEVTOOLS_OUT_DIR="$out_dir"
+
+    ${devtoolsArtifactRepackExec "--dry-run"}
+
+    repacked_tarball="$out_dir/livestore-devtools-vite-$LIVESTORE_RELEASE_VERSION.tgz"
+    if [ ! -f "$repacked_tarball" ]; then
+      echo "Expected repacked DevTools tarball not found: $repacked_tarball" >&2
+      exit 1
+    fi
+
+    package_link="tests/integration/node_modules/@livestore/devtools-vite"
+    if [ ! -e "$package_link" ]; then
+      echo "Expected installed @livestore/devtools-vite package link not found: $package_link" >&2
+      exit 1
+    fi
+
+    backup_dir="$(mktemp -d)"
+    cp -a "$package_link" "$backup_dir/devtools-vite"
+    restore_node_modules() {
+      rm -rf "$package_link"
+      cp -a "$backup_dir/devtools-vite" "$package_link"
+      rm -rf "$backup_dir"
+    }
+    trap restore_node_modules EXIT
+
+    unpack_dir="$(mktemp -d)"
+    tar -xzf "$repacked_tarball" -C "$unpack_dir"
+    rm -rf "$package_link"
+    mv "$unpack_dir/package" "$package_link"
+    rm -rf "$unpack_dir"
+
+    CI=true \
+      FORCE_PLAYWRIGHT_VIA_CLI=1 \
+      PLAYWRIGHT_SUITE=devtools \
+      PLAYWRIGHT_HEADLESS="''${PLAYWRIGHT_HEADLESS:-1}" \
+      DT_PASSTHROUGH=1 \
+      pnpm --dir tests/integration exec playwright test \
+        src/tests/playwright/devtools/node-adapter-timeout.play.ts \
+        --reporter=line
+  '';
+
   devtoolsArtifactRepackTask =
     {
       description,
@@ -286,6 +335,17 @@ in
     description = "Verify and repack a public LiveStore DevTools artifact after release setup has already run";
     publishFlag = "--dry-run";
     withInstall = false;
+  };
+
+  tasks."release:devtools-artifact:certify-liveness" = {
+    description = "Repack the public DevTools artifact and run the strict Playwright liveness certification";
+    exec = devtoolsArtifactCertifyLivenessExec;
+    after = [ "pnpm:install" ];
+  };
+
+  tasks."release:devtools-artifact:certify-liveness:no-install" = {
+    description = "Run the strict DevTools artifact liveness certification after release setup has already run";
+    exec = devtoolsArtifactCertifyLivenessExec;
   };
 
   tasks."release:devtools-artifact:publish" = devtoolsArtifactRepackTask {

--- a/devenv.nix
+++ b/devenv.nix
@@ -118,25 +118,37 @@ let
       exit 1
     fi
 
-    package_link="tests/integration/node_modules/@livestore/devtools-vite"
-    if [ ! -e "$package_link" ]; then
-      echo "Expected installed @livestore/devtools-vite package link not found: $package_link" >&2
-      exit 1
-    fi
-
     backup_dir="$(mktemp -d)"
-    cp -a "$package_link" "$backup_dir/devtools-vite"
+    package_links=(
+      "tests/integration/node_modules/@livestore/devtools-vite"
+      "packages/@livestore/adapter-node/node_modules/@livestore/devtools-vite"
+    )
+
+    for index in "''${!package_links[@]}"; do
+      package_link="''${package_links[$index]}"
+      if [ ! -e "$package_link" ]; then
+        echo "Expected installed @livestore/devtools-vite package link not found: $package_link" >&2
+        exit 1
+      fi
+      cp -a "$package_link" "$backup_dir/devtools-vite-$index"
+    done
+
     restore_node_modules() {
-      rm -rf "$package_link"
-      cp -a "$backup_dir/devtools-vite" "$package_link"
+      for index in "''${!package_links[@]}"; do
+        package_link="''${package_links[$index]}"
+        rm -rf "$package_link"
+        cp -a "$backup_dir/devtools-vite-$index" "$package_link"
+      done
       rm -rf "$backup_dir"
     }
     trap restore_node_modules EXIT
 
     unpack_dir="$(mktemp -d)"
     tar -xzf "$repacked_tarball" -C "$unpack_dir"
-    rm -rf "$package_link"
-    mv "$unpack_dir/package" "$package_link"
+    for package_link in "''${package_links[@]}"; do
+      rm -rf "$package_link"
+      cp -a "$unpack_dir/package" "$package_link"
+    done
     rm -rf "$unpack_dir"
 
     CI=true \

--- a/devenv.nix
+++ b/devenv.nix
@@ -79,9 +79,16 @@ let
     : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
     artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
     if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" || -n "''${LIVESTORE_DEVTOOLS_CHROME_ZIP:-}" ]]; then
-      echo "release:devtools-artifact repack requires LIVESTORE_DEVTOOLS_MANIFEST so LiveStore-owned certification is available." >&2
+      echo "release:devtools-artifact repack requires LIVESTORE_DEVTOOLS_MANIFEST so release-candidate certification can bind to the selected artifact." >&2
       echo "Use release:devtools-artifact:verify for direct metadata/tarball integrity checks." >&2
       exit 1
+    fi
+    certification_path="''${LIVESTORE_DEVTOOLS_CERTIFICATION:-release/devtools-artifact.certification.json}"
+    if [[ -f "$certification_path" ]]; then
+      artifact_args+=(--certification "$certification_path")
+    fi
+    if [[ "''${LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK:-}" = "1" ]]; then
+      artifact_args+=(--allow-uncertified)
     fi
 
     bun scripts/src/commands/devtools-artifact.ts repack \
@@ -101,7 +108,9 @@ let
     mkdir -p "$out_dir"
     export LIVESTORE_DEVTOOLS_OUT_DIR="$out_dir"
 
+    export LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK=1
     ${devtoolsArtifactRepackExec "--dry-run"}
+    unset LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK
 
     repacked_tarball="$out_dir/livestore-devtools-vite-$LIVESTORE_RELEASE_VERSION.tgz"
     if [ ! -f "$repacked_tarball" ]; then
@@ -138,6 +147,20 @@ let
       pnpm --dir tests/integration exec playwright test \
         src/tests/playwright/devtools/node-adapter-timeout.play.ts \
         --reporter=line
+
+    certification_path="''${LIVESTORE_DEVTOOLS_CERTIFICATION:-release/devtools-artifact.certification.json}"
+    evidence="DevTools exact-artifact liveness passed for $LIVESTORE_RELEASE_VERSION"
+    if [[ -n "''${GITHUB_SERVER_URL:-}" && -n "''${GITHUB_REPOSITORY:-}" && -n "''${GITHUB_RUN_ID:-}" ]]; then
+      evidence="$evidence in $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+    fi
+    bun scripts/src/commands/devtools-artifact.ts certify \
+      --manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}" \
+      --version "$LIVESTORE_RELEASE_VERSION" \
+      --out "$certification_path" \
+      --evidence "$evidence"
+    if [[ -n "''${GITHUB_ENV:-}" ]]; then
+      echo "LIVESTORE_DEVTOOLS_CERTIFICATION=$certification_path" >> "$GITHUB_ENV"
+    fi
   '';
 
   devtoolsArtifactRepackTask =
@@ -392,7 +415,6 @@ in
       DT_PASSTHROUGH=1 pnpm exec changeset version
       bun scripts/src/commands/changesets.ts restore-prerelease-changesets
       bun scripts/src/commands/changesets.ts sync-version-source
-      bun scripts/src/commands/changesets.ts sync-devtools-artifact-certification
       DT_PASSTHROUGH=1 genie
       bun scripts/src/commands/changesets.ts sync-standalone-consumers
       DT_PASSTHROUGH=1 pnpm install --lockfile-only --no-frozen-lockfile

--- a/devenv.nix
+++ b/devenv.nix
@@ -118,6 +118,13 @@ let
       exit 1
     fi
 
+    playwright_bin="tests/integration/node_modules/.bin/playwright"
+    if [ ! -x "$playwright_bin" ]; then
+      echo "Expected Playwright binary not found: $playwright_bin" >&2
+      echo "Run release:devtools-artifact:certify-liveness instead of the no-install variant when dependencies are not installed yet." >&2
+      exit 1
+    fi
+
     backup_dir="$(mktemp -d)"
     package_links=(
       "tests/integration/node_modules/@livestore/devtools-vite"
@@ -151,15 +158,26 @@ let
     done
     rm -rf "$unpack_dir"
 
-    CI=true \
-      FORCE_PLAYWRIGHT_VIA_CLI=1 \
-      PLAYWRIGHT_SUITE=devtools \
-      PLAYWRIGHT_HEADLESS="''${PLAYWRIGHT_HEADLESS:-1}" \
-      LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false \
-      DT_PASSTHROUGH=1 \
-      pnpm --dir tests/integration exec playwright test \
-        src/tests/playwright/devtools/node-adapter-timeout.play.ts \
-        --reporter=line
+    for package_link in "''${package_links[@]}"; do
+      package_version="$(bun -e "console.log(require('./$package_link/package.json').version)")"
+      if [ "$package_version" != "$LIVESTORE_RELEASE_VERSION" ]; then
+        echo "Expected $package_link to contain exact DevTools artifact version $LIVESTORE_RELEASE_VERSION, found $package_version" >&2
+        exit 1
+      fi
+    done
+
+    (
+      cd tests/integration
+      CI=true \
+        FORCE_PLAYWRIGHT_VIA_CLI=1 \
+        PLAYWRIGHT_SUITE=devtools \
+        PLAYWRIGHT_HEADLESS="''${PLAYWRIGHT_HEADLESS:-1}" \
+        LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false \
+        DT_PASSTHROUGH=1 \
+        ./node_modules/.bin/playwright test \
+          src/tests/playwright/devtools/node-adapter-timeout.play.ts \
+          --reporter=line
+    )
 
     certification_path="''${LIVESTORE_DEVTOOLS_CERTIFICATION:-release/devtools-artifact.certification.json}"
     evidence="DevTools exact-artifact liveness passed for $LIVESTORE_RELEASE_VERSION"

--- a/devenv.nix
+++ b/devenv.nix
@@ -155,6 +155,7 @@ let
       FORCE_PLAYWRIGHT_VIA_CLI=1 \
       PLAYWRIGHT_SUITE=devtools \
       PLAYWRIGHT_HEADLESS="''${PLAYWRIGHT_HEADLESS:-1}" \
+      LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false \
       DT_PASSTHROUGH=1 \
       pnpm --dir tests/integration exec playwright test \
         src/tests/playwright/devtools/node-adapter-timeout.play.ts \

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -6,17 +6,5 @@
     "sha256": "1e766d5b1e0226c3c70c29c0dff24ee4da0ff8593b813c4b5fd29e852696f3f0",
     "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/livestore-devtools-chrome.zip",
     "chromeZipSha256": "f1feead7eb67f620a119ce92d35f84238274128cc480e3a851f1cc20785e2ed2"
-  },
-  "certification": {
-    "livestoreVersion": "0.4.0-dev.26",
-    "devtoolsBuildId": "dt-20260513-27179788",
-    "devtoolsProtocolVersion": 1,
-    "status": "passed",
-    "testSuite": "tests/integration/src/tests/playwright/devtools",
-    "scenarios": [
-      "direct web session loads and stays connected past heartbeat window",
-      "node adapter session loads through Vite and stays connected past 35 seconds"
-    ],
-    "evidence": "Verified locally on 2026-05-13 for the 0.4.0-dev.26 release branch against exact artifact tarball from https://github.com/livestorejs/livestore-devtools-artifacts/releases/tag/devtools-artifact-dt-20260513-27179788."
   }
 }

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
   "artifact": {
-    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-42b1c0b1/release-metadata.json",
-    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-42b1c0b1/livestore-devtools-vite.tgz",
-    "sha256": "7296945f665607bb76f9599b2e2cd9beb726895aa442abf24cafd788f713d8e8",
-    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-42b1c0b1/livestore-devtools-chrome.zip",
-    "chromeZipSha256": "e916a3e7823a66e82ebe9344338cca3a131ad283f96a07d99dd52229e181ea85"
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260519-ecda82cd/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260519-ecda82cd/livestore-devtools-vite.tgz",
+    "sha256": "dc4827699b62eca99a963cd2736c13ec617c993d6a2a306c77fc3f322c7197e4",
+    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260519-ecda82cd/livestore-devtools-chrome.zip",
+    "chromeZipSha256": "1604a9b135cc1e7841cbea47ab900faa10e0884f8a952d063efb1bc9ca3bbcfe"
   }
 }

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
   "artifact": {
-    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-24e5cc3b/release-metadata.json",
-    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-24e5cc3b/livestore-devtools-vite.tgz",
-    "sha256": "89e9367e43f49937f8a30e02748a889cf486105f954998b98628e81585154fb5",
-    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-24e5cc3b/livestore-devtools-chrome.zip",
-    "chromeZipSha256": "a093e31fa31193cbf63c8ae3e7e08b956babc8ac21e8cd9d7b726b2f53406d95"
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-c3145811/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-c3145811/livestore-devtools-vite.tgz",
+    "sha256": "0ac7d560b69eeeaaedc6b4efb11f17cdb770b039eb3cbafa716d56f520fff1ad",
+    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-c3145811/livestore-devtools-chrome.zip",
+    "chromeZipSha256": "0defd26fa5b13d90c21ae92a7a97316615d622bf0a5e8096743bac63ec6b0702"
   }
 }

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
   "artifact": {
-    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/release-metadata.json",
-    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/livestore-devtools-vite.tgz",
-    "sha256": "1e766d5b1e0226c3c70c29c0dff24ee4da0ff8593b813c4b5fd29e852696f3f0",
-    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260513-27179788/livestore-devtools-chrome.zip",
-    "chromeZipSha256": "f1feead7eb67f620a119ce92d35f84238274128cc480e3a851f1cc20785e2ed2"
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-3c09df24/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-3c09df24/livestore-devtools-vite.tgz",
+    "sha256": "3f8eeb23cd070d4b6277a2a63529dcef74495283ae926bc9b698de7193094a01",
+    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-3c09df24/livestore-devtools-chrome.zip",
+    "chromeZipSha256": "247cb74fea3b05a2d141ba4a5b4ae330cccd236666c96a088f0db70ee05890be"
   }
 }

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
   "artifact": {
-    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-3c09df24/release-metadata.json",
-    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-3c09df24/livestore-devtools-vite.tgz",
-    "sha256": "3f8eeb23cd070d4b6277a2a63529dcef74495283ae926bc9b698de7193094a01",
-    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-3c09df24/livestore-devtools-chrome.zip",
-    "chromeZipSha256": "247cb74fea3b05a2d141ba4a5b4ae330cccd236666c96a088f0db70ee05890be"
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-24e5cc3b/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-24e5cc3b/livestore-devtools-vite.tgz",
+    "sha256": "89e9367e43f49937f8a30e02748a889cf486105f954998b98628e81585154fb5",
+    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-24e5cc3b/livestore-devtools-chrome.zip",
+    "chromeZipSha256": "a093e31fa31193cbf63c8ae3e7e08b956babc8ac21e8cd9d7b726b2f53406d95"
   }
 }

--- a/release/devtools-artifact.json
+++ b/release/devtools-artifact.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 2,
   "artifact": {
-    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-c3145811/release-metadata.json",
-    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-c3145811/livestore-devtools-vite.tgz",
-    "sha256": "0ac7d560b69eeeaaedc6b4efb11f17cdb770b039eb3cbafa716d56f520fff1ad",
-    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-c3145811/livestore-devtools-chrome.zip",
-    "chromeZipSha256": "0defd26fa5b13d90c21ae92a7a97316615d622bf0a5e8096743bac63ec6b0702"
+    "metadataUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-42b1c0b1/release-metadata.json",
+    "tarballUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-42b1c0b1/livestore-devtools-vite.tgz",
+    "sha256": "7296945f665607bb76f9599b2e2cd9beb726895aa442abf24cafd788f713d8e8",
+    "chromeZipUrl": "https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-dt-20260518-42b1c0b1/livestore-devtools-chrome.zip",
+    "chromeZipSha256": "e916a3e7823a66e82ebe9344338cca3a131ad283f96a07d99dd52229e181ea85"
   }
 }

--- a/scripts/src/commands/changesets.ts
+++ b/scripts/src/commands/changesets.ts
@@ -8,7 +8,6 @@ const usage = `Usage:
   bun scripts/src/commands/changesets.ts check-pr [--base <ref>]
   bun scripts/src/commands/changesets.ts restore-prerelease-changesets
   bun scripts/src/commands/changesets.ts sync-version-source
-  bun scripts/src/commands/changesets.ts sync-devtools-artifact-certification
   bun scripts/src/commands/changesets.ts sync-standalone-consumers
   bun scripts/src/commands/changesets.ts write-release-plan [--npm-tag <tag>]
   bun scripts/src/commands/changesets.ts assert-fixed-versions
@@ -257,59 +256,6 @@ const syncVersionSource = () => {
   console.log(`Synced release/version.json to ${version}`)
 }
 
-type DevtoolsArtifactManifest = {
-  readonly schemaVersion?: number
-  readonly artifact?: {
-    readonly metadataUrl?: string
-  }
-  readonly certification?: {
-    readonly livestoreVersion?: string
-    readonly status?: string
-    readonly testSuite?: string
-    readonly evidence?: string
-  }
-}
-
-const syncDevtoolsArtifactCertification = () => {
-  const file = 'release/devtools-artifact.json'
-  if (existsSync(file) === false) {
-    console.log('No release/devtools-artifact.json to sync')
-    return
-  }
-
-  const version = readReleaseVersion()
-  const manifest = readJson<DevtoolsArtifactManifest>(file)
-  if (manifest.schemaVersion !== 2 || manifest.certification === undefined) {
-    console.log('DevTools artifact manifest has no LiveStore-owned certification to sync')
-    return
-  }
-  if (manifest.certification.status !== 'passed') {
-    console.log(`DevTools artifact certification is ${manifest.certification.status}; leaving it unchanged`)
-    return
-  }
-  if (manifest.certification.livestoreVersion === version) {
-    console.log(`DevTools artifact certification already targets ${version}`)
-    return
-  }
-
-  // The artifact build stays the same; the release PR only assigns it to the
-  // generated LiveStore release-group version. Release PR CI must still pass
-  // before auto-merge, and publish re-runs the same repack gate from main.
-  const nextManifest = {
-    ...manifest,
-    certification: {
-      ...manifest.certification,
-      livestoreVersion: version,
-      evidence:
-        `Release automation assigned this passed DevTools artifact certification to LiveStore ${version}. ` +
-        `The release PR must pass CI, including ${manifest.certification.testSuite ?? 'the DevTools repack gate'}, ` +
-        `before auto-merge. Artifact metadata: ${manifest.artifact?.metadataUrl ?? file}.`,
-    },
-  }
-  writeJson(file, nextManifest)
-  console.log(`Synced DevTools artifact certification to ${version}`)
-}
-
 const writeReleasePlan = (flags: Map<string, string | true>) => {
   const version = readReleaseVersion()
   const npmTag = readFlag(flags, 'npm-tag') ?? process.env.LIVESTORE_NPM_TAG ?? 'latest'
@@ -357,7 +303,6 @@ const main = () => {
   if (command === 'check-pr') return checkPr(flags)
   if (command === 'restore-prerelease-changesets') return restorePrereleaseChangesets()
   if (command === 'sync-version-source') return syncVersionSource()
-  if (command === 'sync-devtools-artifact-certification') return syncDevtoolsArtifactCertification()
   if (command === 'sync-standalone-consumers') return syncStandaloneConsumers()
   if (command === 'write-release-plan') return writeReleasePlan(flags)
   if (command === 'assert-fixed-versions') return assertFixedVersions()

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -4,6 +4,7 @@ import {
   assertCertifiedDevtoolsArtifactForLivestore,
   containsForbiddenPattern,
   type ArtifactManifest,
+  type DevtoolsArtifactCertification,
   type ArtifactMetadata,
   forbiddenPatterns,
 } from './devtools-artifact.ts'
@@ -23,36 +24,36 @@ const metadata: ArtifactMetadata = {
   },
 }
 
-const manifest = (
-  overrides: Partial<NonNullable<Extract<ArtifactManifest, { schemaVersion: 2 }>['certification']>> = {},
-) =>
+const manifest = () =>
   ({
     schemaVersion: 2,
     artifact: {
       metadataUrl: 'release-metadata.json',
       tarballUrl: 'livestore-devtools-vite.tgz',
     },
-    certification: {
-      livestoreVersion: '0.4.0-dev.25',
-      devtoolsBuildId: 'dt-test-build',
-      devtoolsProtocolVersion: 1,
-      status: 'passed',
-      testSuite: 'tests/integration/src/tests/playwright/devtools',
-      scenarios: [
-        'direct web session loads and stays connected past heartbeat window',
-        'node adapter session loads through Vite and stays connected past 35 seconds',
-      ],
-      ...overrides,
-    },
   }) satisfies ArtifactManifest
 
+const certification = (overrides: Partial<DevtoolsArtifactCertification> = {}) => ({
+  livestoreVersion: '0.4.0-dev.25',
+  devtoolsBuildId: 'dt-test-build',
+  devtoolsProtocolVersion: 1,
+  status: 'passed' as const,
+  testSuite: 'tests/integration/src/tests/playwright/devtools',
+  scenarios: [
+    'direct web session loads and stays connected past heartbeat window',
+    'node adapter session loads through Vite and stays connected past 35 seconds',
+  ],
+  ...overrides,
+})
+
 describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
-  it('accepts an exact LiveStore-owned certification', () => {
+  it('accepts an exact release-candidate certification', () => {
     expect(
       assertCertifiedDevtoolsArtifactForLivestore({
         manifest: manifest(),
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification(),
       }),
     ).toMatchObject({ livestoreVersion: '0.4.0-dev.25', devtoolsBuildId: 'dt-test-build' })
   })
@@ -67,8 +68,27 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
     ).toThrow(/requires --manifest/)
   })
 
-  it('rejects legacy manifests that only describe the artifact pointer', () => {
+  it('rejects missing or non-passing release-candidate certification', () => {
     expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: { schemaVersion: 2, artifact: { metadataUrl: 'release-metadata.json', tarballUrl: 'devtools.tgz' } },
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/release-candidate certification/)
+
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest(),
+        metadata,
+        version: '0.4.0-dev.25',
+        certification: certification({ status: 'pending' }),
+      }),
+    ).toThrow(/expected passed/)
+  })
+
+  it('allows an artifact-only manifest when release-candidate certification is provided', () => {
+    expect(
       assertCertifiedDevtoolsArtifactForLivestore({
         manifest: {
           schemaVersion: 1,
@@ -79,26 +99,9 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
         },
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification(),
       }),
-    ).toThrow(/schemaVersion 2/)
-  })
-
-  it('rejects missing or non-passing certification', () => {
-    expect(() =>
-      assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: { schemaVersion: 2, artifact: { metadataUrl: 'release-metadata.json', tarballUrl: 'devtools.tgz' } },
-        metadata,
-        version: '0.4.0-dev.25',
-      }),
-    ).toThrow(/certification entry/)
-
-    expect(() =>
-      assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: manifest({ status: 'pending' }),
-        metadata,
-        version: '0.4.0-dev.25',
-      }),
-    ).toThrow(/expected passed/)
+    ).toMatchObject({ livestoreVersion: '0.4.0-dev.25', status: 'passed' })
   })
 
   it('allows CI snapshot repack through the artifact and protocol gates without release certification', () => {
@@ -130,20 +133,37 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
     })
   })
 
+  it('allows an explicit uncertified dry-run repack before liveness certification', () => {
+    expect(
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest(),
+        metadata,
+        version: '0.4.0-dev.25',
+        allowUncertified: true,
+      }),
+    ).toMatchObject({
+      livestoreVersion: '0.4.0-dev.25',
+      status: 'ci-uncertified-repack',
+      scenarios: ['ci-uncertified-repack'],
+    })
+  })
+
   it('rejects certification for a different LiveStore release or DevTools build', () => {
     expect(() =>
       assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: manifest({ livestoreVersion: '0.4.0-dev.24' }),
+        manifest: manifest(),
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification({ livestoreVersion: '0.4.0-dev.24' }),
       }),
     ).toThrow(/not release 0\.4\.0-dev\.25/)
 
     expect(() =>
       assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: manifest({ devtoolsBuildId: 'dt-other-build' }),
+        manifest: manifest(),
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification({ devtoolsBuildId: 'dt-other-build' }),
       }),
     ).toThrow(/does not match metadata build/)
   })
@@ -151,25 +171,30 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
   it('rejects certification for a different protocol or incomplete test evidence', () => {
     expect(() =>
       assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: manifest({ devtoolsProtocolVersion: 2 }),
+        manifest: manifest(),
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification({ devtoolsProtocolVersion: 2 }),
       }),
     ).toThrow(/does not match metadata protocol/)
 
     expect(() =>
       assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: manifest({ scenarios: [] }),
+        manifest: manifest(),
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification({ scenarios: [] }),
       }),
     ).toThrow(/missing scenarios/)
 
     expect(() =>
       assertCertifiedDevtoolsArtifactForLivestore({
-        manifest: manifest({ scenarios: ['direct web session loads and stays connected past heartbeat window'] }),
+        manifest: manifest(),
         metadata,
         version: '0.4.0-dev.25',
+        certification: certification({
+          scenarios: ['direct web session loads and stays connected past heartbeat window'],
+        }),
       }),
     ).toThrow(/missing required scenario: node adapter session loads through Vite/)
   })

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -37,8 +37,11 @@ const manifest = (
       devtoolsBuildId: 'dt-test-build',
       devtoolsProtocolVersion: 1,
       status: 'passed',
-      testSuite: 'devtools-direct-connect-e2e',
-      scenarios: ['direct-url-connects-and-stays-connected'],
+      testSuite: 'tests/integration/src/tests/playwright/devtools',
+      scenarios: [
+        'direct web session loads and stays connected past heartbeat window',
+        'node adapter session loads through Vite and stays connected past 35 seconds',
+      ],
       ...overrides,
     },
   }) satisfies ArtifactManifest
@@ -161,6 +164,14 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
         version: '0.4.0-dev.25',
       }),
     ).toThrow(/missing scenarios/)
+
+    expect(() =>
+      assertCertifiedDevtoolsArtifactForLivestore({
+        manifest: manifest({ scenarios: ['direct web session loads and stays connected past heartbeat window'] }),
+        metadata,
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/missing required scenario: node adapter session loads through Vite/)
   })
 })
 

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   assertCertifiedDevtoolsArtifactForLivestore,
+  assertUncertifiedRepackMode,
   containsForbiddenPattern,
   type ArtifactManifest,
   type DevtoolsArtifactCertification,
@@ -39,10 +40,7 @@ const certification = (overrides: Partial<DevtoolsArtifactCertification> = {}) =
   devtoolsProtocolVersion: 1,
   status: 'passed' as const,
   testSuite: 'tests/integration/src/tests/playwright/devtools',
-  scenarios: [
-    'direct web session loads and stays connected past heartbeat window',
-    'node adapter session loads through Vite and stays connected past 35 seconds',
-  ],
+  scenarios: ['node adapter session loads through Vite and stays connected past 35 seconds'],
   ...overrides,
 })
 
@@ -146,6 +144,13 @@ describe('assertCertifiedDevtoolsArtifactForLivestore', () => {
       status: 'ci-uncertified-repack',
       scenarios: ['ci-uncertified-repack'],
     })
+  })
+
+  it('rejects an uncertified publish repack before liveness certification', () => {
+    expect(() => assertUncertifiedRepackMode({ allowUncertified: true, publish: true })).toThrow(
+      /allow-uncertified.*dry-run/,
+    )
+    expect(() => assertUncertifiedRepackMode({ allowUncertified: true, publish: false })).not.toThrow()
   })
 
   it('rejects certification for a different LiveStore release or DevTools build', () => {

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -56,7 +56,7 @@ type ArtifactSource = {
   readonly chromeZipSha256?: string
 }
 
-type DevtoolsArtifactCertification = {
+export type DevtoolsArtifactCertification = {
   readonly livestoreVersion: string
   readonly devtoolsBuildId: string
   readonly devtoolsProtocolVersion: number
@@ -70,9 +70,9 @@ type DevtoolsArtifactEphemeralCertification = {
   readonly livestoreVersion: string
   readonly devtoolsBuildId: string
   readonly devtoolsProtocolVersion: number
-  readonly status: 'ci-snapshot' | 'ci-release-validation'
+  readonly status: 'ci-snapshot' | 'ci-release-validation' | 'ci-uncertified-repack'
   readonly testSuite: 'artifact-integrity-and-protocol-gate'
-  readonly scenarios: ReadonlyArray<'ci-snapshot-repack' | 'ci-release-validation-repack'>
+  readonly scenarios: ReadonlyArray<'ci-snapshot-repack' | 'ci-release-validation-repack' | 'ci-uncertified-repack'>
 }
 
 const requiredReleaseCertificationScenarios = [
@@ -88,22 +88,24 @@ type ArtifactManifestV1 = {
 type ArtifactManifestV2 = {
   readonly schemaVersion: 2
   readonly artifact: ArtifactSource
-  readonly certification?: DevtoolsArtifactCertification
 }
 
 export type ArtifactManifest = ArtifactManifestV1 | ArtifactManifestV2
 
 const usage = `Usage:
   bun scripts/src/commands/devtools-artifact.ts verify (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>)
-  bun scripts/src/commands/devtools-artifact.ts repack --manifest <file> --version <version> [--dry-run|--publish]
+  bun scripts/src/commands/devtools-artifact.ts certify --manifest <file> --version <version> --out <file> [--evidence <text>]
+  bun scripts/src/commands/devtools-artifact.ts repack --manifest <file> --version <version> [--certification <file>|--allow-uncertified] [--dry-run|--publish]
 
 Options:
-  --manifest <file>        Checked-in public artifact manifest. Repack requires schemaVersion 2 with passed certification.
+  --manifest <file>        Checked-in public artifact manifest.
   --metadata <url-or-file>  Public release-metadata.json URL or local path
   --tarball <url-or-file>   Public artifact tarball URL or local path
   --chrome-zip <url-or-file> Public Chrome extension ZIP URL or local path
   --version <version>       LiveStore release-group package version for repack
+  --certification <file>    Ephemeral release-candidate certification produced by the liveness gate
   --out-dir <dir>           Output directory for verified/repacked artifacts
+  --out <file>              Certification output path for the certify command
   --dry-run                 Run npm publish dry-run for the repacked package
   --publish                 Publish the repacked package to npm
 `
@@ -321,31 +323,31 @@ export const assertCertifiedDevtoolsArtifactForLivestore = ({
   manifest,
   metadata,
   version,
+  certification,
+  allowUncertified,
 }: {
   readonly manifest: ArtifactManifest | undefined
   readonly metadata: ArtifactMetadata
   readonly version: string
+  readonly certification?: DevtoolsArtifactCertification
+  readonly allowUncertified?: boolean
 }) => {
   const protocolVersion = devtoolsProtocolVersionForArtifact(metadata)
 
   if (manifest === undefined) {
     throw new Error(
-      'DevTools repack requires --manifest because LiveStore-owned certification is checked in release/devtools-artifact.json',
+      'DevTools repack requires --manifest so release-candidate certification is bound to the checked-in artifact pointer',
     )
   }
-  if (manifest.schemaVersion !== 2) {
-    throw new Error(
-      'DevTools repack requires release/devtools-artifact.json schemaVersion 2 with LiveStore-owned certification',
-    )
-  }
+  if (manifest.schemaVersion !== 1 && manifest.schemaVersion !== 2) throw new Error('Unsupported artifact manifest')
 
   // Ephemeral CI versions cannot be pre-certified in a checked-in manifest:
   // snapshot versions are produced by the snapshot publisher, and
   // ci.release-validation versions are synthetic PR-only release-plan probes.
-  // They still require the LiveStore-owned manifest pointer and pass through
+  // They still require the LiveStore-owned artifact pointer and pass through
   // artifact checksums, package-shape audit, secret scan, and protocol
   // validation; dev/stable release-channel packages below fail closed unless
-  // LiveStore records an exact passed e2e certification.
+  // LiveStore CI records an exact passed e2e certification for the release candidate.
   if (isSnapshotVersion(version) === true || isCiReleaseValidationVersion(version) === true) {
     return {
       livestoreVersion: version,
@@ -357,39 +359,53 @@ export const assertCertifiedDevtoolsArtifactForLivestore = ({
     } satisfies DevtoolsArtifactEphemeralCertification
   }
 
-  const certification = manifest.certification
-  if (certification === undefined) {
-    throw new Error('DevTools repack requires a LiveStore-owned certification entry in the artifact manifest')
+  if (allowUncertified === true) {
+    return {
+      livestoreVersion: version,
+      devtoolsBuildId: metadata.devtoolsBuildId,
+      devtoolsProtocolVersion: protocolVersion,
+      status: 'ci-uncertified-repack',
+      testSuite: 'artifact-integrity-and-protocol-gate',
+      scenarios: ['ci-uncertified-repack'],
+    } satisfies DevtoolsArtifactEphemeralCertification
   }
-  if (certification.status !== 'passed') {
-    throw new Error(`DevTools artifact certification is ${certification.status}; expected passed`)
-  }
-  if (certification.livestoreVersion !== version) {
+
+  const releaseCertification = certification
+  if (releaseCertification === undefined) {
     throw new Error(
-      `DevTools artifact is certified for LiveStore ${certification.livestoreVersion}, not release ${version}`,
+      'DevTools repack requires release-candidate certification from release:devtools-artifact:certify-liveness',
     )
   }
-  if (certification.devtoolsBuildId !== metadata.devtoolsBuildId) {
+  if (releaseCertification.status !== 'passed') {
+    throw new Error(`DevTools artifact certification is ${releaseCertification.status}; expected passed`)
+  }
+  if (releaseCertification.livestoreVersion !== version) {
     throw new Error(
-      `DevTools artifact certification build ${certification.devtoolsBuildId} does not match metadata build ${metadata.devtoolsBuildId}`,
+      `DevTools artifact is certified for LiveStore ${releaseCertification.livestoreVersion}, not release ${version}`,
+    )
+  }
+  if (releaseCertification.devtoolsBuildId !== metadata.devtoolsBuildId) {
+    throw new Error(
+      `DevTools artifact certification build ${releaseCertification.devtoolsBuildId} does not match metadata build ${metadata.devtoolsBuildId}`,
     )
   }
 
-  if (certification.devtoolsProtocolVersion !== protocolVersion) {
+  if (releaseCertification.devtoolsProtocolVersion !== protocolVersion) {
     throw new Error(
-      `DevTools artifact certification protocol ${certification.devtoolsProtocolVersion} does not match metadata protocol ${protocolVersion}`,
+      `DevTools artifact certification protocol ${releaseCertification.devtoolsProtocolVersion} does not match metadata protocol ${protocolVersion}`,
     )
   }
-  if (certification.testSuite.trim().length === 0)
+  if (releaseCertification.testSuite.trim().length === 0)
     throw new Error('DevTools artifact certification is missing testSuite')
-  if (certification.scenarios.length === 0) throw new Error('DevTools artifact certification is missing scenarios')
+  if (releaseCertification.scenarios.length === 0)
+    throw new Error('DevTools artifact certification is missing scenarios')
   for (const scenario of requiredReleaseCertificationScenarios) {
-    if (certification.scenarios.includes(scenario) === false) {
+    if (releaseCertification.scenarios.includes(scenario) === false) {
       throw new Error(`DevTools artifact certification is missing required scenario: ${scenario}`)
     }
   }
 
-  return certification
+  return releaseCertification
 }
 
 const assertMetadata = (metadata: ArtifactMetadata, tarballPath: string, chromeZipPath: string | undefined) => {
@@ -519,6 +535,36 @@ const verifyArtifact = async (flags: Map<string, string | true>) => {
   return { metadata, tarballPath, chromeZipPath, workDir, manifest }
 }
 
+const readCertification = (flags: Map<string, string | true>) => {
+  const certificationPath = readFlag(flags, 'certification')
+  if (certificationPath === undefined) return undefined
+  return JSON.parse(readFileSync(path.resolve(certificationPath), 'utf8')) as DevtoolsArtifactCertification
+}
+
+const certifyArtifact = async (flags: Map<string, string | true>) => {
+  const version = readFlag(flags, 'version')
+  if (version === undefined) throw new Error('--version is required')
+  const out = readFlag(flags, 'out')
+  if (out === undefined) throw new Error('--out is required')
+
+  const { metadata } = await verifyArtifact(flags)
+  const protocolVersion = devtoolsProtocolVersionForArtifact(metadata)
+  const evidence = readFlag(flags, 'evidence')
+  const certification = {
+    livestoreVersion: version,
+    devtoolsBuildId: metadata.devtoolsBuildId,
+    devtoolsProtocolVersion: protocolVersion,
+    status: 'passed',
+    testSuite: 'tests/integration/src/tests/playwright/devtools',
+    scenarios: requiredReleaseCertificationScenarios,
+    ...(evidence === undefined ? {} : { evidence }),
+  } satisfies DevtoolsArtifactCertification
+
+  mkdirSync(path.dirname(path.resolve(out)), { recursive: true })
+  writeFileSync(path.resolve(out), `${JSON.stringify(certification, null, 2)}\n`)
+  console.log(JSON.stringify({ certificationPath: path.resolve(out), certification }, null, 2))
+}
+
 const materializeChromeZipAsset = (version: string, chromeZipPath: string, workDir: string) => {
   const assetPath = path.join(workDir, `livestore-devtools-chrome-${version}.zip`)
   writeFileSync(assetPath, readFileSync(chromeZipPath))
@@ -550,11 +596,18 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
   const { metadata, tarballPath, chromeZipPath, workDir, manifest } = await verifyArtifact(flags)
   // The public DevTools artifact describes what was built; it does not decide which
   // LiveStore releases may ship it. LiveStore releases much more frequently than
-  // DevTools artifacts, so repack/publish requires this repo to certify the exact
-  // build id and protocol against the exact release version after the release e2e
-  // suite has passed. This prevents stale artifacts with broad compatibility
-  // metadata, such as "*", from being republished as if they were current.
-  const livestoreCertification = assertCertifiedDevtoolsArtifactForLivestore({ manifest, metadata, version })
+  // DevTools artifacts, so release-channel repack/publish requires a CI proof
+  // that binds the exact build id and protocol to the exact release candidate
+  // after the release e2e suite has passed. This prevents stale artifacts with
+  // broad compatibility metadata, such as "*", from being republished as current.
+  const certification = readCertification(flags)
+  const livestoreCertification = assertCertifiedDevtoolsArtifactForLivestore({
+    manifest,
+    metadata,
+    version,
+    ...(certification === undefined ? {} : { certification }),
+    allowUncertified: hasFlag(flags, 'allow-uncertified'),
+  })
   const unpackDir = path.join(workDir, 'package-src')
   rmSync(unpackDir, { recursive: true, force: true })
   mkdirSync(unpackDir, { recursive: true })
@@ -651,6 +704,10 @@ const main = async () => {
   if (command === 'verify') {
     const result = await verifyArtifact(flags)
     console.log(JSON.stringify({ devtoolsBuildId: result.metadata.devtoolsBuildId, workDir: result.workDir }, null, 2))
+    return
+  }
+  if (command === 'certify') {
+    await certifyArtifact(flags)
     return
   }
   if (command === 'repack') {

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -75,6 +75,11 @@ type DevtoolsArtifactEphemeralCertification = {
   readonly scenarios: ReadonlyArray<'ci-snapshot-repack' | 'ci-release-validation-repack'>
 }
 
+const requiredReleaseCertificationScenarios = [
+  'direct web session loads and stays connected past heartbeat window',
+  'node adapter session loads through Vite and stays connected past 35 seconds',
+] as const
+
 type ArtifactManifestV1 = {
   readonly schemaVersion: 1
   readonly artifact: ArtifactSource
@@ -378,6 +383,11 @@ export const assertCertifiedDevtoolsArtifactForLivestore = ({
   if (certification.testSuite.trim().length === 0)
     throw new Error('DevTools artifact certification is missing testSuite')
   if (certification.scenarios.length === 0) throw new Error('DevTools artifact certification is missing scenarios')
+  for (const scenario of requiredReleaseCertificationScenarios) {
+    if (certification.scenarios.includes(scenario) === false) {
+      throw new Error(`DevTools artifact certification is missing required scenario: ${scenario}`)
+    }
+  }
 
   return certification
 }

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -76,7 +76,10 @@ type DevtoolsArtifactEphemeralCertification = {
 }
 
 const requiredReleaseCertificationScenarios = [
-  'direct web session loads and stays connected past heartbeat window',
+  // Exact artifact certification installs the repacked @livestore/devtools-vite
+  // package into the Node adapter fixture. Direct web transport liveness is
+  // covered by the normal Playwright DevTools suite, but it is not evidence
+  // that this selected npm artifact was installed and exercised.
   'node adapter session loads through Vite and stays connected past 35 seconds',
 ] as const
 
@@ -408,6 +411,18 @@ export const assertCertifiedDevtoolsArtifactForLivestore = ({
   return releaseCertification
 }
 
+export const assertUncertifiedRepackMode = ({
+  allowUncertified,
+  publish,
+}: {
+  readonly allowUncertified: boolean
+  readonly publish: boolean
+}) => {
+  if (allowUncertified === true && publish === true) {
+    throw new Error('--allow-uncertified is only valid for dry-run repack; publish requires liveness certification')
+  }
+}
+
 const assertMetadata = (metadata: ArtifactMetadata, tarballPath: string, chromeZipPath: string | undefined) => {
   if (metadata.schemaVersion !== 1) throw new Error('Unsupported metadata schemaVersion')
   if (metadata.artifactName !== 'livestore-devtools-vite') throw new Error('Unexpected artifactName')
@@ -592,6 +607,10 @@ const publishChromeZipReleaseAsset = (version: string, assetPath: string) => {
 const repackArtifact = async (flags: Map<string, string | true>) => {
   const version = readFlag(flags, 'version')
   if (version === undefined) throw new Error('--version is required')
+  assertUncertifiedRepackMode({
+    allowUncertified: hasFlag(flags, 'allow-uncertified'),
+    publish: hasFlag(flags, 'publish'),
+  })
 
   const { metadata, tarballPath, chromeZipPath, workDir, manifest } = await verifyArtifact(flags)
   // The public DevTools artifact describes what was built; it does not decide which

--- a/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
@@ -21,13 +21,16 @@ import process from 'node:process'
 
 import { expect, test } from '@playwright/test'
 
+import { schema } from '../fixtures/devtools/node-adapter-timeout/schema.ts'
 import { checkConnectionRemainsActive } from './shared.ts'
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '../fixtures/devtools/node-adapter-timeout')
 const TIMEOUT_WAIT_MS = 35_000 // 35 seconds, to exceed the 30 second timeout
+const CONNECTED_STATUS_TIMEOUT_MS = 15_000
 
 let nodeProcess: ChildProcess | undefined
 let devtoolsPort: number
+let storeId: string
 
 /**
  * Get an available port by binding to port 0 and reading the assigned port.
@@ -53,6 +56,7 @@ const getAvailablePort = (): Promise<number> => {
  */
 const startNodeApp = async (): Promise<void> => {
   devtoolsPort = await getAvailablePort()
+  storeId = `test-store-${Date.now()}`
 
   return new Promise((resolve, reject) => {
     const mainPath = path.join(FIXTURE_DIR, 'main.ts')
@@ -63,7 +67,7 @@ const startNodeApp = async (): Promise<void> => {
       env: {
         ...process.env,
         DEVTOOLS_PORT: String(devtoolsPort),
-        STORE_ID: `test-store-${Date.now()}`,
+        STORE_ID: storeId,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
@@ -135,6 +139,11 @@ test.describe('Node adapter devtools timeout', () => {
     // Set a longer timeout for this test since we're waiting 35+ seconds
     test.setTimeout(90_000)
 
+    let connectedStatusResolve: () => void = () => {}
+    const connectedStatus = new Promise<void>((resolve) => {
+      connectedStatusResolve = resolve
+    })
+
     // Capture browser console output to debug what's being loaded
     page.on('console', (msg) => {
       const text = msg.text()
@@ -149,14 +158,22 @@ test.describe('Node adapter devtools timeout', () => {
         text.includes('ProxyChannel') === true ||
         text.includes('Pong') === true ||
         text.includes('Ping') === true ||
+        text.includes('message=status') === true ||
         text.includes('recv') === true ||
         text.includes('listenQueue') === true
       ) {
         console.log(`[browser console] ${text}`)
       }
+
+      if (
+        text.includes('message=status') === true &&
+        (text.includes('"_tag": "connected"') === true || text.includes('\\"_tag\\": \\"connected\\"') === true)
+      ) {
+        connectedStatusResolve()
+      }
     })
 
-    const devtoolsUrl = `http://localhost:${devtoolsPort}/_livestore/node?autoconnect`
+    const devtoolsUrl = `http://localhost:${devtoolsPort}/_livestore/node/${storeId}/test-client/static/${schema.devtools.alias}`
     console.log(`Navigating to devtools: ${devtoolsUrl}`)
 
     // Retry navigation a few times in case Vite is still warming up
@@ -175,45 +192,18 @@ test.describe('Node adapter devtools timeout', () => {
       throw new Error('Failed to navigate to devtools after 3 attempts')
     }
 
-    // Wait for the devtools to connect and show the session
-    // With ?autoconnect, it should auto-connect to the first session
-    // Wait for either Sessions list or Database tab (if already connected)
+    await expect(page).toHaveURL(/\/_livestore\/node\/test-store-/, { timeout: 10_000 })
     await Promise.race([
-      page.waitForSelector('text=Sessions', { timeout: 15_000 }),
-      page.waitForSelector('text=Database', { timeout: 15_000 }),
-      page.waitForSelector('text=Tables', { timeout: 15_000 }),
+      connectedStatus,
+      page.waitForTimeout(CONNECTED_STATUS_TIMEOUT_MS).then(() => {
+        throw new Error(`DevTools did not report connected status within ${CONNECTED_STATUS_TIMEOUT_MS}ms`)
+      }),
     ])
-    console.log('Devtools loaded')
-
-    // Check if we need to click on a session link (if not auto-connected)
-    const sessionLink = page
-      .locator('a')
-      .filter({ hasText: /test-store/ })
-      .first()
-    if ((await sessionLink.isVisible({ timeout: 1000 }).catch(() => false)) === true) {
-      await sessionLink.click()
-      console.log('Clicked on session link')
-    } else {
-      console.log('Auto-connected to session (no link to click)')
-    }
-
-    // Wait for the devtools to show connected state (e.g., Database tab)
-    await page.waitForSelector('text=Database', { timeout: 10_000 }).catch(() => {
-      // Sometimes it shows Tables directly
-      return page.waitForSelector('text=Tables', { timeout: 5_000 })
-    })
     console.log('Devtools connected to session')
-
-    // Record the initial state - check that we can see the todo table
-    const initialState = await page.locator('text=todo').first().isVisible()
-    console.log('Initial state - todo table visible:', initialState)
 
     console.log(`Watching connection for ${TIMEOUT_WAIT_MS / 1000} seconds...`)
     await checkConnectionRemainsActive({ devtools: page, label: 'node-devtools', durationMs: TIMEOUT_WAIT_MS })
 
-    const databaseTabStillVisible = await page.locator('text=Database').isVisible()
-    const tablesStillVisible = await page.locator('text=Tables').isVisible()
-
-    expect(databaseTabStillVisible === true || tablesStillVisible === true).toBe(true)
+    await expect(page).toHaveURL(/\/_livestore\/node\/test-store-/)
   })
 })

--- a/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
@@ -26,7 +26,7 @@ import { checkConnectionRemainsActive } from './shared.ts'
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '../fixtures/devtools/node-adapter-timeout')
 const TIMEOUT_WAIT_MS = 35_000 // 35 seconds, to exceed the 30 second timeout
-const CONNECTED_STATUS_TIMEOUT_MS = 60_000
+const DEVTOOLS_READY_TIMEOUT_MS = 60_000
 
 let nodeProcess: ChildProcess | undefined
 let devtoolsPort: number
@@ -140,11 +140,6 @@ test.describe('Node adapter devtools timeout', () => {
     // watch starts.
     test.setTimeout(180_000)
 
-    let connectedStatusResolve: () => void = () => {}
-    const connectedStatus = new Promise<void>((resolve) => {
-      connectedStatusResolve = resolve
-    })
-
     // Capture browser console output to debug what's being loaded
     page.on('console', (msg) => {
       const text = msg.text()
@@ -156,6 +151,7 @@ test.describe('Node adapter devtools timeout', () => {
         text.includes('runPingPong') === true ||
         text.includes('devtools-api') === true ||
         text.includes('mesh-node') === true ||
+        text.includes('devtools heartbeat') === true ||
         text.includes('ProxyChannel') === true ||
         text.includes('Pong') === true ||
         text.includes('Ping') === true ||
@@ -166,12 +162,6 @@ test.describe('Node adapter devtools timeout', () => {
         console.log(`[browser console] ${text}`)
       }
 
-      if (
-        text.includes('message=status') === true &&
-        (text.includes('"_tag": "connected"') === true || text.includes('\\"_tag\\": \\"connected\\"') === true)
-      ) {
-        connectedStatusResolve()
-      }
     })
     page.on('pageerror', (error) => console.log(`[browser pageerror] ${error.message}`))
     page.on('requestfailed', (request) => {
@@ -198,12 +188,10 @@ test.describe('Node adapter devtools timeout', () => {
     }
 
     await expect(page).toHaveURL(/\/_livestore\/node\/test-store-/, { timeout: 10_000 })
-    await Promise.race([
-      connectedStatus,
-      page.waitForTimeout(CONNECTED_STATUS_TIMEOUT_MS).then(() => {
-        throw new Error(`DevTools did not report connected status within ${CONNECTED_STATUS_TIMEOUT_MS}ms`)
-      }),
-    ])
+    await page
+      .getByRole('tab', { name: 'Database' })
+      .describe('node-devtools:Database')
+      .waitFor({ state: 'attached', timeout: DEVTOOLS_READY_TIMEOUT_MS })
     console.log('Devtools connected to session')
 
     console.log(`Watching connection for ${TIMEOUT_WAIT_MS / 1000} seconds...`)

--- a/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
@@ -26,7 +26,7 @@ import { checkConnectionRemainsActive } from './shared.ts'
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '../fixtures/devtools/node-adapter-timeout')
 const TIMEOUT_WAIT_MS = 35_000 // 35 seconds, to exceed the 30 second timeout
-const CONNECTED_STATUS_TIMEOUT_MS = 30_000
+const CONNECTED_STATUS_TIMEOUT_MS = 60_000
 
 let nodeProcess: ChildProcess | undefined
 let devtoolsPort: number
@@ -138,7 +138,7 @@ test.describe('Node adapter devtools timeout', () => {
   test('should maintain connection to devtools after 30+ seconds', async ({ page }) => {
     // Cold CI artifact loading can take time before the 35 second heartbeat
     // watch starts.
-    test.setTimeout(120_000)
+    test.setTimeout(180_000)
 
     let connectedStatusResolve: () => void = () => {}
     const connectedStatus = new Promise<void>((resolve) => {
@@ -172,6 +172,10 @@ test.describe('Node adapter devtools timeout', () => {
       ) {
         connectedStatusResolve()
       }
+    })
+    page.on('pageerror', (error) => console.log(`[browser pageerror] ${error.message}`))
+    page.on('requestfailed', (request) => {
+      console.log(`[browser requestfailed] ${request.url()} ${request.failure()?.errorText ?? 'unknown error'}`)
     })
 
     const devtoolsUrl = `http://localhost:${devtoolsPort}/_livestore/node/${storeId}/test-client/static/${schema.devtools.alias}`

--- a/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
@@ -26,7 +26,7 @@ import { checkConnectionRemainsActive } from './shared.ts'
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '../fixtures/devtools/node-adapter-timeout')
 const TIMEOUT_WAIT_MS = 35_000 // 35 seconds, to exceed the 30 second timeout
-const CONNECTED_STATUS_TIMEOUT_MS = 15_000
+const CONNECTED_STATUS_TIMEOUT_MS = 30_000
 
 let nodeProcess: ChildProcess | undefined
 let devtoolsPort: number
@@ -136,8 +136,9 @@ test.describe('Node adapter devtools timeout', () => {
   })
 
   test('should maintain connection to devtools after 30+ seconds', async ({ page }) => {
-    // Set a longer timeout for this test since we're waiting 35+ seconds
-    test.setTimeout(90_000)
+    // Cold CI artifact loading can take time before the 35 second heartbeat
+    // watch starts.
+    test.setTimeout(120_000)
 
     let connectedStatusResolve: () => void = () => {}
     const connectedStatus = new Promise<void>((resolve) => {

--- a/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/node-adapter-timeout.play.ts
@@ -26,7 +26,7 @@ import { checkConnectionRemainsActive } from './shared.ts'
 
 const FIXTURE_DIR = path.join(import.meta.dirname, '../fixtures/devtools/node-adapter-timeout')
 const TIMEOUT_WAIT_MS = 35_000 // 35 seconds, to exceed the 30 second timeout
-const DEVTOOLS_READY_TIMEOUT_MS = 60_000
+const DEVTOOLS_READY_TIMEOUT_MS = 120_000
 
 let nodeProcess: ChildProcess | undefined
 let devtoolsPort: number
@@ -126,6 +126,7 @@ const stopNodeApp = (): void => {
 test.describe('Node adapter devtools timeout', () => {
   // Run tests serially since each test needs its own Node process
   test.describe.configure({ mode: 'serial' })
+  test.setTimeout(240_000)
 
   test.beforeEach(async () => {
     await startNodeApp()
@@ -136,10 +137,6 @@ test.describe('Node adapter devtools timeout', () => {
   })
 
   test('should maintain connection to devtools after 30+ seconds', async ({ page }) => {
-    // Cold CI artifact loading can take time before the 35 second heartbeat
-    // watch starts.
-    test.setTimeout(180_000)
-
     // Capture browser console output to debug what's being loaded
     page.on('console', (msg) => {
       const text = msg.text()
@@ -157,15 +154,22 @@ test.describe('Node adapter devtools timeout', () => {
         text.includes('Ping') === true ||
         text.includes('message=status') === true ||
         text.includes('recv') === true ||
-        text.includes('listenQueue') === true
+        text.includes('listenQueue') === true ||
+        msg.type() === 'error' ||
+        msg.type() === 'warning'
       ) {
-        console.log(`[browser console] ${text}`)
+        console.log(`[browser console:${msg.type()}] ${text}`)
       }
 
     })
     page.on('pageerror', (error) => console.log(`[browser pageerror] ${error.message}`))
     page.on('requestfailed', (request) => {
       console.log(`[browser requestfailed] ${request.url()} ${request.failure()?.errorText ?? 'unknown error'}`)
+    })
+    page.on('response', (response) => {
+      if (response.status() >= 400) {
+        console.log(`[browser response] ${response.status()} ${response.url()}`)
+      }
     })
 
     const devtoolsUrl = `http://localhost:${devtoolsPort}/_livestore/node/${storeId}/test-client/static/${schema.devtools.alias}`
@@ -188,10 +192,18 @@ test.describe('Node adapter devtools timeout', () => {
     }
 
     await expect(page).toHaveURL(/\/_livestore\/node\/test-store-/, { timeout: 10_000 })
-    await page
-      .getByRole('tab', { name: 'Database' })
-      .describe('node-devtools:Database')
-      .waitFor({ state: 'attached', timeout: DEVTOOLS_READY_TIMEOUT_MS })
+    try {
+      await page
+        .getByRole('tab', { name: 'Database' })
+        .describe('node-devtools:Database')
+        .waitFor({ state: 'attached', timeout: DEVTOOLS_READY_TIMEOUT_MS })
+    } catch (error) {
+      console.log(`[devtools diagnostics] url=${page.url()}`)
+      console.log(`[devtools diagnostics] title=${await page.title().catch(() => '<unavailable>')}`)
+      const bodyText = await page.locator('body').innerText({ timeout: 1000 }).catch(() => '<unavailable>')
+      console.log(`[devtools diagnostics] body=${bodyText.slice(0, 2000)}`)
+      throw error
+    }
     console.log('Devtools connected to session')
 
     console.log(`Watching connection for ${TIMEOUT_WAIT_MS / 1000} seconds...`)


### PR DESCRIPTION
## Problem

LiveStore release validation could pass while testing a different DevTools package than the one selected in `release/devtools-artifact.json`. That let artifact/source skew slip through and users could still hit DevTools "connection lost" behavior after a release.

## Goal

Make the DevTools artifact handoff immutable, certify the exact selected artifact in CI, and preserve the release-cadence invariant: ordinary LiveStore releases must not require work in `overeng` as long as the pinned DevTools artifact remains protocol-compatible.

## Decisions

- Store immutable DevTools artifact URLs and checksums in the LiveStore release manifest.
- Repack and install the exact artifact into both DevTools resolution paths used by the Node adapter fixture before certification.
- Run the strict Playwright liveness test against the installed artifact and wait for real UI readiness plus the heartbeat window.
- Avoid `pnpm exec` after the artifact swap; run the Playwright binary directly and assert installed package versions first.
- Keep npm package snapshot publishing auth-aware: invalid npm auth skips package snapshots and dependent example-create checks, but the DevTools artifact snapshot still runs.

## Release Scenarios

- LiveStore-only release: no overeng work is required when the pinned DevTools artifact remains protocol-compatible and exact-artifact certification passes.
- DevTools runtime/source release: publish a new immutable overeng artifact, dispatch the manifest update into LiveStore, then certify that exact artifact before merging the LiveStore release PR.
- Broken or incompatible artifact: keep LiveStore pinned to the last certified artifact until a corrected artifact passes exact-artifact liveness.

## Verification

- Local exact public artifact liveness passed for `dt-20260519-ecda82cd` with the 35s heartbeat.
- Published artifact: https://github.com/livestorejs/livestore-devtools-artifacts/releases/tag/devtools-artifact-dt-20260519-ecda82cd
- Automated artifact dispatch triggered LiveStore workflow run: https://github.com/livestorejs/livestore/actions/runs/26070561912
- LiveStore CI is rerunning on `4ecc8cdc` after the final manifest update.

## Complexity

No new runtime abstraction. The extra complexity is limited to release certification guards and explicit CI auth/output wiring.

## Concerns

`NPM_TOKEN` is currently invalid for npm in PR CI, so package snapshots are skipped. Stable package releases still fail fast on invalid npm auth; only PR package snapshots are treated as optional side effects. DevTools artifact snapshots remain verified.

## References

- overeng runtime fix: https://github.com/overengineeringstudio/overeng/pull/191
- overeng release docs: https://github.com/overengineeringstudio/overeng/pull/190

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ❄️ co2-frost |
| `agent_session_id` | e9e5f226-7818-40f6-b14c-c34c4a2da475 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | megarepo-all/schickling/2026-05-10-livestore |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@75f90cf |
</details>
<!-- agent-footer:end -->