### PR TITLE
Bump effect-utils to f29b791b for dedicated workflow-report CLI

### DIFF
--- a/.changeset/empty-effect-utils-bump-733.md
+++ b/.changeset/empty-effect-utils-bump-733.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Bumps the `effect-utils` pin to pick up the dedicated `@overeng/workflow-report` CLI (effect-utils#733); regenerates the `pr-preview` workflow-report collector step to invoke the upstream Nix-packaged binary instead of inlining the JS runtime, and adds `**/tmp/**` to the shared `.oxfmtrc.json` ignore list.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4064,60 +4064,25 @@ jobs:
       - name: Collect workflow report bundle
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_REPORT_FLAKE_REF: 'github:overengineeringstudio/effect-utils/main#workflow-report'
           WORKFLOW_REPORT_BUNDLE_ID: pr-preview
           WORKFLOW_REPORT_INPUT_PATHS_JSON: '["${{ runner.temp }}/workflow-reports/snapshot-publish-download/snapshot-publish.jsonl","${{ runner.temp }}/workflow-reports/docs-deploy-download/docs-deploy.jsonl","${{ runner.temp }}/workflow-reports/examples-deploy-download/examples-deploy.jsonl"]'
           WORKFLOW_REPORT_OUTPUT_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-bundle.json'
           WORKFLOW_REPORT_RECORD_MARKER: 'WORKFLOW_REPORT_V1: '
           WORKFLOW_REPORT_ALLOW_MISSING_INPUT: '1'
         run: |
-          if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
-            if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
-              export WORKFLOW_REPORT_RUNTIME_MODULE=packages/@overeng/genie/src/runtime/mod.ts
-            elif [ -f repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts ]; then
-              export WORKFLOW_REPORT_RUNTIME_MODULE=repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts
-            else
-              echo "::error::unable to locate @overeng/genie runtime module for workflow reports"
-              exit 1
-            fi
+          if [ -n "${GH_TOKEN:-}" ]; then
+            export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
           fi
-          cat > /tmp/collect-workflow-report-bundle.mjs <<'EOF'
-          import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-          import { dirname, resolve } from 'node:path'
-          import { pathToFileURL } from 'node:url'
-
-          const runtimeModule = process.env.WORKFLOW_REPORT_RUNTIME_MODULE
-          if (typeof runtimeModule !== "string" || runtimeModule.length === 0) throw new Error("WORKFLOW_REPORT_RUNTIME_MODULE is required")
-          const { collectWorkflowReportBundle, encodeWorkflowReportBundleJson } = await import(pathToFileURL(resolve(runtimeModule)).href)
-
-          const expectString = (value, path) =>
-            typeof value === "string" && value.length > 0 ? value : (() => { throw new Error(`${path} must be a non-empty string`) })()
-
-          const marker = expectString(process.env.WORKFLOW_REPORT_RECORD_MARKER, "WORKFLOW_REPORT_RECORD_MARKER")
-          const inputPaths = JSON.parse(expectString(process.env.WORKFLOW_REPORT_INPUT_PATHS_JSON, "WORKFLOW_REPORT_INPUT_PATHS_JSON"))
-          const outputPath = expectString(process.env.WORKFLOW_REPORT_OUTPUT_PATH, "WORKFLOW_REPORT_OUTPUT_PATH")
-          const bundleId = expectString(process.env.WORKFLOW_REPORT_BUNDLE_ID, "WORKFLOW_REPORT_BUNDLE_ID")
-          const allowMissingInput = process.env.WORKFLOW_REPORT_ALLOW_MISSING_INPUT === "1"
-
-          const sources = []
-          for (const path of inputPaths) {
-            if (!existsSync(path)) {
-              if (allowMissingInput) continue
-              throw new Error(`workflow report input file does not exist: ${path}`)
-            }
-            sources.push(readFileSync(path, "utf8"))
-          }
-
-          const bundle = collectWorkflowReportBundle({ bundleId, generatedAtUtc: new Date().toISOString(), sources, marker })
-
-          mkdirSync(dirname(outputPath), { recursive: true })
-          writeFileSync(outputPath, encodeWorkflowReportBundleJson(bundle))
-          EOF
-          nix run nixpkgs#bun -- /tmp/collect-workflow-report-bundle.mjs
+          workflow_report_flake_ref="${WORKFLOW_REPORT_FLAKE_REF:-github:overengineeringstudio/effect-utils/main#workflow-report}"
+          nix run "$workflow_report_flake_ref" -- collect-bundle --bundle-id "$WORKFLOW_REPORT_BUNDLE_ID" --input-paths-json "$WORKFLOW_REPORT_INPUT_PATHS_JSON" --output-path "$WORKFLOW_REPORT_OUTPUT_PATH" --record-marker "$WORKFLOW_REPORT_RECORD_MARKER" --allow-missing-input
       - name: Render workflow report comment
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          WORKFLOW_REPORT_FLAKE_REF: 'github:overengineeringstudio/effect-utils/main#workflow-report'
           WORKFLOW_REPORT_BUNDLE_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-bundle.json'
           WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-comment.md'
           WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-summary.md'
@@ -4130,101 +4095,32 @@ jobs:
           WORKFLOW_REPORT_TIME_ZONE: UTC
           WORKFLOW_REPORT_MANAGED_MARKER: '<!-- workflow-report:managed -->'
         run: |
-          if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
-            if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
-              export WORKFLOW_REPORT_RUNTIME_MODULE=packages/@overeng/genie/src/runtime/mod.ts
-            elif [ -f repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts ]; then
-              export WORKFLOW_REPORT_RUNTIME_MODULE=repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts
-            else
-              echo "::error::unable to locate @overeng/genie runtime module for workflow reports"
-              exit 1
-            fi
+          if [ -n "${GH_TOKEN:-}" ]; then
+            export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
           fi
           comments_json="$(mktemp)"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
             nix run nixpkgs#gh -- api "repos/$GH_REPO/issues/${{ github.event.pull_request.number }}/comments" --paginate > "$comments_json"
           else
             printf '[]' > "$comments_json"
           fi
 
-          nix run nixpkgs#bun -- - "$comments_json" <<'EOF'
-          import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-          import { dirname, resolve } from 'node:path'
-          import { pathToFileURL } from 'node:url'
-
-          const [commentsPath] = process.argv.slice(2)
-          const runtimeModule = process.env.WORKFLOW_REPORT_RUNTIME_MODULE
-          if (typeof runtimeModule !== "string" || runtimeModule.length === 0) throw new Error("WORKFLOW_REPORT_RUNTIME_MODULE is required")
-          const {
-            decodeWorkflowReportBundleJson,
-            deriveWorkflowReportManagedState,
-            findWorkflowReportManagedComment,
-            renderWorkflowReportCommentBody,
-          } = await import(pathToFileURL(resolve(runtimeModule)).href)
-
-          const expectString = (value, path) =>
-            typeof value === "string" && value.length > 0 ? value : (() => { throw new Error(`${path} must be a non-empty string`) })()
-
-          const optionalString = (value) => (typeof value === "string" && value.length > 0 ? value : undefined)
-          const latestCreatedAtUtc = (records, fallback) =>
-            records.reduce((latest, record) => (record.createdAtUtc > latest ? record.createdAtUtc : latest), fallback)
-
-          const bundlePath = expectString(process.env.WORKFLOW_REPORT_BUNDLE_PATH, "WORKFLOW_REPORT_BUNDLE_PATH")
-          const commentBodyPath = expectString(process.env.WORKFLOW_REPORT_COMMENT_BODY_PATH, "WORKFLOW_REPORT_COMMENT_BODY_PATH")
-          const summaryPath = expectString(process.env.WORKFLOW_REPORT_SUMMARY_PATH, "WORKFLOW_REPORT_SUMMARY_PATH")
-          const title = expectString(process.env.WORKFLOW_REPORT_TITLE, "WORKFLOW_REPORT_TITLE")
-          const noRecordsMessage = expectString(process.env.WORKFLOW_REPORT_NO_RECORDS_MESSAGE, "WORKFLOW_REPORT_NO_RECORDS_MESSAGE")
-          const stateId = expectString(process.env.WORKFLOW_REPORT_STATE_ID, "WORKFLOW_REPORT_STATE_ID")
-          const entryId = expectString(process.env.WORKFLOW_REPORT_ENTRY_ID, "WORKFLOW_REPORT_ENTRY_ID")
-          const entryLabel = expectString(process.env.WORKFLOW_REPORT_ENTRY_LABEL, "WORKFLOW_REPORT_ENTRY_LABEL")
-          const timeZone = expectString(process.env.WORKFLOW_REPORT_TIME_ZONE, "WORKFLOW_REPORT_TIME_ZONE")
-          const marker = expectString(process.env.WORKFLOW_REPORT_MANAGED_MARKER, "WORKFLOW_REPORT_MANAGED_MARKER")
-
-          const bundle = decodeWorkflowReportBundleJson(readFileSync(bundlePath, "utf8"))
-          const comments = JSON.parse(readFileSync(commentsPath, "utf8"))
-          if (!Array.isArray(comments)) throw new Error("comments response must be an array")
-
-          const existingComment = findWorkflowReportManagedComment(comments, { stateId, marker })
-          const createdAtUtc = optionalString(process.env.WORKFLOW_REPORT_CREATED_AT_UTC) ?? latestCreatedAtUtc(bundle.records, bundle.generatedAtUtc)
-          const state = deriveWorkflowReportManagedState({
-            stateId,
-            timeZone,
-            priorState: existingComment?.state,
-            entryId,
-            entryLabel,
-            createdAtUtc,
-            records: bundle.records,
-          })
-          const body = renderWorkflowReportCommentBody({ title, noRecordsMessage, state })
-          const markerIndex = body.indexOf(marker)
-          const visibleBody = markerIndex === -1 ? body : `${body.slice(0, markerIndex).trimEnd()}\n`
-
-          mkdirSync(dirname(commentBodyPath), { recursive: true })
-          mkdirSync(dirname(summaryPath), { recursive: true })
-          writeFileSync(commentBodyPath, body)
-          writeFileSync(summaryPath, visibleBody)
-          EOF
+          workflow_report_flake_ref="${WORKFLOW_REPORT_FLAKE_REF:-github:overengineeringstudio/effect-utils/main#workflow-report}"
+          nix run "$workflow_report_flake_ref" -- render-comment-body --bundle-path "$WORKFLOW_REPORT_BUNDLE_PATH" --comments-path "$comments_json" --comment-body-path "$WORKFLOW_REPORT_COMMENT_BODY_PATH" --summary-path "$WORKFLOW_REPORT_SUMMARY_PATH" --title "$WORKFLOW_REPORT_TITLE" --no-records-message "$WORKFLOW_REPORT_NO_RECORDS_MESSAGE" --state-id "$WORKFLOW_REPORT_STATE_ID" --entry-id "$WORKFLOW_REPORT_ENTRY_ID" --entry-label "$WORKFLOW_REPORT_ENTRY_LABEL" --created-at-utc "$WORKFLOW_REPORT_CREATED_AT_UTC" --time-zone "$WORKFLOW_REPORT_TIME_ZONE" --managed-marker "$WORKFLOW_REPORT_MANAGED_MARKER"
       - name: Publish workflow report
         if: always() && !cancelled()
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          WORKFLOW_REPORT_FLAKE_REF: 'github:overengineeringstudio/effect-utils/main#workflow-report'
           WORKFLOW_REPORT_STATE_ID: pr-preview
           WORKFLOW_REPORT_COMMENT_BODY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-comment.md'
           WORKFLOW_REPORT_SUMMARY_PATH: '${{ runner.temp }}/workflow-reports/pr-preview-summary.md'
           WORKFLOW_REPORT_MANAGED_MARKER: '<!-- workflow-report:managed -->'
         run: |
-          if [ -z "${WORKFLOW_REPORT_RUNTIME_MODULE:-}" ]; then
-            if [ -f packages/@overeng/genie/src/runtime/mod.ts ]; then
-              export WORKFLOW_REPORT_RUNTIME_MODULE=packages/@overeng/genie/src/runtime/mod.ts
-            elif [ -f repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts ]; then
-              export WORKFLOW_REPORT_RUNTIME_MODULE=repos/effect-utils/packages/@overeng/genie/src/runtime/mod.ts
-            else
-              echo "::error::unable to locate @overeng/genie runtime module for workflow reports"
-              exit 1
-            fi
+          if [ -n "${GH_TOKEN:-}" ]; then
+            export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
           fi
           if [ -s "$WORKFLOW_REPORT_SUMMARY_PATH" ]; then
             cat "$WORKFLOW_REPORT_SUMMARY_PATH" >> "$GITHUB_STEP_SUMMARY"
@@ -4241,30 +4137,9 @@ jobs:
 
           comments_json="$(mktemp)"
           comment_id_file="$(mktemp)"
-          export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG$'\n'}access-tokens = github.com=${GH_TOKEN}"
           nix run nixpkgs#gh -- api "repos/$GH_REPO/issues/${{ github.event.pull_request.number }}/comments" --paginate > "$comments_json"
