### PR TITLE
chore: sync effect-utils main lock

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1780483804,
-        "narHash": "sha256-ZhB/0NiJS7PvDXUU3DFwSBVFf4TMzC/MQvXEbs9M+RA=",
+        "lastModified": 1780846181,
+        "narHash": "sha256-as3iQ2FEweF+d3GjuFEOO4dvjpCODU/OF1uPcO+AqFk=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "b5e983b0be87c4ae5c06d64bbd6852c9518a77c3",
+        "rev": "50a31ad5f6493074afed6335cbf24f7add4db4ff",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1780483804,
-        "narHash": "sha256-ZhB/0NiJS7PvDXUU3DFwSBVFf4TMzC/MQvXEbs9M+RA=",
+        "lastModified": 1780846181,
+        "narHash": "sha256-as3iQ2FEweF+d3GjuFEOO4dvjpCODU/OF1uPcO+AqFk=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "b5e983b0be87c4ae5c06d64bbd6852c9518a77c3",
+        "rev": "50a31ad5f6493074afed6335cbf24f7add4db4ff",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "b5e983b0be87c4ae5c06d64bbd6852c9518a77c3",
+      "commit": "50a31ad5f6493074afed6335cbf24f7add4db4ff",
       "pinned": true,
-      "lockedAt": "2026-06-03T13:18:06.910Z"
+      "lockedAt": "2026-06-07T19:38:35.645Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
**Problem**
The megarepo/devenv lock authority still consumed an older effect-utils main commit.

**Goal**
Consume effect-utils main at `50a31ad5f6493074afed6335cbf24f7add4db4ff` with the smallest lock-only diff.

**Decisions**
Used a narrow `mr fetch --apply --only effect-utils --worktree-mode commit --force` and named devenv updates for `effect-utils` and `playwright`.

**Verification**
- `mr check`
- `CI=1 devenv tasks run mr:lock-sync-check --no-tui`
- `CI=1 devenv tasks run check:quick --no-tui`
- `git diff --check`

**Complexity**
No new complexity; lock-only sync.

**Concerns**
None from this diff.

**Follow-ups**
None.

**References**
B3 downstream projection lock sync.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🪑 co1-teak |
| `agent_session_id` | 368af832-7d31-44cd-8f8d-f6db44be4472 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.137.0 |
| `agent_runtime` | Codex CLI 0.137.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/ydra79j74jb7vhpq03hdilpv4gs1hny9-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/0dxb1fwc823x880rm6ykisgaywgplzdn-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-06-07-b3-effect-utils-main |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->