### PR TITLE
WIP: Re-export CI setup atoms for contrib composition

### DIFF
--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -256,11 +256,20 @@ export const devenvShellDefaults = {
 } as const
 export { bashShellDefaults }
 export {
+  applyMegarepoLockStep,
+  cachixCliBuildStep,
+  cachixStep,
+  checkoutStep,
   defaultActionlintConfig,
   dispatchAlignmentStep,
-  runDevenvTasksBefore,
+  installNixStep,
   nixDiagnosticsArtifactStep,
+  pnpmStateSetupStep,
+  preparePinnedDevenvStep,
+  restorePnpmStateStep,
+  runDevenvTasksBefore,
   savePnpmStateStep,
+  validateNixStoreStep,
   workflowReportCollectorStep,
   workflowReportCommentBodyStep,
   workflowReportProducerStep,


### PR DESCRIPTION
## Problem

The repo split needs `livestore-contrib` to compose CI from the same setup primitives as core, but core only exports the `livestoreSetupSteps` composite. That composite bakes in core-specific identifiers such as the `livestore` Cachix cache and pnpm state key.

## Goal

Expose the existing CI setup atoms through `genie/repo.ts` so contrib can reuse the same source of truth while choosing contrib-scoped cache/state identifiers.

## Decisions

- Re-export the existing atoms from core instead of copying effect-utils imports into contrib.
- Keep the change limited to the public genie surface; no workflow behavior changes in core.

## Verification

- Before the 0.4.0 release rebase, `devenv tasks run lint:fix:oxlint` passed.
- Before the 0.4.0 release rebase, `devenv tasks run check:quick` passed `lint:check:format`, `lint:check:oxlint`, `lint:check:lockfile`, `lint:check:genie`, `genie:run`, `mr:apply`, `mr:check`, `pnpm:install`, and `ts:check`, then failed only at `mr:lock-sync-check`.
- After rebasing onto `main`, `devenv tasks run check:quick` did not reach repo tasks because shell realization failed on a fixed-output hash mismatch in `oxc-config-pnpm-deps-czlypma8-v15-0.0.0`: specified `sha256-vtXpMCXoovDXhOGp0StGxfUdze8GLsagrJapSLrRIRc=`, got `sha256-vXbUYELGr9xnvSLU7EhN9JESrOrgbsKID9CX/E24bwA=`.
- The worktree is clean after the failed post-rebase check.

## Complexity

No new complexity. This only widens the existing export surface for already-imported helpers.

## Concerns

Post-rebase local validation is currently blocked by a fixed-output hash mismatch while realizing the shared shell. I did not change lockfiles for this PR.

## Friction & bottlenecks

- `lint:full:fix` ran the repo-wide formatter before `oxlint` failed and touched unrelated files. I discarded those formatter side effects and verified the final branch is a single-file diff.
- No bottlenecks.

## Follow-ups

- Use these exports from `livestore-contrib` CI after the bootstrap branch materializes core via megarepo.

## References

Refs #1265

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎐 co3-willow |
| `agent_session_id` | d1592577-dfdf-4274-9131-734c6cff6137 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.131.0 |
| `agent_runtime` | Codex CLI 0.131.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling-assistant/2026-06-01-genie-reexport-ci-atoms |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4db6783 |
</details>
<!-- agent-footer:end -->