### PR TITLE
refactor: always await leader push processing

### DIFF
--- a/.changeset/few-changes-quiet-foxes-join.md
+++ b/.changeset/few-changes-quiet-foxes-join.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Always await local push processing in `LeaderSyncProcessor.push` by removing the `waitForProcessing: false` branch, simplifying queue behavior and deferred completion handling.

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -111,11 +111,7 @@ export const makeAdapter =
           {
             events: {
               pull: ({ cursor }) => syncProcessor.pull({ cursor }),
-              push: (batch) =>
-                syncProcessor.push(
-                  batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item)),
-                  { waitForProcessing: true },
-                ),
+              push: (batch) => syncProcessor.push(batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item))),
               stream: (options) =>
                 streamEventsWithSyncState({
                   dbEventlog,

--- a/packages/@livestore/adapter-expo/src/index.ts
+++ b/packages/@livestore/adapter-expo/src/index.ts
@@ -312,11 +312,7 @@ const makeLeaderThread = ({
       const leaderThread = ClientSessionLeaderThreadProxy.of({
         events: {
           pull: ({ cursor }) => syncProcessor.pull({ cursor }),
-          push: (batch) =>
-            syncProcessor.push(
-              batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item)),
-              { waitForProcessing: true },
-            ),
+          push: (batch) => syncProcessor.push(batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item))),
           stream: (options) =>
             streamEventsWithSyncState({
               dbEventlog,

--- a/packages/@livestore/adapter-node/src/client-session/adapter.ts
+++ b/packages/@livestore/adapter-node/src/client-session/adapter.ts
@@ -402,11 +402,7 @@ const makeLocalLeaderThread = ({
         {
           events: {
             pull: ({ cursor }) => syncProcessor.pull({ cursor }),
-            push: (batch) =>
-              syncProcessor.push(
-                batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item)),
-                { waitForProcessing: true },
-              ),
+            push: (batch) => syncProcessor.push(batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item))),
             stream: (options) =>
               streamEventsWithSyncState({
                 dbEventlog,

--- a/packages/@livestore/adapter-node/src/make-leader-worker.ts
+++ b/packages/@livestore/adapter-node/src/make-leader-worker.ts
@@ -75,11 +75,7 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
       }).pipe(Layer.unwrapScoped),
     PushToLeader: ({ batch }) =>
       Effect.andThen(LeaderThreadCtx, (_) =>
-        _.syncProcessor.push(
-          batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item)),
-          // We'll wait in order to keep back pressure on the client session
-          { waitForProcessing: true },
-        ),
+        _.syncProcessor.push(batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item))),
       ).pipe(Effect.uninterruptible, Effect.withSpan('@livestore/adapter-node:worker:PushToLeader')),
     BootStatusStream: () =>
       Effect.andThen(LeaderThreadCtx, (_) => Stream.fromQueue(_.bootStatusQueue)).pipe(Stream.unwrap),

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -266,11 +266,7 @@ const makeLeaderThread = ({
       const leaderThread = ClientSessionLeaderThreadProxy.of({
         events: {
           pull: ({ cursor }) => syncProcessor.pull({ cursor }),
-          push: (batch) =>
-            syncProcessor.push(
-              batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item)),
-              { waitForProcessing: true },
-            ),
+          push: (batch) => syncProcessor.push(batch.map((item) => new LiveStoreEvent.Client.EncodedWithMeta(item))),
           stream: (options) =>
             streamEventsWithSyncState({
               dbEventlog,

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -225,11 +225,7 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
       ),
     PushToLeader: ({ batch }) =>
       Effect.andThen(LeaderThreadCtx, ({ syncProcessor }) =>
-        syncProcessor.push(
-          batch.map((event) => new LiveStoreEvent.Client.EncodedWithMeta(event)),
-          // We'll wait in order to keep back pressure on the client session
-          { waitForProcessing: true },
-        ),
+        syncProcessor.push(batch.map((event) => new LiveStoreEvent.Client.EncodedWithMeta(event))),
       ).pipe(Effect.uninterruptible, Effect.withSpan('@livestore/adapter-web:worker:PushToLeader')),
     StreamEvents: (options) =>
       LeaderThreadCtx.pipe(

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -45,7 +45,7 @@ const jsonStringify = Schema.encodeSync(Schema.parseJson())
 
 type LocalPushQueueItem = [
   event: LiveStoreEvent.Client.EncodedWithMeta,
-  deferred: Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError> | undefined,
+  deferred: Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError>,
 ]
 
 /**
@@ -205,7 +205,7 @@ export const makeLeaderSyncProcessor = ({
     }
 
     // NOTE: New events are only pushed to sync backend after successful local push processing
-    const push: LeaderSyncProcessor['push'] = (newEvents, options) =>
+    const push: LeaderSyncProcessor['push'] = (newEvents) =>
       Effect.gen(function* () {
         if (newEvents.length === 0) return
 
@@ -215,22 +215,15 @@ export const makeLeaderSyncProcessor = ({
 
         advancePushHead(newEvents.at(-1)!.seqNum)
 
-        const waitForProcessing = options?.waitForProcessing ?? false
+        const deferreds = yield* Effect.forEach(newEvents, () =>
+          Deferred.make<void, LeaderAheadError | StaleRebaseGenerationError>(),
+        )
 
-        if (waitForProcessing === true) {
-          const deferreds = yield* Effect.forEach(newEvents, () =>
-            Deferred.make<void, LeaderAheadError | StaleRebaseGenerationError>(),
-          )
+        const items = newEvents.map((eventEncoded, i) => [eventEncoded, deferreds[i]] as LocalPushQueueItem)
 
-          const items = newEvents.map((eventEncoded, i) => [eventEncoded, deferreds[i]] as LocalPushQueueItem)
+        yield* BucketQueue.offerAll(localPushesQueue, items)
 
-          yield* BucketQueue.offerAll(localPushesQueue, items)
-
-          yield* Effect.all(deferreds)
-        } else {
-          const items = newEvents.map((eventEncoded) => [eventEncoded, undefined] as LocalPushQueueItem)
-          yield* BucketQueue.offerAll(localPushesQueue, items)
-        }
+        yield* Effect.all(deferreds)
       }).pipe(
         Effect.withSpan('@livestore/common:LeaderSyncProcessor:push', {
           attributes: {
@@ -489,28 +482,15 @@ const backgroundApplyLocalPushes = ({
             currentRebaseGeneration,
           })
 
-          /**
-           * Dropped pushes may still have a deferred awaiting completion.
-           * Fail it so the caller learns the leader advanced and resubmits with the updated generation.
-           */
-          yield* Effect.forEach(
-            droppedItems.filter(
-              (
-                item,
-              ): item is [
-                LiveStoreEvent.Client.EncodedWithMeta,
-                Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError>,
-              ] => item[1] !== undefined,
+          yield* Effect.forEach(droppedItems, ([eventEncoded, deferred]) =>
+            Deferred.fail(
+              deferred,
+              StaleRebaseGenerationError.make({
+                currentRebaseGeneration,
+                providedRebaseGeneration: eventEncoded.seqNum.rebaseGeneration,
+                sessionId: eventEncoded.sessionId,
+              }),
             ),
-            ([eventEncoded, deferred]) =>
-              Deferred.fail(
-                deferred,
-                StaleRebaseGenerationError.make({
-                  currentRebaseGeneration,
-                  providedRebaseGeneration: eventEncoded.seqNum.rebaseGeneration,
-                  sessionId: eventEncoded.sessionId,
-                }),
-              ),
           )
         }
 
@@ -564,7 +544,7 @@ const backgroundApplyLocalPushes = ({
             const allDeferredsToReject = [
               ...deferreds,
               ...remainingEventsMatchingGeneration.map(([_, deferred]) => deferred),
-            ].filter(isNotUndefined)
+            ]
 
             yield* Effect.forEach(allDeferredsToReject, (deferred) =>
               Deferred.fail(

--- a/packages/@livestore/common/src/leader-thread/types.ts
+++ b/packages/@livestore/common/src/leader-thread/types.ts
@@ -193,18 +193,14 @@ export interface LeaderSyncProcessor {
     cursor: EventSequenceNumber.Client.Composite
   }) => Effect.Effect<Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>, never, Scope.Scope>
 
-  /** Used by client sessions to push events to the leader thread */
+  /**
+   * Used by client sessions to push events to the leader thread.
+   * The effect only finishes when the local push has been processed (i.e. succeeded or was rejected).
+   * This doesn't mean the events have been pushed to the sync backend.
+   */
   push: (
     /** `batch` needs to follow the same rules as `batch` in `SyncBackend.push` */
     batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
-    options?: {
-      /**
-       * If true, the effect will only finish when the local push has been processed (i.e. succeeded or was rejected).
-       * `true` doesn't mean the events have been pushed to the sync backend.
-       * @default false
-       */
-      waitForProcessing?: boolean
-    },
   ) => Effect.Effect<void, RejectedPushError>
 
   /** Currently only used by devtools which don't provide their own event numbers */

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -147,7 +147,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         parentSeqNum: nextPair.parentSeqNum,
       })
 
-      yield* leaderThreadCtx.syncProcessor.push([localEvent], { waitForProcessing: true })
+      yield* leaderThreadCtx.syncProcessor.push([localEvent])
 
       yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain, Effect.timeout(5000))
 
@@ -200,7 +200,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         parentSeqNum: nextPair.parentSeqNum,
       })
 
-      yield* leaderThreadCtx.syncProcessor.push([localEvent], { waitForProcessing: true })
+      yield* leaderThreadCtx.syncProcessor.push([localEvent])
 
       const rows = leaderThreadCtx.dbState.select<{ id: string }>(tables.todos.asSql().query)
       expect(rows.map((row) => row.id).toSorted()).toEqual(['backend-1', 'local-after-pull-failure'])
@@ -265,7 +265,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         parentSeqNum: nextPair.parentSeqNum,
       })
 
-      yield* leaderThreadCtx.syncProcessor.push([localEvent], { waitForProcessing: true })
+      yield* leaderThreadCtx.syncProcessor.push([localEvent])
 
       const rows = leaderThreadCtx.dbState.select<{ id: string }>(tables.todos.asSql().query)
       expect(rows.map((row) => row.id).toSorted()).toEqual(['backend-1', 'local-after-pull-interrupt'])
@@ -315,16 +315,14 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         rebaseGeneration: syncStateBefore.localHead.rebaseGeneration - 1,
       })
 
