### PR TITLE
Update effect-utils devenv stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -211,7 +211,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -227,18 +227,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -253,8 +257,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -421,7 +425,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -469,7 +473,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -485,18 +489,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -511,8 +519,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -679,7 +687,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -727,7 +735,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -743,18 +751,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -769,8 +781,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -936,7 +948,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -984,7 +996,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1000,18 +1012,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1026,8 +1042,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1191,7 +1207,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1239,7 +1255,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1255,18 +1271,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1281,8 +1301,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1456,7 +1476,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1504,7 +1524,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1520,18 +1540,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1546,8 +1570,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1769,7 +1793,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1817,7 +1841,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1833,18 +1857,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1859,8 +1887,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -2042,7 +2070,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -2090,7 +2118,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -2106,18 +2134,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -2132,8 +2164,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -2162,7 +2194,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -2210,7 +2242,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -2226,18 +2258,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -2252,8 +2288,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -2430,7 +2466,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -2478,7 +2514,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -2494,18 +2530,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -2520,8 +2560,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -2699,7 +2739,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -2747,7 +2787,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -2763,18 +2803,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -2789,8 +2833,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -2809,7 +2853,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -2857,7 +2901,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -2873,18 +2917,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -2899,8 +2947,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3078,7 +3126,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3126,7 +3174,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3142,18 +3190,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3168,8 +3220,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3190,7 +3242,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3238,7 +3290,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3254,18 +3306,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3280,8 +3336,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3455,7 +3511,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3503,7 +3559,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3519,18 +3575,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3545,8 +3605,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3565,7 +3625,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3613,7 +3673,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3629,18 +3689,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3655,8 +3719,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3675,7 +3739,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3723,7 +3787,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3739,18 +3803,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3765,8 +3833,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3786,7 +3854,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3834,7 +3902,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3850,18 +3918,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3876,8 +3948,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -3899,7 +3971,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -3947,7 +4019,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -3963,18 +4035,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -3989,8 +4065,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -4154,7 +4230,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -4202,7 +4278,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -4218,18 +4294,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -4244,8 +4324,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -4264,7 +4344,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -4312,7 +4392,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -4328,18 +4408,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -4354,8 +4438,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -4374,7 +4458,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -4422,7 +4506,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -4438,18 +4522,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -4464,8 +4552,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -4485,7 +4573,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -4533,7 +4621,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -4549,18 +4637,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -4575,8 +4667,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -4603,7 +4695,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -4651,7 +4743,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -4667,18 +4759,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -4693,8 +4789,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -241,7 +241,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -257,18 +257,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -283,8 +287,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -538,7 +542,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -586,7 +590,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -602,18 +606,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -628,8 +636,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -662,7 +670,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -710,7 +718,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -726,18 +734,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -752,8 +764,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -781,7 +793,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -829,7 +841,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -845,18 +857,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -871,8 +887,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1059,7 +1075,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1107,7 +1123,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1123,18 +1139,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1149,8 +1169,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1169,7 +1189,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1217,7 +1237,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1233,18 +1253,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1259,8 +1283,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1288,7 +1312,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1336,7 +1360,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1352,18 +1376,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1378,8 +1406,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1399,7 +1427,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1447,7 +1475,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1463,18 +1491,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1489,8 +1521,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF
@@ -1512,7 +1544,7 @@ jobs:
             local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
             local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
             local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature had_errexit
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
 
             start="$(date +%s)"
 
@@ -1560,7 +1592,7 @@ jobs:
               if [ "$rc" -eq 0 ]; then
                 echo "::notice::[ci] completed $task in $elapsed s"
                 if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from Nix GC race after retry"
+                  write_summary success "Recovered from transient Nix failure after retry"
                 else
                   write_summary success
                 fi
@@ -1576,18 +1608,22 @@ jobs:
                 tr -d '[:space:]' || true)
               saw_invalid_path=false
               saw_cachix_signature=false
+              saw_fetch_signature=false
               [ -n "$path" ] && saw_invalid_path=true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
               printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
               rm -f "$log"
 
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected Nix store validity race"
-                write_summary failure "No Nix GC race signature detected"
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
                 return "$rc"
               fi
 
-              if [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
               elif [ "$saw_cachix_signature" = true ]; then
                 echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
@@ -1602,8 +1638,8 @@ jobs:
 
             now=$(date +%s)
             elapsed=$((now - start))
-            echo "::error::Nix GC race retry exhausted for $task ($max attempts)"
-            write_summary failure "Nix GC race retry exhausted"
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
             return 1
           }
           EOF

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1779030141,
-        "narHash": "sha256-k7ssDuWTLZjTSZyE15sJ9MZ/iractZ6tY6bR+/PFYIc=",
+        "lastModified": 1779333665,
+        "narHash": "sha256-F4Ytzu05q1xytQEcnZAoKCXMNzDu5GFjs/s19MoyBME=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca",
+        "rev": "b3f33c5802fee99e74da73ebe7301f2c2490265a",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1779030141,
-        "narHash": "sha256-k7ssDuWTLZjTSZyE15sJ9MZ/iractZ6tY6bR+/PFYIc=",
+        "lastModified": 1779333665,
+        "narHash": "sha256-F4Ytzu05q1xytQEcnZAoKCXMNzDu5GFjs/s19MoyBME=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca",
+        "rev": "b3f33c5802fee99e74da73ebe7301f2c2490265a",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,8 +3,8 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "ce7cf8f8ebfaa1da6c7e9122cd195a5f95ce2fca",
+      "ref": "schickling/2026-05-21-ci-concurrency-actionlint",
+      "commit": "b3f33c5802fee99e74da73ebe7301f2c2490265a",
       "pinned": true,
       "lockedAt": "2026-05-18T06:45:33.610Z"
     },


### PR DESCRIPTION
## Summary
- pin this repo's nested effect-utils megarepo/devenv inputs to upstream follow-up PR overengineeringstudio/effect-utils#669
- regenerate Genie-owned workflow/package/config outputs with the merged devenv/CI helper stack
- keep `megarepo.lock` and `devenv.lock` in sync for the stacked validation path

## Verification
- `devenv tasks run mr:lock-sync-check genie:check --mode before --refresh-task-cache --no-tui --show-output`

## Stack
- Depends on https://github.com/overengineeringstudio/effect-utils/pull/669

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🔔 co2-bell |
| `agent_session_id` | d4fe2a2f-be5f-468e-be47-cf35c97811b7 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.129.0 |
| `agent_runtime` | Codex CLI 0.129.0 |
| `agent_model` | unknown |
| `worktree` | megarepo-all/schickling/2026-05-08-devenv |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@bff5c42 |
</details>
<!-- agent-footer:end -->