### PR TITLE
Detect npm latest vs release/version.json drift via daily health check

### DIFF
--- a/.github/workflows/health-npm-version-drift.yml
+++ b/.github/workflows/health-npm-version-drift.yml
@@ -1,0 +1,31 @@
+# Generated file - DO NOT EDIT
+# Source: health-npm-version-drift.yml.genie.ts
+
+name: 'Health: npm version drift'
+
+on:
+  schedule:
+    - cron: 0 8 * * *
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Compare npm latest vs release/version.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/src/commands/health/npm-version-drift.ts

--- a/.github/workflows/health-npm-version-drift.yml.genie.ts
+++ b/.github/workflows/health-npm-version-drift.yml.genie.ts
@@ -1,0 +1,45 @@
+import { defaultActionlintConfig, githubWorkflow } from '../../genie/repo.ts'
+
+/**
+ * Daily health check: compare npm `latest` for `@livestore/livestore` to the
+ * version recorded in `release/version.json` on `main`. Drift inside a 48h
+ * grace window is just a `::notice::`; sustained drift opens (or warms) a
+ * `type:bug area:release` issue.
+ *
+ * Intentionally minimal: no devenv / nix setup. Bun is already on the
+ * GitHub-hosted runner image and the script only needs `npm view`, `gh`, and
+ * `git log`.
+ */
+export default githubWorkflow({
+  name: 'Health: npm version drift',
+  actionlint: defaultActionlintConfig,
+
+  on: {
+    schedule: [{ cron: '0 8 * * *' }],
+    workflow_dispatch: {},
+  },
+
+  // Issue management requires write; everything else is read-only.
+  permissions: {
+    contents: 'read',
+    issues: 'write',
+  },
+
+  jobs: {
+    check: {
+      'runs-on': 'ubuntu-latest',
+      'timeout-minutes': 5,
+      steps: [
+        { name: 'Checkout', uses: 'actions/checkout@v4', with: { ref: 'main' } },
+        { name: 'Setup Bun', uses: 'oven-sh/setup-bun@v2', with: { 'bun-version': 'latest' } },
+        {
+          name: 'Compare npm latest vs release/version.json',
+          env: {
+            GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+          },
+          run: 'bun scripts/src/commands/health/npm-version-drift.ts',
+        },
+      ],
+    },
+  },
+})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Reworked the documentation tooling so maintainers continuously publish token-efficient, TypeScript-backed snippets that stay reliable for coding agents (#715)
 - **Snapshot release confirmation prompt:** The `mono release snapshot` command now prompts for confirmation before publishing. Pass `--yes` to skip the prompt in scripts and CI. The prompt is also auto-skipped when `CI` is set (#1049).
 - **Prod docs deploy phase split:** The stable-release docs deploy is now split into six independently-timed phases (snippets, diagrams, astro, upload, verify, purge), each wrapped in an OS-level `timeout(1)` + heartbeat. This caps orphan Chromium children from the tldraw renderer at the OS boundary so a single hang no longer blocks the post-publish release flow. A new `deploy-prod.yml` workflow lets operators re-dispatch a single failing target (`gh workflow run deploy-prod.yml -f target=docs`) without re-running the entire publish chain ([#1279](https://github.com/livestorejs/livestore/issues/1279)).
+- **Release health check — npm `latest` vs `release/version.json` drift:** Daily workflow compares the npm `latest` dist-tag of `@livestore/livestore` against `release/version.json` on `main`. Drift inside a 48h grace window emits a `::notice::`; sustained drift opens (or warms) a `bug`-labelled issue so a missed publish never goes silent.
 
 #### wa-sqlite Integration
 

--- a/scripts/src/commands/health/npm-version-drift.ts
+++ b/scripts/src/commands/health/npm-version-drift.ts
@@ -1,0 +1,199 @@
+/**
+ * Health check: detect drift between the npm `latest` dist-tag for
+ * `@livestore/livestore` and the `.version` field in `release/version.json`
+ * on the default branch.
+ *
+ * Drift is allowed for up to 48h to absorb the normal gap between cutting a
+ * release PR and the publish job completing. Past the grace window the check
+ * opens (or warms) a GitHub issue so a human can intervene.
+ *
+ * Run via `bun scripts/src/commands/health/npm-version-drift.ts`.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const OWNER = 'livestorejs'
+const REPO = 'livestore'
+const NPM_PACKAGE = '@livestore/livestore'
+const ISSUE_TITLE = 'npm latest tag drifted from release/version.json for >48h'
+// Only existing repo labels (CLAUDE.md: "Don't create new labels, but only reuse existing ones").
+// The repo lacks structured `type:* area:* origin:*` axes; `bug` is the closest fit.
+const ISSUE_LABELS = ['bug']
+const GRACE_HOURS = 48
+
+const runCapture = (command: ReadonlyArray<string>): string => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status ?? 'signal'}): ${command.join(' ')}\n${result.stderr}`)
+  }
+  return result.stdout.trim()
+}
+
+const runCaptureOptional = (command: ReadonlyArray<string>): string | undefined => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return result.status === 0 ? result.stdout.trim() : undefined
+}
+
+const npmLatestVersion = () => runCapture(['npm', 'view', NPM_PACKAGE, 'dist-tags.latest'])
+
+const versionFromFile = () => {
+  const filePath = path.join(process.cwd(), 'release', 'version.json')
+  const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as { version?: unknown }
+  if (typeof parsed.version !== 'string') {
+    throw new Error(`release/version.json is missing a string .version field`)
+  }
+  return parsed.version
+}
+
+/**
+ * Find the publish time of the GitHub Release tag matching the version in
+ * release/version.json. We use this as a proxy for "drift first seen": the
+ * file changed in `main` at release-PR merge time, so this is the earliest
+ * moment the npm publish should have caught up.
+ */
+const releaseTagPublishedAt = (version: string): Date | undefined => {
+  const tag = `v${version}`
+  const raw = runCaptureOptional([
+    'gh',
+    'api',
+    `repos/${OWNER}/${REPO}/releases/tags/${tag}`,
+    '--jq',
+    '.published_at // empty',
+  ])
+  if (raw === undefined || raw === '') return undefined
+  const date = new Date(raw)
+  return Number.isNaN(date.getTime()) === true ? undefined : date
+}
+
+/**
+ * Fallback: the commit time of release/version.json on the default branch.
+ * Used when no GitHub Release exists yet (e.g. dev pre-releases).
+ */
+const versionFileLastCommitAt = (): Date | undefined => {
+  const raw = runCaptureOptional(['git', 'log', '-1', '--format=%cI', '--', 'release/version.json'])
+  if (raw === undefined || raw === '') return undefined
+  const date = new Date(raw)
+  return Number.isNaN(date.getTime()) === true ? undefined : date
+}
+
+const findOpenDriftIssue = (): { number: number } | undefined => {
+  const raw = runCaptureOptional([
+    'gh',
+    'issue',
+    'list',
+    '--repo',
+    `${OWNER}/${REPO}`,
+    '--state',
+    'open',
+    '--search',
+    `${ISSUE_TITLE} in:title`,
+    '--json',
+    'number,title',
+  ])
+  if (raw === undefined || raw === '') return undefined
+  const parsed = JSON.parse(raw) as ReadonlyArray<{ number: number; title: string }>
+  const hit = parsed.find((issue) => issue.title === ISSUE_TITLE)
+  return hit === undefined ? undefined : { number: hit.number }
+}
+
+const openDriftIssue = (body: string): number => {
+  const labelArgs = ISSUE_LABELS.flatMap((label) => ['--label', label])
+  const raw = runCapture([
+    'gh',
+    'issue',
+    'create',
+    '--repo',
+    `${OWNER}/${REPO}`,
+    '--title',
+    ISSUE_TITLE,
+    '--body',
+    body,
+    ...labelArgs,
+  ])
+  const match = raw.match(/\/issues\/(\d+)/)
+  if (match === null) throw new Error(`Failed to parse issue URL from: ${raw}`)
+  return Number(match[1])
+}
+
+const commentOnIssue = (issueNumber: number, body: string) => {
+  runCapture(['gh', 'issue', 'comment', String(issueNumber), '--repo', `${OWNER}/${REPO}`, '--body', body])
+}
+
+const formatBody = ({
+  npmVersion,
+  fileVersion,
+  firstSeen,
+  hoursElapsed,
+}: {
+  readonly npmVersion: string
+  readonly fileVersion: string
+  readonly firstSeen: Date
+  readonly hoursElapsed: number
+}) =>
+  [
+    `npm \`latest\` for \`${NPM_PACKAGE}\` is \`${npmVersion}\` but \`release/version.json\` on \`main\` is \`${fileVersion}\`.`,
+    '',
+    `Drift first observable at: \`${firstSeen.toISOString()}\` (~${hoursElapsed.toFixed(1)}h ago).`,
+    '',
+    'Either the publish job did not run, the npm dist-tag update failed, or the version file was advanced without a successful release.',
+    '',
+    'Filed automatically by `.github/workflows/health-npm-version-drift.yml`.',
+  ].join('\n')
+
+const isPrerelease = (version: string) => version.includes('-')
+
+const main = () => {
+  const npmVersion = npmLatestVersion()
+  const fileVersion = versionFromFile()
+
+  // `latest` only ever points at a stable version. Pre-release file versions
+  // (e.g. `0.4.0-dev.26`) are never expected to match `latest`; they ship under
+  // a different dist-tag (`dev`, `next`, ...).
+  if (isPrerelease(fileVersion) === true) {
+    console.log(`::notice::release/version.json is a pre-release (${fileVersion}); skipping latest-tag drift check`)
+    return
+  }
+
+  if (npmVersion === fileVersion) {
+    console.log(`::notice::npm latest (${npmVersion}) matches release/version.json`)
+    return
+  }
+
+  const firstSeen = releaseTagPublishedAt(fileVersion) ?? versionFileLastCommitAt() ?? new Date()
+  const hoursElapsed = (Date.now() - firstSeen.getTime()) / (1000 * 60 * 60)
+
+  const message = `npm-vs-version-json-drift detected (npm=${npmVersion} file=${fileVersion} first-seen=${firstSeen.toISOString()})`
+
+  if (hoursElapsed < GRACE_HOURS) {
+    console.log(`::notice::${message} — within ${GRACE_HOURS}h grace window (${hoursElapsed.toFixed(1)}h)`)
+    return
+  }
+
+  const body = formatBody({ npmVersion, fileVersion, firstSeen, hoursElapsed })
+  const existing = findOpenDriftIssue()
+  if (existing === undefined) {
+    const issueNumber = openDriftIssue(body)
+    console.log(`::warning::Opened drift issue #${issueNumber}`)
+    return
+  }
+
+  commentOnIssue(existing.number, `Drift still present after ${hoursElapsed.toFixed(1)}h.\n\n${body}`)
+  console.log(`::warning::Daily warm-up comment on issue #${existing.number}`)
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (cause) {
+    console.error(cause instanceof Error ? cause.message : String(cause))
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## Problem

When a release PR merges but the npm publish job fails (token expired, OIDC misconfig, network flake), `release/version.json` on `main` advances past what npm `latest` actually serves. Today nothing surfaces that gap — the next release just rolls forward and downstream users keep installing the old version.

## Solution

Daily workflow at 09:00 Europe/Berlin (and `workflow_dispatch`) compares `npm view @livestore/livestore version` against the `.version` field in `release/version.json` on `main`.

Behaviour:

- pre-release file versions (e.g. `0.4.0-dev.26`) are skipped — `latest` only ever points at a stable release.
- inside a 48h grace window: `::notice::` with the elapsed delta.
- past 48h: opens (or daily-warms) a GitHub issue titled \`npm latest tag drifted from release/version.json for >48h\` with label \`bug\`.

\"First seen\" is derived from the GitHub Release tag's \`published_at\` when available, falling back to the commit time of \`release/version.json\` on \`main\`.

## Trade-offs / follow-ups

- The repo lacks the structured \`type:* area:* origin:*\` label taxonomy from CLAUDE.md, so the issue is filed with only the existing \`bug\` label. If the team later adds \`area:release\` / \`origin:janitor\`, swap them into \`ISSUE_LABELS\` in \`scripts/src/commands/health/npm-version-drift.ts\`.

## Validation

- \`bun scripts/src/commands/health/npm-version-drift.ts\` runs locally and currently emits the pre-release \`::notice::\` path (skipping the check) because \`release/version.json\` is a dev version.
- \`devenv tasks run lint:check\` passes.
- \`devenv tasks run genie:run --mode before --no-tui\` regenerates \`.github/workflows/health-npm-version-drift.yml\` cleanly.

## Files

- \`.github/workflows/health-npm-version-drift.yml.genie.ts\` — workflow source.
- \`scripts/src/commands/health/npm-version-drift.ts\` — the comparison + issue management.
- \`CHANGELOG.md\` — entry under \`### Internal Changes > Development Tooling\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)