-          nix run nixpkgs#bun -- - "$comments_json" "$comment_id_file" <<'EOF'
-          import { readFileSync, writeFileSync } from 'node:fs'
-          import { resolve } from 'node:path'
-          import { pathToFileURL } from 'node:url'
-
-          const [commentsPath, commentIdPath] = process.argv.slice(2)
-          const runtimeModule = process.env.WORKFLOW_REPORT_RUNTIME_MODULE
-          if (typeof runtimeModule !== "string" || runtimeModule.length === 0) throw new Error("WORKFLOW_REPORT_RUNTIME_MODULE is required")
-          const { extractWorkflowReportManagedState, findWorkflowReportManagedComment } = await import(pathToFileURL(resolve(runtimeModule)).href)
-          const stateId = process.env.WORKFLOW_REPORT_STATE_ID
-          if (typeof stateId !== "string" || stateId.length === 0) throw new Error("WORKFLOW_REPORT_STATE_ID is required")
-          const marker = process.env.WORKFLOW_REPORT_MANAGED_MARKER
-          if (typeof marker !== "string" || marker.length === 0) throw new Error("WORKFLOW_REPORT_MANAGED_MARKER is required")
-          const commentBodyPath = process.env.WORKFLOW_REPORT_COMMENT_BODY_PATH
-          if (typeof commentBodyPath !== "string" || commentBodyPath.length === 0) throw new Error("WORKFLOW_REPORT_COMMENT_BODY_PATH is required")
-          const targetState = extractWorkflowReportManagedState(readFileSync(commentBodyPath, "utf8"), { stateId })
-          if (targetState === undefined) throw new Error("workflow report comment body is missing managed state")
-          const comments = JSON.parse(readFileSync(commentsPath, "utf8"))
-          if (!Array.isArray(comments)) throw new Error("comments response must be an array")
-          const existingComment = findWorkflowReportManagedComment(comments, { stateId: targetState.stateId, marker })
-          writeFileSync(commentIdPath, existingComment?.id ?? "")
-          EOF
+          workflow_report_flake_ref="${WORKFLOW_REPORT_FLAKE_REF:-github:overengineeringstudio/effect-utils/main#workflow-report}"
+          nix run "$workflow_report_flake_ref" -- find-comment --comments-path "$comments_json" --comment-body-path "$WORKFLOW_REPORT_COMMENT_BODY_PATH" --comment-id-path "$comment_id_file" --state-id "$WORKFLOW_REPORT_STATE_ID" --managed-marker "$WORKFLOW_REPORT_MANAGED_MARKER"
 
           comment_id="$(cat "$comment_id_file")"
           if [ -n "$comment_id" ]; then

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -19,6 +19,7 @@
     "**/dist/**",
     "**/storybook-static/**",
     "**/.turbo/**",
