### PR TITLE
Bump effect-utils to pick up #730 / #731 / #732

### DIFF
--- a/.changeset/empty-tsgolint-tsconfig-fixes.md
+++ b/.changeset/empty-tsgolint-tsconfig-fixes.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Fixes tsconfig validation errors surfaced by tsgolint 0.23.0 (pulled in via the effect-utils bump). All changes are tsconfig-only and do not affect runtime behavior.

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1779827190,
-        "narHash": "sha256-gJkTIDvppLj4hMqdFb0RaW+KONlq2ha9MyU4eI61Tqk=",
+        "lastModified": 1780338095,
+        "narHash": "sha256-kLxWEy7K5n57SCrtXl2I6KDYNxvPnsumyTywAS2Dzec=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "8c5bc8e6be49440f03b9b0bb9504264352d47bd8",
+        "rev": "5ee1fc08670b318a8eb954badec96f9106514a15",
         "type": "github"
       },
       "original": {
@@ -135,16 +135,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1780125817,
+        "narHash": "sha256-A44psESF9sRBg5kkkYwPPKcDakheLDnpwWMguKpA2xw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "cc8609d47cd9ddda67f70bd4729b0c1dfb2e7f21",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "8c5bc8e6be49440f03b9b0bb9504264352d47bd8",
+      "commit": "5ee1fc08670b318a8eb954badec96f9106514a15",
       "pinned": true,
-      "lockedAt": "2026-05-26T22:15:00.000Z"
+      "lockedAt": "2026-06-01T18:21:35.000Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/packages/@livestore/wa-sqlite/jsconfig.json
+++ b/packages/@livestore/wa-sqlite/jsconfig.json
@@ -4,7 +4,7 @@
     "checkJs": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "lib": ["DOM", "ESNext", "WebWorker"]
   },
   "typeAcquisition": {

--- a/packages/@local/astro-twoslash-code/example/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/example/tsconfig.json
@@ -26,7 +26,7 @@
     "sourceMap": true,
     "rootDir": ".",
     "outDir": "./dist",
-    "types": ["node", "@astrojs/astro-types"],
+    "types": ["node"],
     "jsx": "preserve",
     "jsxImportSource": "astro"
   },

--- a/packages/@local/astro-twoslash-code/example/tsconfig.json.genie.ts
+++ b/packages/@local/astro-twoslash-code/example/tsconfig.json.genie.ts
@@ -11,7 +11,7 @@ export default tsconfigJson({
     sourceMap: true,
     rootDir: '.',
     outDir: './dist',
-    types: ['node', '@astrojs/astro-types'],
+    types: ['node'],
     jsx: 'preserve',
     jsxImportSource: 'astro',
   },

--- a/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
@@ -39,7 +39,6 @@
       }
     ],
     "rootDir": "./",
-    "types": ["vite/client"],
     "noEmit": true
   },
   "include": ["./**/*.ts", "./**/*.tsx", "./**/*.d.ts"]

--- a/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json.genie.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json.genie.ts
@@ -8,7 +8,6 @@ export default tsconfigJson({
   compilerOptions: {
     ...baseTsconfigCompilerOptions,
     rootDir: './',
-    types: ['vite/client'],
     noEmit: true,
   },
   include: ['./**/*.ts', './**/*.tsx', './**/*.d.ts'],


### PR DESCRIPTION
## Summary

Bumps the `effect-utils` pin in `megarepo.lock` and `devenv.lock` from `8c5bc8e6` to `5ee1fc08`, picking up three merged upstream PRs.

### What this pulls in

| Upstream | Title | Effect on LiveStore |
|---|---|---|
| [effect-utils#730](https://github.com/overengineeringstudio/effect-utils/pull/730) | `injectWorkspacePackages` moved to effect-utils internal-only `commonPnpmWorkspaceData` | Resolves the regression tracked in #1271. Our local `pnpm-workspace.yaml` no longer needs to carry the workspace setting; the genie-source drift on this repo is gone. |
| [effect-utils#731](https://github.com/overengineeringstudio/effect-utils/pull/731) | Reusable `tasks.changesets` devenv module exposing `release:changeset:check-bodies` | Available for adoption. Wiring this repo to the shared module (and dropping the local duplicate task + script from #1269) will be a small follow-up once #1269 lands. |
| [effect-utils#732](https://github.com/overengineeringstudio/effect-utils/pull/732) | Sketches a shared `releaseWorkflow({...})` helper | Design-pending. No action required here. |

### Verification

- `genie:run` is a no-op against the new commit — confirmed locally. The previously latent `injectWorkspacePackages` drift in `pnpm-workspace.yaml.genie.ts` output is gone now that the upstream policy no longer ships the setting.
- Local `lint:check:genie` shows a preexisting FOD hash mismatch on `oxc-config-pnpm-deps` that exists independently of this PR and is environmental (CI on main is green). Not introduced by this change.

### What stays

The local `release:changeset:check-bodies` task + script shipped by #1269 stays in place for now. Once #1269 merges, we'll open a small follow-up to switch the import to the shared module:

```nix
imports = [ (inputs.effect-utils.devenvModules.tasks.changesets { }) ];
```

and delete the local duplicate.

### Test plan

- [ ] CI passes lint, changeset-check, full integration suite.
- [ ] Snapshot publish still works under the new effect-utils pin.

Closes #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)