### PR TITLE
Use MXBAI_VECTOR_STORE_ID (not _PROD suffix) in publish-release

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1771,11 +1771,11 @@ jobs:
         run: |
           set -euo pipefail
           : "${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
-          : "${MXBAI_VECTOR_STORE_ID_PROD:?Missing MXBAI_VECTOR_STORE_ID_PROD secret}"
-          pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID_PROD" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
+          : "${MXBAI_VECTOR_STORE_ID:?Missing MXBAI_VECTOR_STORE_ID secret}"
+          pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
-          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
+          MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/deploy-prod.yml.genie.ts
+++ b/.github/workflows/deploy-prod.yml.genie.ts
@@ -186,11 +186,11 @@ export default githubWorkflow({
           name: 'Sync production docs search',
           run: `set -euo pipefail
 : "\${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
-: "\${MXBAI_VECTOR_STORE_ID_PROD:?Missing MXBAI_VECTOR_STORE_ID_PROD secret}"
-pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID_PROD" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast`,
+: "\${MXBAI_VECTOR_STORE_ID:?Missing MXBAI_VECTOR_STORE_ID secret}"
+pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast`,
           env: {
             MXBAI_API_KEY: '${{ secrets.MXBAI_API_KEY }}',
-            MXBAI_VECTOR_STORE_ID_PROD: '${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}',
+            MXBAI_VECTOR_STORE_ID: '${{ secrets.MXBAI_VECTOR_STORE_ID }}',
           },
         },
       ]),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2879,11 +2879,11 @@ jobs:
         run: |
           set -euo pipefail
           : "${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
-          : "${MXBAI_VECTOR_STORE_ID_PROD:?Missing MXBAI_VECTOR_STORE_ID_PROD secret}"
-          pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID_PROD" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
+          : "${MXBAI_VECTOR_STORE_ID:?Missing MXBAI_VECTOR_STORE_ID secret}"
+          pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
-          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
+          MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -431,11 +431,11 @@ NPM_CONFIG_USERCONFIG="$npmrc" NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ n
           'timeout-minutes': 15,
           run: `set -euo pipefail
 : "\${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
-: "\${MXBAI_VECTOR_STORE_ID_PROD:?Missing MXBAI_VECTOR_STORE_ID_PROD secret}"
-pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID_PROD" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast`,
+: "\${MXBAI_VECTOR_STORE_ID:?Missing MXBAI_VECTOR_STORE_ID secret}"
+pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast`,
           env: {
             MXBAI_API_KEY: '${{ secrets.MXBAI_API_KEY }}',
-            MXBAI_VECTOR_STORE_ID_PROD: '${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}',
+            MXBAI_VECTOR_STORE_ID: '${{ secrets.MXBAI_VECTOR_STORE_ID }}',
           },
         },
       ]),


### PR DESCRIPTION
## Problem

`Sync production docs search` step in `publish-release` failed on the first run that reached it:

```
MXBAI_VECTOR_STORE_ID_PROD: Missing MXBAI_VECTOR_STORE_ID_PROD secret
```

The actual repo secret is named `MXBAI_VECTOR_STORE_ID` (verified via `gh secret list`). The `_PROD` suffix was speculative — no such secret exists in the repo.

## Fix

Drop the `_PROD` suffix from the env var name + reference in `release.yml.genie.ts`. Three occurrences in one step.

## Recovery

Trigger `release.yml workflow_dispatch mode=publish-release` once this lands. All publish/deploy steps are idempotent at this point — only the search sync will actually do work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)