### PR TITLE
docs: document sync merge event predicates

### DIFF
--- a/.changeset/quiet-sync-predicates.md
+++ b/.changeset/quiet-sync-predicates.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Documents how sync merge predicates distinguish local push-ahead events from backend replay events.

--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -201,9 +201,10 @@ export const merge = Effect.fnUntraced(function* ({
    */
   isClientEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   /**
-   * Pending events are confirmed by comparing their encoded identity with
-   * upstream events. This is caller-supplied because equality ignores
-   * transport/meta differences and may eventually become schema-aware.
+   * Pending events are confirmed by comparing their logical encoded identity with
+   * upstream events. This is caller-supplied because comparing encoded args may
+   * require event-schema knowledge that the generic merge algorithm does not own.
+   * Implementations should ignore transport/runtime metadata.
    */
   isEqualEvent: (a: LiveStoreEvent.Client.EncodedWithMeta, b: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   /**

--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -193,9 +193,23 @@ export const merge = Effect.fnUntraced(function* ({
 }: {
   syncState: SyncState
   payload: typeof Payload.Type
+  /**
+   * `LiveStoreEvent.Client.EncodedWithMeta` does not carry the event definition's
+   * `clientOnly` flag. The caller supplies this schema-aware predicate so `merge`
+   * can preserve the correct sequence-number shape when rebasing: client-only
+   * events advance the client component, synced events advance the global component.
+   */
   isClientEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
+  /**
+   * Pending events are confirmed by comparing their encoded identity with
+   * upstream events. This is caller-supplied because equality ignores
+   * transport/meta differences and may eventually become schema-aware.
+   */
   isEqualEvent: (a: LiveStoreEvent.Client.EncodedWithMeta, b: LiveStoreEvent.Client.EncodedWithMeta) => boolean
-  /** This is used in the leader which should ignore client events when receiving an upstream-advance payload */
+  /**
+   * This is used in the leader which should ignore client events when
+   * receiving an upstream-advance payload
+   */
   ignoreClientEvents?: boolean
 }) {
   yield* validateSyncState(syncState)
@@ -475,6 +489,8 @@ const rebaseEvents = ({
   let prevEventSequenceNumber = baseEventSequenceNumber
   const rebaseGeneration = baseEventSequenceNumber.rebaseGeneration + 1
   return events.map((event) => {
+    // Rebasing must preserve whether an event is client-only: client-only
+    // events become eN.1/eN.2, while synced events become eN+1.
     const isClient = isClientEvent(event)
     const newEvent = event.rebase({
       parentSeqNum: prevEventSequenceNumber,


### PR DESCRIPTION
## Problem

The sync merge event predicate helpers in `syncstate.ts` encode subtle client/server event filtering behavior, but the surrounding docs did not explain why the predicates differ. That makes the replay and merge workflow harder to reason about when reviewing downstream sync changes.

## Solution

Document how the merge predicates distinguish local push-ahead events from backend replay events, and clarify why the filter uses event ids differently for each side of the sync workflow. The equality predicate docs now make explicit that caller-supplied comparison is about schema-aware encoded-arg semantics, not merely ignoring runtime metadata.

## Trade-offs / follow-up

No follow-up issue is linked; this is a docs-only split from `igor/sync-refactors`. Includes an empty no-release-impact changeset.

## Validation

- `check-quick` via pre-commit hook for the pushed docs commits
- Runtime tests not run; docs-only change to an inline comment.

## Demo evidence

The updated comment in `packages/@livestore/common/src/sync/syncstate.ts` now describes which data-workflow events are kept or skipped during merge processing, and why merge receives caller-supplied predicates for client classification and logical event equality.