### PR TITLE
Use trusted publishing for snapshot releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,9 +63,18 @@ plan is still the intended release; the publisher is idempotent for already
 published packages, but production deploys still reflect the checked-in release
 state.
 
-The publish job uses the repository `NPM_TOKEN` secret. Snapshot publishing uses
-npm trusted publishing from `ci.yml`; release publishing should move to trusted
-publishing too once `release.yml` is authorized for the npm packages.
+Snapshot package publishing uses npm trusted publishing from `ci.yml`. Only the
+final publish job runs on a GitHub-hosted runner because npm trusted publishing
+currently requires GitHub-hosted OIDC; the heavier validation jobs may continue
+to run on Namespace/self-hosted runners. Do not configure an npm write token for
+the snapshot publish job. Each published `@livestore/*` package must trust
+`livestorejs/livestore` with workflow filename `ci.yml` in npm package settings.
+
+Stable release publishing still uses the repository `NPM_TOKEN` secret from
+`release.yml`. npm currently allows only one trusted publisher workflow per
+package, so moving stable releases to trusted publishing requires a deliberate
+workflow consolidation that preserves the ability to cut LiveStore releases
+without touching the overeng repository.
 
 ## `devtools-artifact.yml`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2936,7 +2936,6 @@ jobs:
     needs: [test-unit, test-integration-node-sync, test-integration-sync-provider, test-integration-playwright]
     env:
       GH_TOKEN: ${{ github.token }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     defaults:
       run:
         shell: bash
@@ -3064,12 +3063,6 @@ jobs:
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
         shell: bash
-      - name: Configure npm token fallback
-        run: |
-          set -euo pipefail
-          : "${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
-          printf '%s\n' "always-auth=true" > "$HOME/.npmrc"
-          printf '%s\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"
       - name: Publish snapshot version
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -313,10 +313,11 @@ done`,
     },
 
     /**
-     * Publish job runs on GitHub-hosted runner (not Namespace) because npm OIDC
-     * trusted publishing with --provenance requires sigstore, which only supports
-     * GitHub-hosted runners. We still configure the npm token fallback to avoid
-     * interactive auth if trusted publishing is unavailable for a package.
+     * Keep only the publish boundary on GitHub-hosted runners. The heavy tests
+     * above may use Namespace/self-hosted runners, but npm trusted publishing
+     * currently requires GitHub-hosted OIDC and does not support self-hosted
+     * runners. Do not add an npm write token here; the npm package settings
+     * should trust this workflow file (`ci.yml`) for snapshot publishes.
      */
     'publish-snapshot-version': {
       if: IS_NOT_FORK,
@@ -333,18 +334,10 @@ done`,
       ],
       env: {
         GH_TOKEN: '${{ github.token }}',
-        NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}',
       },
       defaults: bashShellDefaults,
       steps: withNixDiagnosticsOnFailure([
         ...livestoreSetupSteps,
-        {
-          name: 'Configure npm token fallback',
-          run: `set -euo pipefail
-: "\${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
-printf '%s\\n' "always-auth=true" > "$HOME/.npmrc"
-printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$HOME/.npmrc"`,
-        },
         {
           name: 'Publish snapshot version',
           run: runDevenvTasksBefore('release:snapshot:git-sha'),

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -292,6 +292,36 @@ const restoreGeneratedReleaseFiles = (cwd: string) =>
     ),
   )
 
+const packPackageForPublish = ({ cwd, pkg, version }: { cwd: string; pkg: string; version: string }) =>
+  Effect.gen(function* () {
+    const fsEffect = yield* FileSystem.FileSystem
+    const pkgDir = `${cwd}/packages/${pkg}`
+    const safePackageName = pkg.replaceAll('/', '__').replaceAll('@', '')
+    const packDir = `${cwd}/tmp/release-pack/${version}/${safePackageName}`
+
+    yield* fsEffect.remove(packDir, { recursive: true }).pipe(Effect.catchAll(() => Effect.void))
+    yield* fsEffect.makeDirectory(packDir, { recursive: true })
+
+    /**
+     * Use pnpm for packaging because the repo intentionally keeps source-time
+     * `exports`/`bin` in package.json and publish-time dist mappings in
+     * `publishConfig`. `pnpm pack` materializes those mappings into the tarball;
+     * plain `npm publish <directory>` would publish the source mappings instead.
+     */
+    yield* cmd(`DT_PASSTHROUGH=1 pnpm --dir ${pkgDir} pack --pack-destination ${packDir}`, { shell: true }).pipe(
+      Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
+    )
+
+    const tarballs = (yield* fsEffect.readDirectory(packDir)).filter((entry) => entry.endsWith('.tgz'))
+    if (tarballs.length !== 1) {
+      return yield* Effect.fail(
+        new Error(`Expected exactly one packed tarball for ${pkg}@${version}, found ${tarballs.length}`),
+      )
+    }
+
+    return `${packDir}/${tarballs[0]}`
+  })
+
 const publishReleasePackages = ({
   cwd,
   version,
@@ -350,8 +380,15 @@ const publishReleasePackages = ({
         continue
       }
 
-      const publishArgs = ['pnpm', 'publish', `--tag=${npmTag}`, '--access=public', '--no-git-checks']
-      if (isCI === true) publishArgs.push('--provenance')
+      const packedTarballPath = yield* packPackageForPublish({ cwd, pkg, version })
+      const publishArgs = [
+        'npm',
+        'publish',
+        packedTarballPath,
+        `--tag=${npmTag}`,
+        '--access=public',
+        '--ignore-scripts',
+      ]
       if (dryRun === true) publishArgs.push('--dry-run')
       const versionIsVisible = cmd(`npm view ${pkg}@${version} version`, { stdout: 'pipe', stderr: 'pipe' }).pipe(
         Effect.provide(cwdLayer),
@@ -366,32 +403,16 @@ const publishReleasePackages = ({
           return versionIsVisible.pipe(
             Effect.flatMap((isVisible) => {
               if (isVisible === true) {
-                return Effect.logWarning(
-                  `${pkg}@${version} became visible after a failed provenance publish; continuing`,
-                )
+                return Effect.logWarning(`${pkg}@${version} became visible after a failed publish; continuing`)
               }
 
-              const fallbackArgs = publishArgs.filter((arg) => arg !== '--provenance')
-              return Effect.logWarning(
-                `Retrying ${pkg}@${version} snapshot publish without provenance after provenance publish failed`,
-              ).pipe(
-                Effect.zipRight(
-                  cmd(`DT_PASSTHROUGH=1 ${fallbackArgs.join(' ')}`, { shell: true }).pipe(
-                    Effect.provide(cwdLayer),
-                    Effect.catchTag('CmdError', (fallbackError) =>
-                      versionIsVisible.pipe(
-                        Effect.flatMap((isVisibleAfterFallback) =>
-                          isVisibleAfterFallback === true
-                            ? Effect.logWarning(
-                                `${pkg}@${version} became visible after the fallback publish failed; continuing`,
-                              )
-                            : Effect.fail(fallbackError),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              )
+              return Effect.logError(
+                [
+                  `Failed to publish ${pkg}@${version} from CI.`,
+                  'Snapshot publishing must authenticate through npm trusted publishing from .github/workflows/ci.yml.',
+                  'Check that npm has this package configured for GitHub Actions trusted publishing and that this job uses a GitHub-hosted runner with id-token: write.',
+                ].join(' '),
+              ).pipe(Effect.zipRight(Effect.fail(error)))
             }),
           )
         }),


### PR DESCRIPTION
**Problem**

`publish-snapshot-version` was still configured as a hybrid npm-token/provenance flow. That regressed against npm trusted publishing: the CI job used a token fallback and the release command invoked `pnpm publish --provenance`, which is not the right boundary for GitHub OIDC trusted publishing.

**Goal**

Snapshot releases publish through npm trusted publishing from `.github/workflows/ci.yml`, with only the final publish job on GitHub-hosted runners. Heavier validation can continue to run on Namespace/self-hosted runners, and stable LiveStore releases remain independent of overeng.

**Decisions**

- Removed the snapshot job's `NPM_TOKEN` fallback. Snapshot publish failures should now point at npm trusted-publisher package settings instead of silently taking a second auth path.
- Kept `pnpm pack` for package assembly and switched only the registry upload to `npm publish <tarball>`. This preserves the existing `publishConfig` contract that maps source-time `exports`/`bin` to dist-time package manifests.
- Left stable releases on `NPM_TOKEN` from `release.yml`. npm only allows one trusted publisher workflow per package, so moving stable releases to trusted publishing needs a deliberate workflow consolidation rather than a hidden trade-off in this fix.

**Verification**

- `devenv tasks run genie:run --mode before --no-tui --show-output` passed and regenerated `.github/workflows/ci.yml`.
- `CI=true FORCE_SETUP=1 DT_PASSTHROUGH=1 devenv shell mono release snapshot --dry-run --version 0.0.0-snapshot-oidc-pack2 --yes` passed end to end for all public `@livestore/*` packages.
- Inspected the packed CLI manifest from the dry-run tarball; it contains `bin.livestore = ./dist/bin.js` and `exports["."] = ./dist/mod.js`, confirming the npm upload path does not regress the pnpm publish manifest transform.
- `devenv tasks run lint:check:format --mode before --no-tui --show-output` passed after formatting the release command change.
- `devenv tasks run check:all --mode before --no-tui --show-output` passed locally after warming the install cache.
- CI run https://github.com/livestorejs/livestore/actions/runs/26154012075 passed all checks, including `publish-snapshot-version`.
- `publish-snapshot-version` ran on runner group `GitHub Actions` with label `ubuntu-24.04`; the validation jobs stayed off GitHub-hosted runners.
- npm registry verification passed for `@livestore/livestore@0.0.0-snapshot-636f33afe2f1cdf933594cb5bcb19bda4de6c7f3`.
- npm registry verification for `@livestore/cli@0.0.0-snapshot-636f33afe2f1cdf933594cb5bcb19bda4de6c7f3` shows `bin.livestore = dist/bin.js` and `exports["."] = ./dist/mod.js`.
- Downloaded the DevTools Chrome artifact from the same CI run and verified the zip contains the extension bundle.
- Release workflow run https://github.com/livestorejs/livestore/actions/runs/26154012079 passed `validate-release-plan`; PR-unsafe release jobs were skipped as expected.

**Complexity**

Adds one small helper to package via `pnpm pack` before `npm publish`. That is intentional complexity to keep the package-manifest contract stable while using npm's OIDC-aware publisher for the registry write.

**Concerns**

Actual snapshot publishing still depends on npm package settings: every published `@livestore/*` package must trust `livestorejs/livestore` with workflow filename `ci.yml`. If a package is missing that npm-side setting, CI should now fail directly with an actionable trusted-publishing diagnostic.

There is a related open PR, #1242, that also touches the workflow docs/generated CI files for DevTools artifact hardening. This PR is still the focused trusted-publishing fix, but whichever lands second may need a small generated-workflow/doc conflict resolution.

**Friction & Bottlenecks**

`devenv shell` still reports a local git-hooks setup failure when `core.hooksPath` is already set, but the release command continues and completed successfully. No CI capacity bottleneck introduced; only the final publish boundary is pinned to GitHub-hosted runners.

**Follow-ups**

Consider a separate design/PR for stable trusted publishing if we want to remove `NPM_TOKEN`, but it must preserve the ability to cut LiveStore releases without touching overeng.

**References**

Refs #1251.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ❄️ co2-frost |
| `agent_session_id` | e9e5f226-7818-40f6-b14c-c34c4a2da475 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | livestore-pr1251/pr-1251-hosted-links |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@75f90cf |
</details>
<!-- agent-footer:end -->