-      // The waitForProcessing flag ensures push waits on the deferred, so we observe the rejection path.
+      // push waits on the deferred, so we observe the rejection path.
       const staleEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
         ...LiveStoreEvent.Global.toClientEncoded(baseEvent),
         seqNum: staleSeq,
         parentSeqNum: staleParent,
       })
 
-      const error = yield* leaderThreadCtx.syncProcessor
-        .push([staleEvent], { waitForProcessing: true })
-        .pipe(Effect.flip)
+      const error = yield* leaderThreadCtx.syncProcessor.push([staleEvent]).pipe(Effect.flip)
 
       expect(error._tag).toBe('StaleRebaseGenerationError')
       assert(error instanceof StaleRebaseGenerationError)
@@ -664,11 +662,12 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       // First create some data
       yield* testContext.pushEncoded(eventFactory.todoCreated.next({ id: '1', text: 't1', completed: false }))
 
-      // Wait for sync to complete
+      // Wait for local processing and backend sync to complete before arming the next push failure.
       yield* leaderThreadCtx.syncProcessor.syncState.changes.pipe(
         Stream.takeUntil((_) => _.localHead.global === 1),
         Stream.runDrain,
       )
+      yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain, Effect.timeout(3000))
 
       // Verify data exists in eventlog before the error
       const beforeRows = leaderThreadCtx.dbEventlog.select<{ name: string }>(`SELECT name FROM eventlog`)


### PR DESCRIPTION
## Problem
The `LeaderSyncProcessor.push` API included a `waitForProcessing` flag with a `false` path that could skip waiting on local push completion. This added branching in queue bookkeeping and in tests, even though the processor can now function with a single always-waiting behavior.

Additionally, that `false` path was not used in production code, so removing it avoids carrying dead branching without altering actual runtime behavior in shipped flows.

## Solution
Removed the `waitForProcessing` false path and made push always create and await deferred completion for local queue items. This enabled simplifications across push queue creation, drop/reject handling, and generation reset behavior, including:
- simplified `LeaderSyncProcessor.push` control flow,
- tightened `LocalPushQueueItem` usage to avoid unnecessary casting,
- updated callers to rely on default single-path behavior and removed explicit wait flags in tests.

## Validation
- Focused tests for `LeaderSyncProcessor` passed previously in this branch (`17` tests passed, `1` skipped).
- Lint/format was run via `dt lint:full:fix` as part of the refactor.

### Demo (optional)
N/A

## Related issues
- #...