+    "**/tmp/**",
     "**/*.gen.ts",
     "**/*.gen.tsx",
     "**/*.generated.ts",

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1780338095,
-        "narHash": "sha256-kLxWEy7K5n57SCrtXl2I6KDYNxvPnsumyTywAS2Dzec=",
+        "lastModified": 1780403834,
+        "narHash": "sha256-kqDwgBq0LxpigfaxbJbhXEkZ0ubeIgvx/GLLh7hMpDg=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "5ee1fc08670b318a8eb954badec96f9106514a15",
+        "rev": "f29b791b25f080bcf73438c9dfa5434f2572d2c4",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1779827190,
-        "narHash": "sha256-gJkTIDvppLj4hMqdFb0RaW+KONlq2ha9MyU4eI61Tqk=",
+        "lastModified": 1780403834,
+        "narHash": "sha256-kqDwgBq0LxpigfaxbJbhXEkZ0ubeIgvx/GLLh7hMpDg=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "8c5bc8e6be49440f03b9b0bb9504264352d47bd8",
+        "rev": "f29b791b25f080bcf73438c9dfa5434f2572d2c4",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "5ee1fc08670b318a8eb954badec96f9106514a15",
+      "commit": "f29b791b25f080bcf73438c9dfa5434f2572d2c4",
       "pinned": true,
