### PR TITLE
docs: add LiveStore Contributor Sync section

### DIFF
--- a/docs/src/content/docs/misc/community.mdx
+++ b/docs/src/content/docs/misc/community.mdx
@@ -30,6 +30,19 @@ You can join future office hour events [here](https://lu.ma/livestore).
   ))
 }
 
+## LiveStore Contributor Sync
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/bGF7vbjME1E"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+  style={{ aspectRatio: '16 / 9' }}
+/>
+
 ## Conference talks & podcasts
 
 - [Native-Grade Web Apps with Local-First Data (ViteConf 2025)](https://www.youtube.com/watch?v=h5Bs0vEka5U)


### PR DESCRIPTION
**Problem:** The LiveStore Contributor Sync (a recurring community sync) was not documented on the website. The first session streamed on May 28, 2026.

**Goal:** Make past and future Contributor Sync sessions discoverable from the Community page, alongside the existing Office Hours section.

**Decisions:** Placed as a sibling `##` section to "Office hours" in `community.mdx`, following the same `<iframe>` embed pattern used for Office Hours recordings.

**Verification:** `pnpm build` and `devenv tasks run check:quick` pass locally. The page renders the YouTube embed at `https://www.youtube.com/embed/bGF7vbjME1E`.

**Complexity:** No new complexity. 13-line addition following an existing pattern.

**Concerns:** None.

**Follow-ups:** Add a link to a recurring event registration (e.g. lu.ma) for future sessions if one is set up.

**References:** N/A