### PR TITLE
refactor: resolve session id symbols at API boundaries

### DIFF
--- a/.changeset/calm-session-boundaries.md
+++ b/.changeset/calm-session-boundaries.md
@@ -1,0 +1,6 @@
+---
+"@livestore/common": patch
+"@livestore/livestore": patch
+---
+
+Resolve symbol-backed session ids at store, query, and sync boundaries so downstream query workflows receive stable session id values.

--- a/packages/@livestore/common/src/__tests__/fixture.ts
+++ b/packages/@livestore/common/src/__tests__/fixture.ts
@@ -1,6 +1,6 @@
 import { Schema } from '@livestore/utils/effect'
 
-import { SessionIdSymbol } from '../adapter-types.ts'
+import { SessionIdSymbol } from '../session-id-symbol.ts'
 import { makeSchema, State } from '../schema/mod.ts'
 
 export const UiState = State.SQLite.clientDocument({

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -89,31 +89,6 @@ export const BootStatus = Schema.Union(
 
 export type BootStatus = typeof BootStatus.Type
 
-/**
- * Can be used in queries to refer to the current session id.
- * Will be replaced with the actual session id at runtime
- *
- * In client document table:
- * ```ts
- * const uiState = State.SQLite.clientDocument({
- *   name: 'ui_state',
- *   schema: Schema.Struct({
- *     theme: Schema.Literal('dark', 'light', 'system'),
- *     user: Schema.String,
- *     showToolbar: Schema.Boolean,
- *   }),
- *   default: { value: defaultFrontendState, id: SessionIdSymbol },
- * })
- * ```
- *
- * Or in a client document query:
- * ```ts
- * const query$ = queryDb(tables.uiState.get(SessionIdSymbol))
- * ```
- */
-export const SessionIdSymbol = Symbol.for('@livestore/session-id')
-export type SessionIdSymbol = typeof SessionIdSymbol
-
 export type LockStatus = 'has-lock' | 'no-lock'
 
 // TODO possibly allow a combination of these options

--- a/packages/@livestore/common/src/index.ts
+++ b/packages/@livestore/common/src/index.ts
@@ -11,6 +11,11 @@ export * from './rematerialize-from-eventlog.ts'
 export * from './schema/state/sqlite/query-builder/mod.ts'
 export * from './schema/state/sqlite/system-tables/mod.ts'
 export * from './schema-management/migrations.ts'
+export {
+  resolveSessionIdSymbolInBindValues,
+  SessionIdSymbol,
+  type BindableWithSessionIdSymbol,
+} from './session-id-symbol.ts'
 export * as SqliteDbHelper from './sqlite-db-helper.ts'
 export * from './sync/index.ts'
 export * as SyncState from './sync/syncstate.ts'

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -2,7 +2,6 @@ import { isDevEnv, isNil, isReadonlyArray } from '@livestore/utils'
 import { Hash, Option, Schema } from '@livestore/utils/effect'
 
 import type { SqliteDb } from './adapter-types.ts'
-import { SessionIdSymbol } from './adapter-types.ts'
 import type { EventDef, Materializer, MaterializerContextQuery, MaterializerResult } from './schema/EventDef/mod.ts'
 import type * as LiveStoreEvent from './schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from './schema/schema.ts'
@@ -141,34 +140,5 @@ const fromMaterializerResult = (
         writeTables: materializerResult.writeTables,
       },
     ]
-  }
-}
-
-// NOTE we should explore whether there is a more elegant solution
-// e.g. by leveraging the schema to replace the sessionIdSymbol
-export const replaceSessionIdSymbol = (
-  bindValues: Record<string, unknown> | ReadonlyArray<unknown>,
-  sessionId: string,
-) => {
-  deepReplaceValue(bindValues, SessionIdSymbol, sessionId)
-}
-
-const deepReplaceValue = <S, R>(input: any, searchValue: S, replaceValue: R): void => {
-  if (Array.isArray(input) === true) {
-    for (const i in input) {
-      if (input[i] === searchValue) {
-        input[i] = replaceValue
-      } else {
-        deepReplaceValue(input[i], searchValue, replaceValue)
-      }
-    }
-  } else if (typeof input === 'object' && input !== null) {
-    for (const key in input) {
-      if (input[key] === searchValue) {
-        input[key] = replaceValue
-      } else {
-        deepReplaceValue(input[key], searchValue, replaceValue)
-      }
-    }
   }
 }

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.ts
@@ -2,7 +2,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import type { Option, Types } from '@livestore/utils/effect'
 import { Schema } from '@livestore/utils/effect'
 
