### PR TITLE
URGENT: Unblock 0.4.0 prod deploys (deploy target env + cert-liveness idempotency)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1425,8 +1425,19 @@ jobs:
         run: |
           set -euo pipefail
           release_version="$(jq -r '.version' release/release-plan.json)"
+          npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
           : "${release_version:?Missing release version}"
+          : "${npm_tag:?Missing npm tag}"
           echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+          echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
+          # Env vars do not carry across jobs in GitHub Actions, so the deploy-target
+          # gate that the validate-release-plan job sets must be re-derived here for the
+          # Deploy production docs/examples and Sync production docs search steps below.
+          if [ "$npm_tag" = "latest" ]; then
+            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
+          else
+            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
+          fi
       - name: Configure npm token fallback
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -279,8 +279,19 @@ fi`,
           name: 'Read release plan',
           run: `set -euo pipefail
 release_version="$(jq -r '.version' release/release-plan.json)"
+npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
 : "\${release_version:?Missing release version}"
-echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"`,
+: "\${npm_tag:?Missing npm tag}"
+echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
+echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
+# Env vars do not carry across jobs in GitHub Actions, so the deploy-target
+# gate that the validate-release-plan job sets must be re-derived here for the
+# Deploy production docs/examples and Sync production docs search steps below.
+if [ "$npm_tag" = "latest" ]; then
+  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
+else
+  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
+fi`,
         },
         /*
          * Stable package publishing uses the NPM_TOKEN secret. npm currently

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -682,7 +682,16 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
 
   const publishTag = publishTagForVersion(version)
   if (hasFlag(flags, 'dry-run') === true) {
-    run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
+    // npm publish --dry-run still pre-checks the registry and errors with
+    // "cannot publish over previously published versions" when the version
+    // already exists. Treat existing-on-npm as stronger evidence that the
+    // artifact is publishable than a dry-run could provide, so cert-liveness
+    // reruns after a successful publish stay idempotent.
+    if (packageVersionExists(metadata.packageName, version) === true) {
+      console.warn(`${metadata.packageName}@${version} already published, skipping dry-run publish check`)
+    } else {
+      run(['npm', 'publish', '--dry-run', '--tag', publishTag, repackedPath], { cwd: workDir })
+    }
   }
   if (hasFlag(flags, 'publish') === true) {
     const alreadyPublished = packageVersionExists(metadata.packageName, version)


### PR DESCRIPTION
## Problem

The 0.4.0 publish-release job ran successfully BUT all three production deploy steps silently **skipped**, and a retry to recover the deploys failed at the cert-liveness gate.

- First run (https://github.com/livestorejs/livestore/actions/runs/26818008579): npm + DevTools artifact published, three deploys skipped (env bug).
- Retry on this branch (https://github.com/livestorejs/livestore/actions/runs/26819104786): cert-liveness failed because `npm publish --dry-run` rejects already-published 0.4.0.

## Two fixes in this PR

1. **publish-release deploy target env not exported**: The deploy steps gate on `env.LIVESTORE_RELEASE_DEPLOY_TARGET == 'prod'`, but the var was only set in validate-release-plan. GitHub Actions env doesn't carry across jobs. Re-derive in publish-release's "Read release plan" step.

2. **cert-liveness not idempotent**: Internal `npm publish --dry-run` errors with "cannot publish over previously published versions" on reruns. Skip the dry-run when `packageVersionExists()` returns true — mirrors the `--publish` path that already does this.

## Recovery

After merge:
1. Trigger `release.yml workflow_dispatch` with `mode=publish-release`.
2. All idempotent steps skip, deploys run, prod surfaces (docs.livestore.dev, Cloudflare examples, Mixedbread index) catch up to 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)