### PR TITLE
URGENT: Restore NPM_TOKEN for stable publish (0.4.0 blocker)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1293,6 +1293,7 @@ jobs:
       id-token: write
     env:
       GH_TOKEN: ${{ github.token }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     defaults:
       run:
         shell: bash
@@ -1426,6 +1427,16 @@ jobs:
           release_version="$(jq -r '.version' release/release-plan.json)"
           : "${release_version:?Missing release version}"
           echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+      - name: Configure npm token fallback
+        run: |
+          set -euo pipefail
+          : "${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
+          npmrc="$HOME/.npmrc"
+          printf '%s\n' "always-auth=true" > "$npmrc"
+          printf '%s\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$npmrc"
+          printf '%s\n' "NPM_CONFIG_USERCONFIG=$npmrc" >> "$GITHUB_ENV"
+          printf '%s\n' "NPM_CONFIG_REGISTRY=https://registry.npmjs.org/" >> "$GITHUB_ENV"
+          NPM_CONFIG_USERCONFIG="$npmrc" NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ npm whoami >/dev/null
       - name: Publish stable package release
         run: |
           __nix_gc_retry_helper=$(mktemp)

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -270,6 +270,7 @@ fi`,
       },
       env: {
         GH_TOKEN: '${{ github.token }}',
+        NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}',
       },
       defaults: bashShellDefaults,
       steps: withNixDiagnosticsOnFailure([
@@ -282,13 +283,25 @@ release_version="$(jq -r '.version' release/release-plan.json)"
 echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"`,
         },
         /*
-         * Stable package publishing uses npm trusted publishing (OIDC). Each
-         * `@livestore/*` npm package authorizes this workflow file
-         * (`release.yml`) as a trusted publisher with no environment scope.
-         * The npm CLI auto-detects the OIDC exchange when `id-token: write` is
-         * granted, so no NPM_TOKEN secret is required. Keep this on
-         * GitHub-hosted runners (npm OIDC does not support self-hosted).
+         * Stable package publishing uses the NPM_TOKEN secret. npm currently
+         * allows only one trusted publisher workflow per package, and
+         * `ci.yml` already owns that slot for snapshot publishing. Moving
+         * stable releases to trusted publishing would require consolidating
+         * the snapshot + stable publish into a single workflow file or
+         * giving up snapshot OIDC — neither is worth doing right now.
+         * See .github/workflows/README.md `release.yml` section.
          */
+        {
+          name: 'Configure npm token fallback',
+          run: `set -euo pipefail
+: "\${NODE_AUTH_TOKEN:?Missing NPM_TOKEN secret}"
+npmrc="$HOME/.npmrc"
+printf '%s\\n' "always-auth=true" > "$npmrc"
+printf '%s\\n' "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> "$npmrc"
+printf '%s\\n' "NPM_CONFIG_USERCONFIG=$npmrc" >> "$GITHUB_ENV"
+printf '%s\\n' "NPM_CONFIG_REGISTRY=https://registry.npmjs.org/" >> "$GITHUB_ENV"
+NPM_CONFIG_USERCONFIG="$npmrc" NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ npm whoami >/dev/null`,
+        },
         {
           name: 'Publish stable package release',
           run: runDevenvTasksBefore('release:stable:publish'),


### PR DESCRIPTION
## Summary

**0.4.0 publish is currently broken on main** because #1269 removed the NPM_TOKEN fallback from release.yml's publish-release job. The npm publish step fails with \`npm error need auth\` — see https://github.com/livestorejs/livestore/actions/runs/26810829534/job/79040035219.

The root cause is structural, not a config oversight: **npm allows only ONE trusted publisher workflow per package**, and \`ci.yml\` already owns that slot for snapshot publishes. So configuring \`release.yml\` as a second trusted publisher isn't possible. The .github/workflows/README.md release.yml section already documented this constraint — I missed it when writing #1269.

## Fix

Reverts the trusted-publishing change from release.yml only (snapshot publishing in ci.yml stays on OIDC):

- Re-add \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` env on publish-release
- Re-add "Configure npm token fallback" step
- Update inline comment to reflect the structural reason

## Recovery

After merge:
1. Trigger \`release.yml workflow_dispatch\` with \`mode=publish-release\`.
2. The publisher is idempotent — already-published 0.4.0 packages will be skipped, missing ones (most of them) will be published.
3. DevTools artifact + prod docs/examples deploys will follow automatically.

## Test plan

- [ ] CI lint/changeset-check pass.
- [ ] After merge: \`workflow_dispatch mode=publish-release\` succeeds.
- [ ] All \`@livestore/*\` packages at 0.4.0 visible on npm.
- [ ] Prod docs and examples deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)