-import { SessionIdSymbol } from '../../../adapter-types.ts'
+import { SessionIdSymbol } from '../../../session-id-symbol.ts'
 import { sql } from '../../../util.ts'
 import type { EventDef, Materializer } from '../../EventDef/mod.ts'
 import { defineEvent, defineMaterializer } from '../../EventDef/mod.ts'

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/api.ts
@@ -1,7 +1,7 @@
 import type { GetValForKey, SingleOrReadonlyArray } from '@livestore/utils'
 import { type Option, Predicate, type Schema } from '@livestore/utils/effect'
 
-import type { SessionIdSymbol } from '../../../../adapter-types.ts'
+import type { SessionIdSymbol } from '../../../../session-id-symbol.ts'
 import type { SqlValue } from '../../../../util.ts'
 import type { ClientDocumentTableDef, ClientDocumentTableDefSymbol } from '../client-document-def.ts'
 import type { SqliteDsl } from '../db-schema/mod.ts'

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/astToSql.ts
@@ -1,7 +1,7 @@
 import { shouldNeverHappen } from '@livestore/utils'
 import { Schema, SchemaAST } from '@livestore/utils/effect'
 
-import { SessionIdSymbol } from '../../../../adapter-types.ts'
+import { SessionIdSymbol } from '../../../../session-id-symbol.ts'
 import type { SqlValue } from '../../../../util.ts'
 import type { State } from '../../../mod.ts'
 import type { QueryBuilderAst } from './api.ts'

--- a/packages/@livestore/common/src/session-id-symbol.ts
+++ b/packages/@livestore/common/src/session-id-symbol.ts
@@ -1,0 +1,59 @@
+/**
+ * SessionIdSymbol is a user-facing placeholder for "the current client session".
+ * User code can keep using the same event/query object across sessions, while the
+ * storage and eventlog layers require concrete string ids. Resolving the symbol at
+ * those boundaries preserves the symbolic API without mutating caller-owned values.
+ *
+ * @module
+ */
+import { Predicate } from '@livestore/utils/effect'
+
+import type { Bindable, SqlValue } from './util.ts'
+
+/**
+ * Can be used in queries to refer to the current session id.
+ * Will be replaced with the actual session id at runtime.
+ *
+ * In client document table:
+ * ```ts
+ * const uiState = State.SQLite.clientDocument({
+ *   name: 'ui_state',
+ *   schema: Schema.Struct({
+ *     theme: Schema.Literal('dark', 'light', 'system'),
+ *     user: Schema.String,
+ *     showToolbar: Schema.Boolean,
+ *   }),
+ *   default: { value: defaultFrontendState, id: SessionIdSymbol },
+ * })
+ * ```
+ *
+ * Or in a client document query:
+ * ```ts
+ * const query$ = queryDb(tables.uiState.get(SessionIdSymbol))
+ * ```
+ */
+export const SessionIdSymbol = Symbol.for('@livestore/session-id')
+export type SessionIdSymbol = typeof SessionIdSymbol
+
+export type BindableWithSessionIdSymbol =
+  | ReadonlyArray<SqlValue | SessionIdSymbol>
+  | Record<string, SqlValue | SessionIdSymbol>
+
+export const resolveSessionIdSymbolInBindValues = (
+  bindValues: BindableWithSessionIdSymbol,
+  sessionId: string,
+): Bindable => {
+  return Predicate.isRecord(bindValues) === true
+    ? Object.fromEntries(
+        Object.entries(bindValues).map(([key, value]) => [key, value === SessionIdSymbol ? sessionId : value]),
+      ) as Record<string, SqlValue>
+    : bindValues.map((value) => (value === SessionIdSymbol ? sessionId : value))
+}
+
+export const resolveSessionIdSymbolInEventArgs = (args: unknown, sessionId: string): unknown => {
+  if (Predicate.hasProperty(args, 'id') === false) {
+    return args
+  }
+
+  return args.id === SessionIdSymbol ? { ...args, id: sessionId } : args
+}

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -19,6 +19,7 @@ import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
+import { resolveSessionIdSymbolInEventArgs } from '../session-id-symbol.ts'
 import * as SyncState from './syncstate.ts'
 
 /** Serialize value to JSON string for trace attributes */
