### PR TITLE
WIP: Disable live workspace injection

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -117,6 +117,8 @@ dedupePeerDependents: true
 
 strictPeerDependencies: false
 
+injectWorkspacePackages: false
+
 enableGlobalVirtualStore: true
 
 storeDir: .devenv/pnpm-store-pure-v1

--- a/pnpm-workspace.yaml.genie.ts
+++ b/pnpm-workspace.yaml.genie.ts
@@ -61,6 +61,13 @@ export default pnpmWorkspaceYaml.root({
   repoName: 'livestore',
   extraMembers: ['examples/*'],
   ...commonPnpmPolicySettings,
+  /**
+   * LiveStore's live CI/dev workspace typechecks package source and generated
+   * dist outputs together. pnpm's injected workspace snapshots are still used
+   * by Nix/FOD package preparation, but enabling them for the live workspace
+   * makes TypeScript see duplicate package identities through GVS links.
+   */
+  injectWorkspacePackages: false,
   allowBuilds: repoPnpmAllowBuilds,
   packageExtensions: repoPackageExtensions,
   /** Relaxed until @livestore/devtools-vite publishes with updated Effect peer ranges */


### PR DESCRIPTION
## Problem

#1258 was the original split gate for pnpm pure-store/source-policy work, but it is now based on the old `dev` line. `main` already has pnpm 11.3, pure-store settings, the newer effect-utils pin, and the newer source-policy job shape, so merging #1258 as-is would roll back release-line workflow work.

One useful semantic remains: the live root workspace should not use injected workspace package snapshots, because LiveStore typechecks package source and generated dist outputs together and injected snapshots can create duplicate package identities through GVS links.

## Goal

Carry only that remaining pnpm workspace policy onto `main`.

## Decisions

- Replace #1258 with a narrow `main`-based PR instead of rebasing the obsolete full PR.
- Set `injectWorkspacePackages: false` only for the live root workspace.
- Leave Nix/FOD package-preparation projection behavior to the existing shared generator output.

## Verification

- `devenv tasks run genie:run` completed.
- `devenv tasks run lint:check:format` passed.
- `git diff --check` passed.

## Complexity

No new complexity. This is a single pnpm policy setting plus the generator comment explaining why it is local to the live workspace.

## Concerns

Full `check:quick` was not rerun here because current `main` shell validation recently failed on a fixed-output hash mismatch while realizing `oxc-config-pnpm-deps` in adjacent validation. This PR was kept deliberately small and format/generator checked.

## Friction & bottlenecks

- #1258 is now structurally obsolete after the 0.4.0 release moved the active line to `main`.
- No bottlenecks.

## Follow-ups

- Close or supersede #1258 after this replacement is accepted.

## References

Refs #1265
Supersedes #1258

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🎐 co3-willow |
| `agent_session_id` | d1592577-dfdf-4274-9131-734c6cff6137 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.131.0 |
| `agent_runtime` | Codex CLI 0.131.0 |
| `agent_model` | unknown |
| `worktree` | livestore/schickling-assistant/2026-06-03-pnpm-injection-policy |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4db6783 |
</details>
<!-- agent-footer:end -->