### PR TITLE
ci: enforce default refs for effect-utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -65,8 +411,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -313,6 +658,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -325,8 +1016,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -577,6 +1267,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -589,8 +1625,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -838,6 +1873,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -850,8 +2231,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -1097,6 +2477,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1109,8 +2835,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -1356,6 +3081,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1368,8 +3439,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -1659,6 +3729,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1671,8 +4087,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -1948,6 +4363,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1960,8 +4721,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -2346,6 +5106,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2358,8 +5464,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -2619,6 +5724,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2631,8 +6082,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -3015,6 +6465,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -3027,8 +6823,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -3401,6 +7196,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -3413,8 +7554,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -4120,6 +8260,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -4132,8 +8618,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -90,6 +90,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -102,8 +448,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -95,8 +441,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -397,6 +742,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -409,8 +1100,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
@@ -949,6 +1639,352 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Check first-party default refs
+        env:
+          FIRST_PARTY_OWNERS_JSON: '["overengineeringstudio"]'
+          DEFAULT_REF: main
+          DEFAULT_REFS_JSON: '{}'
+          VERIFY_REACHABLE: '1'
+          NORMALIZE_GIT_BRANCH_REFS: '1'
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs')
+          const path = require('node:path')
+          const os = require('node:os')
+          const cp = require('node:child_process')
+
+          const cwd = process.cwd()
+          const firstPartyOwners = new Set(JSON.parse(process.env.FIRST_PARTY_OWNERS_JSON).map((owner) => owner.toLowerCase()))
+          const defaultRef = process.env.DEFAULT_REF || 'main'
+          const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
+          const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const violations = []
+
+          const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
+          const isFirstParty = (repo) => firstPartyOwners.has(repo.owner.toLowerCase())
+          const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
+          const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+          const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+
+          const githubRepoFromUrl = (url) => {
+            const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
+            return match ? { owner: match[1], repo: match[2] } : undefined
+          }
+
+          const parseGithubLikeRef = (value) => {
+            const hashIndex = value.indexOf('#')
+            const baseWithQuery = hashIndex >= 0 ? value.slice(0, hashIndex) : value
+            const hashRef = hashIndex >= 0 ? value.slice(hashIndex + 1) : undefined
+            const queryIndex = baseWithQuery.indexOf('?')
+            const base = queryIndex >= 0 ? baseWithQuery.slice(0, queryIndex) : baseWithQuery
+            const params = new URLSearchParams(queryIndex >= 0 ? baseWithQuery.slice(queryIndex + 1) : '')
+            const queryRef = params.get('ref') || undefined
+
+            if (base.startsWith('github:')) {
+              const parts = base.slice('github:'.length).split('/')
+              if (parts.length < 2) return undefined
+              return {
+                repo: { owner: parts[0], repo: parts[1] },
+                ref: hashRef || queryRef || (parts.length > 2 ? parts.slice(2).join('/') : undefined),
+              }
+            }
+
+            if (base.startsWith('git+https://github.com/')) {
+              const repo = githubRepoFromUrl(base.slice('git+'.length))
+              return repo ? { repo, ref: hashRef || queryRef } : undefined
+            }
+
+            if (base.startsWith('git+ssh://git@github.com/')) {
+              const pathParts = base.slice('git+ssh://git@github.com/'.length).replace(/\.git$/, '').split('/')
+              return pathParts.length >= 2
+                ? { repo: { owner: pathParts[0], repo: pathParts[1] }, ref: hashRef || queryRef }
+                : undefined
+            }
+
+            const urlRepo = githubRepoFromUrl(base)
+            if (urlRepo) return { repo: urlRepo, ref: hashRef || queryRef }
+
+            if (!value.includes('://') && !value.startsWith('./') && !value.startsWith('../') && !value.startsWith('/')) {
+              const parts = base.split('/')
+              if (parts.length === 2 && parts[0] && parts[1]) {
+                return { repo: { owner: parts[0], repo: parts[1] }, ref: hashRef }
+              }
+            }
+
+            return undefined
+          }
+
+          const addRefViolation = ({ file, repo, ref, field, inputName, memberName }) => {
+            if (!repo || !ref || !isFirstParty(repo)) return
+            const expectedRef = expectedRefFor(repo)
+            const normalizedRef = normalizeRef(ref)
+            if (normalizedRef === expectedRef) return
+            violations.push({
+              type: 'ref',
+              file,
+              repo: repoKey(repo),
+              ref: normalizedRef,
+              expectedRef,
+              field,
+              inputName,
+              memberName,
+            })
+          }
+
+          const readJson = (file) => {
+            try {
+              return JSON.parse(fs.readFileSync(file, 'utf8'))
+            } catch {
+              return undefined
+            }
+          }
+
+          const displayPath = (file) => path.relative(cwd, file) || path.basename(file)
+          const authorityNames = new Set(['megarepo.kdl', 'megarepo.json', 'megarepo.lock', 'flake.nix', 'flake.lock', 'devenv.yaml', 'devenv.lock'])
+          const ignoredDirs = new Set(['.git', 'node_modules', 'dist', 'result', '.devenv', '.direnv', '.next', '.storybook-static'])
+
+          const collectAuthorityFiles = (root) => {
+            const files = []
+            const walk = (dir) => {
+              let entries = []
+              try {
+                entries = fs.readdirSync(dir)
+              } catch {
+                return
+              }
+              for (const entry of entries) {
+                const full = path.join(dir, entry)
+                let stat
+                try {
+                  stat = fs.statSync(full)
+                } catch {
+                  continue
+                }
+                if (stat.isDirectory()) {
+                  if (ignoredDirs.has(entry)) continue
+                  if (dir === root && entry === 'repos') continue
+                  walk(full)
+                } else if (stat.isFile() && authorityNames.has(entry)) {
+                  files.push(full)
+                }
+              }
+            }
+            walk(root)
+            return files
+          }
+
+          const extractFlakeNixInputs = (content) => {
+            const inputs = []
+            const directPattern = /(?:inputs\.)?([a-zA-Z0-9_-]+)\.url\s*=\s*"([^"]+)"/g
+            let match
+            while ((match = directPattern.exec(content)) !== null) {
+              inputs.push({ inputName: match[1], url: match[2] })
+            }
+
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            let currentInputIndent = -1
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed.startsWith('inputs = {')) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                currentInputIndent = -1
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && trimmed.startsWith('};')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              if (currentInputName && trimmed === '};' && indent <= currentInputIndent) {
+                currentInputName = undefined
+                continue
+              }
+              const inputStart = trimmed.match(/^(?:inputs\.)?([a-zA-Z0-9_-]+)\s*=\s*\{\s*$/)
+              if (inputStart && indent > inputsIndent) {
+                currentInputName = inputStart[1]
+                currentInputIndent = indent
+                continue
+              }
+              const urlMatch = trimmed.match(/^url\s*=\s*"([^"]+)"/)
+              if (currentInputName && urlMatch) inputs.push({ inputName: currentInputName, url: urlMatch[1] })
+            }
+            return inputs
+          }
+
+          const extractDevenvYamlInputs = (content) => {
+            const inputs = []
+            const lines = content.split('\n')
+            let inInputs = false
+            let inputsIndent = -1
+            let currentInputName
+            for (const line of lines) {
+              const trimmed = line.trimStart()
+              const indent = line.length - trimmed.length
+              if (trimmed === 'inputs:' && !inInputs) {
+                inInputs = true
+                inputsIndent = indent
+                currentInputName = undefined
+                continue
+              }
+              if (!inInputs) continue
+              if (trimmed && indent <= inputsIndent && !trimmed.startsWith('#')) {
+                inInputs = false
+                currentInputName = undefined
+                continue
+              }
+              const inputNameMatch = trimmed.match(/^([a-zA-Z0-9_-]+):$/)
+              if (inputNameMatch && indent > inputsIndent) {
+                currentInputName = inputNameMatch[1]
+                continue
+              }
+              const urlMatch = trimmed.match(/^url:\s*(.+)$/)
+              if (currentInputName && urlMatch) {
+                const raw = urlMatch[1].trim()
+                const url = (raw.startsWith('"') && raw.endsWith('"')) || (raw.startsWith("'") && raw.endsWith("'"))
+                  ? raw.slice(1, -1)
+                  : raw
+                inputs.push({ inputName: currentInputName, url })
+              }
+            }
+            return inputs
+          }
+
+          const lockInputs = (content) => {
+            const parsed = readJsonContent(content)
+            const rootName = parsed && (parsed.root || 'root')
+            const root = parsed && parsed.nodes && parsed.nodes[rootName]
+            if (!root || !root.inputs || !parsed.nodes) return []
+            return Object.entries(root.inputs).flatMap(([inputName, nodeName]) => {
+              const node = parsed.nodes[nodeName]
+              return node ? [{ inputName, original: node.original, locked: node.locked }] : []
+            })
+          }
+
+          const readJsonContent = (content) => {
+            try {
+              return JSON.parse(content)
+            } catch {
+              return undefined
+            }
+          }
+
+          const repoFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (section.type === 'github' && typeof section.owner === 'string' && typeof section.repo === 'string') {
+              return { owner: section.owner, repo: section.repo }
+            }
+            if (section.type === 'git' && typeof section.url === 'string') return githubRepoFromUrl(section.url)
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.repo || githubRepoFromUrl(section.url)
+            return undefined
+          }
+
+          const refFromLockSection = (section) => {
+            if (!section || typeof section !== 'object') return undefined
+            if (typeof section.ref === 'string') return section.ref
+            if (typeof section.url === 'string') return parseGithubLikeRef(section.url)?.ref
+            return undefined
+          }
+
+          const roots = [cwd]
+          const reposRoot = path.join(cwd, 'repos')
+          if (fs.existsSync(reposRoot)) {
+            for (const entry of fs.readdirSync(reposRoot)) {
+              roots.push(path.join(reposRoot, entry))
+            }
+          }
+
+          for (const root of roots) {
+            for (const file of collectAuthorityFiles(root)) {
+              const base = path.basename(file)
+              const rel = displayPath(file)
+              const content = fs.readFileSync(file, 'utf8')
+
+              if (base === 'megarepo.kdl') {
+                for (const line of content.split('\n')) {
+                  const match = line.trim().match(/^([A-Za-z0-9_.-]+)\s+"([^"]+)"/)
+                  if (!match) continue
+                  const parsed = parseGithubLikeRef(match[2])
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'members.source', memberName: match[1] })
+                }
+              } else if (base === 'megarepo.lock') {
+                const parsed = readJson(file)
+                for (const [memberName, member] of Object.entries((parsed && parsed.members) || {})) {
+                  const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+                  addRefViolation({ file: rel, repo, ref: member.ref, field: 'members.ref', memberName })
+                }
+              } else if (base === 'flake.nix') {
+                for (const input of extractFlakeNixInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'devenv.yaml') {
+                for (const input of extractDevenvYamlInputs(content)) {
+                  const parsed = parseGithubLikeRef(input.url)
+                  addRefViolation({ file: rel, repo: parsed && parsed.repo, ref: parsed && parsed.ref, field: 'url.ref', inputName: input.inputName })
+                }
+              } else if (base === 'flake.lock' || base === 'devenv.lock') {
+                for (const input of lockInputs(content)) {
+                  for (const [field, section] of [['original', input.original], ['locked', input.locked]]) {
+                    addRefViolation({ file: rel, repo: repoFromLockSection(section), ref: refFromLockSection(section), field: field + '.ref', inputName: input.inputName })
+                  }
+                }
+              }
+            }
+          }
+
+          if (verifyReachable) {
+            const lock = readJson(path.join(cwd, 'megarepo.lock'))
+            for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
+              const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
+              if (!repo || !isFirstParty(repo)) continue
+              const expectedRef = expectedRefFor(repo)
+              const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
+              const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
+              let ok = false
+              try {
+                cp.execFileSync('git', ['-C', tmp, 'init', '-q'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'remote', 'add', 'origin', remote], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'fetch', '-q', '--filter=blob:none', 'origin', 'refs/heads/' + expectedRef + ':refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'cat-file', '-e', member.commit + '^{commit}'], { stdio: 'ignore' })
+                cp.execFileSync('git', ['-C', tmp, 'merge-base', '--is-ancestor', member.commit, 'refs/remotes/origin/' + expectedRef], { stdio: 'ignore' })
+                ok = true
+              } catch {
+                ok = false
+              } finally {
+                fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+              }
+              if (!ok) {
+                violations.push({ type: 'reachability', file: 'megarepo.lock', repo: repoKey(repo), rev: member.commit, expectedRef, memberName })
+              }
+            }
+          }
+
+          if (violations.length === 0) {
+            console.log('Default ref policy OK')
+            process.exit(0)
+          }
+
+          console.error('Default ref policy failed:')
+          for (const violation of violations) {
+            if (violation.type === 'reachability') {
+              console.error('  - ' + violation.file + ': member ' + violation.memberName + ' ' + violation.repo + ' locks ' + violation.rev.slice(0, 12) + " outside '" + violation.expectedRef + "'")
+            } else {
+              const name = violation.memberName ? ' member ' + violation.memberName : violation.inputName ? ' input ' + violation.inputName : ''
+              console.error('  - ' + violation.file + ':' + name + ' ' + violation.repo + " uses ref '" + violation.ref + "' in " + violation.field + "; expected '" + violation.expectedRef + "'")
+            }
+          }
+          console.error('')
+          console.error('Fix: merge upstream PRs first, retarget first-party inputs back to their default refs, then refresh locks.')
+          process.exit(1)
+          NODE
+        shell: bash
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -961,8 +1997,7 @@ jobs:
           mkdir -p "$MEGAREPO_STORE"
           echo "Using job-local megarepo store: $MEGAREPO_STORE"
           if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s
