### PR TITLE
Extract reusable validate-publish-substance workflow with typed cross-job outputs

### DIFF
--- a/.changeset/reusable-validate-publish-substance.md
+++ b/.changeset/reusable-validate-publish-substance.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Extracts a reusable `validate-publish-substance.yml` workflow that both `ci.yml` (snapshot rehearsal) and `release.yml` (stable validation) call via `workflow_call`. Models cross-job state (`release-version`, `npm-tag`, `deploy-target`) as typed workflow outputs instead of `$GITHUB_ENV` writes, making the bug class behind livestorejs/livestore#1278 (env vars silently not carrying across jobs) unrepresentable. Stacks on overengineeringstudio/effect-utils#735, which adds a `JobWithUses` variant to the genie github-workflow runtime so `uses:` reusable-workflow jobs can be expressed with full type-checking.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3458,6 +3458,14 @@ jobs:
           path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore
           retention-days: 14
+  validate-snapshot-substance:
+    if: github.event.pull_request.head.repo.fork != true
+    uses: ./.github/workflows/validate-publish-substance.yml
+    with:
+      release-plan-source: synthetic
+      synthetic-version-prefix: 0.0.0-ci.snapshot-validation
+      target-scope: snapshot
+    secrets: inherit
   publish-snapshot-version:
     if: github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -418,6 +418,30 @@ done`,
     },
 
     /**
+     * Snapshot substance validation. Shares the
+     * `validate-publish-substance.yml` reusable workflow with the stable
+     * release path (`release.yml#validate-release-plan`), so the
+     * version/tag/deploy-target derivation and the stable-publish dry-run +
+     * DevTools repack-dryrun + liveness certification are validated once and
+     * stay in sync between snapshot and stable. Uses a synthetic plan so PRs
+     * don't depend on a checked-in `release/release-plan.json`.
+     *
+     * The actual snapshot publish in `publish-snapshot-version` below remains
+     * separate because it's the OIDC trusted-publish boundary; bundling that
+     * into a reusable workflow would change the npm trust contract.
+     */
+    'validate-snapshot-substance': {
+      if: IS_NOT_FORK,
+      uses: './.github/workflows/validate-publish-substance.yml',
+      with: {
+        'release-plan-source': 'synthetic',
+        'synthetic-version-prefix': '0.0.0-ci.snapshot-validation',
+        'target-scope': 'snapshot',
+      },
+      secrets: 'inherit',
+    },
+
+    /**
      * Keep only the publish boundary on GitHub-hosted runners. The heavy tests
      * above may use Namespace/self-hosted runners, but npm trusted publishing
      * currently requires GitHub-hosted OIDC and does not support self-hosted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ on:
     paths:
       - .github/workflows/release.yml
       - .github/workflows/release.yml.genie.ts
+      - .github/workflows/validate-publish-substance.yml
+      - .github/workflows/validate-publish-substance.yml.genie.ts
       - .github/workflows/deploy-prod.yml
       - .github/workflows/deploy-prod.yml.genie.ts
       - genie/repo.ts
@@ -859,552 +861,42 @@ jobs:
           else
             gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto --merge
           fi
-  validate-release-plan:
+  select-plan-source:
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')
     runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
+    outputs:
+      release-plan-source: ${{ steps.choose.outputs.release-plan-source }}
     steps:
-      - uses: actions/checkout@v6
-      - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
-        with:
-          extra-conf: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
-            extra-substituters = https://devenv.cachix.org
-            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
-            access-tokens = github.com=${{ github.token }}
-            extra-substituters = https://cache.nixos.org
-            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          summarize: true
-      - name: Provide cachix CLI from nixpkgs
-        shell: bash
+      - name: Checkout
+        uses: actions/checkout@v4
+      - id: choose
+        name: Decide whether to use the committed plan or a synthetic one
         run: |
           set -euo pipefail
-          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
-          echo "$out/bin" >> "$GITHUB_PATH"
-      - name: Enable Cachix cache
-        uses: cachix/cachix-action@v17
-        with:
-          name: livestore
-          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
-          skipPush: true
-      - name: Sync megarepo dependencies
-        env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
-        run: |
-          EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
-          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
-            echo '::error::megarepo.lock missing members["effect-utils"].commit'
-            exit 1
-          fi
-          mkdir -p "$MEGAREPO_STORE"
-          echo "Using job-local megarepo store: $MEGAREPO_STORE"
-          if [ -n "${GITHUB_ENV:-}" ]; then
-            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
-          fi
-
-          nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
-        shell: bash
-      - name: Use pinned devenv from lock
-        run: |
-          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
-          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
-            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
-            exit 1
-          fi
-          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
-          echo "Pinned devenv rev: $DEVENV_REV"
-        shell: bash
-      - name: Isolate pnpm state
-        shell: bash
-        run: |
-          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
-          echo "PNPM_CONFIG_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
-          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
-      - id: restore-pnpm-state
-        name: Restore pnpm state
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            ${{ github.workspace }}/.pnpm-home
-            ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-      - name: Resolve devenv
-        run: |
-          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
-          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
-            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
-            exit 1
-          fi
-
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
-
-          # Temporary: capture diagnostics dir for #272 root-cause analysis.
-          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
-          mkdir -p "$DIAG_ROOT"
-          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
-
-          {
-            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "runner_name=${RUNNER_NAME:-unknown}"
-            echo "runner_os=${RUNNER_OS:-unknown}"
-            echo "runner_arch=${RUNNER_ARCH:-unknown}"
-            echo "github_job=${GITHUB_JOB:-unknown}"
-            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
-            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
-            nix --version || true
-          } > "$DIAG_ROOT/environment.txt" 2>&1
-
-          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
-            echo "::error::resolve_devenv failed. Last 30 lines of log:"
-            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
-            exit 1
-          fi
-          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-
-          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
-          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
-            echo "::warning::devenv store path invalid, repairing targeted path..."
-            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
-            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
-            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
-              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
-              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
-              exit 1
-            fi
-            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
-          fi
-
-          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
-          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
-        shell: bash
-      - name: Select release plan for validation
-        run: |
-          set -euo pipefail
-          use_synthetic_plan=false
+          source="plan-file"
 
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             git fetch origin "${{ github.base_ref }}" --depth=1
             if ! git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -qx 'release/release-plan.json'; then
-              use_synthetic_plan=true
+              source="synthetic"
             fi
           elif [ ! -f release/release-plan.json ]; then
-            use_synthetic_plan=true
+            source="synthetic"
           fi
 
-          if [ "$use_synthetic_plan" = "false" ]; then
-            exit 0
-          fi
-
-          mkdir -p release
-          # PRs that touch release machinery but do not carry an actual release plan still
-          # need to exercise package publishing and DevTools repacking. Use a unique,
-          # unpublished prerelease instead of the checked-in package version: current dev
-          # versions can already exist on npm, while snapshot versions intentionally
-          # belong to the separate snapshot publisher.
-          short_sha="${GITHUB_SHA:0:12}"
-          version="0.0.0-ci.release-validation.$short_sha"
-          npm_tag="next"
-          jq -n \
-            --arg version "$version" \
-            --arg npmTag "$npm_tag" \
-            '{
-              schemaVersion: 1,
-              version: $version,
-              npmTag: $npmTag
-            }' > release/release-plan.json
-      - name: Dry-run stable package publish
-        run: |
-          __nix_gc_retry_helper=$(mktemp)
-          cat > "$__nix_gc_retry_helper" <<'EOF'
-          #!/usr/bin/env bash
-
-          run_nix_gc_race_retry() {
-            local task="$1"
-            local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
-            local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
-
-            start="$(date +%s)"
-
-            write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
-              {
-                echo "### CI Task"
-                echo "- Task: $task"
-                echo "- Status: $1"
-                echo "- Duration: $elapsed s"
-                echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
-              } >> "$GITHUB_STEP_SUMMARY"
-            }
-
-            while [ "$attempt" -le "$max" ]; do
-              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
-              (
-                while sleep "$heartbeat"; do
-                  now=$(date +%s)
-                  elapsed=$((now - start))
-                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
-                done
-              ) &
-              hb_pid=$!
-
-              log=$(mktemp)
-              had_errexit=false
-              case $- in
-                *e*) had_errexit=true ;;
-              esac
-              set +e
-              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
-              rc=$?
-              if [ "$had_errexit" = true ]; then
-                set -e
-              fi
-
-              kill "$hb_pid" 2>/dev/null || true
-              wait "$hb_pid" 2>/dev/null || true
-
-              now=$(date +%s)
-              elapsed=$((now - start))
-
-              if [ "$rc" -eq 0 ]; then
-                echo "::notice::[ci] completed $task in $elapsed s"
-                if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from transient Nix failure after retry"
-                else
-                  write_summary success
-                fi
-                rm -f "$log"
-                return 0
-              fi
-
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
-              path=$(printf '%s' "$flattened" |
-                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
-                head -1 |
-                grep -o "/nix/store/[^']*" |
-                tr -d '[:space:]' || true)
-              saw_invalid_path=false
-              saw_cachix_signature=false
-              saw_fetch_signature=false
-              [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
-              rm -f "$log"
-
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
-                write_summary failure "No transient Nix failure signature detected"
-                return "$rc"
-              fi
-
-              if [ "$saw_fetch_signature" = true ]; then
-                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
-              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
-                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
-              elif [ "$saw_cachix_signature" = true ]; then
-                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
-              else
-                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
-              fi
-
-              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
-              rm -rf ~/.cache/nix/eval-cache-*
-              attempt=$((attempt + 1))
-            done
-
-            now=$(date +%s)
-            elapsed=$((now - start))
-            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
-            write_summary failure "Transient Nix retry exhausted"
-            return 1
-          }
-          EOF
-          . "$__nix_gc_retry_helper"
-          rm -f "$__nix_gc_retry_helper"
-          run_nix_gc_race_retry 'devenv tasks run release:stable:dryrun --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:stable:dryrun --mode before'
-      - name: Read release plan
-        run: |
-          set -euo pipefail
-          release_version="$(jq -r '.version' release/release-plan.json)"
-          npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
-          : "${release_version:?Missing release version}"
-          : "${npm_tag:?Missing npm tag}"
-          echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
-          echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
-          if [ "$npm_tag" = "latest" ]; then
-            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
-          else
-            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
-          fi
-      - name: Certify DevTools artifact liveness
-        run: |
-          __nix_gc_retry_helper=$(mktemp)
-          cat > "$__nix_gc_retry_helper" <<'EOF'
-          #!/usr/bin/env bash
-
-          run_nix_gc_race_retry() {
-            local task="$1"
-            local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
-            local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
-
-            start="$(date +%s)"
-
-            write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
-              {
-                echo "### CI Task"
-                echo "- Task: $task"
-                echo "- Status: $1"
-                echo "- Duration: $elapsed s"
-                echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
-              } >> "$GITHUB_STEP_SUMMARY"
-            }
-
-            while [ "$attempt" -le "$max" ]; do
-              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
-              (
-                while sleep "$heartbeat"; do
-                  now=$(date +%s)
-                  elapsed=$((now - start))
-                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
-                done
-              ) &
-              hb_pid=$!
-
-              log=$(mktemp)
-              had_errexit=false
-              case $- in
-                *e*) had_errexit=true ;;
-              esac
-              set +e
-              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
-              rc=$?
-              if [ "$had_errexit" = true ]; then
-                set -e
-              fi
-
-              kill "$hb_pid" 2>/dev/null || true
-              wait "$hb_pid" 2>/dev/null || true
-
-              now=$(date +%s)
-              elapsed=$((now - start))
-
-              if [ "$rc" -eq 0 ]; then
-                echo "::notice::[ci] completed $task in $elapsed s"
-                if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from transient Nix failure after retry"
-                else
-                  write_summary success
-                fi
-                rm -f "$log"
-                return 0
-              fi
-
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
-              path=$(printf '%s' "$flattened" |
-                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
-                head -1 |
-                grep -o "/nix/store/[^']*" |
-                tr -d '[:space:]' || true)
-              saw_invalid_path=false
-              saw_cachix_signature=false
-              saw_fetch_signature=false
-              [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
-              rm -f "$log"
-
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
-                write_summary failure "No transient Nix failure signature detected"
-                return "$rc"
-              fi
-
-              if [ "$saw_fetch_signature" = true ]; then
-                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
-              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
-                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
-              elif [ "$saw_cachix_signature" = true ]; then
-                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
-              else
-                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
-              fi
-
-              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
-              rm -rf ~/.cache/nix/eval-cache-*
-              attempt=$((attempt + 1))
-            done
-
-            now=$(date +%s)
-            elapsed=$((now - start))
-            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
-            write_summary failure "Transient Nix retry exhausted"
-            return 1
-          }
-          EOF
-          . "$__nix_gc_retry_helper"
-          rm -f "$__nix_gc_retry_helper"
-          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:certify-liveness:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:certify-liveness:no-install --mode before'
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: 'devtools-certification-playwright-artifacts-${{ github.job }}'
-          path: |
-            tests/integration/playwright-report/
-            tests/integration/test-results/devtools/
-          retention-days: 30
-          if-no-files-found: ignore
-      - name: Dry-run DevTools artifact repack
-        run: |
-          __nix_gc_retry_helper=$(mktemp)
-          cat > "$__nix_gc_retry_helper" <<'EOF'
-          #!/usr/bin/env bash
-
-          run_nix_gc_race_retry() {
-            local task="$1"
-            local command="$2"
-            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
-            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
-            local attempt=1
-            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
-
-            start="$(date +%s)"
-
-            write_summary() {
-              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
-              {
-                echo "### CI Task"
-                echo "- Task: $task"
-                echo "- Status: $1"
-                echo "- Duration: $elapsed s"
-                echo "- Attempts: $attempt/$max"
-                [ -z "${2:-}" ] || echo "- Note: $2"
-              } >> "$GITHUB_STEP_SUMMARY"
-            }
-
-            while [ "$attempt" -le "$max" ]; do
-              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
-              (
-                while sleep "$heartbeat"; do
-                  now=$(date +%s)
-                  elapsed=$((now - start))
-                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
-                done
-              ) &
-              hb_pid=$!
-
-              log=$(mktemp)
-              had_errexit=false
-              case $- in
-                *e*) had_errexit=true ;;
-              esac
-              set +e
-              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
-              rc=$?
-              if [ "$had_errexit" = true ]; then
-                set -e
-              fi
-
-              kill "$hb_pid" 2>/dev/null || true
-              wait "$hb_pid" 2>/dev/null || true
-
-              now=$(date +%s)
-              elapsed=$((now - start))
-
-              if [ "$rc" -eq 0 ]; then
-                echo "::notice::[ci] completed $task in $elapsed s"
-                if [ "$attempt" -gt 1 ]; then
-                  write_summary success "Recovered from transient Nix failure after retry"
-                else
-                  write_summary success
-                fi
-                rm -f "$log"
-                return 0
-              fi
-
-              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
-              path=$(printf '%s' "$flattened" |
-                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
-                head -1 |
-                grep -o "/nix/store/[^']*" |
-                tr -d '[:space:]' || true)
-              saw_invalid_path=false
-              saw_cachix_signature=false
-              saw_fetch_signature=false
-              [ -n "$path" ] && saw_invalid_path=true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
-              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
-              rm -f "$log"
-
-              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
-                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
-                write_summary failure "No transient Nix failure signature detected"
-                return "$rc"
-              fi
-
-              if [ "$saw_fetch_signature" = true ]; then
-                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
-              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
-                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
-              elif [ "$saw_cachix_signature" = true ]; then
-                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
-              else
-                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
-              fi
-
-              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
-              rm -rf ~/.cache/nix/eval-cache-*
-              attempt=$((attempt + 1))
-            done
-
-            now=$(date +%s)
-            elapsed=$((now - start))
-            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
-            write_summary failure "Transient Nix retry exhausted"
-            return 1
-          }
-          EOF
-          . "$__nix_gc_retry_helper"
-          rm -f "$__nix_gc_retry_helper"
-          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:repack-dryrun:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:repack-dryrun:no-install --mode before'
-      - name: Save pnpm state
-        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ github.workspace }}/.pnpm-home
-            ${{ runner.temp }}/pnpm-store/${{ github.job }}
-          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
-      - name: Upload Nix diagnostics artifact
-        if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
-          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
-          if-no-files-found: ignore
-          retention-days: 14
+          echo "release-plan-source=$source" >> "$GITHUB_OUTPUT"
+          echo "Selected release-plan-source=$source"
+  validate-release-plan:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')
+    needs: select-plan-source
+    uses: ./.github/workflows/validate-publish-substance.yml
+    with:
+      release-plan-source: ${{ needs.select-plan-source.outputs.release-plan-source }}
+      target-scope: stable
+    secrets: inherit
   publish-release:
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-release')
     runs-on: ubuntu-24.04
@@ -1551,13 +1043,14 @@ jobs:
           echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
           echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
           # Env vars do not carry across jobs in GitHub Actions, so the deploy-target
-          # gate that the validate-release-plan job sets must be re-derived here for the
-          # Deploy production docs/examples and Sync production docs search steps below.
-          if [ "$npm_tag" = "latest" ]; then
-            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
-          else
-            echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
-          fi
+          # gate that the validate-release-plan job derives must be re-derived here for
+          # the Deploy production docs/examples and Sync production docs search steps
+          # below. Tracked by #1278 follow-up above.
+          case "$npm_tag" in
+            latest) echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV" ;;
+            dev)    echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev"  >> "$GITHUB_ENV" ;;
+            *)      echo "LIVESTORE_RELEASE_DEPLOY_TARGET=none" >> "$GITHUB_ENV" ;;
+          esac
       - name: Configure npm token fallback
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -31,6 +31,8 @@ tests/integration/test-results/devtools/`,
 const releasePlanPaths = [
   '.github/workflows/release.yml',
   '.github/workflows/release.yml.genie.ts',
+  '.github/workflows/validate-publish-substance.yml',
+  '.github/workflows/validate-publish-substance.yml.genie.ts',
   '.github/workflows/deploy-prod.yml',
   '.github/workflows/deploy-prod.yml.genie.ts',
   'genie/repo.ts',
@@ -205,77 +207,53 @@ fi`,
       ],
     },
 
-    'validate-release-plan': {
+    /**
+     * Stable release validation. Delegates to the reusable
+     * `validate-publish-substance.yml` workflow so the plan-source selection
+     * + version/tag/deploy-target derivation is shared with the snapshot
+     * substance check in `ci.yml`. Decides between the checked-in
+     * `release/release-plan.json` and a synthetic plan based on whether the
+     * PR actually edits the plan file.
+     */
+    'select-plan-source': {
       if: "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')",
       'runs-on': 'ubuntu-24.04',
       defaults: bashShellDefaults,
-      steps: withNixDiagnosticsOnFailure([
-        ...livestoreSetupSteps,
+      outputs: {
+        'release-plan-source': '${{ steps.choose.outputs.release-plan-source }}',
+      },
+      steps: [
+        { name: 'Checkout', uses: 'actions/checkout@v4' },
         {
-          name: 'Select release plan for validation',
+          id: 'choose',
+          name: 'Decide whether to use the committed plan or a synthetic one',
           run: `set -euo pipefail
-use_synthetic_plan=false
+source="plan-file"
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
   git fetch origin "\${{ github.base_ref }}" --depth=1
   if ! git diff --name-only "origin/\${{ github.base_ref }}...HEAD" | grep -qx 'release/release-plan.json'; then
-    use_synthetic_plan=true
+    source="synthetic"
   fi
 elif [ ! -f release/release-plan.json ]; then
-  use_synthetic_plan=true
+  source="synthetic"
 fi
 
-if [ "$use_synthetic_plan" = "false" ]; then
-  exit 0
-fi
+echo "release-plan-source=$source" >> "$GITHUB_OUTPUT"
+echo "Selected release-plan-source=$source"`,
+        },
+      ],
+    },
 
-mkdir -p release
-# PRs that touch release machinery but do not carry an actual release plan still
-# need to exercise package publishing and DevTools repacking. Use a unique,
-# unpublished prerelease instead of the checked-in package version: current dev
-# versions can already exist on npm, while snapshot versions intentionally
-# belong to the separate snapshot publisher.
-short_sha="\${GITHUB_SHA:0:12}"
-version="0.0.0-ci.release-validation.$short_sha"
-npm_tag="next"
-jq -n \\
-  --arg version "$version" \\
-  --arg npmTag "$npm_tag" \\
-  '{
-    schemaVersion: 1,
-    version: $version,
-    npmTag: $npmTag
-  }' > release/release-plan.json`,
-        },
-        {
-          name: 'Dry-run stable package publish',
-          run: runDevenvTasksBefore('release:stable:dryrun'),
-        },
-        {
-          name: 'Read release plan',
-          run: `set -euo pipefail
-release_version="$(jq -r '.version' release/release-plan.json)"
-npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
-: "\${release_version:?Missing release version}"
-: "\${npm_tag:?Missing npm tag}"
-echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
-echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
-if [ "$npm_tag" = "latest" ]; then
-  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
-else
-  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
-fi`,
-        },
-        {
-          name: 'Certify DevTools artifact liveness',
-          run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
-        },
-        devtoolsCertificationArtifactsStep,
-        {
-          name: 'Dry-run DevTools artifact repack',
-          run: runDevenvTasksBefore('release:devtools-artifact:repack-dryrun:no-install'),
-        },
-      ]),
+    'validate-release-plan': {
+      if: "github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'validate-release-plan')",
+      needs: 'select-plan-source',
+      uses: './.github/workflows/validate-publish-substance.yml',
+      with: {
+        'release-plan-source': '${{ needs.select-plan-source.outputs.release-plan-source }}',
+        'target-scope': 'stable',
+      },
+      secrets: 'inherit',
     },
 
     'publish-release': {
@@ -293,6 +271,20 @@ fi`,
       steps: withNixDiagnosticsOnFailure([
         ...livestoreSetupSteps,
         {
+          /**
+           * TODO(#1278-followup): Migrate this job to `uses:
+           * ./.github/workflows/validate-publish-substance.yml` so the version /
+           * tag / deploy-target triple is sourced from typed workflow_call
+           * outputs instead of re-derived here. Kept inline for now because the
+           * publish-release job has many downstream steps that still read these
+           * values as `env.LIVESTORE_RELEASE_DEPLOY_TARGET` — migrating them is
+           * a separate change.
+           *
+           * The duplicated jq/case block below intentionally mirrors the
+           * `Derive release-version / npm-tag / deploy-target outputs` step in
+           * `validate-publish-substance.yml`. Any change to the mapping must be
+           * applied in both places until the migration completes.
+           */
           name: 'Read release plan',
           run: `set -euo pipefail
 release_version="$(jq -r '.version' release/release-plan.json)"
@@ -302,13 +294,14 @@ npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
 echo "LIVESTORE_RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
 echo "LIVESTORE_NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
 # Env vars do not carry across jobs in GitHub Actions, so the deploy-target
-# gate that the validate-release-plan job sets must be re-derived here for the
-# Deploy production docs/examples and Sync production docs search steps below.
-if [ "$npm_tag" = "latest" ]; then
-  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV"
-else
-  echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev" >> "$GITHUB_ENV"
-fi`,
+# gate that the validate-release-plan job derives must be re-derived here for
+# the Deploy production docs/examples and Sync production docs search steps
+# below. Tracked by #1278 follow-up above.
+case "$npm_tag" in
+  latest) echo "LIVESTORE_RELEASE_DEPLOY_TARGET=prod" >> "$GITHUB_ENV" ;;
+  dev)    echo "LIVESTORE_RELEASE_DEPLOY_TARGET=dev"  >> "$GITHUB_ENV" ;;
+  *)      echo "LIVESTORE_RELEASE_DEPLOY_TARGET=none" >> "$GITHUB_ENV" ;;
+esac`,
         },
         /*
          * Stable package publishing uses the NPM_TOKEN secret. npm currently

--- a/.github/workflows/validate-publish-substance.yml
+++ b/.github/workflows/validate-publish-substance.yml
@@ -1,0 +1,607 @@
+# Generated file - DO NOT EDIT
+# Source: validate-publish-substance.yml.genie.ts
+
+name: Validate publish substance (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      release-plan-source:
+        description: 'Where the release plan comes from: plan-file | synthetic'
+        required: true
+        type: string
+      synthetic-version-prefix:
+        description: Version prefix for synthetic plans (only used when release-plan-source=synthetic)
+        required: false
+        default: 0.0.0-ci.release-validation
+        type: string
+      target-scope:
+        description: 'Caller scope: stable | snapshot | rehearsal'
+        required: true
+        type: string
+      npm-tag-override:
+        description: Optional npm tag override (empty string = no override)
+        required: false
+        default: ''
+        type: string
+    outputs:
+      release-version:
+        description: Version string from the validated release plan
+        value: ${{ jobs.validate.outputs.release-version }}
+      npm-tag:
+        description: npm dist-tag from the validated release plan
+        value: ${{ jobs.validate.outputs.npm-tag }}
+      deploy-target:
+        description: prod | dev | none (derived once from npm-tag)
+        value: ${{ jobs.validate.outputs.deploy-target }}
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+  CI: 'true'
+  FORCE_SETUP: '1'
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    outputs:
+      release-version: ${{ steps.derive.outputs.release-version }}
+      npm-tag: ${{ steps.derive.outputs.npm-tag }}
+      deploy-target: ${{ steps.derive.outputs.deploy-target }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+        run: |
+          EU_REV=$(jq -r '.members["effect-utils"].commit' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '::error::megarepo.lock missing members["effect-utils"].commit'
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf 'MEGAREPO_STORE=%s\n' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+          fi
+
+          nix run "github:overengineeringstudio/effect-utils/$EU_REV#megarepo" -- apply --all
+        shell: bash
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_CONFIG_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+
+          resolve_devenv() {
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"
+        shell: bash
+      - name: Materialize release plan
+        env:
+          RELEASE_PLAN_SOURCE: ${{ inputs.release-plan-source }}
+          SYNTHETIC_VERSION_PREFIX: ${{ inputs.synthetic-version-prefix }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_PLAN_SOURCE" in
+            plan-file)
+              if [ ! -f release/release-plan.json ]; then
+                echo "release-plan-source=plan-file but release/release-plan.json is missing" >&2
+                exit 1
+              fi
+              ;;
+            synthetic)
+              mkdir -p release
+              short_sha="${GITHUB_SHA:0:12}"
+              version="${SYNTHETIC_VERSION_PREFIX}.${short_sha}"
+              # Snapshot/rehearsal plans publish under the `next` dist-tag so they never
+              # collide with the `latest` or `dev` channels the production release
+              # pipeline owns.
+              npm_tag="next"
+              jq -n \
+                --arg version "$version" \
+                --arg npmTag "$npm_tag" \
+                '{ schemaVersion: 1, version: $version, npmTag: $npmTag }' \
+                > release/release-plan.json
+              ;;
+            *)
+              echo "Unknown release-plan-source: $RELEASE_PLAN_SOURCE (expected: plan-file | synthetic)" >&2
+              exit 1
+              ;;
+          esac
+      - id: derive
+        name: Derive release-version / npm-tag / deploy-target outputs
+        env:
+          NPM_TAG_OVERRIDE: ${{ inputs.npm-tag-override }}
+        run: |
+          set -euo pipefail
+          release_version="$(jq -r '.version' release/release-plan.json)"
+          npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
+          : "${release_version:?Missing release version}"
+          : "${npm_tag:?Missing npm tag}"
+
+          if [ -n "$NPM_TAG_OVERRIDE" ]; then
+            npm_tag="$NPM_TAG_OVERRIDE"
+          fi
+
+          # Canonical npm-tag -> deploy-target mapping. Previously inlined in three
+          # places (validate-release-plan, publish-release, deploy-prod).
+          case "$npm_tag" in
+            latest) deploy_target="prod" ;;
+            dev)    deploy_target="dev"  ;;
+            *)      deploy_target="none" ;;
+          esac
+
+          echo "release-version=$release_version" >> "$GITHUB_OUTPUT"
+          echo "npm-tag=$npm_tag" >> "$GITHUB_OUTPUT"
+          echo "deploy-target=$deploy_target" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved: version=$release_version npm-tag=$npm_tag deploy-target=$deploy_target"
+      - name: Dry-run stable package publish
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from transient Nix failure after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              saw_fetch_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run release:stable:dryrun --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:stable:dryrun --mode before'
+      - name: Certify DevTools artifact liveness
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from transient Nix failure after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              saw_fetch_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:certify-liveness:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:certify-liveness:no-install --mode before'
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: 'devtools-certification-playwright-artifacts-${{ github.job }}'
+          path: |
+            tests/integration/playwright-report/
+            tests/integration/test-results/devtools/
+          retention-days: 30
+          if-no-files-found: ignore
+      - name: Dry-run DevTools artifact repack
+        run: |
+          __nix_gc_retry_helper=$(mktemp)
+          cat > "$__nix_gc_retry_helper" <<'EOF'
+          #!/usr/bin/env bash
+
+          run_nix_gc_race_retry() {
+            local task="$1"
+            local command="$2"
+            local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
+            local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+            local attempt=1
+            local log rc path start now elapsed hb_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature had_errexit
+
+            start="$(date +%s)"
+
+            write_summary() {
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+              {
+                echo "### CI Task"
+                echo "- Task: $task"
+                echo "- Status: $1"
+                echo "- Duration: $elapsed s"
+                echo "- Attempts: $attempt/$max"
+                [ -z "${2:-}" ] || echo "- Note: $2"
+              } >> "$GITHUB_STEP_SUMMARY"
+            }
+
+            while [ "$attempt" -le "$max" ]; do
+              echo "::notice::[ci] starting $task (attempt $attempt/$max)"
+              (
+                while sleep "$heartbeat"; do
+                  now=$(date +%s)
+                  elapsed=$((now - start))
+                  echo "::notice::[ci] $task still running after $elapsed s (attempt $attempt/$max)"
+                done
+              ) &
+              hb_pid=$!
+
+              log=$(mktemp)
+              had_errexit=false
+              case $- in
+                *e*) had_errexit=true ;;
+              esac
+              set +e
+              eval "$command" > >(tee -a "$log") 2> >(tee -a "$log" >&2)
+              rc=$?
+              if [ "$had_errexit" = true ]; then
+                set -e
+              fi
+
+              kill "$hb_pid" 2>/dev/null || true
+              wait "$hb_pid" 2>/dev/null || true
+
+              now=$(date +%s)
+              elapsed=$((now - start))
+
+              if [ "$rc" -eq 0 ]; then
+                echo "::notice::[ci] completed $task in $elapsed s"
+                if [ "$attempt" -gt 1 ]; then
+                  write_summary success "Recovered from transient Nix failure after retry"
+                else
+                  write_summary success
+                fi
+                rm -f "$log"
+                return 0
+              fi
+
+              flattened=$(tr '\r\n' '  ' < "$log" | sed -E $'s/\x1B\[[0-9;]*m//g')
+              path=$(printf '%s' "$flattened" |
+                grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" |
+                head -1 |
+                grep -o "/nix/store/[^']*" |
+                tr -d '[:space:]' || true)
+              saw_invalid_path=false
+              saw_cachix_signature=false
+              saw_fetch_signature=false
+              [ -n "$path" ] && saw_invalid_path=true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*Failed to convert config\.cachix to JSON' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*.*while evaluating the option.*cachix\.package' && saw_cachix_signature=true || true
+              printf '%s' "$flattened" | grep -Eq 'error:[[:space:]]*cannot read file from tarball:[[:space:]]*Truncated tar archive detected while reading data' && saw_fetch_signature=true || true
+              rm -f "$log"
+
+              if [ "$saw_invalid_path" != true ] && [ "$saw_cachix_signature" != true ] && [ "$saw_fetch_signature" != true ]; then
+                echo "::warning::[ci] $task failed after $elapsed s without a detected transient Nix failure"
+                write_summary failure "No transient Nix failure signature detected"
+                return "$rc"
+              fi
+
+              if [ "$saw_fetch_signature" = true ]; then
+                echo "::warning::Nix source fetch corruption detected for $task (attempt $attempt/$max); retrying with a refreshed eval cache"
+              elif [ "$saw_cachix_signature" = true ] && [ -n "$path" ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper (attempt $attempt/$max): $path"
+              elif [ "$saw_cachix_signature" = true ]; then
+                echo "::warning::Nix store validity race detected for $task via cachix eval wrapper without extracted store path (attempt $attempt/$max)"
+              else
+                echo "::warning::Nix store validity race detected for $task (attempt $attempt/$max): $path"
+              fi
+
+              [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
+              rm -rf ~/.cache/nix/eval-cache-*
+              attempt=$((attempt + 1))
+            done
+
+            now=$(date +%s)
+            elapsed=$((now - start))
+            echo "::error::Transient Nix retry exhausted for $task ($max attempts)"
+            write_summary failure "Transient Nix retry exhausted"
+            return 1
+          }
+          EOF
+          . "$__nix_gc_retry_helper"
+          rm -f "$__nix_gc_retry_helper"
+          run_nix_gc_race_retry 'devenv tasks run release:devtools-artifact:repack-dryrun:no-install --mode before' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DT_PASSTHROUGH=1 "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:devtools-artifact:repack-dryrun:no-install --mode before'
+      - name: Save pnpm state
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Upload Nix diagnostics artifact
+        if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/validate-publish-substance.yml.genie.ts
+++ b/.github/workflows/validate-publish-substance.yml.genie.ts
@@ -1,0 +1,243 @@
+/**
+ * Reusable workflow: validate that the release/publish substance is consistent
+ * with the declared release plan.
+ *
+ * Called by:
+ *   - `release.yml#validate-release-plan` — stable release path (PRs + dispatch).
+ *   - `ci.yml#validate-snapshot-substance` — snapshot rehearsal path on PRs.
+ *
+ * Why this exists (livestorejs/livestore#1278):
+ *   The pre-refactor world hand-rolled an `echo X=Y >> $GITHUB_ENV` block in two
+ *   places (`validate-release-plan` and `publish-release`) to derive
+ *   `LIVESTORE_RELEASE_VERSION` / `LIVESTORE_NPM_TAG` /
+ *   `LIVESTORE_RELEASE_DEPLOY_TARGET` from `release/release-plan.json`. Env vars
+ *   do not carry across jobs, so each downstream job had to re-derive them. The
+ *   `LIVESTORE_RELEASE_DEPLOY_TARGET` line got dropped on one path and the
+ *   `Deploy production *` steps silently skipped — a propagation bug that the
+ *   compiler cannot represent away.
+ *
+ *   Modelling this as a reusable workflow with typed `inputs` / `outputs` makes
+ *   the cross-job state explicit and untestable bugs in the propagation layer
+ *   disappear: dependent jobs read
+ *   `needs.<job>.outputs.release-version` etc., and the schema fails CI if a
+ *   caller forgets to wire an output.
+ *
+ * Required upstream change:
+ *   @overeng/genie modelled `Job` as steps-only until this refactor. The
+ *   companion PR (`overengineeringstudio/effect-utils#735`) adds `JobWithUses`
+ *   so callers can express `uses: ./.github/workflows/<name>.yml` jobs.
+ */
+import {
+  bashShellDefaults,
+  defaultActionlintConfig,
+  githubWorkflow,
+  livestoreSetupSteps,
+  nixDiagnosticsArtifactStep,
+  runDevenvTasksBefore,
+  savePnpmStateStep,
+} from '../../genie/repo.ts'
+
+const withNixDiagnosticsOnFailure = (steps: unknown[]) => [
+  ...steps,
+  savePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),
+  nixDiagnosticsArtifactStep(),
+]
+
+/**
+ * Playwright artifacts produced by `release:devtools-artifact:certify-liveness`.
+ * Uploaded unconditionally so failures surface the screenshots/reports that
+ * make liveness regressions debuggable.
+ */
+const devtoolsCertificationArtifactsStep = {
+  uses: 'actions/upload-artifact@v4',
+  if: '${{ !cancelled() }}',
+  with: {
+    name: 'devtools-certification-playwright-artifacts-${{ github.job }}',
+    path: `tests/integration/playwright-report/
+tests/integration/test-results/devtools/`,
+    'retention-days': 30,
+    'if-no-files-found': 'ignore',
+  },
+}
+
+export default githubWorkflow({
+  name: 'Validate publish substance (reusable)',
+  actionlint: defaultActionlintConfig,
+
+  on: {
+    workflow_call: {
+      inputs: {
+        /**
+         * `plan-file` reads `release/release-plan.json` from the checked-out
+         * tree. `synthetic` writes a unique `0.0.0-...` plan first so PRs that
+         * touch release machinery (without an actual release plan) can still
+         * exercise the publish pipeline end-to-end.
+         */
+        'release-plan-source': {
+          description: 'Where the release plan comes from: plan-file | synthetic',
+          required: true,
+          type: 'string',
+        },
+        /**
+         * Prefix for the synthetic version when `release-plan-source = synthetic`.
+         * Final version is `<prefix>.<short-sha>`, e.g.
+         * `0.0.0-ci.release-validation` → `0.0.0-ci.release-validation.abc123def456`.
+         */
+        'synthetic-version-prefix': {
+          description: 'Version prefix for synthetic plans (only used when release-plan-source=synthetic)',
+          required: false,
+          default: '0.0.0-ci.release-validation',
+          type: 'string',
+        },
+        /**
+         * Identifies which higher-level pipeline is calling, used for
+         * observability and to gate behaviour that differs between paths.
+         * Currently informational; reserved for future per-scope branching.
+         */
+        'target-scope': {
+          description: 'Caller scope: stable | snapshot | rehearsal',
+          required: true,
+          type: 'string',
+        },
+        /**
+         * Force the npm tag, overriding whatever the plan/synthesizer chose.
+         * Empty string means "no override; use the value from the plan."
+         */
+        'npm-tag-override': {
+          description: 'Optional npm tag override (empty string = no override)',
+          required: false,
+          default: '',
+          type: 'string',
+        },
+      },
+      outputs: {
+        'release-version': {
+          description: 'Version string from the validated release plan',
+          value: '${{ jobs.validate.outputs.release-version }}',
+        },
+        'npm-tag': {
+          description: 'npm dist-tag from the validated release plan',
+          value: '${{ jobs.validate.outputs.npm-tag }}',
+        },
+        /**
+         * Where prod deploys are eligible to run. `latest` -> prod,
+         * `dev` -> dev, anything else -> none. Callers gate their deploy
+         * steps on this output instead of re-deriving from `npm-tag`.
+         */
+        'deploy-target': {
+          description: 'prod | dev | none (derived once from npm-tag)',
+          value: '${{ jobs.validate.outputs.deploy-target }}',
+        },
+      },
+    },
+  },
+
+  permissions: {
+    contents: 'read',
+    'id-token': 'write',
+  },
+
+  env: {
+    CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_AUTH_TOKEN }}',
+    CI: 'true',
+    FORCE_SETUP: '1',
+  },
+
+  jobs: {
+    validate: {
+      'runs-on': 'ubuntu-24.04',
+      outputs: {
+        'release-version': '${{ steps.derive.outputs.release-version }}',
+        'npm-tag': '${{ steps.derive.outputs.npm-tag }}',
+        'deploy-target': '${{ steps.derive.outputs.deploy-target }}',
+      },
+      defaults: bashShellDefaults,
+      steps: withNixDiagnosticsOnFailure([
+        ...livestoreSetupSteps,
+        {
+          name: 'Materialize release plan',
+          env: {
+            RELEASE_PLAN_SOURCE: '${{ inputs.release-plan-source }}',
+            SYNTHETIC_VERSION_PREFIX: '${{ inputs.synthetic-version-prefix }}',
+          },
+          run: `set -euo pipefail
+case "$RELEASE_PLAN_SOURCE" in
+  plan-file)
+    if [ ! -f release/release-plan.json ]; then
+      echo "release-plan-source=plan-file but release/release-plan.json is missing" >&2
+      exit 1
+    fi
+    ;;
+  synthetic)
+    mkdir -p release
+    short_sha="\${GITHUB_SHA:0:12}"
+    version="\${SYNTHETIC_VERSION_PREFIX}.\${short_sha}"
+    # Snapshot/rehearsal plans publish under the \`next\` dist-tag so they never
+    # collide with the \`latest\` or \`dev\` channels the production release
+    # pipeline owns.
+    npm_tag="next"
+    jq -n \\
+      --arg version "$version" \\
+      --arg npmTag "$npm_tag" \\
+      '{ schemaVersion: 1, version: $version, npmTag: $npmTag }' \\
+      > release/release-plan.json
+    ;;
+  *)
+    echo "Unknown release-plan-source: $RELEASE_PLAN_SOURCE (expected: plan-file | synthetic)" >&2
+    exit 1
+    ;;
+esac`,
+        },
+        {
+          /**
+           * Single source of truth for the version / tag / deploy-target
+           * triple. Callers get these as typed `needs.<job>.outputs.*` values
+           * instead of having to repeat this jq + tag-mapping shell block in
+           * every downstream job.
+           */
+          id: 'derive',
+          name: 'Derive release-version / npm-tag / deploy-target outputs',
+          env: {
+            NPM_TAG_OVERRIDE: '${{ inputs.npm-tag-override }}',
+          },
+          run: `set -euo pipefail
+release_version="$(jq -r '.version' release/release-plan.json)"
+npm_tag="$(jq -r '.npmTag' release/release-plan.json)"
+: "\${release_version:?Missing release version}"
+: "\${npm_tag:?Missing npm tag}"
+
+if [ -n "$NPM_TAG_OVERRIDE" ]; then
+  npm_tag="$NPM_TAG_OVERRIDE"
+fi
+
+# Canonical npm-tag -> deploy-target mapping. Previously inlined in three
+# places (validate-release-plan, publish-release, deploy-prod).
+case "$npm_tag" in
+  latest) deploy_target="prod" ;;
+  dev)    deploy_target="dev"  ;;
+  *)      deploy_target="none" ;;
+esac
+
+echo "release-version=$release_version" >> "$GITHUB_OUTPUT"
+echo "npm-tag=$npm_tag" >> "$GITHUB_OUTPUT"
+echo "deploy-target=$deploy_target" >> "$GITHUB_OUTPUT"
+
+echo "Resolved: version=$release_version npm-tag=$npm_tag deploy-target=$deploy_target"`,
+        },
+        {
+          name: 'Dry-run stable package publish',
+          run: runDevenvTasksBefore('release:stable:dryrun'),
+        },
+        {
+          name: 'Certify DevTools artifact liveness',
+          run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
+        },
+        devtoolsCertificationArtifactsStep,
+        {
+          name: 'Dry-run DevTools artifact repack',
+          run: runDevenvTasksBefore('release:devtools-artifact:repack-dryrun:no-install'),
+        },
+      ]),
+    },
+  },
+})

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1776802132,
-        "narHash": "sha256-2yO2SGA7zVFYKe0qyJjdg7WHuMOKNwTQmigL7ydD8hI=",
+        "lastModified": 1780459148,
+        "narHash": "sha256-oIpiel88r8zV/WqTFwcGAjWXKOASHNzq7wjXQ6ORTvg=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "91affc7a7b6646852a0079678eadf12ac5029d9d",
+        "rev": "493ed7ef062ba3972c06e60970fe5ebe014f5c33",
         "type": "github"
       },
       "original": {
@@ -24,16 +24,16 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1780403834,
-        "narHash": "sha256-kqDwgBq0LxpigfaxbJbhXEkZ0ubeIgvx/GLLh7hMpDg=",
+        "lastModified": 1780470039,
+        "narHash": "sha256-zOGA7zg+C1kC3Qcn5ST1OAyNCNzx99QfB7V4r8oLe7o=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "f29b791b25f080bcf73438c9dfa5434f2572d2c4",
+        "rev": "cac20e6be3ba04dc52b7e190f7e134dd5e24ee38",
         "type": "github"
       },
       "original": {
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "ref": "schickling-assistant/2026-06-03-workflow-call-job",
         "repo": "effect-utils",
         "type": "github"
       }
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -190,17 +190,17 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1780403834,
-        "narHash": "sha256-kqDwgBq0LxpigfaxbJbhXEkZ0ubeIgvx/GLLh7hMpDg=",
+        "lastModified": 1780470039,
+        "narHash": "sha256-zOGA7zg+C1kC3Qcn5ST1OAyNCNzx99QfB7V4r8oLe7o=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "f29b791b25f080bcf73438c9dfa5434f2572d2c4",
+        "rev": "cac20e6be3ba04dc52b7e190f7e134dd5e24ee38",
         "type": "github"
       },
       "original": {
         "dir": "nix/playwright-flake",
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "ref": "schickling-assistant/2026-06-03-workflow-call-job",
         "repo": "effect-utils",
         "type": "github"
       }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -7,9 +7,11 @@ inputs:
       nixpkgs:
         follows: nixpkgs
   playwright:
