### PR TITLE
Detect stale docs.livestore.dev deploys via version meta tag

### DIFF
--- a/.github/workflows/health-docs-version.yml
+++ b/.github/workflows/health-docs-version.yml
@@ -1,0 +1,37 @@
+# Generated file - DO NOT EDIT
+# Source: health-docs-version.yml.genie.ts
+
+name: 'Health: docs version'
+
+on:
+  schedule:
+    - cron: 15 8 * * *
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Compare docs version vs npm latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bun scripts/src/commands/health/docs-version.ts \
+            --trigger="${{ github.event_name }}" \
+            --release-published-at="${{ github.event.release.published_at }}" \
+            --release-grace-min=30

--- a/.github/workflows/health-docs-version.yml.genie.ts
+++ b/.github/workflows/health-docs-version.yml.genie.ts
@@ -1,0 +1,58 @@
+import { defaultActionlintConfig, githubWorkflow } from '../../genie/repo.ts'
+
+/**
+ * Health check: confirm https://docs.livestore.dev serves the same version
+ * that npm `latest` points at. Reads the `<meta name="livestore-version">`
+ * tag emitted by `docs/astro.config.ts`.
+ *
+ * Triggers:
+ * - daily cron (09:15 Europe/Berlin),
+ * - GitHub Release `published` (with a 30m grace window for the docs deploy
+ *   to catch up),
+ * - manual `workflow_dispatch`.
+ *
+ * No devenv / nix setup needed — `bun`, `curl`, `npm view`, and `gh` are all
+ * present on the GitHub-hosted runner image.
+ *
+ * Note: this check does not automatically re-trigger a docs deploy because
+ * the docs pipeline runs through Netlify (not a first-party workflow); see
+ * the PR description for context on the deferred auto-recovery hook.
+ */
+export default githubWorkflow({
+  name: 'Health: docs version',
+  actionlint: defaultActionlintConfig,
+
+  on: {
+    schedule: [{ cron: '15 8 * * *' }],
+    release: { types: ['published'] },
+    workflow_dispatch: {},
+  },
+
+  permissions: {
+    contents: 'read',
+    issues: 'write',
+  },
+
+  jobs: {
+    check: {
+      'runs-on': 'ubuntu-latest',
+      'timeout-minutes': 5,
+      steps: [
+        { name: 'Checkout', uses: 'actions/checkout@v4', with: { ref: 'main' } },
+        { name: 'Setup Bun', uses: 'oven-sh/setup-bun@v2', with: { 'bun-version': 'latest' } },
+        {
+          name: 'Compare docs version vs npm latest',
+          env: {
+            GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+          },
+          run: [
+            'bun scripts/src/commands/health/docs-version.ts',
+            '  --trigger="${{ github.event_name }}"',
+            '  --release-published-at="${{ github.event.release.published_at }}"',
+            '  --release-grace-min=30',
+          ].join(' \\\n'),
+        },
+      ],
+    },
+  },
+})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,6 +511,7 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 - Add GitHub issue templates to improve issue quality (#602)
 - Reworked the documentation tooling so maintainers continuously publish token-efficient, TypeScript-backed snippets that stay reliable for coding agents (#715)
 - **Snapshot release confirmation prompt:** The `mono release snapshot` command now prompts for confirmation before publishing. Pass `--yes` to skip the prompt in scripts and CI. The prompt is also auto-skipped when `CI` is set (#1049).
+- **Release health check — docs.livestore.dev version:** Docs builds now emit a `<meta name="livestore-version" content="…">` tag and a daily workflow + post-release hook compares it against the npm `latest` dist-tag. Mismatch outside a 30m post-release grace window opens (or warms) a `bug`-labelled issue so a stale docs deploy never goes unnoticed.
 
 #### wa-sqlite Integration
 

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -84,6 +84,16 @@ export default defineConfig({
     createCopyPageClipboardFallbackIntegration(),
     starlight({
       title: `LiveStore (${liveStoreVersion})`,
+      // Stable, machine-readable version marker for the docs health check
+      // (`.github/workflows/health-docs-version.yml`). Unlike the dynamic
+      // `og:site_name`, this tag is reserved for the deployed-vs-npm check
+      // so renaming the site title cannot accidentally break the probe.
+      head: [
+        {
+          tag: 'meta',
+          attrs: { name: 'livestore-version', content: liveStoreVersion },
+        },
+      ],
       social: [
         {
           icon: 'github',

--- a/scripts/src/commands/health/docs-version.ts
+++ b/scripts/src/commands/health/docs-version.ts
@@ -1,0 +1,223 @@
+/**
+ * Health check: verify https://docs.livestore.dev serves the same LiveStore
+ * version that npm currently points `latest` at.
+ *
+ * The docs build emits `<meta name="livestore-version" content="X.Y.Z">`
+ * from `docs/astro.config.ts`. This script fetches the landing page, parses
+ * that tag, and compares it against `npm view @livestore/livestore version`.
+ *
+ * Behaviour by trigger:
+ *   - `schedule` / `workflow_dispatch`: mismatch opens (or warms) a `bug`
+ *     issue.
+ *   - `release` (GitHub Release `published`): mismatch is tolerated up to
+ *     `--release-grace-min` (default 30) minutes to let the docs deploy
+ *     catch up.
+ *
+ * Run via `bun scripts/src/commands/health/docs-version.ts [--trigger=...] [--release-published-at=ISO]`.
+ */
+
+import { spawnSync } from 'node:child_process'
+
+const OWNER = 'livestorejs'
+const REPO = 'livestore'
+const NPM_PACKAGE = '@livestore/livestore'
+const DOCS_URL = 'https://docs.livestore.dev/'
+const META_TAG_NAME = 'livestore-version'
+const ISSUE_TITLE = 'docs.livestore.dev version drifted from npm latest'
+const ISSUE_LABELS = ['bug', 'docs']
+const DEFAULT_RELEASE_GRACE_MINUTES = 30
+
+type Trigger = 'schedule' | 'workflow_dispatch' | 'release'
+
+const parseArgs = () => {
+  const args = process.argv.slice(2)
+  const flags = new Map<string, string>()
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!
+    if (arg.startsWith('--') === false) continue
+    const eqIndex = arg.indexOf('=')
+    if (eqIndex !== -1) {
+      flags.set(arg.slice(2, eqIndex), arg.slice(eqIndex + 1))
+      continue
+    }
+    const next = args[index + 1]
+    if (next !== undefined && next.startsWith('--') === false) {
+      flags.set(arg.slice(2), next)
+      index++
+    } else {
+      flags.set(arg.slice(2), 'true')
+    }
+  }
+  return flags
+}
+
+const runCapture = (command: ReadonlyArray<string>): string => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (result.status !== 0) {
+    throw new Error(`Command failed (${result.status ?? 'signal'}): ${command.join(' ')}\n${result.stderr}`)
+  }
+  return result.stdout.trim()
+}
+
+const runCaptureOptional = (command: ReadonlyArray<string>): string | undefined => {
+  const result = spawnSync(command[0]!, command.slice(1), {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  return result.status === 0 ? result.stdout.trim() : undefined
+}
+
+const fetchDocsHtml = async (): Promise<string> => {
+  const response = await fetch(DOCS_URL, {
+    headers: { accept: 'text/html', 'user-agent': 'livestore-health-docs-version/1.0' },
+  })
+  if (response.ok === false) {
+    throw new Error(`GET ${DOCS_URL} failed: ${response.status} ${response.statusText}`)
+  }
+  return response.text()
+}
+
+const parseDocsVersion = (html: string): string | undefined => {
+  // Match either attr order: name first or content first.
+  const patterns = [
+    new RegExp(`<meta[^>]*name=["']${META_TAG_NAME}["'][^>]*content=["']([^"']+)["']`, 'i'),
+    new RegExp(`<meta[^>]*content=["']([^"']+)["'][^>]*name=["']${META_TAG_NAME}["']`, 'i'),
+  ]
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+    if (match !== null) return match[1]
+  }
+  return undefined
+}
+
+const npmLatestVersion = () => runCapture(['npm', 'view', NPM_PACKAGE, 'dist-tags.latest'])
+
+const findOpenIssue = (): { number: number } | undefined => {
+  const raw = runCaptureOptional([
+    'gh',
+    'issue',
+    'list',
+    '--repo',
+    `${OWNER}/${REPO}`,
+    '--state',
+    'open',
+    '--search',
+    `${ISSUE_TITLE} in:title`,
+    '--json',
+    'number,title',
+  ])
+  if (raw === undefined || raw === '') return undefined
+  const parsed = JSON.parse(raw) as ReadonlyArray<{ number: number; title: string }>
+  const hit = parsed.find((issue) => issue.title === ISSUE_TITLE)
+  return hit === undefined ? undefined : { number: hit.number }
+}
+
+const openIssue = (body: string): number => {
+  const labelArgs = ISSUE_LABELS.flatMap((label) => ['--label', label])
+  const raw = runCapture([
+    'gh',
+    'issue',
+    'create',
+    '--repo',
+    `${OWNER}/${REPO}`,
+    '--title',
+    ISSUE_TITLE,
+    '--body',
+    body,
+    ...labelArgs,
+  ])
+  const match = raw.match(/\/issues\/(\d+)/)
+  if (match === null) throw new Error(`Failed to parse issue URL from: ${raw}`)
+  return Number(match[1])
+}
+
+const commentOnIssue = (issueNumber: number, body: string) => {
+  runCapture(['gh', 'issue', 'comment', String(issueNumber), '--repo', `${OWNER}/${REPO}`, '--body', body])
+}
+
+const formatBody = ({
+  npmVersion,
+  docsVersion,
+  trigger,
+}: {
+  readonly npmVersion: string
+  readonly docsVersion: string | undefined
+  readonly trigger: Trigger
+}) =>
+  [
+    `npm \`latest\` for \`${NPM_PACKAGE}\` is \`${npmVersion}\`, but ${DOCS_URL} reports \`${docsVersion ?? '<missing meta tag>'}\`.`,
+    '',
+    `Trigger: \`${trigger}\`. The expected meta tag is \`<meta name="${META_TAG_NAME}" content="...">\` rendered by \`docs/astro.config.ts\`.`,
+    '',
+    'Likely causes:',
+    '- the docs site was not redeployed after the last npm publish,',
+    '- the deploy succeeded but is stuck on an old build, or',
+    '- the meta tag was accidentally removed from the Astro config.',
+    '',
+    'Filed automatically by `.github/workflows/health-docs-version.yml`.',
+  ].join('\n')
+
+const main = async () => {
+  const flags = parseArgs()
+  const trigger = (flags.get('trigger') ?? process.env.GITHUB_EVENT_NAME ?? 'workflow_dispatch') as Trigger
+  const releaseGraceMinutes = Number(flags.get('release-grace-min') ?? DEFAULT_RELEASE_GRACE_MINUTES)
+  const releasePublishedAtRaw = flags.get('release-published-at')
+  const dryRun = flags.get('dry-run') === 'true'
+
+  const npmVersion = npmLatestVersion()
+  const html = await fetchDocsHtml()
+  const docsVersion = parseDocsVersion(html)
+
+  if (docsVersion === undefined) {
+    console.log(`::warning::docs site is missing <meta name="${META_TAG_NAME}"> tag`)
+  }
+
+  if (docsVersion === npmVersion) {
+    console.log(`::notice::docs version (${docsVersion}) matches npm latest`)
+    return
+  }
+
+  // Fresh-release grace: a freshly published Release is allowed to lag the docs
+  // deploy for up to N minutes before we escalate.
+  if (trigger === 'release' && releasePublishedAtRaw !== undefined) {
+    const publishedAt = new Date(releasePublishedAtRaw)
+    if (Number.isNaN(publishedAt.getTime()) === false) {
+      const minutesElapsed = (Date.now() - publishedAt.getTime()) / (1000 * 60)
+      if (minutesElapsed < releaseGraceMinutes) {
+        console.log(
+          `::notice::docs version (${docsVersion ?? 'missing'}) != npm latest (${npmVersion}); within ${releaseGraceMinutes}m release grace (${minutesElapsed.toFixed(1)}m elapsed)`,
+        )
+        return
+      }
+    }
+  }
+
+  const body = formatBody({ npmVersion, docsVersion, trigger })
+
+  if (dryRun === true) {
+    console.log(`::warning::[dry-run] would file docs-version drift issue with title: ${ISSUE_TITLE}`)
+    console.log('--- body ---')
+    console.log(body)
+    return
+  }
+
+  const existing = findOpenIssue()
+  if (existing === undefined) {
+    const issueNumber = openIssue(body)
+    console.log(`::warning::Opened docs-version drift issue #${issueNumber}`)
+    return
+  }
+
+  commentOnIssue(existing.number, `Still mismatched on \`${trigger}\` run.\n\n${body}`)
+  console.log(`::warning::Updated docs-version drift issue #${existing.number}`)
+}
+
+if (import.meta.main) {
+  main().catch((cause) => {
+    console.error(cause instanceof Error ? cause.message : String(cause))
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Problem

\`https://docs.livestore.dev\` can fall behind the latest LiveStore release if the Netlify deploy fails or never runs. Nothing currently surfaces a stale docs deploy until a user complains.

## Solution

1. Docs build emits \`<meta name=\"livestore-version\" content=\"…\">\` from \`docs/astro.config.ts\` (Starlight \`head\` option). This is a stable, machine-readable marker reserved for the health check so renaming the site title can't accidentally break the probe.
2. Daily workflow (09:15 Europe/Berlin) + GitHub Release \`published\` hook + manual dispatch fetches the docs landing page, parses the meta tag, and compares it against npm \`latest\`.

Behaviour:

- match: \`::notice::docs version matches npm latest\`.
- release-triggered mismatch within 30m of \`published_at\`: notice only (lets the docs deploy catch up).
- otherwise: opens (or warms) a \`bug docs\` issue titled \`docs.livestore.dev version drifted from npm latest\`.

## Deferred sub-features

- **Auto-trigger docs redeploy on mismatch**: the spec mentioned dispatching \`deploy-prod.yml\` with \`target=docs\`; this workflow does not exist in the repo today (docs go through Netlify), so the check escalates by opening an issue instead of silently re-triggering deploys.
- **Discord \`#release-alerts\` notification**: no Discord webhook secret is configured in the repo (\`gh secret list\` confirmed), so the check relies on the GitHub issue alone. If a webhook is added later, hook it in alongside \`openIssue()\` in \`scripts/src/commands/health/docs-version.ts\`.

## Observation about existing version markers

Today the docs site only exposes the version through \`og:site_name\` (\`LiveStore (0.4.0)\`), which doubles as the human-readable site title. Tying a health check to a render-cosmetic string is fragile — hence the dedicated \`livestore-version\` meta tag.

## Validation

- \`bun scripts/src/commands/health/docs-version.ts --trigger=workflow_dispatch --dry-run\` runs locally; it correctly detects that production currently lacks the meta tag (it will once this PR ships).
- \`devenv tasks run lint:check\` passes.
- \`devenv tasks run genie:run --mode before --no-tui\` regenerates the workflow cleanly.

## Files

- \`docs/astro.config.ts\` — adds the \`head\` option emitting the meta tag.
- \`.github/workflows/health-docs-version.yml.genie.ts\` — workflow source.
- \`scripts/src/commands/health/docs-version.ts\` — fetch + compare + issue management.
- \`CHANGELOG.md\` — entry under \`### Internal Changes > Development Tooling\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)