-          ' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
           nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1779333665,
-        "narHash": "sha256-F4Ytzu05q1xytQEcnZAoKCXMNzDu5GFjs/s19MoyBME=",
+        "lastModified": 1779603561,
+        "narHash": "sha256-CBStRAdivbnhYiY3eh3KVZQGFoP8JNfKPPztzSvyJEc=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "b3f33c5802fee99e74da73ebe7301f2c2490265a",
+        "rev": "21774b60d1924e477325a8eab29a24951cbce5d6",
         "type": "github"
       },
       "original": {

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -237,6 +237,7 @@ import {
   installNixStep,
   applyMegarepoLockStep,
   checkoutStep,
+  defaultRefPolicyCheckStep,
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
   restorePnpmStateStep,
@@ -261,6 +262,13 @@ export {
 export const namespaceRunner = (runId: string) =>
   namespaceRunnerBase({ profile: 'namespace-profile-linux-x86-64', runId })
 
+const defaultRefPolicyCheckStepForGitHubRefs = () =>
+  defaultRefPolicyCheckStep({
+    firstPartyOwners: ['overengineeringstudio'],
+    normalizeGitBranchRefs: true,
+    verifyReachable: true,
+  })
+
 /**
  * Setup steps for livestore CI jobs (without checkout).
  * Uses shared step atoms from effect-utils/genie/ci-workflow.ts.
@@ -275,6 +283,7 @@ export const livestoreSetupStepsAfterCheckout = [
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
     return { ...base, with: { ...base.with, skipPush: true } }
   })(),
+  defaultRefPolicyCheckStepForGitHubRefs(),
   applyMegarepoLockStep(),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,17 +3,17 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "schickling/2026-05-21-ci-concurrency-actionlint",
-      "commit": "b3f33c5802fee99e74da73ebe7301f2c2490265a",
-      "pinned": true,
-      "lockedAt": "2026-05-18T06:45:33.610Z"
+      "ref": "main",
+      "commit": "21774b60d1924e477325a8eab29a24951cbce5d6",
+      "pinned": false,
+      "lockedAt": "2026-05-24T06:21:39.809Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",
       "ref": "main",
-      "commit": "e71ba68273026a1a2c1ace7218bdb206b0d3386d",
+      "commit": "e5998a45f69960b38eb2b8cb67cbb07b9e6962c7",
       "pinned": false,
-      "lockedAt": "2026-05-18T06:45:33.610Z"
+      "lockedAt": "2026-05-24T05:29:38.531Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- unpin Livestore's root megarepo lock back to effect-utils#main
- update devenv.lock to the same effect-utils revision so local and CI tooling agree
- add the shared default-ref policy check before megarepo apply in CI setup

## Verification
- mr fetch --apply --all -o ci-plain
- devenv update effect-utils
- devenv tasks run genie:run --mode before --no-tui --show-output
- direct default-ref policy script: current repo passes
- direct default-ref policy script: mutated stale effect-utils branch ref fails with expected diagnostics
- devenv tasks run genie:check --mode before --no-tui --show-output
- git diff --check

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌊 co3-gorge |
| `agent_session_id` | 5c075603-28d0-4b6d-ae70-857f26d20929 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.131.0 |
| `agent_runtime` | Codex CLI 0.131.0 |
| `agent_model` | unknown |
| `worktree` | livestore-default-ref-guard/schickling/default-ref-policy-guard |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4db6783 |
</details>
<!-- agent-footer:end -->