### PR TITLE
refactor: move changesets out of events

### DIFF
--- a/.changeset/move-changesets-out-of-events.md
+++ b/.changeset/move-changesets-out-of-events.md
@@ -1,0 +1,7 @@
+---
+"@livestore/adapter-web": patch
+"@livestore/common": patch
+"@livestore/livestore": patch
+---
+
+Store SQLite rollback changesets in a state-database materialization journal instead of embedding them in event metadata. Track the state database head separately so persisted web snapshots resume from the correct cursor after confirmed journal entries are pruned.

--- a/docs/src/content/docs/building-with-livestore/state/sqlite.md
+++ b/docs/src/content/docs/building-with-livestore/state/sqlite.md
@@ -38,7 +38,7 @@ LiveStore operates two SQLite databases by default: a state database (your mater
 - `__livestore_state_head`
   - Stores the latest composite event sequence number reflected by the state database snapshot.
 - `__livestore_session_changeset`
-  - Stores SQLite session changeset blobs keyed by event sequence numbers. Used to efficiently roll back and re‑apply state during rebases.
+  - Stores the materialization journal: SQLite session changeset blobs keyed by complete composite event sequence numbers. LiveStore uses these records to roll back affected materializations during a rebase.
 - Your application tables
   - All tables you define via `State.SQLite.table(...)` live in the state database.
 

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -7,6 +7,7 @@ import {
   type SyncOptions,
   UnknownError,
   StateHead,
+  MaterializationJournal,
 } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
 import {
@@ -94,7 +95,7 @@ export const makeAdapter =
           shutdownChannel,
           syncPayloadEncoded,
           syncPayloadSchema,
-        }).pipe(Layer.provide(StateHead.layer({ dbState }))),
+        }).pipe(Layer.provide(Layer.mergeAll(StateHead.layer({ dbState }), MaterializationJournal.layer({ dbState })))),
       )
 
       const { leaderThread, initialSnapshot } = yield* Effect.gen(function* () {

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -4,6 +4,7 @@ import {
   Devtools,
   type LockStatus,
   makeClientSession,
+  MaterializationJournal,
   migrateDb,
   StateHead,
   type SyncOptions,
@@ -273,7 +274,7 @@ const makeLeaderThread = ({
         shutdownChannel,
         syncPayloadEncoded,
         syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
-      }).pipe(Layer.provide(StateHead.layer({ dbState }))),
+      }).pipe(Layer.provide(Layer.mergeAll(StateHead.layer({ dbState }), MaterializationJournal.layer({ dbState })))),
     )
 
     return yield* Effect.gen(function* () {

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -1,5 +1,6 @@
 import {
   BootStatus,
+  ClientSessionLeaderThreadProxy,
   Devtools,
   liveStoreVersion,
   MigrationsReport,
@@ -86,9 +87,7 @@ export class LeaderWorkerInnerPullStream extends Rpc.make('PullStream', {
   payload: {
     cursor: Schema.toType(EventSequenceNumber.Client.Composite),
   },
-  success: Schema.Struct({
-    payload: SyncState.PayloadUpstream,
-  }),
+  success: ClientSessionLeaderThreadProxy.PullItem,
   error: Schema.Never,
   stream: true,
 }) {}

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -1,6 +1,13 @@
 import type * as otel from '@opentelemetry/api'
 
-import type { BootStatus, BootWarningReason, LogConfig, SqliteDb, SyncOptions } from '@livestore/common'
+import {
+  type BootStatus,
+  type BootWarningReason,
+  type LogConfig,
+  MaterializationJournal,
+  type SqliteDb,
+  type SyncOptions,
+} from '@livestore/common'
 import { Devtools, StateHead, UnknownError } from '@livestore/common'
 import type { DevtoolsOptions, StreamEventsOptions } from '@livestore/common/leader-thread'
 import {
@@ -280,7 +287,9 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
               syncPayloadEncoded,
               syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
               ...(bootWarning !== undefined ? { bootWarning } : {}),
-            }).pipe(Layer.provide(StateHead.layer({ dbState }))),
+            }).pipe(
+              Layer.provide(Layer.mergeAll(StateHead.layer({ dbState }), MaterializationJournal.layer({ dbState }))),
+            ),
             leaderThreadScope,
           )
         }).pipe(

--- a/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
+++ b/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
@@ -1,20 +1,24 @@
-import type { Effect, Stream, Subscribable } from '@livestore/utils/effect'
+import { type Effect, Schema, type Stream, type Subscribable } from '@livestore/utils/effect'
 
 import type { StorageMode } from './adapter-types.ts'
 import type { MigrationsReport } from './defs.ts'
 import type * as Devtools from './devtools/mod.ts'
 import type { RejectedPushError } from './leader-thread/RejectedPushError.ts'
 import type { StreamEventsOptions } from './leader-thread/types.ts'
-import type * as EventSequenceNumber from './schema/EventSequenceNumber/mod.ts'
+import * as EventSequenceNumber from './schema/EventSequenceNumber/mod.ts'
 import type { LiveStoreEvent } from './schema/mod.ts'
 import type { SyncBackend } from './sync/sync.ts'
-import type { PayloadUpstream, SyncState } from './sync/syncstate.ts'
+import { PayloadUpstream, type SyncState } from './sync/syncstate.ts'
+
+export const PullItem = Schema.Struct({
+  payload: PayloadUpstream,
+  /** The globally confirmed prefix after `payload` has been fully applied. */
+  globalHead: EventSequenceNumber.Client.Composite,
+})
 
 export interface ClientSessionLeaderThreadProxy {
   events: {
-    pull: (args: {
-      cursor: EventSequenceNumber.Client.Composite
-    }) => Stream.Stream<{ payload: typeof PayloadUpstream.Type }>
+    pull: (args: { cursor: EventSequenceNumber.Client.Composite }) => Stream.Stream<typeof PullItem.Type>
     /** It's important that a client session doesn't call `push` concurrently. */
     push(batch: ReadonlyArray<LiveStoreEvent.Client.Encoded>): Effect.Effect<void, RejectedPushError>
     /** Stream events with filtering */

--- a/packages/@livestore/common/src/MaterializationJournal.ts
+++ b/packages/@livestore/common/src/MaterializationJournal.ts
@@ -82,8 +82,6 @@ export const make = ({ dbState }: Options) => {
             seqNumClient: record.key.client,
             seqNumRebaseGeneration: record.key.rebaseGeneration,
             changeset: record.changeset._tag === 'changeset' ? record.changeset.data : null,
-            // Legacy processors still expose this column for development diagnostics.
-            debug: null,
           },
         })
 

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -12,6 +12,7 @@ import {
 import type { ClientSessionLeaderThreadProxy } from './ClientSessionLeaderThreadProxy.ts'
 import type * as Devtools from './devtools/mod.ts'
 import type { IntentionalShutdownCause, MaterializeError, UnknownError } from './errors.ts'
+import type { MaterializationJournalError } from './MaterializationJournal.ts'
 import type { LiveStoreSchema } from './schema/mod.ts'
 import type { SqliteDb } from './sqlite-types.ts'
 import type { BackendIdMismatchError } from './sync/index.ts'
@@ -35,7 +36,10 @@ export interface ClientSession {
   /** Status info whether current session is leader or not */
   lockStatus: SubscriptionRef.SubscriptionRef<LockStatus>
   shutdown: (
-    cause: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
+    cause: Exit.Exit<
+      IntentionalShutdownCause,
+      UnknownError | MaterializeError | MaterializationJournalError | BackendIdMismatchError
+    >,
   ) => Effect.Effect<void>
   /** A proxy API to communicate with the leader thread */
   leaderThread: ClientSessionLeaderThreadProxy
@@ -129,7 +133,10 @@ export interface AdapterArgs {
   debugInstanceId: string
   bootStatusQueue: Queue.Queue<BootStatus>
   shutdown: (
-    exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
+    exit: Exit.Exit<
+      IntentionalShutdownCause,
+      UnknownError | MaterializeError | MaterializationJournalError | BackendIdMismatchError
+    >,
   ) => Effect.Effect<void>
   connectDevtoolsToStore: ConnectDevtoolsToStore
   /**

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -27,19 +27,21 @@ import {
   TxQueue,
 } from '@livestore/utils/effect'
 
-import { MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
+import { type MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
+import { PullItem } from '../ClientSessionLeaderThreadProxy.ts'
 import type { UnknownEventError } from '../errors.ts'
 import { IntentionalShutdownCause } from '../errors.ts'
+import * as MaterializationJournal from '../MaterializationJournal.ts'
 import { makeMaterializerHash } from '../materializer-helper.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
-import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '../schema/mod.ts'
+import { EventSequenceNumber, LiveStoreEvent, resolveEventDef } from '../schema/mod.ts'
 import { EVENTLOG_META_TABLE, SYNC_STATUS_TABLE } from '../schema/state/sqlite/system-tables/eventlog-tables.ts'
+import * as SqliteDbHelper from '../sqlite-db-helper.ts'
 import * as StateHead from '../StateHead.ts'
 import type { BackendIdMismatchError, IsOfflineError, SyncBackend } from '../sync/sync.ts'
 import * as SyncState from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
 import * as Eventlog from './eventlog.ts'
-import { rollback } from './materialize-event.ts'
 import {
   isRejectedPushError,
   LeaderAheadError,
@@ -91,13 +93,11 @@ export class LeaderSyncProcessor extends Context.Service<LeaderSyncProcessor, Se
 export interface Service {
   readonly [TypeId]: TypeId
   /** Used by client sessions to subscribe to upstream sync state changes */
-  readonly pull: (args: {
-    cursor: EventSequenceNumber.Client.Composite
-  }) => Stream.Stream<{ payload: typeof SyncState.PayloadUpstream.Type }>
+  readonly pull: (args: { cursor: EventSequenceNumber.Client.Composite }) => Stream.Stream<typeof PullItem.Type>
   /** The `pullQueue` API can be used instead of `pull` when more convenient */
   readonly pullQueue: (args: {
     cursor: EventSequenceNumber.Client.Composite
-  }) => Effect.Effect<Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>, never, Scope.Scope>
+  }) => Effect.Effect<Queue.Queue<typeof PullItem.Type>, never, Scope.Scope>
 
   /**
    * Used by client sessions to push events to the leader thread.
@@ -211,6 +211,7 @@ export const make = Effect.fnUntraced(function* ({
   params,
   testing,
 }: Options) {
+  const materializationJournal = yield* MaterializationJournal.MaterializationJournal
   const stateHead = yield* StateHead.StateHead
   const syncBackendPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
   const localPushBatchSize = params.localPushBatchSize ?? 10
@@ -388,6 +389,7 @@ export const make = Effect.fnUntraced(function* ({
 
         yield* connectedClientSessionPullQueues.offer({
           payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: acceptedPendingEvents }),
+          globalHead: syncState.upstreamHead,
           leaderHead: mergeResult.newSyncState.localHead,
         })
 
@@ -487,18 +489,19 @@ export const make = Effect.fnUntraced(function* ({
             yield* restartBackendPushing(globalOrUnknownRebasedPendingEvents)
 
             if (mergeResult.rollbackEvents.length > 0) {
-              yield* rollback({
-                dbState: db,
-                dbEventlog,
-                eventNumsToRollback: mergeResult.rollbackEvents.map((_) => _.seqNum),
-              })
-              yield* stateHead
-                .set(mergeResult.rollbackEvents[0]!.parentSeqNum)
-                .pipe(Effect.mapError((cause) => MaterializeError.make({ cause })))
+              const rollbackSeqNums = mergeResult.rollbackEvents.map((_) => _.seqNum)
+              const headAfterRollback = mergeResult.rollbackEvents[0]!.parentSeqNum
+
+              yield* Effect.gen(function* () {
+                yield* materializationJournal.rollback(rollbackSeqNums)
+                yield* stateHead.set(headAfterRollback)
+              }).pipe(SqliteDbHelper.withSavepoint(db), Effect.orDieDebugger)
+              yield* Eventlog.deleteEvents(dbEventlog, rollbackSeqNums).pipe(Effect.orDieDebugger)
             }
 
             yield* connectedClientSessionPullQueues.offer({
               payload: SyncState.payloadFromMergeResult(mergeResult),
+              globalHead: newBackendHead,
               leaderHead: mergeResult.newSyncState.localHead,
             })
           } else {
@@ -513,6 +516,7 @@ export const make = Effect.fnUntraced(function* ({
 
             yield* connectedClientSessionPullQueues.offer({
               payload: SyncState.payloadFromMergeResult(mergeResult),
+              globalHead: newBackendHead,
               leaderHead: mergeResult.newSyncState.localHead,
             })
 
@@ -528,12 +532,12 @@ export const make = Effect.fnUntraced(function* ({
             }
           }
 
-          // Removes the changeset rows which are no longer needed as we'll never have to rollback beyond this point
-          trimChangesetRows(db, newBackendHead)
-
           advancePushHead(mergeResult.newSyncState.localHead)
 
           yield* materializeEventsBatch({ batchItems: mergeResult.newEvents, deferreds: undefined })
+
+          // Discard leader materialization journal records which are no longer needed as we'll never have to rollback beyond this point.
+          yield* materializationJournal.discardUpTo(newBackendHead)
 
           yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
         }).pipe(Effect.exit)
@@ -710,7 +714,9 @@ export const make = Effect.fnUntraced(function* ({
       const handleBackendIdMismatchError = (error: BackendIdMismatchError) =>
         handleBackendIdMismatch({ error, onBackendIdMismatch, shutdownChannel })
 
-      const maybeShutdownOnError = (cause: Cause.Cause<UnknownError | MaterializeError>) =>
+      const maybeShutdownOnError = (
+        cause: Cause.Cause<UnknownError | MaterializeError | MaterializationJournal.MaterializationJournalError>,
+      ) =>
         Effect.gen(function* () {
           if (onError === 'ignore') {
             if (LS_DEV === true) {
@@ -856,7 +862,7 @@ type MaterializeEventsBatch = (_: {
   deferreds:
     | ReadonlyArray<Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError> | undefined>
     | undefined
-}) => Effect.Effect<void, MaterializeError, LeaderThreadCtx>
+}) => Effect.Effect<void, MaterializeError | MaterializationJournal.MaterializationJournalError, LeaderThreadCtx>
 
 // TODO how to handle errors gracefully
 const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds }) =>
@@ -878,9 +884,7 @@ const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds 
     )
 
     for (let i = 0; i < batchItems.length; i++) {
-      const { sessionChangeset, hash } = yield* materializeEvent(batchItems[i]!)
-      batchItems[i]!.meta.sessionChangeset = sessionChangeset
-      batchItems[i]!.meta.materializerHashLeader = hash
+      yield* materializeEvent(batchItems[i]!)
 
       if (deferreds?.[i] !== undefined) {
         yield* Deferred.succeed(deferreds[i]!, void 0)
@@ -898,32 +902,23 @@ const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds 
     Effect.tapCauseLogPretty,
   )
 
-const trimChangesetRows = (db: SqliteDb, newHead: EventSequenceNumber.Client.Composite) => {
-  // Since we're using the session changeset rows to query for the current head,
-  // we're keeping at least one row for the current head, and thus are using `<` instead of `<=`
-  db.execute(sql`DELETE FROM ${SystemTables.SESSION_CHANGESET_META_TABLE} WHERE seqNumGlobal < ${newHead.global}`)
-}
-
 interface PullQueueSet {
   makeQueue: (
     cursor: EventSequenceNumber.Client.Composite,
-  ) => Effect.Effect<
-    Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>,
-    never,
-    Scope.Scope | LeaderThreadCtx
-  >
+  ) => Effect.Effect<Queue.Queue<typeof PullItem.Type>, never, Scope.Scope | LeaderThreadCtx>
   offer: (item: {
     payload: typeof SyncState.PayloadUpstream.Type
+    globalHead: EventSequenceNumber.Client.Composite
     leaderHead: EventSequenceNumber.Client.Composite
   }) => Effect.Effect<void, never>
 }
 
 const makePullQueueSet = Effect.gen(function* () {
-  const set = new Set<Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>>()
+  const set = new Set<Queue.Queue<typeof PullItem.Type>>()
 
   type StringifiedSeqNum = string
   // NOTE this could grow unbounded for long running sessions
-  const cachedPayloads = new Map<StringifiedSeqNum, (typeof SyncState.PayloadUpstream.Type)[]>()
+  const cachedPullItems = new Map<StringifiedSeqNum, (typeof PullItem.Type)[]>()
 
   yield* Effect.addFinalizer(() =>
     Effect.gen(function* () {
@@ -937,33 +932,29 @@ const makePullQueueSet = Effect.gen(function* () {
 
   const makeQueue: PullQueueSet['makeQueue'] = (cursor) =>
     Effect.gen(function* () {
-      const queue = yield* Effect.acquireRelease(
-        Queue.unbounded<{
-          payload: typeof SyncState.PayloadUpstream.Type
-        }>(),
-        Queue.shutdown,
-      )
+      const queue = yield* Effect.acquireRelease(Queue.unbounded<typeof PullItem.Type>(), Queue.shutdown)
 
       yield* Effect.addFinalizer(() => Effect.sync(() => set.delete(queue)))
 
-      const payloadsSinceCursor = Array.from(cachedPayloads.entries())
-        .flatMap(([seqNumStr, payloads]) =>
-          payloads.map((payload) => ({ payload, seqNum: EventSequenceNumber.Client.fromString(seqNumStr) })),
+      const pullItemsSinceCursor = Array.from(cachedPullItems.entries())
+        .flatMap(([seqNumStr, items]) =>
+          items.map((item) => ({ item, seqNum: EventSequenceNumber.Client.fromString(seqNumStr) })),
         )
         .filter(({ seqNum }) => EventSequenceNumber.Client.isGreaterThan(seqNum, cursor))
         .toSorted((a, b) => EventSequenceNumber.Client.compare(a.seqNum, b.seqNum))
-        .map(({ payload }) => {
-          if (payload._tag === 'upstream-advance') {
-            return {
+        .map(({ item }) => {
+          if (item.payload._tag === 'upstream-advance') {
+            return PullItem.make({
+              globalHead: item.globalHead,
               payload: {
                 _tag: 'upstream-advance' as const,
-                newEvents: ReadonlyArray.dropWhile(payload.newEvents, (eventEncoded) =>
+                newEvents: ReadonlyArray.dropWhile(item.payload.newEvents, (eventEncoded) =>
                   EventSequenceNumber.Client.isGreaterThanOrEqual(cursor, eventEncoded.seqNum),
                 ),
               },
-            }
+            })
           } else {
-            return { payload }
+            return item
           }
         })
 
@@ -973,9 +964,9 @@ const makePullQueueSet = Effect.gen(function* () {
       //     cursor,
       //   },
       //   '\n  mergePayloads',
-      //   ...Array.from(cachedPayloads.entries())
-      //     .flatMap(([seqNumStr, payloads]) =>
-      //       payloads.map((payload) => ({ payload, seqNum: EventSequenceNumber.fromString(seqNumStr) })),
+      //   ...Array.from(cachedPullItems.entries())
+      //     .flatMap(([seqNumStr, items]) =>
+      //       items.map(({ payload }) => ({ payload, seqNum: EventSequenceNumber.fromString(seqNumStr) })),
       //     )
       //     .map(({ payload, seqNum }) => [
       //       seqNum,
@@ -985,8 +976,8 @@ const makePullQueueSet = Effect.gen(function* () {
       //       'rollbackEvents',
       //       ...(payload._tag === 'upstream-rebase' ? payload.rollbackEvents.map((_) => _.toJSON()) : []),
       //     ]),
-      //   '\n  payloadsSinceCursor',
-      //   ...payloadsSinceCursor.map(({ payload }) => [
+      //   '\n  pullItemsSinceCursor',
+      //   ...pullItemsSinceCursor.map(({ payload }) => [
       //     payload._tag,
       //     'newEvents',
       //     ...payload.newEvents.map((_) => _.toJSON()),
@@ -995,7 +986,7 @@ const makePullQueueSet = Effect.gen(function* () {
       //   ]),
       // )
 
-      yield* Queue.offerAll(queue, payloadsSinceCursor)
+      yield* Queue.offerAll(queue, pullItemsSinceCursor)
 
       set.add(queue)
 
@@ -1005,21 +996,17 @@ const makePullQueueSet = Effect.gen(function* () {
   const offer: PullQueueSet['offer'] = (item) =>
     Effect.gen(function* () {
       const seqNumStr = EventSequenceNumber.Client.toString(item.leaderHead)
-      if (cachedPayloads.has(seqNumStr) === true) {
-        cachedPayloads.get(seqNumStr)!.push(item.payload)
+      const pullItem = PullItem.make({ payload: item.payload, globalHead: item.globalHead })
+      if (cachedPullItems.has(seqNumStr) === true) {
+        cachedPullItems.get(seqNumStr)!.push(pullItem)
       } else {
-        cachedPayloads.set(seqNumStr, [item.payload])
+        cachedPullItems.set(seqNumStr, [pullItem])
       }
 
       // console.debug(`offering to ${set.size} queues`, item.leaderHead, JSON.stringify(item.payload, null, 2))
 
-      // Short-circuit if the payload is an empty upstream advance
-      if (item.payload._tag === 'upstream-advance' && item.payload.newEvents.length === 0) {
-        return
-      }
-
       for (const queue of set) {
-        yield* Queue.offer(queue, item)
+        yield* Queue.offer(queue, pullItem)
       }
     })
 

--- a/packages/@livestore/common/src/leader-thread/eventlog.ts
+++ b/packages/@livestore/common/src/leader-thread/eventlog.ts
@@ -1,5 +1,5 @@
 import { LS_DEV, shouldNeverHappen } from '@livestore/utils'
-import { Effect, Option, Schema } from '@livestore/utils/effect'
+import { Effect, Option, ReadonlyArray, Schema } from '@livestore/utils/effect'
 
 import type { SqliteDb } from '../adapter-types.ts'
 import { migrateTable } from '../schema-management/migrations.ts'
@@ -11,8 +11,8 @@ import {
   eventlogSystemTables,
   SYNC_STATUS_TABLE,
 } from '../schema/state/sqlite/system-tables/eventlog-tables.ts'
-import { sessionChangesetMetaTable } from '../schema/state/sqlite/system-tables/state-tables.ts'
 import { insertRow, updateRows } from '../sql-queries/sql-queries.ts'
+import * as SqliteDbHelper from '../sqlite-db-helper.ts'
 import type { PreparedBindValues } from '../util.ts'
 import { sql } from '../util.ts'
 import { execSql } from './connection.ts'
@@ -42,31 +42,18 @@ export const initEventlogDb = (dbEventlog: SqliteDb) =>
 
 /**
  * Exclusive of the "since event"
- * Also queries the state db in order to get the SQLite session changeset data.
  */
 export const getEventsSince = ({
   dbEventlog,
-  dbState,
   since,
 }: {
   dbEventlog: SqliteDb
-  dbState: SqliteDb
   since: EventSequenceNumber.Client.Composite
 }): ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta> => {
   const pendingEvents = dbEventlog.select(eventlogMetaTable.where('seqNumGlobal', '>=', since.global))
 
-  const sessionChangesetRowsDecoded = dbState.select(
-    sessionChangesetMetaTable.where('seqNumGlobal', '>=', since.global),
-  )
-
-  // Create a Map for O(1) lookup instead of O(n) find
-  const sessionChangesetMap = new Map(
-    sessionChangesetRowsDecoded.map((row) => [`${row.seqNumGlobal}:${row.seqNumClient}`, row]),
-  )
-
   return pendingEvents
     .map((eventlogEvent) => {
-      const sessionChangeset = sessionChangesetMap.get(`${eventlogEvent.seqNumGlobal}:${eventlogEvent.seqNumClient}`)
       return LiveStoreEvent.Client.EncodedWithMeta.make({
         name: eventlogEvent.name,
         args: eventlogEvent.argsJson,
@@ -83,14 +70,6 @@ export const getEventsSince = ({
         clientId: eventlogEvent.clientId,
         sessionId: eventlogEvent.sessionId,
         meta: {
-          sessionChangeset:
-            sessionChangeset !== undefined && sessionChangeset.changeset !== null
-              ? {
-                  _tag: 'sessionChangeset' as const,
-                  data: sessionChangeset.changeset,
-                  debug: sessionChangeset.debug,
-                }
-              : { _tag: 'unset' as const },
           syncMetadata: eventlogEvent.syncMetadataJson,
           materializerHashLeader: Option.none(),
           materializerHashSession: Option.none(),
@@ -100,6 +79,26 @@ export const getEventsSince = ({
     .filter((_) => EventSequenceNumber.Client.compare(_.seqNum, since) > 0)
     .toSorted((a, b) => EventSequenceNumber.Client.compare(a.seqNum, b.seqNum))
 }
+
+export const deleteEvents = (dbEventlog: SqliteDb, keys: ReadonlyArray<EventSequenceNumber.Client.Composite>) =>
+  Effect.gen(function* () {
+    // Split into batches to keep each DELETE statement and its bound parameter count manageable.
+    const eventNumChunks = ReadonlyArray.chunksOf(100)(keys)
+
+    for (const eventNumChunk of eventNumChunks) {
+      // A global/client pair identifies the logical event position. Deleting it intentionally purges
+      // every rebase-generation incarnation that may remain at that position.
+      const placeholders = eventNumChunk.map(() => '(?, ?)').join(', ')
+      const bindValues = eventNumChunk.flatMap((key) => [key.global, key.client])
+
+      yield* execSql(
+        dbEventlog,
+        sql`DELETE FROM ${EVENTLOG_META_TABLE}
+          WHERE (seqNumGlobal, seqNumClient) IN (${placeholders})`,
+        bindValues,
+      )
+    }
+  }).pipe(SqliteDbHelper.withSavepoint(dbEventlog))
 
 export const getEventsFromEventlog = ({
   dbEventlog,

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -25,6 +25,7 @@ import {
 } from '../adapter-types.ts'
 import type { MigrationsReport } from '../defs.ts'
 import type * as Devtools from '../devtools/mod.ts'
+import type * as MaterializationJournal from '../MaterializationJournal.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '../schema/mod.ts'
 import type * as StateHead from '../StateHead.ts'
@@ -92,7 +93,7 @@ export const makeLeaderThreadLayer = ({
 }: MakeLeaderThreadLayerParams): Layer.Layer<
   LeaderThreadCtx,
   UnknownError,
-  Scope.Scope | HttpClient.HttpClient | StateHead.StateHead
+  Scope.Scope | HttpClient.HttpClient | StateHead.StateHead | MaterializationJournal.MaterializationJournal
 > =>
   Effect.gen(function* () {
     const syncPayloadDecoded =
@@ -175,7 +176,7 @@ export const makeLeaderThreadLayer = ({
     const syncProcessor = yield* LeaderSyncProcessor.make({
       schema,
       dbState,
-      initialSyncState: getInitialSyncState({ dbEventlog, dbState, dbEventlogMissing }),
+      initialSyncState: getInitialSyncState({ dbEventlog, dbEventlogMissing }),
       initialBlockingSyncContext,
       onError: syncOptions?.onSyncError ?? 'ignore',
       onBackendIdMismatch: syncOptions?.onBackendIdMismatch ?? 'reset',
@@ -260,11 +261,9 @@ const hasStateTables = (db: SqliteDb) => {
 
 const getInitialSyncState = ({
   dbEventlog,
-  dbState,
   dbEventlogMissing,
 }: {
   dbEventlog: SqliteDb
-  dbState: SqliteDb
   dbEventlogMissing: boolean
 }) => {
   const initialBackendHead =
@@ -291,7 +290,6 @@ const getInitialSyncState = ({
         ? []
         : Eventlog.getEventsSince({
             dbEventlog,
-            dbState,
             since: {
               global: initialBackendHead,
               client: EventSequenceNumber.Client.DEFAULT,

--- a/packages/@livestore/common/src/leader-thread/materialize-event.ts
+++ b/packages/@livestore/common/src/leader-thread/materialize-event.ts
@@ -1,15 +1,14 @@
-import { isDevEnv, LS_DEV, shouldNeverHappen } from '@livestore/utils'
-import { Effect, Option, ReadonlyArray, Schema } from '@livestore/utils/effect'
+import { isDevEnv, shouldNeverHappen } from '@livestore/utils'
+import { Effect, Option, Schema } from '@livestore/utils/effect'
 
 import { MaterializeError, MaterializerHashMismatchError, type SqliteDb } from '../adapter-types.ts'
+import * as MaterializationJournal from '../MaterializationJournal.ts'
 import { getExecStatementsFromMaterializer, hashMaterializerResults } from '../materializer-helper.ts'
 import { logDeprecationWarnings } from '../schema/EventDef/deprecated.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
-import { EventSequenceNumber, resolveEventDef, SystemTables, UNKNOWN_EVENT_SCHEMA_HASH } from '../schema/mod.ts'
-import { insertRow } from '../sql-queries/index.ts'
+import { EventSequenceNumber, resolveEventDef, UNKNOWN_EVENT_SCHEMA_HASH } from '../schema/mod.ts'
 import * as StateHead from '../StateHead.ts'
-import { sql } from '../util.ts'
-import { execSql, execSqlPrepared } from './connection.ts'
+import { execSqlPrepared } from './connection.ts'
 import * as Eventlog from './eventlog.ts'
 import type { MaterializeEvent } from './types.ts'
 
@@ -22,8 +21,9 @@ export const makeMaterializeEvent = ({
   schema: LiveStoreSchema
   dbState: SqliteDb
   dbEventlog: SqliteDb
-}): Effect.Effect<MaterializeEvent, never, StateHead.StateHead> =>
+}): Effect.Effect<MaterializeEvent, never, MaterializationJournal.MaterializationJournal | StateHead.StateHead> =>
   Effect.gen(function* () {
+    const materializationJournal = yield* MaterializationJournal.MaterializationJournal
     const stateHead = yield* StateHead.StateHead
     const eventDefSchemaHashMap = new Map(
       // TODO Running `Schema.hash` can be a bottleneck for larger schemas. There is an opportunity to run this
@@ -55,13 +55,14 @@ export const makeMaterializeEvent = ({
             )
           }
 
+          yield* materializationJournal.record({
+            key: eventEncoded.seqNum,
+            changeset: { _tag: 'no-op' },
+          })
           yield* stateHead.set(eventEncoded.seqNum)
           dbState.debug.head = eventEncoded.seqNum
 
-          return {
-            sessionChangeset: { _tag: 'no-op' as const },
-            hash: Option.none(),
-          }
+          return
         }
 
         const { eventDef, materializer } = resolution
@@ -86,6 +87,8 @@ export const makeMaterializeEvent = ({
           return yield* MaterializerHashMismatchError.make({ eventName: eventEncoded.name })
         }
 
+        eventEncoded.meta.materializerHashLeader = materializerHash
+
         // NOTE we might want to bring this back if we want to debug no-op events
         // const makeExecuteOptions = (statementSql: string, bindValues: any) => ({
         //   onRowsChanged: (rowsChanged: number) => {
@@ -105,28 +108,16 @@ export const makeMaterializeEvent = ({
           yield* execSqlPrepared(dbState, statementSql, bindValues)
         }
 
-        dbState.debug.head = eventEncoded.seqNum
-
         const changeset = session.changeset()
         session.finish()
 
-        // TODO use prepared statements
-        yield* execSql(
-          dbState,
-          ...insertRow({
-            tableName: SystemTables.SESSION_CHANGESET_META_TABLE,
-            columns: SystemTables.sessionChangesetMetaTable.sqliteDef.columns,
-            values: {
-              seqNumGlobal: eventEncoded.seqNum.global,
-              seqNumClient: eventEncoded.seqNum.client,
-              seqNumRebaseGeneration: eventEncoded.seqNum.rebaseGeneration,
-              // NOTE the changeset will be empty (i.e. null) for no-op events
-              changeset: changeset ?? null,
-              debug: LS_DEV === true ? execArgsArr : null,
-            },
-          }),
-        )
+        yield* materializationJournal.record({
+          key: eventEncoded.seqNum,
+          changeset:
+            changeset !== undefined ? { _tag: 'changeset' as const, data: changeset } : { _tag: 'no-op' as const },
+        })
         yield* stateHead.set(eventEncoded.seqNum)
+        dbState.debug.head = eventEncoded.seqNum
 
         // console.groupEnd()
 
@@ -147,19 +138,13 @@ export const makeMaterializeEvent = ({
           //   console.debug('[@livestore/common:leader-thread] skipping eventlog write', mutation, statementSql, bindValues)
         }
 
-        return {
-          sessionChangeset:
-            changeset !== undefined
-              ? {
-                  _tag: 'sessionChangeset' as const,
-                  data: changeset,
-                  debug: LS_DEV === true ? execArgsArr : null,
-                }
-              : { _tag: 'no-op' as const },
-          hash: materializerHash,
-        }
+        return
       }).pipe(
-        Effect.mapError((cause) => MaterializeError.make({ cause })),
+        Effect.mapError((cause) =>
+          MaterializationJournal.isMaterializationJournalError(cause) === true
+            ? cause
+            : MaterializeError.make({ cause }),
+        ),
         Effect.withSpan(`@livestore/common:leader-thread:materializeEvent`, {
           attributes: {
             eventName: eventEncoded.name,
@@ -170,59 +155,3 @@ export const makeMaterializeEvent = ({
         // Effect.logDuration('@livestore/common:leader-thread:materializeEvent'),
       )
   })
-
-export const rollback = ({
-  dbState,
-  dbEventlog,
-  eventNumsToRollback,
-}: {
-  dbState: SqliteDb
-  dbEventlog: SqliteDb
-  eventNumsToRollback: EventSequenceNumber.Client.Composite[]
-}) =>
-  Effect.gen(function* () {
-    const rollbackEvents = dbState
-      .select<SystemTables.SessionChangesetMetaRow>(
-        sql`SELECT * FROM ${SystemTables.SESSION_CHANGESET_META_TABLE} WHERE (seqNumGlobal, seqNumClient) IN (${eventNumsToRollback.map((id) => `(${id.global}, ${id.client})`).join(', ')})`,
-      )
-      .map((_) => ({
-        seqNum: {
-          global: _.seqNumGlobal,
-          client: _.seqNumClient,
-          rebaseGeneration: -1, // unused in this code path
-        },
-        changeset: _.changeset,
-        debug: _.debug,
-      }))
-      .toSorted((a, b) => EventSequenceNumber.Client.compare(a.seqNum, b.seqNum))
-
-    // Apply changesets in reverse order
-    for (let i = rollbackEvents.length - 1; i >= 0; i--) {
-      const { changeset } = rollbackEvents[i]!
-      if (changeset !== null) {
-        dbState.makeChangeset(changeset).invert().apply()
-      }
-    }
-
-    const eventNumPairChunks = ReadonlyArray.chunksOf(100)(
-      eventNumsToRollback.map((seqNum) => `(${seqNum.global}, ${seqNum.client})`),
-    )
-
-    // Delete the changeset rows
-    for (const eventNumPairChunk of eventNumPairChunks) {
-      dbState.execute(
-        sql`DELETE FROM ${SystemTables.SESSION_CHANGESET_META_TABLE} WHERE (seqNumGlobal, seqNumClient) IN (${eventNumPairChunk.join(', ')})`,
-      )
-    }
-
-    // Delete the eventlog rows
-    for (const eventNumPairChunk of eventNumPairChunks) {
-      dbEventlog.execute(
-        sql`DELETE FROM ${SystemTables.EVENTLOG_META_TABLE} WHERE (seqNumGlobal, seqNumClient) IN (${eventNumPairChunk.join(', ')})`,
-      )
-    }
-  }).pipe(
-    Effect.withSpan('@livestore/common:LeaderSyncProcessor:rollback', {
-      attributes: { count: eventNumsToRollback.length },
-    }),
-  )

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -10,6 +10,7 @@ import {
   type SqliteError,
   UnknownError,
 } from '../index.ts'
+import type * as MaterializationJournal from '../MaterializationJournal.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { configureConnection } from './connection.ts'
 import type { MaterializeEvent } from './types.ts'
@@ -26,7 +27,10 @@ export const recreateDb = ({
   schema: LiveStoreSchema
   bootStatusQueue: Queue.Queue<BootStatus>
   materializeEvent: MaterializeEvent
-}): Effect.Effect<{ migrationsReport: MigrationsReport }, UnknownError | MaterializeError | SqliteError> =>
+}): Effect.Effect<
+  { migrationsReport: MigrationsReport },
+  UnknownError | MaterializeError | MaterializationJournal.MaterializationJournalError | SqliteError
+> =>
   Effect.gen(function* () {
     const hooks = schema.state.sqlite.migrations.hooks
 

--- a/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
+++ b/packages/@livestore/common/src/leader-thread/shutdown-channel.ts
@@ -1,8 +1,15 @@
 import { type WebChannel, Schema } from '@livestore/utils/effect'
 
 import { BackendIdMismatchError, IntentionalShutdownCause, MaterializeError, UnknownError } from '../index.ts'
+import { MaterializationJournalError } from '../MaterializationJournal.ts'
 
-export const All = Schema.Union([IntentionalShutdownCause, UnknownError, BackendIdMismatchError, MaterializeError])
+export const All = Schema.Union([
+  IntentionalShutdownCause,
+  UnknownError,
+  BackendIdMismatchError,
+  MaterializeError,
+  MaterializationJournalError,
+])
 
 /**
  * Used internally by an adapter to shutdown gracefully.

--- a/packages/@livestore/common/src/leader-thread/types.ts
+++ b/packages/@livestore/common/src/leader-thread/types.ts
@@ -25,6 +25,7 @@ import type {
   SyncBackend,
   UnknownError,
 } from '../index.ts'
+import type * as MaterializationJournal from '../MaterializationJournal.ts'
 import { EventSequenceNumber, type LiveStoreEvent, type LiveStoreSchema } from '../schema/mod.ts'
 import type * as SyncState from '../sync/syncstate.ts'
 import type * as LeaderSyncProcessor from './LeaderSyncProcessor.ts'
@@ -123,13 +124,7 @@ export type MaterializeEvent = (
     /** Needed for rematerializeFromEventlog */
     skipEventlog?: boolean
   },
-) => Effect.Effect<
-  {
-    sessionChangeset: { _tag: 'sessionChangeset'; data: Uint8Array<ArrayBuffer>; debug: any } | { _tag: 'no-op' }
-    hash: Option.Option<number>
-  },
-  MaterializeError
->
+) => Effect.Effect<void, MaterializeError | MaterializationJournal.MaterializationJournalError>
 
 export type InitialBlockingSyncContext = {
   blockingDeferred: Deferred.Deferred<void> | undefined

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -56,8 +56,9 @@ export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerial
     const materializer = schema.state.materializers.get(row.name)
 
     if (eventDef === undefined || materializer === undefined) {
-      // Route unknown events through the normal materialization boundary so
-      // they advance the state snapshot head as no-ops.
+      // Old snapshots can contain newer events. Route them through the normal
+      // materialization boundary so unknown-event policy, no-op journal records,
+      // and state-head advancement stay consistent with live materialization.
       yield* materializeEvent(eventEncoded, { skipEventlog: true })
       return
     }

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts
@@ -16,7 +16,6 @@ Vitest.describe('EncodedWithMeta', () => {
       clientId: 'client-1',
       sessionId: 'session-1',
       meta: {
-        sessionChangeset: { _tag: 'unset' },
         syncMetadata: Option.none(),
         materializerHashLeader: Option.none(),
         materializerHashSession: Option.none(),

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
@@ -60,7 +60,7 @@ export type ForSchema<TSchema extends LiveStoreSchema> = {
 
 /**
  * Internal event representation with metadata for sync processing.
- * Includes changeset data and materializer hashes for conflict detection and rebasing.
+ * Includes materializer hashes for conflict detection and rebasing.
  *
  * Note: This class is exported for internal use. The preferred access is via `LiveStoreEvent.Client.EncodedWithMeta`.
  */
@@ -73,14 +73,6 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
   sessionId: Schema.String,
   // TODO get rid of `meta` again by cleaning up the usage implementations
   meta: Schema.Struct({
-    sessionChangeset: Schema.Union([
-      Schema.TaggedStruct('sessionChangeset', {
-        data: Schema.Uint8Array as any as Schema.Codec<Uint8Array<ArrayBuffer>>,
-        debug: Schema.Any.pipe(Schema.optional),
-      }),
-      Schema.TaggedStruct('no-op', {}),
-      Schema.TaggedStruct('unset', {}),
-    ]),
     syncMetadata: Schema.Option(Schema.Json),
     /** Used to detect if the materializer is side effecting (during dev) */
     materializerHashLeader: Schema.Option(Schema.Finite),
@@ -90,7 +82,6 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
     .pipe(
       Schema.withDecodingDefaultType(
         Effect.succeed({
-          sessionChangeset: { _tag: 'unset' as const },
           syncMetadata: Option.none(),
           materializerHashLeader: Option.none(),
           materializerHashSession: Option.none(),
@@ -98,7 +89,6 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
       ),
       Schema.withConstructorDefault(
         Effect.succeed({
-          sessionChangeset: { _tag: 'unset' as const },
           syncMetadata: Option.none(),
           materializerHashLeader: Option.none(),
           materializerHashSession: Option.none(),
@@ -169,7 +159,6 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
         rebaseGeneration: EventSequenceNumber.Client.REBASE_GENERATION_DEFAULT,
       },
       meta: {
-        sessionChangeset: { _tag: 'unset' as const },
         syncMetadata: meta.syncMetadata,
         materializerHashLeader: meta.materializerHashLeader,
         materializerHashSession: meta.materializerHashSession,

--- a/packages/@livestore/common/src/schema/state/sqlite/system-tables/state-tables.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/system-tables/state-tables.ts
@@ -49,8 +49,11 @@ export const STATE_HEAD_META_TABLE = '__livestore_state_head'
  * Single-row marker for the latest event sequence number reflected by the state DB.
  *
  * @remarks
- * This is separate from the session changeset table because confirmed changesets
- * can be removed after they are no longer needed for rollback.
+ *
+ * This is separate from the materialization journal, so a state database snapshot
+ * carries its own event sequence number. Journal rows are rollback records and
+ * may be pruned after event confirmation, so they are not a reliable marker for
+ * the event sequence number reflected by the current state database contents.
  */
 export const stateHeadMetaTable = table({
   name: STATE_HEAD_META_TABLE,
@@ -64,46 +67,35 @@ export const stateHeadMetaTable = table({
 
 export type StateHeadMetaRow = typeof stateHeadMetaTable.Type
 
-/**
- * Table which stores SQLite changeset blobs which is used for rolling back
- * read-model state during rebasing.
- */
-export const SESSION_CHANGESET_META_TABLE = '__livestore_session_changeset'
+// TODO: Rename the physical table name to `__livestore_materialization_journal`
+export const MATERIALIZATION_JOURNAL_META_TABLE = '__livestore_session_changeset'
 
-export const sessionChangesetMetaTable = table({
-  name: SESSION_CHANGESET_META_TABLE,
+/** @deprecated Use {@link MATERIALIZATION_JOURNAL_META_TABLE}. */
+export const SESSION_CHANGESET_META_TABLE = MATERIALIZATION_JOURNAL_META_TABLE
+
+/**
+ * Materialization journal used to roll back state database changes during rebasing.
+ */
+export const materializationJournalMetaTable = table({
+  name: MATERIALIZATION_JOURNAL_META_TABLE,
   columns: {
     // TODO bring back primary key
     seqNumGlobal: SqliteDsl.integer({ schema: EventSequenceNumber.Global.Schema }),
     seqNumClient: SqliteDsl.integer({ schema: EventSequenceNumber.Client.Schema }),
     seqNumRebaseGeneration: SqliteDsl.integer({}),
     changeset: SqliteDsl.blob({ nullable: true }),
-    debug: SqliteDsl.json({ nullable: true }),
   },
+  // TODO: Rename the index name to `idx_materialization_journal_id`
   indexes: [{ columns: ['seqNumGlobal', 'seqNumClient'], name: 'idx_session_changeset_id' }],
 })
 
-export type SessionChangesetMetaRow = typeof sessionChangesetMetaTable.Type
-
-// TODO: Rename the physical table once legacy session changeset consumers have been migrated.
-export const MATERIALIZATION_JOURNAL_META_TABLE = SESSION_CHANGESET_META_TABLE
-
-/**
- * Materialization journal used to roll back state database changes during rebasing.
- *
- * @remarks
- * This aliases the legacy table definition until all session changeset consumers
- * have adopted the journal service.
- */
-export const materializationJournalMetaTable = sessionChangesetMetaTable
-
-export type MaterializationJournalMetaRow = SessionChangesetMetaRow
+export type MaterializationJournalMetaRow = typeof materializationJournalMetaTable.Type
 
 export const stateSystemTables = [
   schemaMetaTable,
   schemaEventDefsMetaTable,
   stateHeadMetaTable,
-  sessionChangesetMetaTable,
+  materializationJournalMetaTable,
 ] as const
 
 export const isStateSystemTable = (tableName: string) => stateSystemTables.some((_) => _.sqliteDef.name === tableName)

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -18,12 +18,14 @@ import {
 } from '@livestore/utils/effect'
 
 import type { ClientSession } from '../adapter-types.ts'
-import { MaterializeError } from '../errors.ts'
+import type { MaterializeError } from '../errors.ts'
 import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
+import * as MaterializationJournal from '../MaterializationJournal.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { resolveSessionIdSymbolInEventArgs } from '../session-id-symbol.ts'
+import * as SqliteDbHelper from '../sqlite-db-helper.ts'
 import * as StateHead from '../StateHead.ts'
 import * as SyncState from './syncstate.ts'
 
@@ -49,7 +51,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   schema,
   clientSession,
   materializeEvent,
-  rollback,
   refreshTables,
   params,
   confirmUnsavedChanges,
@@ -62,15 +63,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   ) => Effect.Effect<
     {
       writeTables: Set<string>
-      sessionChangeset:
-        | { _tag: 'sessionChangeset'; data: Uint8Array<ArrayBuffer>; debug: any }
-        | { _tag: 'no-op' }
-        | { _tag: 'unset' }
-      materializerHash: Option.Option<number>
     },
-    MaterializeError
+    MaterializeError | MaterializationJournal.MaterializationJournalError
   >
-  rollback: (changeset: Uint8Array<ArrayBuffer>) => void
   refreshTables: (tables: Set<string>) => void
   params: {
     leaderPushBatchSize: number
@@ -88,6 +83,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
    */
   confirmUnsavedChanges: boolean
 }) {
+  const materializationJournal = yield* MaterializationJournal.MaterializationJournal
   const stateHead = yield* StateHead.StateHead
   const eventSchema = LiveStoreEvent.Client.makeSchemaMemo(schema)
 
@@ -189,7 +185,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Stream.tap(() =>
         clientSession.devtools.enabled === true ? clientSession.devtools.pullLatch.await : Effect.void,
       ),
-      Stream.tap(({ payload }) =>
+      Stream.tap(({ payload, globalHead }) =>
         Effect.gen(function* () {
           // yield* Effect.logDebug('ClientSessionSyncProcessor:pull', payload)
 
@@ -232,21 +228,14 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               )
             }
 
-            // Roll back the optimistic session changesets for the events this rebase discards.
-            // (Independent of the push queue below; order relative to the queue reconcile is irrelevant.)
-            for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
-              const event = mergeResult.rollbackEvents[i]!
-              if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
-                rollback(event.meta.sessionChangeset.data)
-                event.meta.sessionChangeset = { _tag: 'unset' }
-              }
-            }
             if (mergeResult.rollbackEvents.length > 0) {
-              yield* stateHead
-                .set(mergeResult.rollbackEvents[0]!.parentSeqNum)
-                .pipe(Effect.mapError((cause) => MaterializeError.make({ cause })))
-            }
+              const headAfterRollback = mergeResult.rollbackEvents[0]!.parentSeqNum
 
+              yield* Effect.gen(function* () {
+                yield* materializationJournal.rollback(mergeResult.rollbackEvents.map((event) => event.seqNum))
+                yield* stateHead.set(headAfterRollback)
+              }).pipe(SqliteDbHelper.withSavepoint(clientSession.sqliteDb), Effect.orDieDebugger)
+            }
             // Barrier: before the atomic queue reconciliation (the "discard + re-offer" step).
             // A `push` admitted here appends its event to `syncStateRef.current.pending` AND to
             // `leaderPushQueue`; the reconciliation below re-reads the LIVE pending, so that event
@@ -296,32 +285,25 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             unresolvedRejection = undefined
           }
 
-          if (mergeResult.newEvents.length === 0) {
-            // If there are no new events, we need to update the sync state as well
-            yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-            return
-          }
-
-          const writeTables = new Set<string>()
-          for (const event of mergeResult.newEvents) {
-            const {
-              writeTables: newWriteTables,
-              sessionChangeset,
-              materializerHash,
-            } = yield* materializeEvent(event, {
-              materializerHashLeader: event.meta.materializerHashLeader,
-            })
-            for (const table of newWriteTables) {
-              writeTables.add(table)
+          if (mergeResult.newEvents.length > 0) {
+            const writeTables = new Set<string>()
+            for (const event of mergeResult.newEvents) {
+              const { writeTables: newWriteTables } = yield* materializeEvent(event, {
+                materializerHashLeader: event.meta.materializerHashLeader,
+              })
+              for (const table of newWriteTables) {
+                writeTables.add(table)
+              }
             }
 
-            event.meta.sessionChangeset = sessionChangeset
-            event.meta.materializerHashSession = materializerHash
+            refreshTables(writeTables)
           }
 
-          refreshTables(writeTables)
+          // The leader's global head becomes a safe rollback-journal frontier
+          // only after this item's rollback and re-materialization are complete.
+          yield* materializationJournal.discardUpTo(globalHead)
 
-          // We're only triggering the sync state update after all events have been materialized
+          // Publish only after rollback, materialization, and pruning complete.
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
         }).pipe(
           rebaseOwnership.withPermits(1),
@@ -406,18 +388,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   )(function* (events) {
     const writeTables = new Set<string>()
     for (const event of events) {
-      const {
-        writeTables: newWriteTables,
-        sessionChangeset,
-        materializerHash,
-      } = yield* materializeEvent(event, {
+      const { writeTables: newWriteTables } = yield* materializeEvent(event, {
         materializerHashLeader: Option.none(),
       })
       for (const table of newWriteTables) {
         writeTables.add(table)
       }
-      event.meta.sessionChangeset = sessionChangeset
-      event.meta.materializerHashSession = materializerHash
     }
     return { writeTables }
   })
@@ -524,7 +500,10 @@ export interface ClientSessionSyncProcessor {
   push: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
   materializeEvents: (
     events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
-  ) => Effect.Effect<{ writeTables: Set<string> }, MaterializeError>
+  ) => Effect.Effect<
+    { writeTables: Set<string> },
+    MaterializeError | MaterializationJournal.MaterializationJournalError
+  >
   /**
    * Only used for debugging / observability.
    */

--- a/packages/@livestore/livestore/src/SqliteDbWrapper.ts
+++ b/packages/@livestore/livestore/src/SqliteDbWrapper.ts
@@ -111,7 +111,7 @@ export class SqliteDbWrapper implements SqliteDb {
 
   withChangeset<TRes>(callback: () => TRes): {
     result: TRes
-    changeset: { _tag: 'sessionChangeset'; data: Uint8Array<ArrayBuffer>; debug: any } | { _tag: 'no-op' }
+    changeset: { _tag: 'changeset'; data: Uint8Array<ArrayBuffer> } | { _tag: 'no-op' }
   } {
     const session = this.db.session()
     const result = callback()
@@ -121,8 +121,7 @@ export class SqliteDbWrapper implements SqliteDb {
 
     return {
       result,
-      changeset:
-        changeset !== undefined ? { _tag: 'sessionChangeset', data: changeset, debug: null } : { _tag: 'no-op' },
+      changeset: changeset !== undefined ? { _tag: 'changeset', data: changeset } : { _tag: 'no-op' },
     }
   }
 

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -9,9 +9,6 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -22,6 +19,9 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -43,6 +43,32 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -167,9 +193,6 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -180,6 +203,9 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -201,6 +227,32 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -325,9 +377,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -338,6 +387,9 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -359,6 +411,32 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -483,9 +561,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -496,6 +571,9 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -517,6 +595,32 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -641,9 +745,6 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -654,6 +755,9 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -675,6 +779,32 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -799,9 +929,6 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -812,6 +939,9 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -833,6 +963,58 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((2, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": true,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -1036,9 +1218,6 @@ exports[`otel > otel 3`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -1049,6 +1228,9 @@ exports[`otel > otel 3`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -1070,6 +1252,32 @@ exports[`otel > otel 3`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -1356,9 +1564,6 @@ exports[`otel > with thunks 7`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -1369,6 +1574,9 @@ exports[`otel > with thunks 7`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -1390,6 +1598,32 @@ exports[`otel > with thunks 7`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -1510,9 +1744,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -1523,6 +1754,9 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -1544,6 +1778,32 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((1, 0, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -7,6 +7,7 @@ import {
   type ClientSession,
   type ClientSessionDevtoolsChannel,
   type IntentionalShutdownCause,
+  type MaterializationJournal,
   type MaterializeError,
   type MigrationsReport,
   provideOtel,
@@ -335,7 +336,10 @@ export const createStore = <
       let shutdownSyncProcessor: ((exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>) | undefined
 
       const shutdown = (
-        exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
+        exit: Exit.Exit<
+          IntentionalShutdownCause,
+          UnknownError | MaterializeError | MaterializationJournal.MaterializationJournalError | BackendIdMismatchError
+        >,
       ) =>
         Effect.gen(function* () {
           // Hard outer bound on the DETACHED teardown: the processor drain `awaitEmpty`s the

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -6,6 +6,7 @@ import {
   type ClientSessionSyncProcessor,
   type IntentionalShutdownCause,
   isQueryBuilder,
+  type MaterializationJournal,
   type MaterializeError,
   type QueryBuilder,
   type StoreInterrupted,
@@ -52,11 +53,19 @@ export type LiveStoreContext<TSchema extends LiveStoreSchema = LiveStoreSchema.A
 
 export type ShutdownDeferred = Deferred.Deferred<
   IntentionalShutdownCause,
-  UnknownError | StoreInterrupted | MaterializeError | BackendIdMismatchError
+  | UnknownError
+  | StoreInterrupted
+  | MaterializeError
+  | MaterializationJournal.MaterializationJournalError
+  | BackendIdMismatchError
 >
 export const makeShutdownDeferred: Effect.Effect<ShutdownDeferred> = Deferred.make<
   IntentionalShutdownCause,
-  UnknownError | StoreInterrupted | MaterializeError | BackendIdMismatchError
+  | UnknownError
+  | StoreInterrupted
+  | MaterializeError
+  | MaterializationJournal.MaterializationJournalError
+  | BackendIdMismatchError
 >()
 
 /**

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -10,6 +10,7 @@ import {
   IntentionalShutdownCause,
   isQueryBuilder,
   liveStoreVersion,
+  MaterializationJournal,
   MaterializeError,
   MaterializerHashMismatchError,
   makeClientSessionSyncProcessor,
@@ -33,6 +34,7 @@ import {
   Exit,
   Fiber,
   Inspectable,
+  Layer,
   Option,
   OtelTracer,
   Queue,
@@ -209,7 +211,11 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     this.storageMode = clientSession.leaderThread.initialState.storageMode
 
     const reactivityGraph = makeReactivityGraph()
-    const stateHead = StateHead.make({ dbState: clientSession.sqliteDb })
+    const sqliteDbWrapper = new SqliteDbWrapper({ otel: otelOptions, db: clientSession.sqliteDb })
+    const materializationLayer = Layer.mergeAll(
+      MaterializationJournal.layer({ dbState: sqliteDbWrapper }),
+      StateHead.layer({ dbState: sqliteDbWrapper }),
+    )
 
     const syncProcessor = makeClientSessionSyncProcessor({
       schema,
@@ -218,6 +224,8 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         (eventEncoded, { materializerHashLeader }) =>
           // We need to use `Effect.gen` (even though we're using `Effect.fn`) so that we can pass `this` to the function
           Effect.gen({ self: this }, function* () {
+            const journal = yield* MaterializationJournal.MaterializationJournal
+            const stateHead = yield* StateHead.StateHead
             const resolution = yield* resolveEventDef(schema, {
               operation: '@livestore/livestore:store:materializeEvent',
               event: eventEncoded,
@@ -226,11 +234,13 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
             if (resolution._tag === 'unknown') {
               // Runtime schema doesn't know this event yet; skip materialization but
               // keep the log entry so upgraded clients can replay it later.
+              yield* journal.record({
+                key: eventEncoded.seqNum,
+                changeset: { _tag: 'no-op' as const },
+              })
               yield* stateHead.set(eventEncoded.seqNum)
               return {
                 writeTables: new Set<string>(),
-                sessionChangeset: { _tag: 'no-op' as const },
-                materializerHash: Option.none(),
               }
             }
 
@@ -257,6 +267,8 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
             ) {
               return yield* MaterializerHashMismatchError.make({ eventName: eventEncoded.name })
             }
+
+            eventEncoded.meta.materializerHashSession = materializerHash
 
             const span = yield* OtelTracer.currentOtelSpan.pipe(Effect.orDie)
             const otelContext = otel.trace.setSpan(otel.context.active(), span)
@@ -291,18 +303,23 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
               }
             }
 
-            const sessionChangeset = this[StoreInternalsSymbol].sqliteDbWrapper.withChangeset(exec).changeset
+            yield* journal.record({
+              key: eventEncoded.seqNum,
+              changeset: this[StoreInternalsSymbol].sqliteDbWrapper.withChangeset(exec).changeset,
+            })
             yield* stateHead.set(eventEncoded.seqNum)
 
-            return { writeTables: writeTablesForEvent, sessionChangeset, materializerHash }
+            return { writeTables: writeTablesForEvent }
           }).pipe(
             SqliteDbHelper.withSavepoint(clientSession.sqliteDb),
-            Effect.mapError((cause) => MaterializeError.make({ cause })),
+            Effect.provide(materializationLayer),
+            Effect.mapError((cause) =>
+              MaterializationJournal.isMaterializationJournalError(cause) === true
+                ? cause
+                : MaterializeError.make({ cause }),
+            ),
           ),
       ),
-      rollback: (changeset) => {
-        this[StoreInternalsSymbol].sqliteDbWrapper.rollback(changeset)
-      },
       refreshTables: (tables) => {
         const tablesToUpdate = [] as [Ref<null, ReactivityGraphContext, RefreshReason>, null][]
         for (const tableName of tables) {
@@ -318,7 +335,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         }),
       },
       confirmUnsavedChanges,
-    }).pipe(Effect.provideService(StateHead.StateHead, stateHead), Effect.runSyncWith(effectContext.services))
+    }).pipe(Effect.provide(materializationLayer), Effect.runSyncWith(effectContext.services))
 
     // TODO generalize the `tableRefs` concept to allow finer-grained refs
     const tableRefs: { [key: string]: Ref<null, ReactivityGraphContext, RefreshReason> } = {}
@@ -386,9 +403,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
       yield* syncProcessor.boot
     })
-
-    // Build Sqlite wrapper last to avoid using getters before internals are set
-    const sqliteDbWrapper = new SqliteDbWrapper({ otel: otelOptions, db: clientSession.sqliteDb })
 
     // Initialize internals bag
     this[StoreInternalsSymbol] = {
@@ -1171,7 +1185,9 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    *
    * This is called automatically when the store was created using the React or Effect API.
    */
-  shutdown = (cause?: Cause.Cause<UnknownError | MaterializeError>): Effect.Effect<void> => {
+  shutdown = (
+    cause?: Cause.Cause<UnknownError | MaterializeError | MaterializationJournal.MaterializationJournalError>,
+  ): Effect.Effect<void> => {
     this[StoreInternalsSymbol].isShutdown = true
     return this[StoreInternalsSymbol].clientSession.shutdown(
       cause !== undefined ? Exit.failCause(cause) : Exit.succeed(IntentionalShutdownCause.make({ reason: 'manual' })),

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -9,9 +9,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -22,6 +19,9 @@ exports[`useClientDocument > otel > should update the data based on component ke
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -43,6 +43,58 @@ exports[`useClientDocument > otel > should update the data based on component ke
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((0, 1, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((0, 2, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": true,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",
@@ -309,9 +361,6 @@ exports[`useClientDocument > otel > should update the data based on component ke
   },
   "children": [
     {
-      "_name": "makeClientSessionSyncProcessor",
-    },
-    {
       "_name": "livestore.in-memory-db:execute",
       "attributes": {
         "sql.query": "
@@ -322,6 +371,9 @@ exports[`useClientDocument > otel > should update the data based on component ke
       PRAGMA foreign_keys='ON'; -- we want foreign key constraints to be enforced
     ",
       },
+    },
+    {
+      "_name": "makeClientSessionSyncProcessor",
     },
     {
       "_name": "client-session-sync-processor:boot",
@@ -343,6 +395,58 @@ exports[`useClientDocument > otel > should update the data based on component ke
           },
         },
       ],
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((0, 1, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": false,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "DELETE FROM __livestore_session_changeset WHERE (seqNumGlobal, seqNumClient, seqNumRebaseGeneration) IN ((0, 2, 0))",
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT INTO __livestore_session_changeset (seqNumGlobal, seqNumClient, seqNumRebaseGeneration, changeset) VALUES ($seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration, $changeset)",
+      },
+    },
+    {
+      "_name": "sql-in-memory-select",
+      "attributes": {
+        "sql.cached": true,
+        "sql.query": "SELECT name FROM sqlite_master WHERE type = 'table' AND name = $tableName",
+        "sql.rowsCount": 1,
+      },
+    },
+    {
+      "_name": "livestore.in-memory-db:execute",
+      "attributes": {
+        "sql.query": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+      },
     },
     {
       "_name": "LiveStore:commits",

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -4,9 +4,13 @@ import type { LockStatus, MockSyncBackend } from '@livestore/common'
 import {
   type BootStatus,
   type ClientSession,
-  type ClientSessionLeaderThreadProxy,
+  ClientSessionLeaderThreadProxy,
   LeaderAheadError,
   makeMockSyncBackend,
+  MATERIALIZATION_JOURNAL_META_TABLE,
+  MaterializationJournal,
+  sql,
+  STATE_HEAD_META_TABLE,
   StateHead,
   SyncState,
   type UnknownError,
@@ -14,19 +18,16 @@ import {
 import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '@livestore/common/schema'
-import {
-  type ClientSessionSyncProcessor,
-  makeClientSessionSyncProcessor,
-  type SyncBackend,
-} from '@livestore/common/sync'
+import { type ClientSessionSyncProcessor, makeClientSessionSyncProcessor, SyncBackend } from '@livestore/common/sync'
 import { EventFactory } from '@livestore/common/testing'
 import type { ShutdownDeferred, Store } from '@livestore/livestore'
 import { createStore, makeShutdownDeferred, StoreInternalsSymbol } from '@livestore/livestore'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
 import { omitUndefineds } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 import {
   Cache,
-  type OtelTracer,
   Cause,
   Context,
   Deferred,
@@ -40,6 +41,7 @@ import {
   Latch,
   Layer,
   Option,
+  type OtelTracer,
   Queue,
   References,
   Result,
@@ -59,6 +61,43 @@ import { makeTestAdapter, type TestingOverrides } from '../test-adapter.ts'
 // TODO fix type level - derived events are missing and thus infers to `never` currently
 const eventSchema = LiveStoreEvent.Input.makeSchema(schema) as TODO as Schema.Codec<LiveStoreEvent.Input.Encoded>
 const encode = Schema.encodeSync(eventSchema)
+const materializationLayerTest = Layer.mergeAll(MaterializationJournal.layerTest, StateHead.layerTest)
+const makeBackendPullGate = Effect.fn(function* (mockSyncBackend: MockSyncBackend) {
+  const permits = yield* Queue.unbounded<void>()
+
+  return {
+    allowNext: Queue.offer(permits, undefined).pipe(Effect.asVoid),
+    backend: () =>
+      mockSyncBackend.makeSyncBackend.pipe(
+        Effect.map((backend) =>
+          SyncBackend.of({
+            ...backend,
+            pull: (cursor, options) =>
+              backend
+                .pull(cursor, options)
+                .pipe(Stream.tap(({ batch }) => (batch.length === 0 ? Effect.void : Queue.take(permits)))),
+          }),
+        ),
+      ),
+  }
+})
+
+const getMaterializationJournalRows = (store: Store) =>
+  store[StoreInternalsSymbol].sqliteDbWrapper.select<{
+    seqNumGlobal: number
+    seqNumClient: number
+    seqNumRebaseGeneration: number
+  }>(
+    sql`SELECT seqNumGlobal, seqNumClient, seqNumRebaseGeneration
+      FROM ${MATERIALIZATION_JOURNAL_META_TABLE}
+      ORDER BY seqNumGlobal, seqNumClient, seqNumRebaseGeneration`,
+  )
+
+const waitForMaterializationJournalRows = Effect.fn(function* (store: Store, expectedCount: number) {
+  while (getMaterializationJournalRows(store).length !== expectedCount) {
+    yield* Effect.sleep(10)
+  }
+})
 
 const withTestCtx = Vitest.makeWithTestCtx({
   makeLayer: () =>
@@ -76,7 +115,6 @@ type ClientProcessorParams = Parameters<typeof makeClientSessionSyncProcessor>[0
 const makeClientProcessorHarness = Effect.fn(function* ({
   push,
   pull = () => Stream.empty,
-  rollback = () => undefined,
   shutdown = () => Effect.void,
   devtools = { enabled: false },
   leaderPushBatchSize = 1,
@@ -84,12 +122,14 @@ const makeClientProcessorHarness = Effect.fn(function* ({
 }: {
   push: LeaderEvents['push']
   pull?: LeaderEvents['pull']
-  rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
   shutdown?: ClientSession['shutdown']
   devtools?: ClientSession['devtools']
   leaderPushBatchSize?: number
   rebaseBarriers?: ClientProcessorParams['params']['rebaseBarriers']
 }) {
+  const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+  const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+  const sqliteDb = yield* makeSqliteDb({ _tag: 'in-memory' })
   const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
   const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
     events: { pull, push, stream: () => Stream.empty },
@@ -112,7 +152,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   }
 
   const clientSession: ClientSession = {
-    sqliteDb: {} as ClientSession['sqliteDb'],
+    sqliteDb,
     devtools,
     clientId: 'client-test',
     sessionId: 'session-test',
@@ -128,14 +168,11 @@ const makeClientProcessorHarness = Effect.fn(function* ({
     materializeEvent: () =>
       Effect.succeed({
         writeTables: new Set<string>(),
-        sessionChangeset: { _tag: 'no-op' as const },
-        materializerHash: Option.none<number>(),
       }),
-    rollback,
     refreshTables: () => undefined,
     params: { leaderPushBatchSize, rebaseBarriers },
     confirmUnsavedChanges: false,
-  }).pipe(Effect.provide(StateHead.layerTest))
+  }).pipe(Effect.provide(materializationLayerTest))
 
   const scope = yield* Scope.make()
   yield* processor.boot.pipe(Scope.provide(scope))
@@ -222,7 +259,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       // Make sure pending events are processed
       yield* store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
-        Stream.filter((_) => _.pending.length === 0),
+        Stream.filter((state) => state.pending.length === 0 && state.localHead.global > 0),
         Stream.take(1),
         Stream.runDrain,
       )
@@ -292,7 +329,9 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
         Stream.filter(
           (state) =>
-            state.pending.length === 0 && EventSequenceNumber.Client.isEqual(state.localHead, state.upstreamHead),
+            state.localHead.global > 0 &&
+            state.pending.length === 0 &&
+            EventSequenceNumber.Client.isEqual(state.localHead, state.upstreamHead),
         ),
         Stream.take(1),
         Stream.runDrain,
@@ -302,6 +341,154 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const finalState = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
       expect(finalState.pending.length).toEqual(0)
       expect(EventSequenceNumber.Client.isEqual(finalState.localHead, finalState.upstreamHead)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('globally confirmed client-session events do not retain materialization journal records', (test) =>
+    Effect.gen(function* () {
+      const { makeStore } = yield* TestContext
+      const store = yield* makeStore()
+
+      store.commit(events.todoCreated({ id: 'confirmed', text: 'confirmed', completed: false }))
+
+      // The synchronous commit materializes and journals the event before any
+      // leader/backend acknowledgement can prune it.
+      expect(getMaterializationJournalRows(store)).toHaveLength(1)
+
+      // Await the observable journal outcome itself. The mock backend exposes
+      // pushedEvents before the leader consumes its confirmation pull item.
+      yield* waitForMaterializationJournalRows(store, 0).pipe(Effect.timeout('5 seconds'))
+      const finalState = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
+      expect(finalState.pending).toEqual([])
+      expect(EventSequenceNumber.Client.isEqual(finalState.localHead, finalState.upstreamHead)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('same-sequence rebase rolls back before pruning the confirmed prefix', (test) =>
+    Effect.gen(function* () {
+      const { mockSyncBackend, shutdownDeferred } = yield* TestContext
+      const backendFactory = EventFactory.makeFactory(events)({
+        client: EventFactory.clientIdentity('remote-client', 'remote-session'),
+      })
+      const remoteEvent = backendFactory.todoCreated.next({
+        id: 'remote-winner',
+        text: 'remote-winner',
+        completed: false,
+      })
+      yield* mockSyncBackend.advance(remoteEvent)
+
+      const backendPullGate = yield* makeBackendPullGate(mockSyncBackend)
+      const localAcknowledgement = yield* Deferred.make<void>()
+      const adapter = makeTestAdapter({
+        sync: {
+          backend: backendPullGate.backend,
+          onSyncError: 'shutdown',
+        },
+        testing: {
+          overrides: {
+            clientSession: {
+              leaderThreadProxy: (leader) => ({
+                events: {
+                  pull: (args) =>
+                    leader.events
+                      .pull(args)
+                      .pipe(
+                        Stream.tap((item) =>
+                          item.payload.newEvents.some((event) => event.args.id === 'local-rebased') === true
+                            ? Deferred.succeed(localAcknowledgement, undefined)
+                            : Effect.void,
+                        ),
+                      ),
+                  push: leader.events.push,
+                  stream: leader.events.stream,
+                },
+              }),
+            },
+          },
+        },
+      })
+      const store = yield* createStore({
+        schema: schema as LiveStoreSchema,
+        adapter,
+        storeId: nanoid(),
+        shutdownDeferred,
+      })
+
+      store.commit(events.todoCreated({ id: 'local-rebased', text: 'local-rebased', completed: false }))
+      yield* Deferred.await(localAcknowledgement).pipe(Effect.timeout('5 seconds'))
+
+      // The old local e1 changeset must survive the leader-local acknowledgement
+      // because the backend's conflicting e1 still has to roll it back.
+      expect(getMaterializationJournalRows(store)).toEqual([
+        {
+          seqNumGlobal: 1,
+          seqNumClient: 0,
+          seqNumRebaseGeneration: 0,
+        },
+      ])
+
+      // Let the leader consume only the remote e1. The rebased local e2 push is
+      // accepted next, but its confirmation remains behind the second permit.
+      yield* backendPullGate.allowNext
+      yield* store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.localHead.global === 2),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.timeout('5 seconds'),
+      )
+
+      // Applying the rebase rolled back old local e1, materialized remote e1
+      // and rebased local e2, then pruned the now-confirmed e1 prefix.
+      expect(getMaterializationJournalRows(store)).toEqual([
+        {
+          seqNumGlobal: 2,
+          seqNumClient: 0,
+          seqNumRebaseGeneration: 1,
+        },
+      ])
+      expect(store.query(tables.todos.orderBy('id', 'asc')).map((todo) => todo.id)).toEqual([
+        'local-rebased',
+        'remote-winner',
+      ])
+
+      yield* backendPullGate.allowNext
+      yield* waitForMaterializationJournalRows(store, 0).pipe(Effect.timeout('5 seconds'))
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('state head is persisted independently from materialization journal rows', (test) =>
+    Effect.gen(function* () {
+      const { makeStore, mockSyncBackend } = yield* TestContext
+      const store = yield* makeStore()
+
+      store.commit(events.todoCreated({ id: 'head-marker', text: 'head-marker', completed: false }))
+
+      yield* mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain)
+
+      yield* store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.pending.length === 0 && state.localHead.global > 0),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.timeout('2 seconds'),
+      )
+
+      const finalState = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
+
+      store[StoreInternalsSymbol].sqliteDbWrapper.execute(sql`DELETE FROM ${MATERIALIZATION_JOURNAL_META_TABLE}`)
+
+      const stateHeadRows = store[StoreInternalsSymbol].sqliteDbWrapper.select<{
+        seqNumGlobal: number
+        seqNumClient: number
+        seqNumRebaseGeneration: number
+      }>(sql`SELECT seqNumGlobal, seqNumClient, seqNumRebaseGeneration FROM ${STATE_HEAD_META_TABLE}`)
+
+      expect(stateHeadRows).toEqual([
+        {
+          seqNumGlobal: finalState.localHead.global,
+          seqNumClient: finalState.localHead.client,
+          seqNumRebaseGeneration: finalState.localHead.rebaseGeneration,
+        },
+      ])
     }).pipe(withTestCtx(test)),
   )
 
@@ -318,9 +505,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
                 events: {
                   pull: () =>
                     Stream.fromQueue(pullQueue).pipe(
-                      Stream.map((item) => ({
-                        payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [item] }),
-                      })),
+                      Stream.map((item) =>
+                        ClientSessionLeaderThreadProxy.PullItem.make({
+                          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [item] }),
+                          globalHead: EventSequenceNumber.Client.ROOT,
+                        }),
+                      ),
                     ),
                   push: () => Effect.void,
                   stream: () => Stream.empty,
@@ -429,7 +619,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
             const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
             const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
-              Effect.provide(StateHead.layer({ dbState })),
+              Effect.provide(Layer.mergeAll(MaterializationJournal.layer({ dbState }), StateHead.layer({ dbState }))),
             )
             yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
 
@@ -538,7 +728,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         pull: () =>
           Stream.fromEffect(
             Deferred.succeed(pullStarted, undefined).pipe(
-              Effect.as({ payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }) }),
+              Effect.as(
+                ClientSessionLeaderThreadProxy.PullItem.make({
+                  payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }),
+                  globalHead: EventSequenceNumber.Client.ROOT,
+                }),
+              ),
             ),
           ),
         push: () => Effect.void,
@@ -662,7 +857,15 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const reconcileBarrier = yield* makeRebaseBarrier()
 
       const { processor, pushIds, close } = yield* makeClientProcessorHarness({
-        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        pull: () =>
+          Stream.fromQueue(pullQueue).pipe(
+            Stream.map((payload) =>
+              ClientSessionLeaderThreadProxy.PullItem.make({
+                payload,
+                globalHead: EventSequenceNumber.Client.ROOT,
+              }),
+            ),
+          ),
         // First push (the initial 'local' admission) blocks so 'local' stays pending until the
         // conflicting upstream forces a rebase; the rebase interrupts it. Later pushes record.
         push: (batch) => {
@@ -717,7 +920,15 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         const barrier = yield* makeRebaseBarrier()
 
         const { processor, pushIds, close } = yield* makeClientProcessorHarness({
-          pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+          pull: () =>
+            Stream.fromQueue(pullQueue).pipe(
+              Stream.map((payload) =>
+                ClientSessionLeaderThreadProxy.PullItem.make({
+                  payload,
+                  globalHead: EventSequenceNumber.Client.ROOT,
+                }),
+              ),
+            ),
           push: (batch) => {
             pushCallCount++
             return pushCallCount === 1
@@ -843,7 +1054,15 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         sessionId: 'session-test',
       })
       const { processor, pushIds, close } = yield* makeClientProcessorHarness({
-        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        pull: () =>
+          Stream.fromQueue(pullQueue).pipe(
+            Stream.map((payload) =>
+              ClientSessionLeaderThreadProxy.PullItem.make({
+                payload,
+                globalHead: EventSequenceNumber.Client.ROOT,
+              }),
+            ),
+          ),
         push: () => Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(pushReturned, undefined))),
       })
 
@@ -875,7 +1094,15 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       })
       let pushCount = 0
       const { processor, pushIds, close } = yield* makeClientProcessorHarness({
-        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        pull: () =>
+          Stream.fromQueue(pullQueue).pipe(
+            Stream.map((payload) =>
+              ClientSessionLeaderThreadProxy.PullItem.make({
+                payload,
+                globalHead: EventSequenceNumber.Client.ROOT,
+              }),
+            ),
+          ),
         push: () => {
           pushCount++
           return pushCount === 1
@@ -1033,16 +1260,13 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
           }).pipe(
             Effect.as({
               writeTables: new Set<string>(),
-              sessionChangeset: { _tag: 'no-op' as const },
-              materializerHash: Option.none<number>(),
             }),
           ),
-        rollback: () => undefined,
         refreshTables: () => undefined,
 
         params: { leaderPushBatchSize: 10 },
         confirmUnsavedChanges: false,
-      }).pipe(Effect.provide(StateHead.layerTest))
+      }).pipe(Effect.provide(materializationLayerTest))
 
       const encoded = yield* syncProcessor.encodeEvents([
         events.todoCreated({ id: 'post-rebase', text: 'after', completed: false }),
@@ -1091,9 +1315,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
                 events: {
                   pull: () =>
                     Stream.fromQueue(pullQueue).pipe(
-                      Stream.map((item) => ({
-                        payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [item] }),
-                      })),
+                      Stream.map((item) =>
+                        ClientSessionLeaderThreadProxy.PullItem.make({
+                          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [item] }),
+                          globalHead: EventSequenceNumber.Client.ROOT,
+                        }),
+                      ),
                     ),
                   push: () => Effect.void,
                   stream: () => Stream.empty,
@@ -1116,7 +1343,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         clientId: 'this-client',
         sessionId: 'static-session-id',
         meta: {
-          sessionChangeset: { _tag: 'no-op' } as const,
           syncMetadata: Option.none(),
           materializerHashSession: Option.none(),
           // Set a leader hash that won't match what our non-deterministic materializer computes
@@ -1156,8 +1382,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
             materializedEvents.push(event)
             return {
               writeTables: new Set<string>(),
-              sessionChangeset: { _tag: 'no-op' as const },
-              materializerHash: Option.none<number>(),
             }
           }),
       )
@@ -1179,9 +1403,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
             push: () => Effect.void,
             pull: () =>
               Stream.fromQueue(upstreamQueue).pipe(
-                Stream.map((event) => ({
-                  payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [event] }),
-                })),
+                Stream.map((event) =>
+                  ClientSessionLeaderThreadProxy.PullItem.make({
+                    payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [event] }),
+                    globalHead: EventSequenceNumber.Client.ROOT,
+                  }),
+                ),
               ),
             stream: () => Stream.empty,
           },
@@ -1201,12 +1428,11 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         schema: schema as LiveStoreSchema,
         clientSession,
         materializeEvent,
-        rollback: () => undefined,
         refreshTables: () => undefined,
 
         params: { leaderPushBatchSize: 10 },
         confirmUnsavedChanges: false,
-      }).pipe(Effect.provide(StateHead.layerTest))
+      }).pipe(Effect.provide(materializationLayerTest))
 
       const unknownEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
         name: 'unknown_event_test',
@@ -1234,7 +1460,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       expect(materializedEvents).toHaveLength(1)
       expect(materializedEvents[0]?.name).toEqual('unknown_event_test')
-      expect(materializedEvents[0]?.meta.sessionChangeset._tag).toEqual('no-op')
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -2,18 +2,21 @@ import { assert, expect } from 'vitest'
 
 import {
   BackendIdMismatchError,
+  type ClientSessionLeaderThreadProxy,
   type IntentionalShutdownCause,
   type MockSyncBackend,
   type MockSyncBackendOptions,
   makeMockSyncBackend,
+  MATERIALIZATION_JOURNAL_META_TABLE,
   type RejectedPushError,
   ServerAheadError,
   StateHead,
   StaleRebaseGenerationError,
+  sql,
   type SyncBackend,
   type SyncOptions,
-  type SyncState,
   UnknownError,
+  MaterializationJournal,
 } from '@livestore/common'
 import type { MakeLeaderThreadLayerParams } from '@livestore/common/leader-thread'
 import { LeaderThreadCtx, makeLeaderThreadLayer, ShutdownChannel as Shutdown } from '@livestore/common/leader-thread'
@@ -119,38 +122,29 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     }).pipe(withTestCtx()(test)),
   )
 
-  Vitest.live('retains leader materialization metadata for pending local events', (test) =>
+  Vitest.live('prunes materialization journal rows for confirmed events', (test) =>
     Effect.gen(function* () {
       const leaderThreadCtx = yield* LeaderThreadCtx
       const testContext = yield* TestContext
-      const sourceSessionChangeset = Uint8Array.from([255])
 
-      yield* testContext.mockSyncBackend.disconnect
+      yield* testContext.pushEncoded(
+        testContext.eventFactory.todoCreated.next({ id: 'confirmed-leader', text: 'confirmed', completed: false }),
+      )
 
-      const localEvent = new LiveStoreEvent.Client.EncodedWithMeta({
-        ...LiveStoreEvent.Global.toClientEncoded(
-          testContext.eventFactory.todoCreated.next({ id: 'local', text: 'local', completed: false }),
-        ),
-      })
-      localEvent.meta.sessionChangeset = {
-        _tag: 'sessionChangeset',
-        data: sourceSessionChangeset,
-        debug: undefined,
-      }
+      yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain)
 
-      yield* leaderThreadCtx.syncProcessor.push([localEvent])
+      yield* leaderThreadCtx.syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.pending.length === 0),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.timeout('5 seconds'),
+      )
 
-      const downstreamItem = yield* Queue.take(testContext.pullQueue)
-      assert(downstreamItem.payload._tag === 'upstream-advance')
+      const remainingJournalRows = leaderThreadCtx.dbState.select<{ count: number }>(
+        sql`SELECT COUNT(*) AS count FROM ${MATERIALIZATION_JOURNAL_META_TABLE}`,
+      )[0]!.count
 
-      const retainedEvent = (yield* leaderThreadCtx.syncProcessor.syncState.get).pending[0]!
-      const publishedEvent = downstreamItem.payload.newEvents[0]!
-      assert(retainedEvent.meta.sessionChangeset._tag === 'sessionChangeset')
-      assert(publishedEvent.meta.sessionChangeset._tag === 'sessionChangeset')
-
-      expect([...retainedEvent.meta.sessionChangeset.data]).toEqual([...publishedEvent.meta.sessionChangeset.data])
-      expect([...retainedEvent.meta.sessionChangeset.data]).not.toEqual([...sourceSessionChangeset])
-      expect(retainedEvent.meta.materializerHashLeader).toEqual(publishedEvent.meta.materializerHashLeader)
+      expect(remainingJournalRows).toEqual(0)
     }).pipe(withTestCtx()(test)),
   )
 
@@ -413,8 +407,11 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       expect(yield* StateHead.make({ dbState: leaderThreadCtx.dbState }).get).toEqual(syncState.localHead)
 
       const queueResults = yield* Queue.clear(testContext.pullQueue)
-      expect(queueResults[0]!.payload._tag).toEqual('upstream-advance')
-      expect(queueResults[1]!.payload._tag).toEqual('upstream-rebase')
+      const reconciliationResults = queueResults.filter(
+        ({ payload }) => payload._tag === 'upstream-rebase' || payload.newEvents.length > 0,
+      )
+      expect(reconciliationResults[0]!.payload._tag).toEqual('upstream-advance')
+      expect(reconciliationResults[1]!.payload._tag).toEqual('upstream-rebase')
     }).pipe(withTestCtx()(test)),
   )
 
@@ -850,7 +847,7 @@ class TestContext extends Context.Service<
   {
     mockSyncBackend: MockSyncBackend
     shutdownDeferred: Deferred.Deferred<void, typeof Shutdown.All.Type>
-    pullQueue: Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>
+    pullQueue: Queue.Queue<typeof ClientSessionLeaderThreadProxy.PullItem.Type>
     eventFactory: LeaderEventFactory
     /** Equivalent to the ClientSessionSyncProcessor calling `.push` on the LeaderThreadCtx */
     pushEncoded: (
@@ -920,7 +917,11 @@ const LeaderThreadCtxLive = ({
         ...omitUndefineds({ syncProcessor }),
       },
       ...omitUndefineds({ params }),
-    }).pipe(Layer.provide(StateHead.layer({ dbState })), Layer.provide(FetchHttpClient.layer))
+    }).pipe(
+      Layer.provide(
+        Layer.mergeAll(StateHead.layer({ dbState }), MaterializationJournal.layer({ dbState }), FetchHttpClient.layer),
+      ),
+    )
 
     const testContextLayer = Effect.gen(function* () {
       const leaderThreadCtx = yield* LeaderThreadCtx

--- a/tests/package-common/src/leader-thread/eventlog.test.ts
+++ b/tests/package-common/src/leader-thread/eventlog.test.ts
@@ -1,0 +1,130 @@
+import { expect, vi } from 'vitest'
+
+import { SqliteError } from '@livestore/common'
+import { Eventlog } from '@livestore/common/leader-thread'
+import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect } from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+const withNodeFs = <R, E, A>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.provide(PlatformNode.NodeFileSystem.layer))
+
+const setup = Effect.gen(function* () {
+  const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+  const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+  const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
+
+  yield* Eventlog.initEventlogDb(dbEventlog)
+
+  return { dbEventlog, sqlite3 }
+})
+
+Vitest.describe.concurrent('Eventlog', () => {
+  Vitest.live('deleteEvents purges every rebase generation at the logical event position', (test) =>
+    withNodeFs(
+      Effect.gen(function* () {
+        const { dbEventlog } = yield* setup
+
+        const makeEvent = (rebaseGeneration: number) =>
+          LiveStoreEvent.Client.EncodedWithMeta.make({
+            name: 'todoCreated',
+            args: { id: `todo-${rebaseGeneration}`, text: 'todo', completed: false },
+            seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 1, rebaseGeneration }),
+            parentSeqNum: EventSequenceNumber.Client.ROOT,
+            clientId: 'client-1',
+            sessionId: 'session-1',
+          })
+
+        const firstGeneration = makeEvent(0)
+        const secondGeneration = makeEvent(1)
+
+        yield* Eventlog.insertIntoEventlog(
+          firstGeneration,
+          dbEventlog,
+          0,
+          firstGeneration.clientId,
+          firstGeneration.sessionId,
+        )
+        yield* Eventlog.insertIntoEventlog(
+          secondGeneration,
+          dbEventlog,
+          0,
+          secondGeneration.clientId,
+          secondGeneration.sessionId,
+        )
+
+        const executeSpy = vi.spyOn(dbEventlog, 'execute')
+
+        yield* Eventlog.deleteEvents(dbEventlog, [firstGeneration.seqNum])
+
+        const executeCalls: ReadonlyArray<ReadonlyArray<unknown>> = executeSpy.mock.calls
+        const deleteCall = executeCalls.find(
+          ([statement]) => typeof statement === 'string' && statement.startsWith('DELETE FROM eventlog'),
+        )
+        expect(deleteCall?.[0]).toContain('IN ((?, ?))')
+        expect(deleteCall?.[0]).not.toContain('(1, 1, 0)')
+        expect(deleteCall?.[1]).toEqual([1, 1])
+
+        const remainingRows = dbEventlog.select<{ seqNumRebaseGeneration: number }>(
+          `SELECT seqNumRebaseGeneration FROM eventlog ORDER BY seqNumRebaseGeneration ASC`,
+        )
+
+        expect(remainingRows).toEqual([])
+      }).pipe(Vitest.withTestCtx(test)),
+    ),
+  )
+
+  Vitest.live('deleteEvents rolls back earlier chunks when a later chunk fails', (test) =>
+    withNodeFs(
+      Effect.gen(function* () {
+        const { dbEventlog, sqlite3 } = yield* setup
+        const events = Array.from({ length: 101 }, (_, index) =>
+          LiveStoreEvent.Client.EncodedWithMeta.make({
+            name: 'todoCreated',
+            args: { id: `todo-${index}`, text: 'todo', completed: false },
+            seqNum: EventSequenceNumber.Client.Composite.make({ global: index + 1, client: 1 }),
+            parentSeqNum: EventSequenceNumber.Client.ROOT,
+            clientId: 'client-1',
+            sessionId: 'session-1',
+          }),
+        )
+
+        yield* Effect.forEach(
+          events,
+          (event) => Eventlog.insertIntoEventlog(event, dbEventlog, 0, event.clientId, event.sessionId),
+          { discard: true },
+        )
+
+        const SQLITE_OK = 0
+        const SQLITE_DENY = 1
+        const SQLITE_DELETE = 9
+        let deleteStatementCount = 0
+
+        sqlite3.set_authorizer(
+          dbEventlog.metadata.dbPointer,
+          (_userData, actionCode, tableName) => {
+            if (actionCode === SQLITE_DELETE && tableName === 'eventlog') {
+              deleteStatementCount++
+              return deleteStatementCount === 2 ? SQLITE_DENY : SQLITE_OK
+            }
+
+            return SQLITE_OK
+          },
+          undefined,
+        )
+
+        const error = yield* Eventlog.deleteEvents(
+          dbEventlog,
+          events.map((event) => event.seqNum),
+        ).pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(SqliteError)
+        expect(deleteStatementCount).toEqual(2)
+        expect(dbEventlog.select<{ count: number }>('SELECT COUNT(*) AS count FROM eventlog')[0]?.count).toEqual(101)
+      }).pipe(Vitest.withTestCtx(test)),
+    ),
+  )
+})

--- a/tests/package-common/src/leader-thread/stream-events.test.ts
+++ b/tests/package-common/src/leader-thread/stream-events.test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'vitest'
 
 import type { BootStatus } from '@livestore/common'
-import { StateHead, SyncState } from '@livestore/common'
+import { MaterializationJournal, StateHead, SyncState } from '@livestore/common'
 import { Eventlog, makeMaterializeEvent, recreateDb, streamEventsWithSyncState } from '@livestore/common/leader-thread'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
 import { EventFactory } from '@livestore/common/testing'
 import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
 import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Effect, Fiber, Option, Queue, Ref, Schema, Stream, Subscribable } from '@livestore/utils/effect'
+import { Effect, Fiber, Layer, Option, Queue, Ref, Schema, Stream, Subscribable } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
 import { appConfigSetEvent, events as fixtureEvents, schema as fixtureSchema } from './fixture.ts'
@@ -31,7 +31,7 @@ const withNodeFs = <R, E, A>(effect: Effect.Effect<A, E, R>) =>
  * (mock sync backend, shutdown plumbing, queues, etc.) because it verifies the
  * processor end-to-end. Here we only need three pieces:
  *   1. sqlite eventlog
- *   2. sqlite state DB (for the session changeset join)
+ *   2. sqlite state DB (for the materialization journal)
  *   3. a controllable `syncState` subscription
  * Pulling those together directly keeps the unit test fast and focused while
  * still relying on the real persistence layer.
@@ -47,7 +47,7 @@ const makeTestEnvironment = Effect.gen(function* () {
 
   const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
   const materializeEvent = yield* makeMaterializeEvent({ schema: fixtureSchema, dbState, dbEventlog }).pipe(
-    Effect.provide(StateHead.layer({ dbState })),
+    Effect.provide(Layer.mergeAll(MaterializationJournal.layer({ dbState }), StateHead.layer({ dbState }))),
   )
   yield* recreateDb({ dbState, dbEventlog, schema: fixtureSchema, bootStatusQueue, materializeEvent })
   yield* Queue.shutdown(bootStatusQueue)

--- a/tests/package-common/src/leader-thread/unknown-events.test.ts
+++ b/tests/package-common/src/leader-thread/unknown-events.test.ts
@@ -1,8 +1,15 @@
 import { expect } from 'vitest'
 
-import type { BootStatus } from '@livestore/common'
-import { sql, StateHead } from '@livestore/common'
-import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
+import {
+  MATERIALIZATION_JOURNAL_META_TABLE,
+  MaterializationJournal,
+  migrateDb,
+  rematerializeFromEventlog,
+  sql,
+  StateHead,
+  type SqliteDb,
+} from '@livestore/common'
+import { Eventlog, makeMaterializeEvent } from '@livestore/common/leader-thread'
 import type { UnknownEvents } from '@livestore/common/schema'
 import {
   EventSequenceNumber,
@@ -15,8 +22,10 @@ import {
 import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
 import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Effect, Option, Queue, Result, Schema } from '@livestore/utils/effect'
+import { Effect, Layer, Option, Result, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
+
+import { events as fixtureEvents, schema as fixtureSchema } from './fixture.ts'
 
 // Verifies the behaviour of LiveStore's unknown-event handling strategies across
 // materialization paths, ensuring events are either skipped, logged, or cause
@@ -29,10 +38,9 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
       const { materializeEvent, dbEventlog, dbState } = yield* setup({ strategy: 'warn' })
       const event = makeUnknownEncodedEvent()
 
-      const result = yield* materializeEvent(event, { skipEventlog: false })
+      yield* materializeEvent(event, { skipEventlog: false })
 
-      expect(result.sessionChangeset._tag).toEqual('no-op')
-      expect(Option.isNone(result.hash)).toBe(true)
+      expect(getMaterializationChangesetTag(dbState, event.seqNum)).toEqual('no-op')
 
       const rows = dbEventlog.select<{ name: string; schemaHash: number }>(sql`SELECT name, schemaHash FROM eventlog`)
       expect(rows).toEqual([{ name: event.name, schemaHash: UNKNOWN_EVENT_SCHEMA_HASH }])
@@ -42,13 +50,12 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
 
   Vitest.live('ignore strategy behaves like warn but silent', (test) =>
     Effect.gen(function* () {
-      const { materializeEvent, dbEventlog } = yield* setup({ strategy: 'ignore' })
+      const { materializeEvent, dbEventlog, dbState } = yield* setup({ strategy: 'ignore' })
       const event = makeUnknownEncodedEvent()
 
-      const result = yield* materializeEvent(event, {})
+      yield* materializeEvent(event, {})
 
-      expect(result.sessionChangeset._tag).toEqual('no-op')
-      expect(Option.isNone(result.hash)).toBe(true)
+      expect(getMaterializationChangesetTag(dbState, event.seqNum)).toEqual('no-op')
 
       const rows = dbEventlog.select<{ name: string; schemaHash: number }>(sql`SELECT name, schemaHash FROM eventlog`)
       expect(rows).toEqual([{ name: event.name, schemaHash: UNKNOWN_EVENT_SCHEMA_HASH }])
@@ -65,7 +72,9 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
         throw new Error('Expected materializeEvent to fail for fail strategy')
       }
       const error = result.failure
-      expect(error._tag).toEqual('MaterializeError')
+      if (error._tag !== 'MaterializeError') {
+        throw new Error(`Unexpected materialization failure: ${error._tag}`)
+      }
       if (error.cause._tag !== 'UnknownEventError') {
         throw new Error(`Unexpected failure cause: ${error.cause._tag}`)
       }
@@ -76,7 +85,7 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
   Vitest.live('callback strategy invokes observer once', (test) =>
     Effect.gen(function* () {
       const calls: Array<{ eventName: string; reason: string }> = []
-      const { materializeEvent } = yield* setup({
+      const { materializeEvent, dbState } = yield* setup({
         strategy: 'callback',
         onUnknownEvent: (context, error) => {
           calls.push({ eventName: context.event.name, reason: error.reason })
@@ -84,9 +93,9 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
       })
       const event = makeUnknownEncodedEvent()
 
-      const result = yield* materializeEvent(event, {})
+      yield* materializeEvent(event, {})
 
-      expect(result.sessionChangeset._tag).toEqual('no-op')
+      expect(getMaterializationChangesetTag(dbState, event.seqNum)).toEqual('no-op')
       expect(calls).toEqual([{ eventName: event.name, reason: 'event-definition-missing' }])
     }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
   )
@@ -109,13 +118,17 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
       const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
       const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
       yield* Eventlog.initEventlogDb(dbEventlog)
+      yield* migrateDb({ db: dbState, schema })
 
-      const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
+      const materializationJournal = MaterializationJournal.make({ dbState })
       const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
-        Effect.provide(StateHead.layer({ dbState })),
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(MaterializationJournal.MaterializationJournal, materializationJournal),
+            StateHead.layer({ dbState }),
+          ),
+        ),
       )
-      yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
-      yield* Queue.shutdown(bootStatusQueue)
 
       const event = new LiveStoreEvent.Client.EncodedWithMeta({
         name: 'known-event',
@@ -126,38 +139,112 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
         sessionId: 'session-2',
       })
 
-      const result = yield* materializeEvent(event, {})
+      yield* materializeEvent(event, {})
 
-      expect(result.sessionChangeset._tag).toEqual('no-op')
+      expect(getMaterializationChangesetTag(dbState, event.seqNum)).toEqual('no-op')
     }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
   )
 
-  Vitest.live('rematerialization advances the state head over unknown no-op events', (test) =>
+  Vitest.live('materialization journal rollback does not mutate state head', (test) =>
     Effect.gen(function* () {
-      const { materializeEvent: sourceMaterializeEvent, dbEventlog, schema } = yield* setup({ strategy: 'warn' })
-      const event = makeUnknownEncodedEvent()
-      yield* sourceMaterializeEvent(event, { skipEventlog: false })
-
       const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
       const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
-      const rematerializedState = yield* makeSqliteDb({ _tag: 'in-memory' })
-      const rematerializeEvent = yield* makeMaterializeEvent({
-        schema,
-        dbState: rematerializedState,
-        dbEventlog,
-      }).pipe(Effect.provide(StateHead.layer({ dbState: rematerializedState })))
+      const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
+      const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
+      yield* Eventlog.initEventlogDb(dbEventlog)
+      yield* migrateDb({ db: dbState, schema: fixtureSchema })
 
-      const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
-      yield* recreateDb({
-        dbState: rematerializedState,
-        dbEventlog,
-        schema,
-        bootStatusQueue,
-        materializeEvent: rematerializeEvent,
+      const materializationJournal = MaterializationJournal.make({ dbState })
+      const stateHead = StateHead.make({ dbState })
+      const materializeEvent = yield* makeMaterializeEvent({ schema: fixtureSchema, dbState, dbEventlog }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(MaterializationJournal.MaterializationJournal, materializationJournal),
+            Layer.succeed(StateHead.StateHead, stateHead),
+          ),
+        ),
+      )
+
+      const event = new LiveStoreEvent.Client.EncodedWithMeta({
+        name: fixtureEvents.todoCreated.name,
+        args: { id: 'head-is-not-journaled', text: 'example', completed: false },
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'client-3',
+        sessionId: 'session-3',
       })
-      yield* Queue.shutdown(bootStatusQueue)
 
-      expect(yield* StateHead.make({ dbState: rematerializedState }).get).toEqual(event.seqNum)
+      yield* materializeEvent(event, {})
+      expect(yield* stateHead.get).toEqual(event.seqNum)
+
+      yield* materializationJournal.rollback([event.seqNum])
+
+      expect(yield* stateHead.get).toEqual(event.seqNum)
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('rematerialization advances state head over unknown no-op events', (test) =>
+    Effect.gen(function* () {
+      const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+      const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+      const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
+      const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
+      yield* Eventlog.initEventlogDb(dbEventlog)
+      yield* migrateDb({ db: dbState, schema: fixtureSchema })
+
+      const materializationJournal = MaterializationJournal.make({ dbState })
+      const stateHead = StateHead.make({ dbState })
+      const materializeEvent = yield* makeMaterializeEvent({ schema: fixtureSchema, dbState, dbEventlog }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(MaterializationJournal.MaterializationJournal, materializationJournal),
+            Layer.succeed(StateHead.StateHead, stateHead),
+          ),
+        ),
+      )
+
+      const knownEvent = new LiveStoreEvent.Client.EncodedWithMeta({
+        name: fixtureEvents.todoCreated.name,
+        args: { id: 'known-before-unknown', text: 'known', completed: false },
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'client-rematerialize',
+        sessionId: 'session-rematerialize',
+      })
+      const unknownEvent = new LiveStoreEvent.Client.EncodedWithMeta({
+        name: 'v2.FutureEvent',
+        args: { payload: 'future' },
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 2, client: 0 }),
+        parentSeqNum: knownEvent.seqNum,
+        clientId: 'client-rematerialize',
+        sessionId: 'session-rematerialize',
+      })
+
+      yield* Eventlog.insertIntoEventlog(
+        knownEvent,
+        dbEventlog,
+        Schema.hash(fixtureEvents.todoCreated.schema),
+        knownEvent.clientId,
+        knownEvent.sessionId,
+      )
+      yield* Eventlog.insertIntoEventlog(
+        unknownEvent,
+        dbEventlog,
+        UNKNOWN_EVENT_SCHEMA_HASH,
+        unknownEvent.clientId,
+        unknownEvent.sessionId,
+      )
+
+      yield* rematerializeFromEventlog({
+        dbEventlog,
+        schema: fixtureSchema,
+        materializeEvent,
+        onProgress: () => Effect.void,
+      })
+
+      expect(yield* stateHead.get).toEqual(unknownEvent.seqNum)
+
+      expect(getMaterializationChangesetTag(dbState, unknownEvent.seqNum)).toEqual('no-op')
     }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
   )
 })
@@ -171,6 +258,18 @@ const makeUnknownEncodedEvent = () =>
     clientId: 'client-1',
     sessionId: 'session-1',
   })
+
+const getMaterializationChangesetTag = (dbState: SqliteDb, key: EventSequenceNumber.Client.Composite) => {
+  const row = dbState.select<{ changeset: Uint8Array<ArrayBuffer> | null }>(
+    sql`SELECT changeset FROM ${MATERIALIZATION_JOURNAL_META_TABLE}
+      WHERE seqNumGlobal = ${key.global}
+        AND seqNumClient = ${key.client}
+        AND seqNumRebaseGeneration = ${key.rebaseGeneration}
+      LIMIT 1`,
+  )[0]
+
+  return row === undefined ? undefined : row.changeset === null ? 'no-op' : 'changeset'
+}
 
 const makeSchemaWith = (config: UnknownEvents.HandlingConfig) =>
   makeSchema({
@@ -190,13 +289,17 @@ const setup = (config: UnknownEvents.HandlingConfig) =>
 
     const schema = makeSchemaWith(config)
     yield* Eventlog.initEventlogDb(dbEventlog)
+    yield* migrateDb({ db: dbState, schema })
 
-    const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
+    const materializationJournal = MaterializationJournal.make({ dbState })
     const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
-      Effect.provide(StateHead.layer({ dbState })),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MaterializationJournal.MaterializationJournal, materializationJournal),
+          StateHead.layer({ dbState }),
+        ),
+      ),
     )
-    yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
-    yield* Queue.shutdown(bootStatusQueue)
 
-    return { materializeEvent, dbEventlog, dbState, schema }
+    return { materializeEvent, dbEventlog, dbState, schema, materializationJournal }
   })

--- a/tests/package-common/src/test-adapter.ts
+++ b/tests/package-common/src/test-adapter.ts
@@ -9,6 +9,7 @@ import {
   StateHead,
   type SyncOptions,
   UnknownError,
+  MaterializationJournal,
 } from '@livestore/common'
 import {
   configureConnection,
@@ -175,7 +176,7 @@ const makeLocalLeaderThread = ({
         shutdownChannel,
         syncPayloadEncoded,
         syncPayloadSchema,
-      }).pipe(Layer.provide(StateHead.layer({ dbState }))),
+      }).pipe(Layer.provide(Layer.mergeAll(StateHead.layer({ dbState }), MaterializationJournal.layer({ dbState })))),
     )
 
     return yield* Effect.gen(function* () {


### PR DESCRIPTION
Follow up:

- [ ] Introduce `Materialization` service that depends on both `MaterializationJournal` and `StateHead` services. `MaterializationJournal` would then have a lower-level API than it currently has.