### PR TITLE
Fix DO-RPC streaming truncation by returning the stream-runner promise from ReadableStream.start()

### DIFF
--- a/.changeset/fix-do-rpc-server-stream-return.md
+++ b/.changeset/fix-do-rpc-server-stream-return.md
@@ -2,4 +2,4 @@
 "@livestore/common-cf": patch
 ---
 
-Fix Durable Object RPC streaming responses being truncated to the first chunk. `createStreamingResponse` now returns the stream-runner promise from `ReadableStream.start()`, so the Cloudflare runtime keeps the stream open until every chunk is enqueued and `close()` is called. Without this, the tail of any multi-chunk catchup payload could be dropped, permanently stalling a Durable-Object-as-LiveStore-client sync head (#1170).
+Fix Durable Object RPC streaming responses being truncated to the first chunk. `createStreamingResponse` now returns the stream-runner promise from `ReadableStream.start()`, so the Cloudflare runtime keeps the stream open until every chunk is enqueued and `close()` is called. Without this, the tail of any multi-chunk catchup payload could be dropped, permanently stalling a Durable-Object-as-LiveStore-client sync head (#1264, follow-up to #1170).

--- a/.changeset/fix-do-rpc-server-stream-return.md
+++ b/.changeset/fix-do-rpc-server-stream-return.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common-cf": patch
+---
+
+Fix Durable Object RPC streaming responses being truncated to the first chunk. `createStreamingResponse` now returns the stream-runner promise from `ReadableStream.start()`, so the Cloudflare runtime keeps the stream open until every chunk is enqueued and `close()` is called. Without this, the tail of any multi-chunk catchup payload could be dropped, permanently stalling a Durable-Object-as-LiveStore-client sync head (#1170).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,7 +459,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 ##### Cloudflare
 
-- Fix Durable Object RPC streaming responses being truncated to the first chunk: `createStreamingResponse` now returns the stream-runner promise from `ReadableStream.start()` so the Cloudflare runtime keeps the stream open until every chunk is enqueued and `close()` is called. Previously the tail of any multi-chunk catchup payload could be dropped, permanently stalling a DO-as-LiveStore-client sync head ([#1170](https://github.com/livestorejs/livestore/pull/1170)).
+- Fix Durable Object RPC streaming responses being truncated to the first chunk: `createStreamingResponse` now returns the stream-runner promise from `ReadableStream.start()` so the Cloudflare runtime keeps the stream open until every chunk is enqueued and `close()` is called. Previously the tail of any multi-chunk catchup payload could be dropped, permanently stalling a DO-as-LiveStore-client sync head ([#1264](https://github.com/livestorejs/livestore/pull/1264), follow-up to #1170).
 
 ##### TypeScript & Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,10 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Fix event equality check failing when args key order differs, which caused duplicate events when syncing with backends that reorder JSON keys (e.g. PostgreSQL `jsonb`) (#1160)
 - Fix event equality check failing when args use `Schema.UndefinedOr` or loose `Schema.optional` and the field is omitted at commit time, which caused the sync merge to falsely take the rebase path and trigger `MaterializerHashMismatchError` for state-dependent materializers ([#1217](https://github.com/livestorejs/livestore/issues/1217))
 
+##### Cloudflare
+
+- Fix Durable Object RPC streaming responses being truncated to the first chunk: `createStreamingResponse` now returns the stream-runner promise from `ReadableStream.start()` so the Cloudflare runtime keeps the stream open until every chunk is enqueued and `close()` is called. Previously the tail of any multi-chunk catchup payload could be dropped, permanently stalling a DO-as-LiveStore-client sync head ([#1170](https://github.com/livestorejs/livestore/pull/1170)).
+
 ##### TypeScript & Build
 
 - Fix TypeScript build issues and examples restructuring

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -290,12 +290,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
           ),
         )
 
-        // Run the stream processing.
-        //
-        // The promise MUST be returned from `start()`: the Cloudflare runtime uses it to know
-        // when the stream is done producing chunks. Without returning it, CF can tear the stream
-        // down before the 2nd+ `controller.enqueue()` calls fire, dropping the tail of any
-        // multi-chunk payload (see do-rpc stream-stall postmortem).
+        // Run the stream processing
         return runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, Effect.runPromise)
       },
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- bridging standard Web API ReadableStream to Cloudflare Worker ReadableStream type

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -290,8 +290,13 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
           ),
         )
 
-        // Run the stream processing
-        runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, Effect.runPromise)
+        // Run the stream processing.
+        //
+        // The promise MUST be returned from `start()`: the Cloudflare runtime uses it to know
+        // when the stream is done producing chunks. Without returning it, CF can tear the stream
+        // down before the 2nd+ `controller.enqueue()` calls fire, dropping the tail of any
+        // multi-chunk payload (see do-rpc stream-stall postmortem).
+        return runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, Effect.runPromise)
       },
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- bridging standard Web API ReadableStream to Cloudflare Worker ReadableStream type
     }) as any as CfTypes.ReadableStream


### PR DESCRIPTION
## Problem

When a Durable Object acts as a LiveStore client over the **DO-RPC transport**, multi-chunk streaming responses (e.g. a cold-boot catchup pull) are silently truncated to the first chunk. The client receives only the head of the payload, its sync head never advances, and synchronization stalls permanently.

The root cause is in `@livestore/common-cf`'s `do-rpc/server.ts`. `createStreamingResponse` runs the Effect stream runner **fire-and-forget** inside `ReadableStream.start()`:

```ts
// Run the stream processing
runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, Effect.runPromise)
```

The Web Streams contract lets `start()` return a promise, and the Cloudflare runtime relies on it to know when the stream is done producing chunks. Because the promise is dropped, CF can tear the stream down before the 2nd+ `controller.enqueue()` calls fire — dropping the tail of any multi-chunk payload.

## Solution

Return the promise from `start()` so the runtime keeps the stream open until every chunk is enqueued and `controller.close()` is called:

```ts
return runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, Effect.runPromise)
```

One-line behavioural fix plus an explanatory comment. No API change; preserves the existing `.flat(1)` merged-enqueue normalization from #1167.

This is the first of the two follow-ups @IGassmann invited when #1170 was closed and asked to be split into smaller PRs. It is the small, self-contained half (server framing). A separate follow-up will cover the client-side stream decoding.

## Validation

- Confirmed against the Web Streams `ReadableStream` underlying-source contract: an async `start()` returning a promise defers stream teardown until it settles.
- Behaviour matches the dist-level patch a downstream consumer (Cloudstash) has been running in production to unstick the stall.
- The existing DO-RPC streaming tests live in `packages/@livestore/common-cf/src/do-rpc/rpc.test.ts` (wrangler-based); CI exercises this path. _Note: the full wrangler suite was not run in my local sandbox (dev environment unavailable); the change is a single `return` and is covered by CI._

## Related issues

- #1170 — earlier combined attempt (closed); @IGassmann asked to split it and invited this follow-up.
- #1167 — `.flat(1)` merged-enqueue normalization (preserved here).
- #1163 — `msgpackr` → `msgpackr/index-no-eval` for CF Workers CSP (merged; unrelated to this framing fix but part of the same DO-RPC hardening effort).