-      "lockedAt": "2026-06-01T18:21:35.000Z"
+      "lockedAt": "2026-06-02T12:37:14.000Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Summary

Bumps the `effect-utils` pin in `megarepo.lock` and `devenv.lock` from `5ee1fc08` to `f29b791b`, picking up one upstream PR.

### What this pulls in

| Upstream | Title | Effect on LiveStore |
|---|---|---|
| [effect-utils#733](https://github.com/overengineeringstudio/effect-utils/pull/733) | `feat(workflow-report): expose dedicated report CLI` | The `pr-preview` workflow-report collector step in `.github/workflows/ci.yml` now invokes the upstream Nix-packaged `@overeng/workflow-report` CLI (`github:overengineeringstudio/effect-utils/main#workflow-report`) instead of locating `@overeng/genie` runtime sources and writing a one-off Node script per run. Generated diff only; no behavioral change for downstream report consumers. |

Also pulled in: a small upstream change to the shared `.oxfmtrc.json` defaults — `**/tmp/**` is now ignored by the formatter.

### Verification

- `devenv tasks run genie:check --mode before --no-tui` — clean after one `genie:run` regen (ci.yml + .oxfmtrc.json updated as listed above).
- `devenv tasks run mr:lock-sync-check --mode before --no-tui` — clean (after running `devenv update playwright` so the `playwright` subflake input — which is `github:overengineeringstudio/effect-utils#nix/playwright-flake` — also points at `f29b791b`).
- `devenv tasks run check:quick --mode before --no-tui` — clean (lint, ts:check, genie:coverage, lock-sync, source-policy all green).

### Investigation: `releaseWorkflow` (effect-utils#732)

The helper survived the merge intact. It lives at `genie/ci-workflow/release.ts` and is re-exported from the `genie/ci-workflow.ts` barrel as `releaseWorkflow`. The design doc is at `context/workflows/release-workflow.md`.

**Today**: it is a documented **skeleton**. `releaseWorkflow({...})` returns a `githubWorkflow({...})` with the correct triggers (`workflow_dispatch` with `mode` + `npm_tag` choice inputs, `pull_request` on `releasePlanPaths`, `push` to `main` on `releasePlanPath`), permissions, env, and job ids / `if` conditions — but the substantive bodies of `create-release-pr` / `validate-release-plan` / `publish-release` are placeholder `echo TODO ... ; exit 1` steps. The next iteration upstream replaces those placeholders.

**Release notes input**: the input shape (`ReleaseWorkflowOptions`) does **not** currently model a `releaseNotesPath` or equivalent. Release-note shape is left to the repo's `validateSteps` / `publishSteps`.

### Proposed adoption shape for LiveStore (sketch, not migrated here)

> Out of scope for this PR: LiveStore 0.4.0 just shipped with the inlined `release.yml.genie.ts`, and the upstream helper still has placeholder job bodies. A migration before both sides stabilize would carry real blast radius. Capturing the shape here so we can move quickly once the helper fills in its job bodies.

LiveStore's current `.github/workflows/release.yml.genie.ts` is ~350 lines and already matches the helper's job structure 1:1 (`source-policy`, `create-release-pr`, `validate-release-plan`, `publish-release` with the same `if` predicates). The migration would look approximately like:

```ts
import { releaseWorkflow } from '@overeng/effect-utils/genie/ci-workflow.ts'
import { livestoreSetupSteps, livestoreDefaultRefPolicyJob, devtoolsCertificationArtifactsStep } from '../genie/repo.ts'

export default releaseWorkflow({
  name: 'Release',
  workspaceName: 'livestore',
  workspaceDisplayName: 'LiveStore',
  releasePlanPath: 'release/release-plan.json',
  releasePlanPaths: [
    '.github/workflows/release.yml',
    '.github/workflows/release.yml.genie.ts',
    'genie/repo.ts',
    'release/release-plan.json',
    'release/version.json',
    'release/devtools-artifact.json',
    'scripts/src/commands/release.ts',
    'scripts/src/commands/changesets.ts',
  ],
  releaseChannels: {
    latest: { manualGate: true },   // stable: human-merged
    dev:    { manualGate: false },  // dev: auto-merge
    next:   { manualGate: false },
  },
  defaultNpmTag: 'latest',
  setupSteps: livestoreSetupSteps,
  validateSteps: [
    devenvTaskStep('Dry-run stable package publish', 'release:stable:dryrun'),
    devenvTaskStep('Repack DevTools artifact (dryrun)', 'release:devtools-artifact:repack-dryrun:no-install'),
  ],
  publishSteps: [
    devenvTaskStep('Publish stable package release', 'release:stable:publish'),
    devenvTaskStep('Publish DevTools artifact release', 'release:devtools-artifact:publish:no-install'),
    devtoolsCertificationArtifactsStep,
    devenvTaskStep('Deploy production docs', 'docs:deploy:prod'),
    devenvTaskStep('Deploy production examples', 'examples:deploy:prod'),
  ],
  trustedPublishing: false, // we keep NPM_TOKEN fallback for now
  sourcePolicyJob: livestoreDefaultRefPolicyJob,
})
```

**What stays inlined / repo-local**:

- DevTools artifact repack-dryrun + publish — flows as extra entries in `validateSteps` / `publishSteps`.
- DevTools certification artifacts upload step — same.
- Prod docs + examples deploys — same; these are LiveStore-specific post-publish hooks.
- `livestoreSetupSteps` (devenv / nix cache / pnpm prep) — passed via `setupSteps`.
- `livestoreDefaultRefPolicyJob` — passed via `sourcePolicyJob`.

**Helper-shape gaps observed (worth raising upstream before LiveStore migrates)**:

1. No `releaseNotesPath` / changelog-artifact input. LiveStore couples the release plan to the `CHANGELOG.md` editorial section; if the helper grows a release-notes story it should be a typed input rather than a freeform step.
2. `releaseChannels` is `{ manualGate: boolean }` only — LiveStore varies the docs/examples deploy target (`prod` vs `dev`) per channel. Either the channel record needs to carry that, or `publishSteps` needs access to the resolved channel at step-build time (today consumers would have to branch inside the bash). Upstream open question #1 in the design doc captures this.
3. `setupSteps` is opaque `WorkflowStep[]`. Works for LiveStore today, but the design doc flags an alternative (`standardSelfHostedPnpmCiPrepSteps(...)`) that would unify prep across jobs. Worth aligning before LiveStore commits.
4. The `create-release-pr` body is currently a ~60-line bash script in the LiveStore reference; upstream design doc explicitly asks whether the helper should own that shell or split it into typed inputs. LiveStore would want typed inputs (branch prefix, PR title template, auto-merge toggle per channel) rather than re-inlining the shell, so a configurable composite-action contract here would be preferred.

The migration becomes a near-pure deletion once those gaps are answered and the upstream job bodies are filled in.

### Test plan

- [ ] CI passes lint, changeset-check, full integration suite on this PR.
- [ ] Workflow-report `pr-preview` collector continues to publish a bundle in the next PR-preview deploy run (validated via the next merged PR that exercises the workflow-report job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)