### PR TITLE
Add docs/examples build+deploy jobs to required status checks

### DIFF
--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -81,6 +81,12 @@
           },
           {
             "context": "wa-sqlite-test"
+          },
+          {
+            "context": "build-deploy-docs"
+          },
+          {
+            "context": "build-and-deploy-examples-src"
           }
         ]
       }

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -28,4 +28,6 @@ export const requiredCIJobs = [
   ...syncProviderMatrix.map((provider) => `test-integration-sync-provider (${provider})`),
   ...playwrightSuites.map((suite) => `test-integration-playwright (${suite})`),
   'wa-sqlite-test',
+  'build-deploy-docs',
+  'build-and-deploy-examples-src',
 ] as const


### PR DESCRIPTION
## Summary

Promotes \`build-deploy-docs\` and \`build-and-deploy-examples-src\` from informational CI jobs to required status checks on the \`main-branch-rules\` ruleset.

Both jobs already run on every PR and gate the dev-surface deploys that downstream contributors rely on. Making them required closes a hole where a docs or examples regression could silently land on \`main\`.

## Change

\`genie/ci.ts\` — extends \`requiredCIJobs\` with the two new contexts. The ruleset projection (\`.github/repo-settings.json\`) regenerates from the same source, so source + checked-in JSON stay aligned.

## Activation

After merge to \`main\`, the live ruleset still needs to be reconciled with the source. Run with admin permissions:

\`\`\`
mono github rulesets sync
\`\`\`

This is the standard activation step — required because GitHub's ruleset API needs admin auth that \`schickling-assistant\` doesn't carry. \`devenv tasks run github:rulesets:check\` will report drift until activation is applied.

## Why these two specifically

The user asked for "build/deploy docs/examples" as required. \`build-example-create\` (the create-example smoke test) was intentionally left out of this PR — if you also want it required, easy follow-up.

## Test plan

- [ ] CI passes \`lint\`, \`changeset-check\`, and the new \`build-deploy-docs\` + \`build-and-deploy-examples-src\` jobs themselves.
- [ ] After merge: \`devenv tasks run github:rulesets:check\` reports drift between source and live until \`mono github rulesets sync\` runs.
- [ ] After sync: \`github:rulesets:check\` reports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)