### PR TITLE
Guard hosted example links with shared deployment metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3819,6 +3819,117 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Validate hosted example links
+        if: github.event.pull_request.head.repo.fork != true
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from Nix GC race after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
+                write_summary failure "No Nix GC race signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
+            write_summary failure "Nix GC race retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run examples:validate-links --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run examples:validate-links --mode before'
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -394,6 +394,11 @@ printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.np
             CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}',
           },
         },
+        {
+          name: 'Validate hosted example links',
+          if: IS_NOT_FORK,
+          run: runDevenvTasksBefore('examples:validate-links'),
+        },
       ]),
     },
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -504,6 +504,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 #### Development Tooling
 
 - **Strict peer dep composition:** Added `@effect/vitest` to `utilsEffectPeerDeps` and `@livestore/peer-deps`, and deduplicated the peer-deps package to derive its dependency list from the canonical `utilsEffectPeerDeps` source ([#1107](https://github.com/livestorejs/livestore/issues/1107)).
+- **Hosted example link validation:** Maintainers now have a shared deployment metadata source and `mono examples validate-links` check so docs and example deployments can catch stale first-party demo URLs before publishing ([#1244](https://github.com/livestorejs/livestore/issues/1244)).
 - Migration from ESLint to Biome for improved performance (#447)
 - Automated dependency management with Renovate
 - Pre-commit hooks via Husky (#522)

--- a/contributor-docs/examples-cloudflare.md
+++ b/contributor-docs/examples-cloudflare.md
@@ -27,9 +27,10 @@ The script uses the directory name inside `/examples` as the `<slug>` (for examp
 direnv exec . mono examples deploy              # build + deploy all configured examples
 direnv exec . mono examples deploy --example-filter web-
 direnv exec . mono examples deploy --prod       # stable release versions only
+direnv exec . mono examples validate-links      # verify published prod/dev demo URLs
 ```
 
-The command builds examples in parallel (three at a time) and retries Worker uploads twice. Preview Workers are accessible exclusively via their Workers.dev host names.
+The deploy command builds examples in parallel (three at a time) and retries Worker uploads twice. Preview Workers are accessible exclusively via their Workers.dev host names. The validation command checks the repo-owned public deployment metadata in `packages/@local/shared/src/example-deployments.ts` without following redirects, so intentional route redirects such as LinearLite remain visible.
 
 ## Creating a New Example Worker
 
@@ -38,10 +39,11 @@ The command builds examples in parallel (three at a time) and retries Worker upl
 3. Add `[env.prod]`, `[env.preview]`, and `[env.dev]` sections in `wrangler.toml`; duplicate any bindings (Durable Objects, D1, queues, secrets, etc.) inside each environment block because Wrangler does not inherit them automatically.
 4. Provision Cloudflare resources if needed (Durable Objects, D1, secrets) via `wrangler`. Update the manifest with any required metadata.
 5. Run `direnv exec . mono examples deploy --example-filter <slug>` locally to verify the Worker deploys.
-6. Update `docs/src/data/examples.ts` with the new production/dev URLs so the documentation links point to the Cloudflare deployment.
+6. Add the public prod/dev URL contract to `packages/@local/shared/src/example-deployments.ts` when the example should be linked from docs.
+7. Update `docs/src/data/examples.ts` to consume the shared deployment entry instead of hard-coding URLs.
+8. Run `direnv exec . mono examples validate-links --example-filter <slug>` to verify the public demo endpoints.
 
 ## Troubleshooting
 
 - `wrangler deploy` fails with `Not logged in`: re-run `direnv exec . bunx wrangler login`.
-- Preview Worker unavailable: ensure the deploy succeeded and visit `https://example-<slug>-preview.livestore.workers.dev`. Check `wrangler deployments list --name <worker-name>` for status.
 - Preview Worker unavailable: the worker is deployed at `https://<worker-name>.livestore.workers.dev`. Check `wrangler deployments list --name <worker-name>` for status.

--- a/docs/src/data/examples.ts
+++ b/docs/src/data/examples.ts
@@ -1,3 +1,5 @@
+import { getExampleDeployment } from '@local/shared'
+
 import { getBranchName, IS_MAIN_BRANCH } from './data.ts'
 
 // Hosted assets - To upload new assets:
@@ -37,6 +39,11 @@ export const getExampleDemoLinks = (example: Example) => {
 
 const branch = getBranchName()
 
+const webTodomvcDeployment = getExampleDeployment('web-todomvc')
+const webLinearliteDeployment = getExampleDeployment('web-linearlite')
+const webTodomvcSyncCfDeployment = getExampleDeployment('web-todomvc-sync-cf')
+const cfChatDeployment = getExampleDeployment('cf-chat')
+
 export const examples: Example[] = [
   // Web Adapter Examples
   {
@@ -50,8 +57,8 @@ export const examples: Example[] = [
       width: 1000,
       height: 700,
     },
-    demoUrl: 'https://example-web-todomvc.livestore.workers.dev',
-    devDemoUrl: 'https://example-web-todomvc-dev.livestore.workers.dev',
+    demoUrl: webTodomvcDeployment.endpoints.prod.url,
+    devDemoUrl: webTodomvcDeployment.endpoints.dev.url,
     sourceUrl: `https://github.com/livestorejs/livestore/tree/${branch}/examples/web-todomvc`,
     status: 'available',
   },
@@ -66,8 +73,8 @@ export const examples: Example[] = [
       width: 1000,
       height: 700,
     },
-    demoUrl: 'https://example-web-linearlite.livestore.workers.dev',
-    devDemoUrl: 'https://example-web-linearlite-dev.livestore.workers.dev',
+    demoUrl: webLinearliteDeployment.endpoints.prod.url,
+    devDemoUrl: webLinearliteDeployment.endpoints.dev.url,
     sourceUrl: `https://github.com/livestorejs/livestore/tree/${branch}/examples/web-linearlite`,
     status: 'available',
   },
@@ -83,8 +90,8 @@ export const examples: Example[] = [
       width: 1000,
       height: 700,
     },
-    demoUrl: 'https://example-web-todomvc-sync-cf.livestore.workers.dev',
-    devDemoUrl: 'https://example-web-todomvc-sync-cf-dev.livestore.workers.dev',
+    demoUrl: webTodomvcSyncCfDeployment.endpoints.prod.url,
+    devDemoUrl: webTodomvcSyncCfDeployment.endpoints.dev.url,
     sourceUrl: `https://github.com/livestorejs/livestore/tree/${branch}/examples/web-todomvc-sync-cf`,
     status: 'available',
   },
@@ -162,8 +169,8 @@ export const examples: Example[] = [
       width: 1000,
       height: 700,
     },
-    demoUrl: 'https://example-cf-chat.livestore.workers.dev',
-    devDemoUrl: 'https://example-cf-chat-dev.livestore.workers.dev',
+    demoUrl: cfChatDeployment.endpoints.prod.url,
+    devDemoUrl: cfChatDeployment.endpoints.dev.url,
     sourceUrl: `https://github.com/livestorejs/livestore/tree/${branch}/examples/cf-chat`,
     status: 'available',
   },

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -299,6 +299,11 @@ in
       exec = "mono examples deploy --prod";
     };
 
+    "examples:validate-links" = {
+      description = "Validate hosted example links";
+      exec = "mono examples validate-links";
+    };
+
     "examples:install" = {
       description = "Install examples workspace dependencies";
       exec = ''

--- a/packages/@local/shared/src/example-deployments.ts
+++ b/packages/@local/shared/src/example-deployments.ts
@@ -1,0 +1,64 @@
+export type ExampleDeploymentEnvironment = 'prod' | 'dev'
+
+export interface ExampleDeploymentEndpoint {
+  url: string
+  /**
+   * Validate without following redirects so route-level regressions stay visible.
+   * LinearLite intentionally redirects from `/` into a generated store route.
+   */
+  expectedStatus: number
+}
+
+export interface ExampleDeployment {
+  slug: string
+  sourcePath: `examples/${string}`
+  workerName: string
+  endpoints: Record<ExampleDeploymentEnvironment, ExampleDeploymentEndpoint>
+}
+
+export const exampleDeployments = [
+  {
+    slug: 'web-todomvc',
+    sourcePath: 'examples/web-todomvc',
+    workerName: 'example-web-todomvc',
+    endpoints: {
+      prod: { url: 'https://example-web-todomvc.livestore.workers.dev', expectedStatus: 200 },
+      dev: { url: 'https://example-web-todomvc-dev.livestore.workers.dev', expectedStatus: 200 },
+    },
+  },
+  {
+    slug: 'web-linearlite',
+    sourcePath: 'examples/web-linearlite',
+    workerName: 'example-web-linearlite',
+    endpoints: {
+      prod: { url: 'https://example-web-linearlite.livestore.workers.dev', expectedStatus: 307 },
+      dev: { url: 'https://example-web-linearlite-dev.livestore.workers.dev', expectedStatus: 307 },
+    },
+  },
+  {
+    slug: 'web-todomvc-sync-cf',
+    sourcePath: 'examples/web-todomvc-sync-cf',
+    workerName: 'example-web-todomvc-sync-cf',
+    endpoints: {
+      prod: { url: 'https://example-web-todomvc-sync-cf.livestore.workers.dev', expectedStatus: 200 },
+      dev: { url: 'https://example-web-todomvc-sync-cf-dev.livestore.workers.dev', expectedStatus: 200 },
+    },
+  },
+  {
+    slug: 'cf-chat',
+    sourcePath: 'examples/cf-chat',
+    workerName: 'example-cf-chat',
+    endpoints: {
+      prod: { url: 'https://example-cf-chat.livestore.workers.dev', expectedStatus: 200 },
+      dev: { url: 'https://example-cf-chat-dev.livestore.workers.dev', expectedStatus: 200 },
+    },
+  },
+] as const satisfies readonly ExampleDeployment[]
+
+export type ExampleDeploymentSlug = (typeof exampleDeployments)[number]['slug']
+
+export const exampleDeploymentsBySlug = Object.fromEntries(
+  exampleDeployments.map((deployment) => [deployment.slug, deployment]),
+) as Record<ExampleDeploymentSlug, (typeof exampleDeployments)[number]>
+
+export const getExampleDeployment = <TSlug extends ExampleDeploymentSlug>(slug: TSlug) => exampleDeploymentsBySlug[slug]

--- a/packages/@local/shared/src/index.ts
+++ b/packages/@local/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from './CONSTANTS.ts'
+export * from './example-deployments.ts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4466,6 +4466,9 @@ importers:
       '@local/docs':
         specifier: workspace:^
         version: link:../docs
+      '@local/shared':
+        specifier: workspace:^
+        version: link:../packages/@local/shared
       '@local/tests-integration':
         specifier: workspace:^
         version: link:../tests/integration

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -30,6 +30,7 @@
     "@local/astro-tldraw": "workspace:^",
     "@local/astro-twoslash-code": "workspace:^",
     "@local/docs": "workspace:^",
+    "@local/shared": "workspace:^",
     "@local/tests-integration": "workspace:^",
     "@local/tests-sync-provider": "workspace:^",
     "@opentelemetry/api": "1.9.0",

--- a/scripts/package.json.genie.ts
+++ b/scripts/package.json.genie.ts
@@ -5,6 +5,7 @@ import utilsDevPkg from '../packages/@livestore/utils-dev/package.json.genie.ts'
 import utilsPkg from '../packages/@livestore/utils/package.json.genie.ts'
 import astroTldrawPkg from '../packages/@local/astro-tldraw/package.json.genie.ts'
 import astroTwoslashCodePkg from '../packages/@local/astro-twoslash-code/package.json.genie.ts'
+import sharedPkg from '../packages/@local/shared/package.json.genie.ts'
 import testsIntegrationPkg from '../tests/integration/package.json.genie.ts'
 import testsSyncProviderPkg from '../tests/sync-provider/package.json.genie.ts'
 
@@ -17,6 +18,7 @@ const composition = catalog.compose({
       commonPkg,
       utilsPkg,
       utilsDevPkg,
+      sharedPkg,
       astroTldrawPkg,
       astroTwoslashCodePkg,
       docsPkg,

--- a/scripts/src/commands/examples/cli.ts
+++ b/scripts/src/commands/examples/cli.ts
@@ -12,6 +12,7 @@ import {
   readExampleSlugs,
   runExampleTests,
 } from './deploy-examples.ts'
+import { validateLinksCommand } from './validate-links.ts'
 
 const workspaceRoot =
   process.env.WORKSPACE_ROOT ?? shouldNeverHappen(`WORKSPACE_ROOT is not set. Make sure to run 'direnv allow'`)
@@ -78,5 +79,11 @@ const examplesRunCommand = Cli.Command.make(
 )
 
 export const examplesCommand = Cli.Command.make('examples').pipe(
-  Cli.Command.withSubcommands([deployExamplesCommand, copyTodomvcSrc, examplesRunCommand, examplesTestCommand]),
+  Cli.Command.withSubcommands([
+    deployExamplesCommand,
+    copyTodomvcSrc,
+    validateLinksCommand,
+    examplesRunCommand,
+    examplesTestCommand,
+  ]),
 )

--- a/scripts/src/commands/examples/validate-links.ts
+++ b/scripts/src/commands/examples/validate-links.ts
@@ -1,0 +1,98 @@
+import { Effect, Option, Schema } from '@livestore/utils/effect'
+import { Cli } from '@livestore/utils/node'
+import { exampleDeployments, type ExampleDeploymentEnvironment } from '@local/shared'
+
+class ExampleLinkValidationError extends Schema.TaggedError<ExampleLinkValidationError>()(
+  'ExampleLinkValidationError',
+  {
+    message: Schema.String,
+  },
+) {}
+
+const environments = ['prod', 'dev'] as const satisfies readonly ExampleDeploymentEnvironment[]
+
+const validateEndpoint = ({
+  slug,
+  environment,
+  url,
+  expectedStatus,
+}: {
+  slug: string
+  environment: ExampleDeploymentEnvironment
+  url: string
+  expectedStatus: number
+}) =>
+  Effect.tryPromise({
+    try: () => fetch(url, { method: 'GET', redirect: 'manual' }),
+    catch: (cause) =>
+      new ExampleLinkValidationError({
+        message: `${slug} (${environment}) failed to fetch ${url}: ${String(cause)}`,
+      }),
+  }).pipe(
+    Effect.flatMap((response) => {
+      const status = Reflect.get(response, 'status')
+
+      if (typeof status !== 'number') {
+        return Effect.fail(
+          new ExampleLinkValidationError({
+            message: `${slug} (${environment}) did not expose a numeric HTTP status: ${url}`,
+          }),
+        )
+      }
+
+      if (status === expectedStatus) {
+        return Effect.succeed({
+          slug,
+          environment,
+          url,
+          status,
+        })
+      }
+
+      return Effect.fail(
+        new ExampleLinkValidationError({
+          message: `${slug} (${environment}) expected HTTP ${expectedStatus} but got ${status}: ${url}`,
+        }),
+      )
+    }),
+  )
+
+export const validateLinksCommand = Cli.Command.make(
+  'validate-links',
+  {
+    exampleFilter: Cli.Options.text('example-filter').pipe(Cli.Options.withAlias('e'), Cli.Options.optional),
+  },
+  Effect.fn(function* ({ exampleFilter }) {
+    const filteredDeployments = exampleDeployments.filter((deployment) =>
+      Option.isSome(exampleFilter) === true ? deployment.slug.includes(exampleFilter.value) : true,
+    )
+
+    if (filteredDeployments.length === 0) {
+      const available = exampleDeployments.map((deployment) => deployment.slug).join(', ')
+      return yield* new ExampleLinkValidationError({
+        message:
+          Option.isSome(exampleFilter) === true
+            ? `No example deployments match filter "${exampleFilter.value}". Available: ${available}`
+            : 'No example deployments are configured.',
+      })
+    }
+
+    const results = yield* Effect.forEach(
+      filteredDeployments,
+      (deployment) =>
+        Effect.forEach(environments, (environment) =>
+          validateEndpoint({
+            slug: deployment.slug,
+            environment,
+            url: deployment.endpoints[environment].url,
+            expectedStatus: deployment.endpoints[environment].expectedStatus,
+          }),
+        ),
+      { concurrency: 4 },
+    )
+
+    for (const result of results.flat()) {
+      console.log(`${result.status} ${result.slug} ${result.environment} ${result.url}`)
+    }
+  }),
+)

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -54,6 +54,9 @@
       "path": "../packages/@livestore/common"
     },
     {
+      "path": "../packages/@local/shared"
+    },
+    {
       "path": "../packages/@local/astro-tldraw"
     },
     {

--- a/scripts/tsconfig.json.genie.ts
+++ b/scripts/tsconfig.json.genie.ts
@@ -33,6 +33,7 @@ export default tsconfigJson({
     { path: '../packages/@livestore/utils' },
     { path: '../packages/@livestore/utils-dev' },
     { path: '../packages/@livestore/common' },
+    { path: '../packages/@local/shared' },
     { path: '../packages/@local/astro-tldraw' },
     { path: '../packages/@local/astro-twoslash-code' },
     { path: '../tests/integration' },


### PR DESCRIPTION
**Problem**

The docs examples page can publish stale hosted demo links because docs data, deployed Worker URLs, and validation live in separate places. This is the immediate Phase 1 guardrail for the 404 regression tracked in #1244.

**Goal**

Make hosted example URLs repo-owned, reusable from docs, and validated after example deployment so stale first-party demo links are caught before publishing.

**Decisions**

- Added shared deployment metadata in `@local/shared` so docs and validation read the same URL contract.
- Kept current production/dev URLs on `*.livestore.workers.dev`; Cloudflare authoritative DNS/custom domains remain the larger Option 2 follow-up in #1244.
- Validates with `redirect: manual` so intentional route redirects, like LinearLite's root redirect, remain explicit expected status codes.
- Added the CI check after the Cloudflare deploy step, where fresh Worker URLs should already be available.

**Verification**

Passed:

```text
mono examples validate-links
200 web-todomvc prod https://example-web-todomvc.livestore.workers.dev
200 web-todomvc dev https://example-web-todomvc-dev.livestore.workers.dev
307 web-linearlite prod https://example-web-linearlite.livestore.workers.dev
307 web-linearlite dev https://example-web-linearlite-dev.livestore.workers.dev
200 web-todomvc-sync-cf prod https://example-web-todomvc-sync-cf.livestore.workers.dev
200 web-todomvc-sync-cf dev https://example-web-todomvc-sync-cf-dev.livestore.workers.dev
200 cf-chat prod https://example-cf-chat.livestore.workers.dev
200 cf-chat dev https://example-cf-chat-dev.livestore.workers.dev
```

```text
targeted oxfmt --check on touched source/genie files: pass
targeted oxlint on touched TypeScript/genie files: pass
docs examples data import: pass, four hosted demo URL pairs produced from shared metadata
```

Attempted broader checks:

```text
tsc --noEmit -p scripts/tsconfig.json
```

This is currently blocked on the rebased `dev` base by an unrelated existing error: `scripts/src/commands/devtools-artifact.ts` imports `supportedDevtoolsProtocolVersions` from `@livestore/common`, but that export is absent on this base.

```text
mono docs build
```

This is blocked locally before exercising this change by tldraw/Puppeteer browser setup. With no configured Puppeteer Chrome it reports the expected browser as missing; pointing it at the existing Playwright Chromium then fails on missing native GUI libraries. `mono docs snippets build` passed, and `mono docs build --skip-deps` then progressed until the separate tldraw diagram cache requirement.

**Complexity**

Small new shared metadata module and one CLI validator. The shared module is intentional: it removes duplicate URL constants between docs and validation.

**Concerns**

This does not yet move domains/DNS into IaC. It protects the current Workers.dev setup and gives CI a regression tripwire while #1244 handles the long-term Cloudflare authoritative DNS plan.

**Friction & Bottlenecks**

- `devenv shell` / `devenv tasks` intermittently hung during shell evaluation in this checkout, so verification used the cached devenv profile binaries directly.
- Local full docs build is sensitive to Puppeteer/tldraw browser runtime setup, which is unrelated to this change but prevented a full docs build proof here.

**Follow-ups**

- Continue Option 2 IaC/domain work in #1244.
- Fix or account for the current `dev` branch scripts typecheck blocker around `supportedDevtoolsProtocolVersions`.
- Make docs diagram rendering easier to run locally without manual browser/native-library setup.

**References**

Refs #1244

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🐦 co2-wren |
| `agent_session_id` | 7bea1ca3-d685-406b-968b-59a70ba4859c |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.130.0 |
| `agent_runtime` | Codex CLI 0.130.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-05-18-examples |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b228ad5 |
</details>
<!-- agent-footer:end -->