### PR TITLE
chore: align effect-utils locks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -353,7 +359,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -607,7 +619,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -858,7 +876,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1107,7 +1131,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1356,7 +1386,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1649,7 +1685,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -1928,7 +1970,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2312,7 +2360,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2575,7 +2629,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -2956,7 +3016,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -3333,7 +3399,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -3916,7 +3988,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -140,7 +140,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -437,7 +443,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
@@ -852,7 +864,13 @@ jobs:
           fi
 
           resolve_devenv() {
-            nix build --no-link --print-out-paths "github:cachix/devenv/$DEVENV_REV#devenv"
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
           }
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1778248487,
-        "narHash": "sha256-j0sRFw1/+CttEmc6E5KrXs/L9ZMrUcbnAI6JomxnwdM=",
+        "lastModified": 1779030141,
+        "narHash": "sha256-k7ssDuWTLZjTSZyE15sJ9MZ/iractZ6tY6bR+/PFYIc=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "c8a6b0f39a42208cc239a772f5fd5a393c1ccfa7",
+        "rev": "ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1778248487,
-        "narHash": "sha256-j0sRFw1/+CttEmc6E5KrXs/L9ZMrUcbnAI6JomxnwdM=",
+        "lastModified": 1779030141,
+        "narHash": "sha256-k7ssDuWTLZjTSZyE15sJ9MZ/iractZ6tY6bR+/PFYIc=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "c8a6b0f39a42208cc239a772f5fd5a393c1ccfa7",
+        "rev": "ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,16 +4,16 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "acd6c63f5e235e7e5f2710fc62b2231e0ba904a6",
+      "commit": "ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca",
       "pinned": true,
-      "lockedAt": "2026-05-12T02:51:58.431Z"
+      "lockedAt": "2026-05-18T06:45:33.610Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "1a63ec87cd295972b05b51c9b4ad2db9567dc994",
+      "commit": "e71ba68273026a1a2c1ace7218bdb206b0d3386d",
       "pinned": false,
-      "lockedAt": "2026-05-12T01:57:03.940Z"
+      "lockedAt": "2026-05-18T06:45:33.610Z"
     }
   }
 }


### PR DESCRIPTION
**Why**
Refresh the repository to the current effect-utils input graph so megarepo and devenv locks agree with the generated CI setup.

**What**
- Updates `effect-utils` and `playwright` lock entries to the current effect-utils revision.
- Updates the composed `effect` member lock to match the refreshed graph.
- Regenerates GitHub workflows so CI uses the current shared devenv resolution snippet.

**How**
Ran megarepo recomposition with `mr fetch --apply --all --force --worktree-mode commit`, refreshed the relevant devenv inputs, then ran the repo generator after `check:quick` reported generated workflow drift.

**Rationale**
This keeps the change as an alignment PR instead of adding repo-local compatibility code. The generated workflow changes are included because the final check only passes with generated outputs committed.

**Verification**
- `mr status --all -o json`: root reports `syncNeeded=false`, `applyNeeded=false`, and `lockNeeded=false`.
- `CI=1 devenv tasks run mr:lock-sync-check`: passed.
- `CI=1 devenv tasks run check:quick`: passed after generator refresh.
- `CI=1 devenv tasks run check:all`: passed in pty session `livestore.effect-utils-lock-sync.check-all-final`.

**Notes**
This overlaps the stale draft validation PR #1142, but this branch is narrower: current locks plus generated workflow output only.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🪨 co1-butte |
| `agent_session_id` | d03e6b40-88b1-4fa3-aa63-b73c83cfdc47 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.130.0 |
| `agent_runtime` | Codex CLI 0.130.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling/2026-05-18-effect-utils-lock-sync |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b228ad5 |
</details>
<!-- agent-footer:end -->