-    url: github:overengineeringstudio/effect-utils/main?dir=nix/playwright-flake
+    # TODO(#1278-followup): Revert to main once effect-utils#735 is merged.
+    url: github:overengineeringstudio/effect-utils/schickling-assistant/2026-06-03-workflow-call-job?dir=nix/playwright-flake
     inputs:
       nixpkgs:
         follows: nixpkgs
   effect-utils:
-    url: github:overengineeringstudio/effect-utils/main
+    # TODO(#1278-followup): Revert to main once effect-utils#735 is merged.
+    url: github:overengineeringstudio/effect-utils/schickling-assistant/2026-06-03-workflow-call-job

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,4 +1,4 @@
 members {
-    effect-utils "overengineeringstudio/effect-utils#main"
+    effect-utils "overengineeringstudio/effect-utils#schickling-assistant/2026-06-03-workflow-call-job"
     effect "effect-ts/effect"
 }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "f29b791b25f080bcf73438c9dfa5434f2572d2c4",
+      "ref": "schickling-assistant/2026-06-03-workflow-call-job",
+      "commit": "cac20e6be3ba04dc52b7e190f7e134dd5e24ee38",
       "pinned": true,
-      "lockedAt": "2026-06-02T12:37:14.000Z"
+      "lockedAt": "2026-06-03T07:03:13.722Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Problem

