### PR TITLE
Surface snapshot + docs + examples preview URLs in a managed PR comment

### DIFF
--- a/.changeset/breezy-parts-wash.md
+++ b/.changeset/breezy-parts-wash.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-No release impact. CI-only: emit a `WORKFLOW_REPORT_V1` record from the snapshot publish job and upsert a managed PR comment so contributors can copy the install command and DevTools Chrome ZIP link without digging into the workflow log. First adoption of the effect-utils workflow-reporting framework (effect-utils#724).
+No release impact. CI-only: emit `WORKFLOW_REPORT_V1` records from the snapshot publish, docs deploy, and examples deploy jobs and aggregate them into a single managed PR comment via the effect-utils workflow-reporting framework (effect-utils#724). Contributors can now grab the snapshot install command, DevTools Chrome ZIP link, docs preview URL, and per-example Cloudflare Worker preview URLs from one comment instead of digging through workflow logs.

--- a/.changeset/breezy-parts-wash.md
+++ b/.changeset/breezy-parts-wash.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. CI-only: emit a `WORKFLOW_REPORT_V1` record from the snapshot publish job and upsert a managed PR comment so contributors can copy the install command and DevTools Chrome ZIP link without digging into the workflow log. First adoption of the effect-utils workflow-reporting framework (effect-utils#724).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3723,6 +3723,59 @@ jobs:
           path: '${{ runner.temp }}/livestore-devtools-snapshot/livestore-devtools-chrome-0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}.zip'
           if-no-files-found: error
           retention-days: 14
+      - name: Emit snapshot publish workflow report
+        shell: bash
+        if: ${{ github.event_name == 'pull_request' && steps.publish-snapshot.outcome == 'success' }}
+        env:
+          WORKFLOW_REPORT_OUTPUT_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish.jsonl'
+          SNAPSHOT_VERSION: '0.0.0-snapshot-${{ github.event.pull_request.head.sha || github.sha }}'
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_PATH")"
+          created_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          record_id="snapshot-publish-${HEAD_SHA}"
+          npm_url="https://www.npmjs.com/package/@livestore/livestore/v/${SNAPSHOT_VERSION}"
+          run_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
+          install_cmd="pnpm add @livestore/livestore@${SNAPSHOT_VERSION}"
+          record_json="$(jq -cn \
+            --arg id "$record_id" \
+            --arg version "$SNAPSHOT_VERSION" \
+            --arg headSha "$HEAD_SHA" \
+            --arg runId "$RUN_ID" \
+            --arg createdAtUtc "$created_at_utc" \
+            --arg npmUrl "$npm_url" \
+            --arg runUrl "$run_url" \
+            --arg installCmd "$install_cmd" \
+            '{
+              _tag: "WorkflowReportRecord",
+              schemaVersion: 1,
+              id: $id,
+              kind: "npm-snapshot-publish",
+              subject: { id: "livestore-npm-snapshot", label: "LiveStore npm snapshot" },
+              status: "success",
+              title: ("Snapshot published as " + $version),
+              summary: ("Install with `" + $installCmd + "`"),
+              createdAtUtc: $createdAtUtc,
+              links: [
+                { label: "@livestore/livestore on npm", url: $npmUrl, primary: true },
+                { label: "Chrome devtools ZIP (workflow run artifacts)", url: $runUrl }
+              ],
+              data: { snapshotVersion: $version, headSha: $headSha, runId: $runId }
+            }')"
+          workflow_report_line="WORKFLOW_REPORT_V1: ${record_json}"
+          printf "%s\n" "$workflow_report_line"
+          printf "%s\n" "$workflow_report_line" > "$WORKFLOW_REPORT_OUTPUT_PATH"
+      - name: Upload snapshot publish workflow report
+        if: ${{ github.event_name == 'pull_request' && steps.publish-snapshot.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-publish-workflow-report
+          path: '${{ runner.temp }}/workflow-reports/snapshot-publish.jsonl'
+          if-no-files-found: error
+          retention-days: 14
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
@@ -3739,6 +3792,359 @@ jobs:
           path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
+  report-snapshot-publish:
+    if: ${{ github.event_name == 'pull_request' && needs.publish-snapshot-version.outputs.npm_snapshot_published == '1' }}
+    needs: publish-snapshot-version
+    runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
+    permissions:
+      contents: read
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+        run: |
+          EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '::error::megarepo.lock missing members["effect-utils"].commit'
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+          fi
+
+          nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
+        shell: bash
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_CONFIG_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+
+          resolve_devenv() {
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
+        shell: bash
+      - name: Download snapshot publish workflow report
+        uses: actions/download-artifact@v4
+        with:
+          name: snapshot-publish-workflow-report
+          path: '${{ runner.temp }}/workflow-reports/snapshot-publish-download'
+      - name: Collect workflow report bundle
+        shell: bash
+        env:
+          WORKFLOW_REPORT_BUNDLE_ID: snapshot-publish
+          WORKFLOW_REPORT_INPUT_PATHS_JSON: '["${{ runner.temp }}/workflow-reports/snapshot-publish-download/snapshot-publish.jsonl"]'
+          WORKFLOW_REPORT_OUTPUT_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
+          WORKFLOW_REPORT_RECORD_MARKER: 'WORKFLOW_REPORT_V1: '
+          WORKFLOW_REPORT_ALLOW_MISSING_INPUT: '0'
+        run: |
+          if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
+            if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
+              export WORKFLOW_REPORT_RUNTIME_MODULE=packages/@overeng/genie/src/runtime/mod.ts
+            elif [ -f repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts ]; then
+              export WORKFLOW_REPORT_RUNTIME_MODULE=repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts
+            else
+              echo "::error::unable to locate @overeng/genie runtime module for workflow reports"
+              exit 1
+            fi
+          fi
+          cat > /tmp/collect-workflow-report-bundle.mjs <<'EOF'
+          import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+          import { dirname, resolve } from 'node:path'
+          import { pathToFileURL } from 'node:url'
+
+          const runtimeModule = process.env.WORKFLOW_REPORT_RUNTIME_MODULE
+          if (typeof runtimeModule !== "string" || runtimeModule.length === 0) throw new Error("WORKFLOW_REPORT_RUNTIME_MODULE is required")
+          const { collectWorkflowReportBundle, encodeWorkflowReportBundleJson } = await import(pathToFileURL(resolve(runtimeModule)).href)
+
+          const expectString = (value, path) =>
+            typeof value === "string" && value.length > 0 ? value : (() => { throw new Error(`${path} must be a non-empty string`) })()
+
+          const marker = expectString(process.env.WORKFLOW_REPORT_RECORD_MARKER, "WORKFLOW_REPORT_RECORD_MARKER")
+          const inputPaths = JSON.parse(expectString(process.env.WORKFLOW_REPORT_INPUT_PATHS_JSON, "WORKFLOW_REPORT_INPUT_PATHS_JSON"))
+          const outputPath = expectString(process.env.WORKFLOW_REPORT_OUTPUT_PATH, "WORKFLOW_REPORT_OUTPUT_PATH")
+          const bundleId = expectString(process.env.WORKFLOW_REPORT_BUNDLE_ID, "WORKFLOW_REPORT_BUNDLE_ID")
+          const allowMissingInput = process.env.WORKFLOW_REPORT_ALLOW_MISSING_INPUT === "1"
+
+          const sources = []
+          for (const path of inputPaths) {
+            if (!existsSync(path)) {
+              if (allowMissingInput) continue
+              throw new Error(`workflow report input file does not exist: ${path}`)
+            }
+            sources.push(readFileSync(path, "utf8"))
+          }
+
+          const bundle = collectWorkflowReportBundle({ bundleId, generatedAtUtc: new Date().toISOString(), sources, marker })
+
+          mkdirSync(dirname(outputPath), { recursive: true })
+          writeFileSync(outputPath, encodeWorkflowReportBundleJson(bundle))
+          EOF
+          nix run nixpkgs#bun -- /tmp/collect-workflow-report-bundle.mjs
+      - name: Render workflow report comment
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          WORKFLOW_REPORT_BUNDLE_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
+          WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
+          WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
+          WORKFLOW_REPORT_TITLE: Snapshot release
+          WORKFLOW_REPORT_NO_RECORDS_MESSAGE: No snapshot release was published for this commit.
+          WORKFLOW_REPORT_STATE_ID: snapshot-publish
+          WORKFLOW_REPORT_ENTRY_ID: ${{ github.event.pull_request.head.sha || github.sha }}
+          WORKFLOW_REPORT_ENTRY_LABEL: 'PR ${{ github.event.pull_request.number }}'
+          WORKFLOW_REPORT_CREATED_AT_UTC: ''
+          WORKFLOW_REPORT_TIME_ZONE: UTC
+          WORKFLOW_REPORT_MANAGED_MARKER: '<!-- workflow-report:managed -->'
+        run: |
+          if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
+            if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
+              export WORKFLOW_REPORT_RUNTIME_MODULE=packages/@overeng/genie/src/runtime/mod.ts
+            elif [ -f repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts ]; then
+              export WORKFLOW_REPORT_RUNTIME_MODULE=repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts
+            else
+              echo "::error::unable to locate @overeng/genie runtime module for workflow reports"
+              exit 1
+            fi
+          fi
+          comments_json="$(mktemp)"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
+            nix run nixpkgs#gh -- api "repos/$GH_REPO/issues/${{ github.event.pull_request.number }}/comments" --paginate > "$comments_json"
+          else
+            printf '[]' > "$comments_json"
+          fi
+
+          nix run nixpkgs#bun -- - "$comments_json" <<'EOF'
+          import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+          import { dirname, resolve } from 'node:path'
+          import { pathToFileURL } from 'node:url'
+
+          const [commentsPath] = process.argv.slice(2)
+          const runtimeModule = process.env.WORKFLOW_REPORT_RUNTIME_MODULE
+          if (typeof runtimeModule !== "string" || runtimeModule.length === 0) throw new Error("WORKFLOW_REPORT_RUNTIME_MODULE is required")
+          const {
+            decodeWorkflowReportBundleJson,
+            deriveWorkflowReportManagedState,
+            findWorkflowReportManagedComment,
+            renderWorkflowReportCommentBody,
+          } = await import(pathToFileURL(resolve(runtimeModule)).href)
+
+          const expectString = (value, path) =>
+            typeof value === "string" && value.length > 0 ? value : (() => { throw new Error(`${path} must be a non-empty string`) })()
+
+          const optionalString = (value) => (typeof value === "string" && value.length > 0 ? value : undefined)
+          const latestCreatedAtUtc = (records, fallback) =>
+            records.reduce((latest, record) => (record.createdAtUtc > latest ? record.createdAtUtc : latest), fallback)
+
+          const bundlePath = expectString(process.env.WORKFLOW_REPORT_BUNDLE_PATH, "WORKFLOW_REPORT_BUNDLE_PATH")
+          const commentBodyPath = expectString(process.env.WORKFLOW_REPORT_COMMENT_BODY_PATH, "WORKFLOW_REPORT_COMMENT_BODY_PATH")
+          const summaryPath = expectString(process.env.WORKFLOW_REPORT_SUMMARY_PATH, "WORKFLOW_REPORT_SUMMARY_PATH")
+          const title = expectString(process.env.WORKFLOW_REPORT_TITLE, "WORKFLOW_REPORT_TITLE")
+          const noRecordsMessage = expectString(process.env.WORKFLOW_REPORT_NO_RECORDS_MESSAGE, "WORKFLOW_REPORT_NO_RECORDS_MESSAGE")
+          const stateId = expectString(process.env.WORKFLOW_REPORT_STATE_ID, "WORKFLOW_REPORT_STATE_ID")
+          const entryId = expectString(process.env.WORKFLOW_REPORT_ENTRY_ID, "WORKFLOW_REPORT_ENTRY_ID")
+          const entryLabel = expectString(process.env.WORKFLOW_REPORT_ENTRY_LABEL, "WORKFLOW_REPORT_ENTRY_LABEL")
+          const timeZone = expectString(process.env.WORKFLOW_REPORT_TIME_ZONE, "WORKFLOW_REPORT_TIME_ZONE")
+          const marker = expectString(process.env.WORKFLOW_REPORT_MANAGED_MARKER, "WORKFLOW_REPORT_MANAGED_MARKER")
+
+          const bundle = decodeWorkflowReportBundleJson(readFileSync(bundlePath, "utf8"))
+          const comments = JSON.parse(readFileSync(commentsPath, "utf8"))
+          if (!Array.isArray(comments)) throw new Error("comments response must be an array")
+
+          const existingComment = findWorkflowReportManagedComment(comments, { stateId, marker })
+          const createdAtUtc = optionalString(process.env.WORKFLOW_REPORT_CREATED_AT_UTC) ?? latestCreatedAtUtc(bundle.records, bundle.generatedAtUtc)
+          const state = deriveWorkflowReportManagedState({
+            stateId,
+            timeZone,
+            priorState: existingComment?.state,
+            entryId,
+            entryLabel,
+            createdAtUtc,
+            records: bundle.records,
+          })
+          const body = renderWorkflowReportCommentBody({ title, noRecordsMessage, state })
+          const markerIndex = body.indexOf(marker)
+          const visibleBody = markerIndex === -1 ? body : `${body.slice(0, markerIndex).trimEnd()}\n`
+
+          mkdirSync(dirname(commentBodyPath), { recursive: true })
+          mkdirSync(dirname(summaryPath), { recursive: true })
+          writeFileSync(commentBodyPath, body)
+          writeFileSync(summaryPath, visibleBody)
+          EOF
+      - name: Publish workflow report
+        if: always() && !cancelled()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          WORKFLOW_REPORT_STATE_ID: snapshot-publish
+          WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
+          WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
+          WORKFLOW_REPORT_MANAGED_MARKER: '<!-- workflow-report:managed -->'
+        run: |
+          if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
+            if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
+              export WORKFLOW_REPORT_RUNTIME_MODULE=packages/@overeng/genie/src/runtime/mod.ts
+            elif [ -f repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts ]; then
+              export WORKFLOW_REPORT_RUNTIME_MODULE=repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts
+            else
+              echo "::error::unable to locate @overeng/genie runtime module for workflow reports"
+              exit 1
+            fi
+          fi
+          if [ -s "$WORKFLOW_REPORT_SUMMARY_PATH" ]; then
+            cat "$WORKFLOW_REPORT_SUMMARY_PATH" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            exit 0
+          fi
+
+          if [ ! -s "$WORKFLOW_REPORT_COMMENT_BODY_PATH" ]; then
+            echo "::notice::workflow report comment body is empty; skipping PR comment"
+            exit 0
+          fi
+
+          comments_json="$(mktemp)"
+          comment_id_file="$(mktemp)"
+          export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
+          nix run nixpkgs#gh -- api "repos/$GH_REPO/issues/${{ github.event.pull_request.number }}/comments" --paginate > "$comments_json"
+          nix run nixpkgs#bun -- - "$comments_json" "$comment_id_file" <<'EOF'
+          import { readFileSync, writeFileSync } from 'node:fs'
+          import { resolve } from 'node:path'
+          import { pathToFileURL } from 'node:url'
+
+          const [commentsPath, commentIdPath] = process.argv.slice(2)
+          const runtimeModule = process.env.WORKFLOW_REPORT_RUNTIME_MODULE
+          if (typeof runtimeModule !== "string" || runtimeModule.length === 0) throw new Error("WORKFLOW_REPORT_RUNTIME_MODULE is required")
+          const { extractWorkflowReportManagedState, findWorkflowReportManagedComment } = await import(pathToFileURL(resolve(runtimeModule)).href)
+          const stateId = process.env.WORKFLOW_REPORT_STATE_ID
+          if (typeof stateId !== "string" || stateId.length === 0) throw new Error("WORKFLOW_REPORT_STATE_ID is required")
+          const marker = process.env.WORKFLOW_REPORT_MANAGED_MARKER
+          if (typeof marker !== "string" || marker.length === 0) throw new Error("WORKFLOW_REPORT_MANAGED_MARKER is required")
+          const commentBodyPath = process.env.WORKFLOW_REPORT_COMMENT_BODY_PATH
+          if (typeof commentBodyPath !== "string" || commentBodyPath.length === 0) throw new Error("WORKFLOW_REPORT_COMMENT_BODY_PATH is required")
+          const targetState = extractWorkflowReportManagedState(readFileSync(commentBodyPath, "utf8"), { stateId })
+          if (targetState === undefined) throw new Error("workflow report comment body is missing managed state")
+          const comments = JSON.parse(readFileSync(commentsPath, "utf8"))
+          if (!Array.isArray(comments)) throw new Error("comments response must be an array")
+          const existingComment = findWorkflowReportManagedComment(comments, { stateId: targetState.stateId, marker })
+          writeFileSync(commentIdPath, existingComment?.id ?? "")
+          EOF
+
+          comment_id="$(cat "$comment_id_file")"
+          if [ -n "$comment_id" ]; then
+            nix run nixpkgs#gh -- api \
+              --method PATCH \
+              "repos/$GH_REPO/issues/comments/$comment_id" \
+              --field body=@"$WORKFLOW_REPORT_COMMENT_BODY_PATH" >/dev/null
+          else
+            nix run nixpkgs#gh -- pr comment "${{ github.event.pull_request.number }}" --body-file "$WORKFLOW_REPORT_COMMENT_BODY_PATH"
+          fi
   build-and-deploy-examples-src:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3792,9 +3792,9 @@ jobs:
           path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
-  report-snapshot-publish:
-    if: ${{ github.event_name == 'pull_request' && needs.publish-snapshot-version.outputs.npm_snapshot_published == '1' }}
-    needs: publish-snapshot-version
+  report-pr-preview:
+    if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+    needs: [publish-snapshot-version, build-deploy-docs, build-and-deploy-examples-src]
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     permissions:
       contents: read
@@ -3927,18 +3927,34 @@ jobs:
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
         shell: bash
       - name: Download snapshot publish workflow report
+        if: ${{ needs.publish-snapshot-version.outputs.npm_snapshot_published == '1' }}
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: snapshot-publish-workflow-report
           path: '${{ runner.temp }}/workflow-reports/snapshot-publish-download'
+      - name: Download docs deploy workflow report
+        if: ${{ needs.build-deploy-docs.result == 'success' }}
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: docs-deploy-workflow-report
+          path: '${{ runner.temp }}/workflow-reports/docs-deploy-download'
+      - name: Download examples deploy workflow report
+        if: ${{ needs.build-and-deploy-examples-src.result == 'success' }}
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: examples-deploy-workflow-report
+          path: '${{ runner.temp }}/workflow-reports/examples-deploy-download'
       - name: Collect workflow report bundle
         shell: bash
         env:
-          WORKFLOW_REPORT_BUNDLE_ID: snapshot-publish
-          WORKFLOW_REPORT_INPUT_PATHS_JSON: '["${{ runner.temp }}/workflow-reports/snapshot-publish-download/snapshot-publish.jsonl"]'
-          WORKFLOW_REPORT_OUTPUT_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
+          WORKFLOW_REPORT_BUNDLE_ID: pr-preview
+          WORKFLOW_REPORT_INPUT_PATHS_JSON: '["${{ runner.temp }}/workflow-reports/snapshot-publish-download/snapshot-publish.jsonl","${{ runner.temp }}/workflow-reports/docs-deploy-download/docs-deploy.jsonl","${{ runner.temp }}/workflow-reports/examples-deploy-download/examples-deploy.jsonl"]'
+          WORKFLOW_REPORT_OUTPUT_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-bundle.json'
           WORKFLOW_REPORT_RECORD_MARKER: 'WORKFLOW_REPORT_V1: '
-          WORKFLOW_REPORT_ALLOW_MISSING_INPUT: '0'
+          WORKFLOW_REPORT_ALLOW_MISSING_INPUT: '1'
         run: |
           if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
             if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
@@ -3988,12 +4004,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          WORKFLOW_REPORT_BUNDLE_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
-          WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
-          WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
-          WORKFLOW_REPORT_TITLE: Snapshot release
-          WORKFLOW_REPORT_NO_RECORDS_MESSAGE: No snapshot release was published for this commit.
-          WORKFLOW_REPORT_STATE_ID: snapshot-publish
+          WORKFLOW_REPORT_BUNDLE_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-bundle.json'
+          WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-comment.md'
+          WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-summary.md'
+          WORKFLOW_REPORT_TITLE: PR preview
+          WORKFLOW_REPORT_NO_RECORDS_MESSAGE: No previews or snapshot were published for this commit.
+          WORKFLOW_REPORT_STATE_ID: pr-preview
           WORKFLOW_REPORT_ENTRY_ID: ${{ github.event.pull_request.head.sha || github.sha }}
           WORKFLOW_REPORT_ENTRY_LABEL: 'PR ${{ github.event.pull_request.number }}'
           WORKFLOW_REPORT_CREATED_AT_UTC: ''
@@ -4081,9 +4097,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          WORKFLOW_REPORT_STATE_ID: snapshot-publish
-          WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
-          WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
+          WORKFLOW_REPORT_STATE_ID: pr-preview
+          WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-comment.md'
+          WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-summary.md'
           WORKFLOW_REPORT_MANAGED_MARKER: '<!-- workflow-report:managed -->'
         run: |
           if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
@@ -4616,9 +4632,11 @@ jobs:
           . "$__nix_gc_retry_helper"
           rm -f "$__nix_gc_retry_helper"
           run_nix_gc_race_retry 'devenv tasks run examples:test --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run examples:test --mode before'
-      - name: Deploy examples to Cloudflare
+      - id: deploy-examples
+        name: Deploy examples to Cloudflare
         if: github.event.pull_request.head.repo.fork != true
         run: |
+          mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
           #!/usr/bin/env bash
@@ -4734,6 +4752,15 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKFLOW_REPORT_OUTPUT_FILE: '${{ runner.temp }}/workflow-reports/examples-deploy.jsonl'
+      - name: Upload examples deploy workflow report
+        if: ${{ github.event_name == 'pull_request' && steps.deploy-examples.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: examples-deploy-workflow-report
+          path: '${{ runner.temp }}/workflow-reports/examples-deploy.jsonl'
+          if-no-files-found: warn
+          retention-days: 14
       - name: Validate hosted example links
         run: |
           __nix_gc_retry_helper=$(mktemp)
@@ -5457,9 +5484,11 @@ jobs:
           name: docs-build-logs
           path: tmp/ci-docs/
           retention-days: 14
-      - name: Deploy docs
+      - id: deploy-docs
+        name: Deploy docs
         if: ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true) }}
         run: |
+          mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"
           __nix_gc_retry_helper=$(mktemp)
           cat > "$__nix_gc_retry_helper" <<'EOF'
           #!/usr/bin/env bash
@@ -5574,6 +5603,15 @@ jobs:
           run_nix_gc_race_retry 'devenv tasks run docs:deploy --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:deploy --mode before'
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          WORKFLOW_REPORT_OUTPUT_FILE: '${{ runner.temp }}/workflow-reports/docs-deploy.jsonl'
+      - name: Upload docs deploy workflow report
+        if: ${{ github.event_name == 'pull_request' && steps.deploy-docs.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-deploy-workflow-report
+          path: '${{ runner.temp }}/workflow-reports/docs-deploy.jsonl'
+          if-no-files-found: warn
+          retention-days: 14
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -45,8 +45,7 @@ const SNAPSHOT_REPORT_ARTIFACT_NAME = 'snapshot-publish-workflow-report'
 const SNAPSHOT_REPORT_RECORD_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish.jsonl'
 const SNAPSHOT_REPORT_DOWNLOAD_DIR = '${{ runner.temp }}/workflow-reports/snapshot-publish-download'
 const SNAPSHOT_REPORT_BUNDLE_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
-const SNAPSHOT_REPORT_COMMENT_BODY_PATH =
-  '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
+const SNAPSHOT_REPORT_COMMENT_BODY_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
 const SNAPSHOT_REPORT_SUMMARY_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
 
 /**
@@ -105,7 +104,7 @@ const emitSnapshotPublishReportStep = {
     '      { label: "Chrome devtools ZIP (workflow run artifacts)", url: $runUrl }',
     '    ],',
     '    data: { snapshotVersion: $version, headSha: $headSha, runId: $runId }',
-    "  }')\"",
+    '  }\')"',
     'workflow_report_line="WORKFLOW_REPORT_V1: ${record_json}"',
     'printf "%s\\n" "$workflow_report_line"',
     'printf "%s\\n" "$workflow_report_line" > "$WORKFLOW_REPORT_OUTPUT_PATH"',

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -30,23 +30,36 @@ const DLX_ALLOW_BUILD_FLAGS = repoPnpmOnlyBuiltDependencies.map((name) => `--all
 const PNPM_ADD_ALLOW_BUILD_FLAGS = repoPnpmOnlyBuiltDependencies.map((name) => `--allow-build=${name}`).join(' ')
 
 // =============================================================================
-// Snapshot Publish Workflow Report
+// PR Preview Workflow Report
 // =============================================================================
 
 /**
- * Surface the snapshot publish outcome as a managed PR comment so contributors
- * can copy the install command + Chrome devtools artifact link without digging
- * into the workflow log. The producer step writes a single JSONL record in the
- * publish job; the dedicated reporting job collects it from an artifact and
- * upserts the PR comment.
+ * Surface PR-time deploy/publish outcomes (npm snapshot, docs preview, examples
+ * previews) as a single managed PR comment. Each producer job writes one or
+ * more JSONL records to its own artifact; the dedicated `report-pr-preview`
+ * job aggregates every artifact into one bundle and upserts the comment.
+ *
+ * Records are deduped by `subject.id` downstream, so each producer owns a
+ * stable subject (`livestore-npm-snapshot`, `livestore-docs-preview`,
+ * `livestore-example-<slug>`) and contributors see the latest URL per surface.
  */
-const SNAPSHOT_REPORT_STATE_ID = 'snapshot-publish'
+const PR_PREVIEW_REPORT_STATE_ID = 'pr-preview'
+
 const SNAPSHOT_REPORT_ARTIFACT_NAME = 'snapshot-publish-workflow-report'
 const SNAPSHOT_REPORT_RECORD_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish.jsonl'
 const SNAPSHOT_REPORT_DOWNLOAD_DIR = '${{ runner.temp }}/workflow-reports/snapshot-publish-download'
-const SNAPSHOT_REPORT_BUNDLE_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
-const SNAPSHOT_REPORT_COMMENT_BODY_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
-const SNAPSHOT_REPORT_SUMMARY_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
+
+const DOCS_REPORT_ARTIFACT_NAME = 'docs-deploy-workflow-report'
+const DOCS_REPORT_RECORD_PATH = '${{ runner.temp }}/workflow-reports/docs-deploy.jsonl'
+const DOCS_REPORT_DOWNLOAD_DIR = '${{ runner.temp }}/workflow-reports/docs-deploy-download'
+
+const EXAMPLES_REPORT_ARTIFACT_NAME = 'examples-deploy-workflow-report'
+const EXAMPLES_REPORT_RECORD_PATH = '${{ runner.temp }}/workflow-reports/examples-deploy.jsonl'
+const EXAMPLES_REPORT_DOWNLOAD_DIR = '${{ runner.temp }}/workflow-reports/examples-deploy-download'
+
+const PR_PREVIEW_REPORT_BUNDLE_PATH = '${{ runner.temp }}/workflow-reports/pr-preview-bundle.json'
+const PR_PREVIEW_REPORT_COMMENT_BODY_PATH = '${{ runner.temp }}/workflow-reports/pr-preview-comment.md'
+const PR_PREVIEW_REPORT_SUMMARY_PATH = '${{ runner.temp }}/workflow-reports/pr-preview-summary.md'
 
 /**
  * Emit the snapshot publish report as a single JSONL line at runtime.
@@ -469,14 +482,15 @@ done`,
     },
 
     /**
-     * Aggregate the snapshot publish workflow report and upsert the managed PR
-     * comment. Runs after `publish-snapshot-version` so a failed publish leaves
-     * the existing comment (if any) untouched rather than overwriting it with a
-     * stale success record.
+     * Aggregate every PR-time deploy/publish workflow report and upsert a
+     * single managed PR comment. Runs after the snapshot/docs/examples jobs so
+     * all producer artifacts are available; individual artifacts are allowed to
+     * be missing (e.g. snapshot is skipped on forks) so the comment still
+     * publishes whatever subset succeeded.
      */
-    'report-snapshot-publish': {
-      if: `\${{ github.event_name == 'pull_request' && needs.publish-snapshot-version.outputs.npm_snapshot_published == '1' }}`,
-      needs: 'publish-snapshot-version',
+    'report-pr-preview': {
+      if: `\${{ github.event_name == 'pull_request' && !cancelled() }}`,
+      needs: ['publish-snapshot-version', 'build-deploy-docs', 'build-and-deploy-examples-src'],
       ...namespaceRunnerConfig,
       permissions: {
         contents: 'read',
@@ -487,31 +501,58 @@ done`,
         ...livestoreSetupSteps,
         {
           name: 'Download snapshot publish workflow report',
+          if: `\${{ needs.publish-snapshot-version.outputs.npm_snapshot_published == '1' }}`,
           uses: 'actions/download-artifact@v4',
+          'continue-on-error': true,
           with: {
             name: SNAPSHOT_REPORT_ARTIFACT_NAME,
             path: SNAPSHOT_REPORT_DOWNLOAD_DIR,
           },
         },
+        {
+          name: 'Download docs deploy workflow report',
+          if: `\${{ needs.build-deploy-docs.result == 'success' }}`,
+          uses: 'actions/download-artifact@v4',
+          'continue-on-error': true,
+          with: {
+            name: DOCS_REPORT_ARTIFACT_NAME,
+            path: DOCS_REPORT_DOWNLOAD_DIR,
+          },
+        },
+        {
+          name: 'Download examples deploy workflow report',
+          if: `\${{ needs.build-and-deploy-examples-src.result == 'success' }}`,
+          uses: 'actions/download-artifact@v4',
+          'continue-on-error': true,
+          with: {
+            name: EXAMPLES_REPORT_ARTIFACT_NAME,
+            path: EXAMPLES_REPORT_DOWNLOAD_DIR,
+          },
+        },
         workflowReportCollectorStep({
-          bundleId: 'snapshot-publish',
-          inputPaths: [`${SNAPSHOT_REPORT_DOWNLOAD_DIR}/snapshot-publish.jsonl`],
-          outputPath: SNAPSHOT_REPORT_BUNDLE_PATH,
+          bundleId: 'pr-preview',
+          inputPaths: [
+            `${SNAPSHOT_REPORT_DOWNLOAD_DIR}/snapshot-publish.jsonl`,
+            `${DOCS_REPORT_DOWNLOAD_DIR}/docs-deploy.jsonl`,
+            `${EXAMPLES_REPORT_DOWNLOAD_DIR}/examples-deploy.jsonl`,
+          ],
+          outputPath: PR_PREVIEW_REPORT_BUNDLE_PATH,
+          allowMissingInput: true,
         }),
         workflowReportCommentBodyStep({
-          bundlePath: SNAPSHOT_REPORT_BUNDLE_PATH,
-          commentBodyPath: SNAPSHOT_REPORT_COMMENT_BODY_PATH,
-          summaryPath: SNAPSHOT_REPORT_SUMMARY_PATH,
-          title: 'Snapshot release',
-          noRecordsMessage: 'No snapshot release was published for this commit.',
-          stateId: SNAPSHOT_REPORT_STATE_ID,
+          bundlePath: PR_PREVIEW_REPORT_BUNDLE_PATH,
+          commentBodyPath: PR_PREVIEW_REPORT_COMMENT_BODY_PATH,
+          summaryPath: PR_PREVIEW_REPORT_SUMMARY_PATH,
+          title: 'PR preview',
+          noRecordsMessage: 'No previews or snapshot were published for this commit.',
+          stateId: PR_PREVIEW_REPORT_STATE_ID,
           entryId: PR_HEAD_SHA,
           entryLabel: `PR \${{ github.event.pull_request.number }}`,
         }),
         workflowReportPublisherStep({
-          commentBodyPath: SNAPSHOT_REPORT_COMMENT_BODY_PATH,
-          summaryPath: SNAPSHOT_REPORT_SUMMARY_PATH,
-          stateId: SNAPSHOT_REPORT_STATE_ID,
+          commentBodyPath: PR_PREVIEW_REPORT_COMMENT_BODY_PATH,
+          summaryPath: PR_PREVIEW_REPORT_SUMMARY_PATH,
+          stateId: PR_PREVIEW_REPORT_STATE_ID,
         }),
       ],
     },
@@ -531,12 +572,28 @@ done`,
         },
         { name: 'Test examples', run: runDevenvTasksBefore('examples:test') },
         {
+          id: 'deploy-examples',
           name: 'Deploy examples to Cloudflare',
           if: IS_NOT_FORK,
-          run: runDevenvTasksBefore('examples:deploy'),
+          run: [
+            'mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"',
+            runDevenvTasksBefore('examples:deploy'),
+          ].join('\n'),
           env: {
             CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}',
             CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}',
+            WORKFLOW_REPORT_OUTPUT_FILE: EXAMPLES_REPORT_RECORD_PATH,
+          },
+        },
+        {
+          name: 'Upload examples deploy workflow report',
+          if: `\${{ github.event_name == 'pull_request' && steps.deploy-examples.outcome == 'success' }}`,
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: EXAMPLES_REPORT_ARTIFACT_NAME,
+            path: EXAMPLES_REPORT_RECORD_PATH,
+            'if-no-files-found': 'warn',
+            'retention-days': 14,
           },
         },
         {
@@ -601,10 +658,28 @@ done`,
           },
         },
         {
+          id: 'deploy-docs',
           name: 'Deploy docs',
           if: `\${{ success() && (github.event_name != 'pull_request' || ${IS_NOT_FORK}) }}`,
-          run: runDevenvTasksBefore('docs:deploy'),
-          env: { NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}' },
+          run: [
+            'mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"',
+            runDevenvTasksBefore('docs:deploy'),
+          ].join('\n'),
+          env: {
+            NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}',
+            WORKFLOW_REPORT_OUTPUT_FILE: DOCS_REPORT_RECORD_PATH,
+          },
+        },
+        {
+          name: 'Upload docs deploy workflow report',
+          if: `\${{ github.event_name == 'pull_request' && steps.deploy-docs.outcome == 'success' }}`,
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: DOCS_REPORT_ARTIFACT_NAME,
+            path: DOCS_REPORT_RECORD_PATH,
+            'if-no-files-found': 'warn',
+            'retention-days': 14,
+          },
         },
       ]),
     },

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -575,10 +575,9 @@ done`,
           id: 'deploy-examples',
           name: 'Deploy examples to Cloudflare',
           if: IS_NOT_FORK,
-          run: [
-            'mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"',
-            runDevenvTasksBefore('examples:deploy'),
-          ].join('\n'),
+          run: ['mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"', runDevenvTasksBefore('examples:deploy')].join(
+            '\n',
+          ),
           env: {
             CLOUDFLARE_API_TOKEN: '${{ secrets.CLOUDFLARE_API_TOKEN }}',
             CLOUDFLARE_ACCOUNT_ID: '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}',
@@ -661,10 +660,7 @@ done`,
           id: 'deploy-docs',
           name: 'Deploy docs',
           if: `\${{ success() && (github.event_name != 'pull_request' || ${IS_NOT_FORK}) }}`,
-          run: [
-            'mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"',
-            runDevenvTasksBefore('docs:deploy'),
-          ].join('\n'),
+          run: ['mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_FILE")"', runDevenvTasksBefore('docs:deploy')].join('\n'),
           env: {
             NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}',
             WORKFLOW_REPORT_OUTPUT_FILE: DOCS_REPORT_RECORD_PATH,

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -13,6 +13,10 @@ import {
   repoPnpmOnlyBuiltDependencies,
   runDevenvTasksBefore,
   savePnpmStateStep,
+  workflowReportCollectorStep,
+  workflowReportCommentBodyStep,
+  workflowReportProducerStep,
+  workflowReportPublisherStep,
 } from '../../genie/repo.ts'
 
 // =============================================================================
@@ -24,6 +28,89 @@ const PR_HEAD_SHA = '${{ github.event.pull_request.head.sha || github.sha }}'
 const IS_NOT_FORK = 'github.event.pull_request.head.repo.fork != true'
 const DLX_ALLOW_BUILD_FLAGS = repoPnpmOnlyBuiltDependencies.map((name) => `--allow-build=${name}`).join(' ')
 const PNPM_ADD_ALLOW_BUILD_FLAGS = repoPnpmOnlyBuiltDependencies.map((name) => `--allow-build=${name}`).join(' ')
+
+// =============================================================================
+// Snapshot Publish Workflow Report
+// =============================================================================
+
+/**
+ * Surface the snapshot publish outcome as a managed PR comment so contributors
+ * can copy the install command + Chrome devtools artifact link without digging
+ * into the workflow log. The producer step writes a single JSONL record in the
+ * publish job; the dedicated reporting job collects it from an artifact and
+ * upserts the PR comment.
+ */
+const SNAPSHOT_REPORT_STATE_ID = 'snapshot-publish'
+const SNAPSHOT_REPORT_ARTIFACT_NAME = 'snapshot-publish-workflow-report'
+const SNAPSHOT_REPORT_RECORD_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish.jsonl'
+const SNAPSHOT_REPORT_DOWNLOAD_DIR = '${{ runner.temp }}/workflow-reports/snapshot-publish-download'
+const SNAPSHOT_REPORT_BUNDLE_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-bundle.json'
+const SNAPSHOT_REPORT_COMMENT_BODY_PATH =
+  '${{ runner.temp }}/workflow-reports/snapshot-publish-comment.md'
+const SNAPSHOT_REPORT_SUMMARY_PATH = '${{ runner.temp }}/workflow-reports/snapshot-publish-summary.md'
+
+/**
+ * Emit the snapshot publish report as a single JSONL line at runtime.
+ *
+ * `workflowReportProducerStep` from effect-utils validates the record at genie
+ * codegen time, which forces every field to a literal value before GitHub
+ * Actions has a chance to interpolate. The `createdAtUtc` ISO timestamp is the
+ * one piece we genuinely need at runtime, so we build the record inline with
+ * `jq` (mirroring the canonical `netlifyDeployStep` pattern in effect-utils).
+ *
+ * The bash payload writes the JSONL line to the agreed shared output path so
+ * the dedicated `report-snapshot-publish` job can collect it from an uploaded
+ * artifact and run the collector → comment-body → publisher pipeline.
+ */
+const emitSnapshotPublishReportStep = {
+  name: 'Emit snapshot publish workflow report',
+  shell: 'bash' as const,
+  if: "${{ github.event_name == 'pull_request' && steps.publish-snapshot.outcome == 'success' }}",
+  env: {
+    WORKFLOW_REPORT_OUTPUT_PATH: SNAPSHOT_REPORT_RECORD_PATH,
+    SNAPSHOT_VERSION: `0.0.0-snapshot-${PR_HEAD_SHA}`,
+    HEAD_SHA: PR_HEAD_SHA,
+    RUN_ID: GITHUB_RUN_ID,
+    REPOSITORY: '${{ github.repository }}',
+  },
+  run: [
+    'set -euo pipefail',
+    'mkdir -p "$(dirname "$WORKFLOW_REPORT_OUTPUT_PATH")"',
+    'created_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+    'record_id="snapshot-publish-${HEAD_SHA}"',
+    'npm_url="https://www.npmjs.com/package/@livestore/livestore/v/${SNAPSHOT_VERSION}"',
+    'run_url="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"',
+    'install_cmd="pnpm add @livestore/livestore@${SNAPSHOT_VERSION}"',
+    'record_json="$(jq -cn \\',
+    '  --arg id "$record_id" \\',
+    '  --arg version "$SNAPSHOT_VERSION" \\',
+    '  --arg headSha "$HEAD_SHA" \\',
+    '  --arg runId "$RUN_ID" \\',
+    '  --arg createdAtUtc "$created_at_utc" \\',
+    '  --arg npmUrl "$npm_url" \\',
+    '  --arg runUrl "$run_url" \\',
+    '  --arg installCmd "$install_cmd" \\',
+    "  '{",
+    '    _tag: "WorkflowReportRecord",',
+    '    schemaVersion: 1,',
+    '    id: $id,',
+    '    kind: "npm-snapshot-publish",',
+    '    subject: { id: "livestore-npm-snapshot", label: "LiveStore npm snapshot" },',
+    '    status: "success",',
+    '    title: ("Snapshot published as " + $version),',
+    '    summary: ("Install with `" + $installCmd + "`"),',
+    '    createdAtUtc: $createdAtUtc,',
+    '    links: [',
+    '      { label: "@livestore/livestore on npm", url: $npmUrl, primary: true },',
+    '      { label: "Chrome devtools ZIP (workflow run artifacts)", url: $runUrl }',
+    '    ],',
+    '    data: { snapshotVersion: $version, headSha: $headSha, runId: $runId }',
+    "  }')\"",
+    'workflow_report_line="WORKFLOW_REPORT_V1: ${record_json}"',
+    'printf "%s\\n" "$workflow_report_line"',
+    'printf "%s\\n" "$workflow_report_line" > "$WORKFLOW_REPORT_OUTPUT_PATH"',
+  ].join('\n'),
+}
 
 // =============================================================================
 // Job Helpers
@@ -367,7 +454,67 @@ done`,
             'retention-days': 14,
           },
         },
+        emitSnapshotPublishReportStep,
+        {
+          name: 'Upload snapshot publish workflow report',
+          if: `\${{ github.event_name == 'pull_request' && steps.publish-snapshot.outcome == 'success' }}`,
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: SNAPSHOT_REPORT_ARTIFACT_NAME,
+            path: SNAPSHOT_REPORT_RECORD_PATH,
+            'if-no-files-found': 'error',
+            'retention-days': 14,
+          },
+        },
       ]),
+    },
+
+    /**
+     * Aggregate the snapshot publish workflow report and upsert the managed PR
+     * comment. Runs after `publish-snapshot-version` so a failed publish leaves
+     * the existing comment (if any) untouched rather than overwriting it with a
+     * stale success record.
+     */
+    'report-snapshot-publish': {
+      if: `\${{ github.event_name == 'pull_request' && needs.publish-snapshot-version.outputs.npm_snapshot_published == '1' }}`,
+      needs: 'publish-snapshot-version',
+      ...namespaceRunnerConfig,
+      permissions: {
+        contents: 'read',
+        'pull-requests': 'write',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        ...livestoreSetupSteps,
+        {
+          name: 'Download snapshot publish workflow report',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: SNAPSHOT_REPORT_ARTIFACT_NAME,
+            path: SNAPSHOT_REPORT_DOWNLOAD_DIR,
+          },
+        },
+        workflowReportCollectorStep({
+          bundleId: 'snapshot-publish',
+          inputPaths: [`${SNAPSHOT_REPORT_DOWNLOAD_DIR}/snapshot-publish.jsonl`],
+          outputPath: SNAPSHOT_REPORT_BUNDLE_PATH,
+        }),
+        workflowReportCommentBodyStep({
+          bundlePath: SNAPSHOT_REPORT_BUNDLE_PATH,
+          commentBodyPath: SNAPSHOT_REPORT_COMMENT_BODY_PATH,
+          summaryPath: SNAPSHOT_REPORT_SUMMARY_PATH,
+          title: 'Snapshot release',
+          noRecordsMessage: 'No snapshot release was published for this commit.',
+          stateId: SNAPSHOT_REPORT_STATE_ID,
+          entryId: PR_HEAD_SHA,
+          entryLabel: `PR \${{ github.event.pull_request.number }}`,
+        }),
+        workflowReportPublisherStep({
+          commentBodyPath: SNAPSHOT_REPORT_COMMENT_BODY_PATH,
+          summaryPath: SNAPSHOT_REPORT_SUMMARY_PATH,
+          stateId: SNAPSHOT_REPORT_STATE_ID,
+        }),
+      ],
     },
 
     'build-and-deploy-examples-src': {

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -245,6 +245,10 @@ import {
   nixDiagnosticsArtifactStep,
   savePnpmStateStep,
   validateNixStoreStep,
+  workflowReportCollectorStep,
+  workflowReportCommentBodyStep,
+  workflowReportProducerStep,
+  workflowReportPublisherStep,
 } from '#mr/effect-utils/genie/ci-workflow.ts'
 
 export const devenvShellDefaults = {
@@ -257,6 +261,10 @@ export {
   runDevenvTasksBefore,
   nixDiagnosticsArtifactStep,
   savePnpmStateStep,
+  workflowReportCollectorStep,
+  workflowReportCommentBodyStep,
+  workflowReportProducerStep,
+  workflowReportPublisherStep,
 }
 
 export const namespaceRunner = (runId: string) =>

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -18,6 +18,7 @@ import {
 } from '../shared/deploy-target.ts'
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../shared/misc.ts'
 import { deployToNetlify, purgeNetlifyCdn } from '../shared/netlify.ts'
+import { emitWorkflowReportRecord, nowIsoUtc } from '../shared/workflow-report.ts'
 import { exportMarkdownCommand } from './docs-export.ts'
 
 const workspaceRoot =
@@ -511,6 +512,47 @@ export const docsCommand = Cli.Command.make('docs').pipe(
               commitDeploy,
             }),
             context: 'docs deployment',
+          })
+
+          /**
+           * Surface the docs deploy as a workflow-report record so the managed
+           * PR comment aggregator can pick it up alongside other deploy/publish
+           * reports. For PR deploys we expose both commit-specific and sticky
+           * aliases (primary link is the commit alias so reviewers always see
+           * the SHA they pushed).
+           */
+          const docsLinks: Array<{ label: string; url: string; primary?: boolean }> = [
+            { label: 'Docs preview', url: commitDeploy.deploy_url, primary: true },
+          ]
+          if (prAliases !== undefined && stickyDeploy.deploy_url !== commitDeploy.deploy_url) {
+            docsLinks.push({ label: 'Docs preview (sticky)', url: stickyDeploy.deploy_url })
+          }
+          if (runUrl !== undefined) {
+            docsLinks.push({ label: 'Workflow run', url: runUrl })
+          }
+
+          yield* emitWorkflowReportRecord({
+            _tag: 'WorkflowReportRecord',
+            schemaVersion: 1,
+            id: `docs-deploy-${fullSha}`,
+            kind: 'docs-deploy-preview',
+            subject: { id: 'livestore-docs-preview', label: 'LiveStore docs preview' },
+            status: 'success',
+            title: prod === true ? 'Docs deployed to production' : `Docs preview deployed (${site})`,
+            summary: prAliases !== undefined ? `PR aliases: ${prAliases.commitAlias}, ${prAliases.stickyAlias}` : site,
+            createdAtUtc: nowIsoUtc(),
+            links: docsLinks,
+            data: {
+              site,
+              prod,
+              deployId: commitDeploy.deploy_id,
+              commitUrl: commitDeploy.deploy_url,
+              ...(prAliases !== undefined
+                ? { stickyAlias: prAliases.stickyAlias, commitAlias: prAliases.commitAlias }
+                : {}),
+              ...(branchAlias !== undefined ? { branchAlias } : {}),
+              sha: fullSha,
+            },
           })
         },
         Effect.catchIf(

--- a/scripts/src/commands/examples/deploy-examples.ts
+++ b/scripts/src/commands/examples/deploy-examples.ts
@@ -23,6 +23,7 @@ import {
   type DeploymentKind,
 } from '../../shared/deploy-target.ts'
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../../shared/misc.ts'
+import { emitWorkflowReportRecord, nowIsoUtc } from '../../shared/workflow-report.ts'
 
 export class ScriptError extends Schema.TaggedError<ScriptError>()('ScriptError', {
   message: Schema.String,
@@ -340,6 +341,40 @@ export const command = Cli.Command.make(
     )
 
     console.log(`Deployed ${results.length} examples`)
+
+    /**
+     * Surface each example deploy as a workflow-report record so the managed PR
+     * comment can list every preview URL alongside other deploy/publish reports
+     * collected for the run. Records are deduped by `subject.id` downstream, so
+     * stable per-example IDs keep history clean across reruns.
+     */
+    const reportCreatedAtUtc = nowIsoUtc()
+    yield* Effect.forEach(
+      results,
+      (result) => {
+        const previewUrl = result.previewUrl ?? `https://${result.workerHost}`
+        return emitWorkflowReportRecord({
+          _tag: 'WorkflowReportRecord',
+          schemaVersion: 1,
+          id: `examples-deploy-${result.example}`,
+          kind: 'examples-deploy-preview',
+          subject: { id: `livestore-example-${result.example}`, label: result.example },
+          status: 'success',
+          title: `${result.example} deployed (${result.env})`,
+          summary: `Worker: ${result.workerHost}`,
+          createdAtUtc: reportCreatedAtUtc,
+          links: [{ label: 'Preview URL', url: previewUrl, primary: true }],
+          data: {
+            example: result.example,
+            workerName: result.workerName,
+            workerHost: result.workerHost,
+            env: result.env,
+            domains: result.domains,
+          },
+        })
+      },
+      { concurrency: 1 },
+    )
 
     const tableRows = results.map((result) => ({
       Example: result.example,

--- a/scripts/src/shared/workflow-report.ts
+++ b/scripts/src/shared/workflow-report.ts
@@ -1,0 +1,57 @@
+import { Effect, FileSystem } from '@livestore/utils/effect'
+
+/**
+ * Marker prefix recognized by effect-utils' workflow-reporting collector.
+ * Keep in sync with `workflowReportRecordLineMarker` in
+ * `@overeng/genie/runtime/workflow-reporting/mod.ts`.
+ */
+export const workflowReportRecordLineMarker = 'WORKFLOW_REPORT_V1: '
+
+/**
+ * Schema-compatible shape for a single record. We intentionally keep this as a
+ * structural type (not a Schema) so deploy commands can compose records inline
+ * without pulling in additional dependencies.
+ *
+ * Validated downstream by the collector step.
+ */
+export interface WorkflowReportRecord {
+  readonly _tag: 'WorkflowReportRecord'
+  readonly schemaVersion: 1
+  readonly id: string
+  readonly kind: string
+  readonly subject: { readonly id: string; readonly label?: string }
+  readonly status: 'success' | 'failure' | 'skipped' | 'neutral'
+  readonly title: string
+  readonly summary?: string
+  readonly createdAtUtc: string
+  readonly links?: ReadonlyArray<{ readonly label: string; readonly url: string; readonly primary?: boolean }>
+  readonly data?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Emit a workflow-report record to stdout (as `WORKFLOW_REPORT_V1: <json>`) and
+ * — when `WORKFLOW_REPORT_OUTPUT_FILE` is set — append the same marker line to
+ * that file so the workflow step can upload it as an artifact.
+ *
+ * This mirrors the effect-utils Netlify deploy pattern: emit canonical records
+ * from the CLI so the collector job can aggregate them without re-parsing
+ * CLI-specific log formats.
+ */
+export const emitWorkflowReportRecord = (record: WorkflowReportRecord) =>
+  Effect.gen(function* () {
+    const line = `${workflowReportRecordLineMarker}${JSON.stringify(record)}`
+    console.log(line)
+
+    const outputPath = process.env.WORKFLOW_REPORT_OUTPUT_FILE
+    if (outputPath === undefined || outputPath.trim() === '') return
+
+    const fs = yield* FileSystem.FileSystem
+    yield* fs.writeFileString(outputPath, `${line}\n`, { flag: 'a' }).pipe(
+      Effect.catchAll((cause) =>
+        Effect.logWarning(`Unable to append workflow-report record to ${outputPath}: ${String(cause)}`),
+      ),
+    )
+  })
+
+/** ISO-8601 UTC timestamp matching the schema's pattern (no fractional seconds). */
+export const nowIsoUtc = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')

--- a/scripts/src/shared/workflow-report.ts
+++ b/scripts/src/shared/workflow-report.ts
@@ -46,11 +46,13 @@ export const emitWorkflowReportRecord = (record: WorkflowReportRecord) =>
     if (outputPath === undefined || outputPath.trim() === '') return
 
     const fs = yield* FileSystem.FileSystem
-    yield* fs.writeFileString(outputPath, `${line}\n`, { flag: 'a' }).pipe(
-      Effect.catchAll((cause) =>
-        Effect.logWarning(`Unable to append workflow-report record to ${outputPath}: ${String(cause)}`),
-      ),
-    )
+    yield* fs
+      .writeFileString(outputPath, `${line}\n`, { flag: 'a' })
+      .pipe(
+        Effect.catchAll((cause) =>
+          Effect.logWarning(`Unable to append workflow-report record to ${outputPath}: ${String(cause)}`),
+        ),
+      )
   })
 
 /** ISO-8601 UTC timestamp matching the schema's pattern (no fractional seconds). */


### PR DESCRIPTION
## Problem

Contributors testing a PR have to dig into the workflow log every time to find:
- the snapshot install command (`pnpm add @livestore/livestore@0.0.0-snapshot-<sha>`)
- the LiveStore DevTools Chrome ZIP attached as a workflow-run artifact
- the docs preview Netlify URL (commit alias + sticky PR alias)
- the per-example Cloudflare Worker preview URLs

All of this info already exists somewhere in step output; it just has no durable surface outside the run.

## Solution

Adopt the workflow-reporting framework from [effect-utils#724](https://github.com/overengineeringstudio/effect-utils/pull/724) for every PR-time deploy/publish surface:

1. **Snapshot publish** (existing): inline `jq` in `publish-snapshot-version` emits a `WORKFLOW_REPORT_V1` JSONL record on success.
2. **Docs deploy** (new): `mono docs deploy` emits a record when `WORKFLOW_REPORT_OUTPUT_FILE` is set; the workflow uploads the file as an artifact.
3. **Examples deploy** (new): `mono examples deploy` emits one record per deployed example to the same env-controlled file.
4. **Aggregator**: the renamed `report-pr-preview` job downloads every artifact (each step gated by the producer job's result, `continue-on-error: true` so partial sets still publish) and runs the canonical pipeline:
   - `workflowReportCollectorStep` (allowMissingInput) → bundles whatever records exist
   - `workflowReportCommentBodyStep` → renders the managed comment markdown
   - `workflowReportPublisherStep` → upserts the managed PR comment (idempotent on retries / rebases)

Gating relaxed from `npm_snapshot_published == '1'` to `github.event_name == 'pull_request' && !cancelled()` so docs/examples previews still publish on forked PRs where the snapshot job is skipped.

### Record shapes

| Producer | `kind` | `subject` | Primary link |
| --- | --- | --- | --- |
| snapshot publish | `npm-snapshot-publish` | `livestore-npm-snapshot` | npm package version page |
| docs deploy | `docs-deploy-preview` | `livestore-docs-preview` | Netlify commit alias URL |
| examples deploy | `examples-deploy-preview` | `livestore-example-<slug>` (one per example) | Worker preview URL |

Per-example aggregation: one record per example so reviewers see a row per surface in the managed comment. The framework dedupes by `subject.id`, so reruns / rebases update the existing row rather than appending.

### Design note on the producer

For the snapshot job we keep the inline `jq` pattern (matches effect-utils' canonical `netlifyDeployStep`). For docs and examples we instead emit from the CLI itself — `scripts/src/shared/workflow-report.ts` writes a `WORKFLOW_REPORT_V1: <json>` line to stdout and (when `WORKFLOW_REPORT_OUTPUT_FILE` is set) appends to that file. This keeps the deploy URLs in a single source of truth instead of duplicating example-manifest slug + worker-name composition logic in YAML.

## Stacking

Based on `schickling-assistant/2026-06-01-adopt-effect-utils` (#1273) because the workflow-reporting helpers ship with that effect-utils bump. Will rebase onto `main` once #1273 lands.

## Validation

| Check | Result |
| --- | --- |
| `devenv tasks run genie:run --mode before --no-tui` | regenerated `.github/workflows/ci.yml` cleanly |
| `devenv tasks run lint:check:genie --mode before --no-tui` | passes (no drift) |
| `devenv tasks run lint:check:format --mode before --no-tui` | passes |
| `devenv tasks run ts:check --mode before --no-tui` | passes |

Pre-existing `lint:check:oxlint` task failure on the base branch is unrelated to this PR.

## Sample comment

```
## PR preview

| Subject | Status | Report | Details | Updated |
| --- | --- | --- | --- | --- |
| LiveStore npm snapshot | success | [Snapshot published as 0.0.0-snapshot-abc1234](https://www.npmjs.com/...) | Install with `pnpm add @livestore/livestore@0.0.0-snapshot-abc1234` | 2026-06-02 12:34 CEST |
| LiveStore docs preview | success | [Docs preview deployed (livestore-docs-dev)](https://pr-1274-abc1234--livestore-docs-dev.netlify.app) | PR aliases: pr-1274-abc1234, pr-1274 | 2026-06-02 12:35 CEST |
| web-todomvc | success | [web-todomvc deployed (preview)](https://example-web-todomvc-preview.livestore.workers.dev) | Worker: example-web-todomvc-preview.livestore.workers.dev | 2026-06-02 12:36 CEST |
| web-linearlite | success | [web-linearlite deployed (preview)](https://example-web-linearlite-preview.livestore.workers.dev) | Worker: example-web-linearlite-preview.livestore.workers.dev | 2026-06-02 12:36 CEST |
| ...one row per cloudflareExamples slug... | | | | |
```

## Test plan

- [ ] Open a draft PR against `main` and confirm `report-pr-preview` runs after snapshot + docs + examples jobs
- [ ] Verify the managed PR comment is created on first run and updated (not duplicated) on rebase / rerun
- [ ] Verify all three subjects render in the table (npm snapshot, docs preview, examples per slug)
- [ ] Confirm partial success (e.g. snapshot fails, docs/examples succeed) still publishes a comment with the surviving subjects
- [ ] Confirm fork PRs still get docs/examples previews even though snapshot is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💨 cl2-mist |
| `agent_session_id` | c1934b02-14a7-4f20-a3e4-9e7b987c77ab |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.145 |
| `agent_runtime` | Claude Code 2.1.145 |
| `agent_model` | claude-opus-4-7 |
| `worktree` | livestore/schickling-assistant/2026-06-02-adopt-workflow-reporting |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->