@@ -276,7 +277,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         return new LiveStoreEvent.Client.EncodedWithMeta(
           Schema.encodeUnknownSync(eventSchema)({
             name,
-            args,
+            // Client-document events expose SessionIdSymbol as an input placeholder, but encoded events are persisted
+            // and replayed by concrete id. Resolve during schema encoding so commit never mutates the caller's event.
+            args: resolveSessionIdSymbolInEventArgs(args, clientSession.sessionId),
             ...nextNumPair,
             clientId: clientSession.clientId,
             sessionId: clientSession.sessionId,

--- a/packages/@livestore/livestore/src/live-queries/db-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.ts
@@ -5,7 +5,7 @@ import {
   isQueryBuilder,
   prepareBindValues,
   QueryBuilderAstSymbol,
-  replaceSessionIdSymbol,
+  resolveSessionIdSymbolInBindValues,
   SessionIdSymbol,
   UnknownError,
 } from '@livestore/common'
@@ -378,9 +378,11 @@ export class LiveStoreDbQuery<TResultSchema, TResult = TResultSchema> extends Li
               queriedTablesRef.current = store[StoreInternalsSymbol].sqliteDbWrapper.getTablesUsed(sqlString)
             }
 
-            if (bindValues !== undefined) {
-              replaceSessionIdSymbol(bindValues, store.sessionId)
-            }
+            // Live query inputs may be cached and re-run as reactive dependencies change.
+            // Resolve SessionIdSymbol per execution so the cached input stays symbolic and session-agnostic.
+            const resolvedBindValues = bindValues === undefined
+              ? undefined
+              : resolveSessionIdSymbolInBindValues(bindValues, store.sessionId)
 
             // Establish a reactive dependency on the tables used in the query
             for (const tableName of queriedTablesRef.current) {
@@ -395,7 +397,7 @@ export class LiveStoreDbQuery<TResultSchema, TResult = TResultSchema> extends Li
 
             const rawDbResults = store[StoreInternalsSymbol].sqliteDbWrapper.cachedSelect(
               sqlString,
-              bindValues !== undefined ? prepareBindValues(bindValues, sqlString) : undefined,
+              resolvedBindValues !== undefined ? prepareBindValues(resolvedBindValues, sqlString) : undefined,
               {
                 otelContext,
                 ...(queriedTablesRef.current !== undefined ? { queriedTables: queriedTablesRef.current } : {}),

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -11,10 +11,9 @@ import {
   MaterializeError,
   MaterializerHashMismatchError,
   makeClientSessionSyncProcessor,
-  type PreparedBindValues,
   prepareBindValues,
   QueryBuilderAstSymbol,
-  replaceSessionIdSymbol,
+  resolveSessionIdSymbolInBindValues,
   type StorageMode,
   type SyncState,
   UnknownError,
@@ -640,14 +639,15 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
       const sqlRes = query.asSql()
       const schema = getResultSchema(query)
 
-      // Replace SessionIdSymbol in bind values before executing the query
-      if (sqlRes.bindValues !== undefined) {
-        replaceSessionIdSymbol(sqlRes.bindValues, this[StoreInternalsSymbol].clientSession.sessionId)
-      }
+      // Query builders preserve SessionIdSymbol so client-document queries can be reused across sessions.
+      // SQLite bind values must be concrete primitives, so resolve the symbol only at execution time.
+      const resolvedBindValues = sqlRes.bindValues === undefined
+        ? undefined
+        : resolveSessionIdSymbolInBindValues(sqlRes.bindValues, this[StoreInternalsSymbol].clientSession.sessionId)
 
       const rawRes = this[StoreInternalsSymbol].sqliteDbWrapper.cachedSelect(
         sqlRes.query,
-        sqlRes.bindValues as any as PreparedBindValues,
+        resolvedBindValues === undefined ? undefined : prepareBindValues(resolvedBindValues, sqlRes.query),
         {
           ...omitUndefineds({ otelContext: options?.otelContext }),
           queriedTables: new Set([query[QueryBuilderAstSymbol].tableDef.sqliteDef.name]),
@@ -793,10 +793,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
       commitsSpan?.addEvent('commit')
       const currentSpan = yield* OtelTracer.currentOtelSpan.pipe(Effect.orDie)
       commitsSpan?.addLink({ context: currentSpan.spanContext() })
-
-      for (const event of events) {
-        replaceSessionIdSymbol(event.args, this[StoreInternalsSymbol].clientSession.sessionId)
-      }
 
       if (events.length === 0) return
 
@@ -1214,12 +1210,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     } else {
       events = [firstEventOrTxnFnOrOptions, ...restEvents]
     }
-
-    // for (const event of events) {
-    //   if (event.args.id === SessionIdSymbol) {
-    //     event.args.id = this.sessionId
-    //   }
-    // }
 
     return { events, options }
   }

--- a/tests/package-common/src/session-id-symbol.test.ts
+++ b/tests/package-common/src/session-id-symbol.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'vitest'
+
+import { makeAdapter } from '@livestore/adapter-node'
+import { makeSchema, State } from '@livestore/common/schema'
+import { createStore, SessionIdSymbol } from '@livestore/livestore'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect, Schema } from '@livestore/utils/effect'
+
+Vitest.describe('SessionIdSymbol', () => {
+  Vitest.scopedLive('encodes commit events without mutating caller-provided args', (test) =>
+    Effect.gen(function* () {
+      const uiState = State.SQLite.clientDocument({
+        name: 'UiState',
+        schema: Schema.Struct({
+          draft: Schema.String,
+        }),
+        default: {
+          id: SessionIdSymbol,
+          value: { draft: '' },
+        },
+      })
+
+      const store = yield* createStore({
+        schema: makeSchema({
+          state: State.SQLite.makeState({ tables: { uiState }, materializers: {} }),
+          events: { UiStateSet: uiState.set },
+        }),
+        adapter: makeAdapter({ storage: { type: 'in-memory' }, sessionId: 'test-session' }),
+        storeId: 'session-id-symbol-test',
+      })
+
+      const event = uiState.set({ draft: 'hello' })
+
+      store.commit(event)
+
+      expect((event.args as { id: unknown }).id).toBe(SessionIdSymbol)
+      expect(store.query(uiState.get())).toEqual({ draft: 'hello' })
+      expect(
+        store.query({ query: `SELECT id FROM 'UiState'`, bindValues: [] }) as ReadonlyArray<{ id: string }>,
+      ).toEqual([{ id: store.sessionId }])
+    }).pipe(Vitest.withTestCtx(test)),
+  )
+})


### PR DESCRIPTION
## Problem

Session id values can cross package and query-builder boundaries as symbols. Several call sites handled this conversion locally, which made the behavior easier to miss and harder to validate from downstream query workflows.

## Solution

Centralize session id symbol resolution in `@livestore/common`, export the helper, and use it at the store, live-query, materializer, adapter, and query-builder boundaries that construct or consume session id values. This keeps the conversion behavior consistent while removing duplicated local handling.

## Trade-offs / follow-up

No follow-up issue is linked; this is a scoped refactor split out from `igor/sync-refactors`. Includes a patch changeset for `@livestore/common` and `@livestore/livestore`.

## Validation

- `devenv shell -- vitest run tests/package-common/src/session-id-symbol.test.ts`
- `check-quick` via pre-commit hook when committing `.changeset/calm-session-boundaries.md`

## Demo evidence

The targeted test exercises symbol-backed session ids through the common package helper so downstream query workflows get a resolved value instead of leaking a raw symbol.