The LiveStore 0.4.0 cut produced six bugs (#1277, #1278, #1281, #1283, #1284, #1285) that shared one underlying weakness: the path from "artifact built" to "artifact published" was hand-rolled and untestable. The most virulent of those (#1278) was a `\$GITHUB_ENV` propagation gap — `LIVESTORE_RELEASE_DEPLOY_TARGET` was written by `validate-release-plan` but never read by `publish-release` because env doesn't carry across jobs. The `Deploy production *` steps silently no-opped on dev releases.

That bug class is unrepresentable if cross-job state moves through typed `workflow_call` outputs instead of `\$GITHUB_ENV` writes.

## Solution

Introduce `.github/workflows/validate-publish-substance.yml(.genie.ts)`, a `workflow_call`-only reusable workflow with typed inputs and outputs:

| Input | Purpose |
| --- | --- |
| `release-plan-source` | `plan-file` (read `release/release-plan.json`) vs `synthetic` (write a unique `0.0.0-...` plan). |
| `synthetic-version-prefix` | Version prefix used when source is synthetic (e.g. `0.0.0-ci.release-validation`). |
| `target-scope` | `stable` / `snapshot` / `rehearsal` — informational, reserved for future per-scope branching. |
| `npm-tag-override` | Optional npm tag override (empty string = no override). |

| Output | Source |
| --- | --- |
| `release-version` | jq from the validated plan file. |
| `npm-tag` | jq from the validated plan file (or the override). |
| `deploy-target` | `latest → prod`, `dev → dev`, `* → none` — single source of truth for the gate that previously lived in three places. |

Steps: synthesise/read plan → derive outputs → \`release:stable:dryrun\` → \`release:devtools-artifact:certify-liveness:no-install\` → upload certification artifacts → \`release:devtools-artifact:repack-dryrun:no-install\`. Each is its own step so callers can read the outputs.

### Migrated callers

- **`release.yml#validate-release-plan`** now delegates to the reusable workflow with \`target-scope: stable\`. The plan-source decision moves to a tiny `select-plan-source` job whose output drives the reusable call.
- **`ci.yml#validate-snapshot-substance`** (new) exercises the same validation pipeline with a synthetic plan under \`target-scope: snapshot\`, so snapshot publishes can't silently drift from the stable substance check.

### `publish-release` follow-up

\`release.yml#publish-release\` keeps its own derivation step temporarily with a \`TODO(#1278-followup)\` pointing at the reusable workflow. Migrating its many downstream env-readers is a separate, focused change.

## Upstream dependency

The genie `github-workflow` runtime modelled `Job` as steps-only. Companion PR overengineeringstudio/effect-utils#735 adds a `JobWithUses` variant so callers can express `uses: ./.github/workflows/<name>.yml` jobs with full type-checking and validation. `devenv.yaml` / `megarepo.kdl` are temporarily pinned to that branch — revert to `main` once it merges.

**Decision (option a vs b):** Took option (a) — landed the upstream schema extension. The patch is small (~40 LOC of type changes + 2 validator skips + 2 unit tests) and made the LiveStore-side authoring use the existing `githubWorkflow()` helper with no escape hatches.

## Net diff

| File | +/- |
| --- | --- |
| `release.yml` (generated) | +0 / −500 |
| `release.yml.genie.ts` | +47 / −74 |
| `ci.yml` (generated) | +8 / −0 |
| `ci.yml.genie.ts` | +24 / −0 |
| `validate-publish-substance.yml(.genie.ts)` | +1041 / 0 (new) |
| `devenv.lock` / `devenv.yaml` / `megarepo.{kdl,lock}` | pin to upstream branch |

**Workflow source LOC:** −303 (after subtracting the new reusable workflow).

## Validation

- \`devenv tasks run check:all --mode before --no-tui\` — green (lint, ts:check, genie drift, lockfile, oxlint, actionlint, megarepo).
- \`devenv tasks run lint:check:genie --mode before --no-tui\` — no drift.
- \`devenv tasks run ts:check --mode before --no-tui\` — clean.

## Follow-ups

- **#1278 follow-up:** migrate \`release.yml#publish-release\` and \`deploy-prod.yml\` to call the same reusable workflow / read its outputs. The `Read release plan` step in `publish-release` already has a TODO comment pointing here.
- Revert \`devenv.yaml\` and \`megarepo.kdl\` to \`main\` once effect-utils#735 merges.

## Open questions

- The reusable workflow currently uses Cachix `skipPush: true` via the existing \`livestoreSetupSteps\`. Worth a second look once we start routing actual publish work through reusable workflows in the follow-up — the snapshot-substance job in particular might want push permissions for cache warming.