### PR TITLE
refactor: clarify client-only event naming and filtering in sync pipeline

### DIFF
--- a/.changeset/clever-kangaroos-bathe.md
+++ b/.changeset/clever-kangaroos-bathe.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Rename client-only event sequencing/merge APIs from `isClient` naming to explicit `isClientOnly` naming, and centralize leader-thread filtering through `isClientOnlyEvent`.

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -292,15 +292,12 @@ export const makeLeaderSyncProcessor = ({
 
       // Rehydrate sync queue
       if (initialSyncState.pending.length > 0) {
-        const globalPendingEvents = initialSyncState.pending
-          // Don't sync client-local events
-          .filter((eventEncoded) => {
-            const eventDef = schema.eventsDefsMap.get(eventEncoded.name)
-            return eventDef === undefined ? true : eventDef.options.clientOnly === false
-          })
+        const globalOrUnknownPendingEvents = initialSyncState.pending
+          // Don't sync client-only events
+          .filter((eventEncoded) => !isClientOnlyEvent(eventEncoded))
 
-        if (globalPendingEvents.length > 0) {
-          yield* BucketQueue.offerAll(syncBackendPushQueue, globalPendingEvents)
+        if (globalOrUnknownPendingEvents.length > 0) {
+          yield* BucketQueue.offerAll(syncBackendPushQueue, globalOrUnknownPendingEvents)
         }
       }
 
@@ -330,7 +327,6 @@ export const makeLeaderSyncProcessor = ({
         localPushesQueue,
         syncStateSref,
         syncBackendPushQueue,
-        schema,
         isClientOnlyEvent,
         connectedClientSessionPullQueues,
         localPushBatchSize,
@@ -437,7 +433,6 @@ const backgroundApplyLocalPushes = ({
   localPushesQueue,
   syncStateSref,
   syncBackendPushQueue,
-  schema,
   isClientOnlyEvent,
   connectedClientSessionPullQueues,
   localPushBatchSize,
@@ -447,7 +442,6 @@ const backgroundApplyLocalPushes = ({
   localPushesQueue: BucketQueue.BucketQueue<LocalPushQueueItem>
   syncStateSref: SubscriptionRef.SubscriptionRef<SyncState.SyncState | undefined>
   syncBackendPushQueue: BucketQueue.BucketQueue<LiveStoreEvent.Client.EncodedWithMeta>
-  schema: LiveStoreSchema
   isClientOnlyEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   connectedClientSessionPullQueues: PullQueueSet
   localPushBatchSize: number
@@ -581,13 +575,10 @@ const backgroundApplyLocalPushes = ({
           ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
         })
 
-        // Don't sync client-local events
-        const filteredBatch = mergeResult.newEvents.filter((eventEncoded) => {
-          const eventDef = schema.eventsDefsMap.get(eventEncoded.name)
-          return eventDef === undefined ? true : eventDef.options.clientOnly === false
-        })
+        // Don't sync client-only events
+        const globalOrUnknownEvents = mergeResult.newEvents.filter((e) => !isClientOnlyEvent(e))
 
-        yield* BucketQueue.offerAll(syncBackendPushQueue, filteredBatch)
+        yield* BucketQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
 
         yield* materializeEventsBatch({ batchItems: mergeResult.newEvents, deferreds })
       }).pipe(localPushBackendPullMutex.withPermits(1))
@@ -735,11 +726,10 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
             ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
           })
 
-          const globalRebasedPendingEvents = mergeResult.newSyncState.pending.filter((event) => {
-            const eventDef = schema.eventsDefsMap.get(event.name)
-            return eventDef === undefined ? true : eventDef.options.clientOnly === false
-          })
-          yield* restartBackendPushing(globalRebasedPendingEvents)
+          const globalOrUnknownRebasedPendingEvents = mergeResult.newSyncState.pending.filter(
+            (e) => !isClientOnlyEvent(e),
+          )
+          yield* restartBackendPushing(globalOrUnknownRebasedPendingEvents)
 
           if (mergeResult.rollbackEvents.length > 0) {
             yield* rollback({
@@ -759,12 +749,9 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
             ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
           })
 
-          // Ensure push fiber is active after advance by restarting with current pending (non-client) events
-          const globalPendingEvents = mergeResult.newSyncState.pending.filter((event) => {
-            const eventDef = schema.eventsDefsMap.get(event.name)
-            return eventDef === undefined ? true : eventDef.options.clientOnly === false
-          })
-          yield* restartBackendPushing(globalPendingEvents)
+          // Ensure push fiber is active after advance by restarting with current pending (non-client-only) events
+          const globalOrUnknownPendingEvents = mergeResult.newSyncState.pending.filter((e) => !isClientOnlyEvent(e))
+          yield* restartBackendPushing(globalOrUnknownPendingEvents)
 
           yield* connectedClientSessionPullQueues.offer({
             payload: SyncState.payloadFromMergeResult(mergeResult),

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -170,7 +170,7 @@ export const makeLeaderSyncProcessor = ({
 
     const syncStateSref = yield* SubscriptionRef.make<SyncState.SyncState | undefined>(undefined)
 
-    const isClientEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
+    const isClientOnlyEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
       schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
     const connectedClientSessionPullQueues = yield* makePullQueueSet
@@ -265,7 +265,7 @@ export const makeLeaderSyncProcessor = ({
           sessionId,
           ...EventSequenceNumber.Client.nextPair({
             seqNum: syncState.localHead,
-            isClient: resolution.eventDef.options.clientOnly,
+            isClientOnly: resolution.eventDef.options.clientOnly,
           }),
         })
 
@@ -331,7 +331,7 @@ export const makeLeaderSyncProcessor = ({
         syncStateSref,
         syncBackendPushQueue,
         schema,
-        isClientEvent,
+        isClientOnlyEvent,
         connectedClientSessionPullQueues,
         localPushBatchSize,
         testing: {
@@ -352,7 +352,7 @@ export const makeLeaderSyncProcessor = ({
       yield* FiberHandle.run(backendPushingFiberHandle, backendPushingEffect)
 
       yield* backgroundBackendPulling({
-        isClientEvent,
+        isClientOnlyEvent,
         restartBackendPushing: (filteredRebasedPending) =>
           Effect.gen(function* () {
             // Stop current pushing fiber
@@ -438,7 +438,7 @@ const backgroundApplyLocalPushes = ({
   syncStateSref,
   syncBackendPushQueue,
   schema,
-  isClientEvent,
+  isClientOnlyEvent,
   connectedClientSessionPullQueues,
   localPushBatchSize,
   testing,
@@ -448,7 +448,7 @@ const backgroundApplyLocalPushes = ({
   syncStateSref: SubscriptionRef.SubscriptionRef<SyncState.SyncState | undefined>
   syncBackendPushQueue: BucketQueue.BucketQueue<LiveStoreEvent.Client.EncodedWithMeta>
   schema: LiveStoreSchema
-  isClientEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
+  isClientOnlyEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   connectedClientSessionPullQueues: PullQueueSet
   localPushBatchSize: number
   testing: {
@@ -508,7 +508,7 @@ const backgroundApplyLocalPushes = ({
         const mergeResult = yield* SyncState.merge({
           syncState,
           payload: { _tag: 'local-push', newEvents },
-          isClientEvent,
+          isClientOnlyEvent,
           isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
         })
 
@@ -646,7 +646,7 @@ const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds 
   )
 
 const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcessor:backend-pulling')(function* ({
-  isClientEvent,
+  isClientOnlyEvent,
   restartBackendPushing,
   dbState,
   syncStateSref,
@@ -657,7 +657,7 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
   connectedClientSessionPullQueues,
   advancePushHead,
 }: {
-  isClientEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
+  isClientOnlyEvent: (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   restartBackendPushing: (
     filteredRebasedPending: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
   ) => Effect.Effect<void, never, LeaderThreadCtx | HttpClient.HttpClient>
@@ -714,9 +714,9 @@ const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcesso
         const mergeResult = yield* SyncState.merge({
           syncState,
           payload: SyncState.PayloadUpstreamAdvance.make({ newEvents }),
-          isClientEvent,
+          isClientOnlyEvent,
           isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-          ignoreClientEvents: true,
+          ignoreClientOnlyEvents: true,
         })
 
         if (mergeResult._tag === 'reject') {

--- a/packages/@livestore/common/src/schema/EventSequenceNumber.test.ts
+++ b/packages/@livestore/common/src/schema/EventSequenceNumber.test.ts
@@ -7,12 +7,12 @@ import { EventSequenceNumber } from './mod.ts'
 Vitest.describe('EventSequenceNumber', () => {
   Vitest.test('nextPair (no rebase)', () => {
     const e_0_0 = EventSequenceNumber.Client.Composite.make({ global: 0, client: 0 })
-    expect(EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClient: false }).seqNum).toStrictEqual({
+    expect(EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClientOnly: false }).seqNum).toStrictEqual({
       global: 1,
       client: 0,
       rebaseGeneration: 0,
     })
-    expect(EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClient: true }).seqNum).toStrictEqual({
+    expect(EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClientOnly: true }).seqNum).toStrictEqual({
       global: 0,
       client: 1,
       rebaseGeneration: 0,
@@ -22,14 +22,14 @@ Vitest.describe('EventSequenceNumber', () => {
   Vitest.test('nextPair (rebase)', () => {
     const e_0_0 = EventSequenceNumber.Client.Composite.make({ global: 0, client: 0 })
     expect(
-      EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClient: false, rebaseGeneration: 1 }).seqNum,
+      EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClientOnly: false, rebaseGeneration: 1 }).seqNum,
     ).toStrictEqual({
       global: 1,
       client: 0,
       rebaseGeneration: 1,
     })
     expect(
-      EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClient: true, rebaseGeneration: 1 }).seqNum,
+      EventSequenceNumber.Client.nextPair({ seqNum: e_0_0, isClientOnly: true, rebaseGeneration: 1 }).seqNum,
     ).toStrictEqual({
       global: 0,
       client: 1,
@@ -37,7 +37,7 @@ Vitest.describe('EventSequenceNumber', () => {
     })
 
     const e_0_0_g1 = EventSequenceNumber.Client.Composite.make({ global: 0, client: 0, rebaseGeneration: 2 })
-    expect(EventSequenceNumber.Client.nextPair({ seqNum: e_0_0_g1, isClient: false }).seqNum).toStrictEqual({
+    expect(EventSequenceNumber.Client.nextPair({ seqNum: e_0_0_g1, isClientOnly: false }).seqNum).toStrictEqual({
       global: 1,
       client: 0,
       rebaseGeneration: 2,

--- a/packages/@livestore/common/src/schema/EventSequenceNumber/client.ts
+++ b/packages/@livestore/common/src/schema/EventSequenceNumber/client.ts
@@ -222,19 +222,19 @@ export const ROOT = {
 /**
  * Computes the next sequence number and its parent based on the current position.
  *
- * For client-local events (isClient=true): increments the client component, keeps global.
- * For global events (isClient=false): increments global, resets client to 0.
+ * For client-only events (isClientOnly=true): increments the client component, keeps global.
+ * For global events (isClientOnly=false): increments global, resets client to 0.
  */
 export const nextPair = ({
   seqNum,
-  isClient,
+  isClientOnly,
   rebaseGeneration,
 }: {
   seqNum: Composite
-  isClient: boolean
+  isClientOnly: boolean
   rebaseGeneration?: number
 }): CompositePair => {
-  if (isClient === true) {
+  if (isClientOnly === true) {
     return {
       seqNum: {
         global: seqNum.global,

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
@@ -134,16 +134,16 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
    */
   rebase = ({
     parentSeqNum,
-    isClient,
+    isClientOnly,
     rebaseGeneration,
   }: {
     parentSeqNum: EventSequenceNumber.Client.Composite
-    isClient: boolean
+    isClientOnly: boolean
     rebaseGeneration: number
   }) =>
     new EncodedWithMeta({
       ...this,
-      ...EventSequenceNumber.Client.nextPair({ seqNum: parentSeqNum, isClient, rebaseGeneration }),
+      ...EventSequenceNumber.Client.nextPair({ seqNum: parentSeqNum, isClientOnly, rebaseGeneration }),
     })
 
   static fromGlobal = (

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -96,7 +96,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** Only used for debugging / observability / testing, it's not relied upon for correctness of the sync processor. */
   const syncStateUpdateQueue = yield* Queue.unbounded<SyncState.SyncState>()
-  const isClientEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
+  const isClientOnlyEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
@@ -155,7 +155,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           const mergeResult = yield* SyncState.merge({
             syncState: syncStateRef.current,
             payload,
-            isClientEvent,
+            isClientOnlyEvent,
             isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
           }).pipe(
             Effect.filterOrDieMessage((r) => r._tag !== 'reject', 'Unexpected reject in client-session-sync-processor'),
@@ -270,7 +270,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         const eventDef = yield* Effect.fromNullable(schema.eventsDefsMap.get(name)).pipe(Effect.orDieDebugger)
         const nextNumPair = EventSequenceNumber.Client.nextPair({
           seqNum: baseEventSequenceNumber,
-          isClient: eventDef.options.clientOnly,
+          isClientOnly: eventDef.options.clientOnly,
           rebaseGeneration: baseEventSequenceNumber.rebaseGeneration,
         })
         baseEventSequenceNumber = nextNumPair.seqNum
@@ -316,7 +316,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       const mergeResult = yield* SyncState.merge({
         syncState: syncStateRef.current,
         payload: { _tag: 'local-push', newEvents: encodedEvents },
-        isClientEvent,
+        isClientOnlyEvent,
         isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
       }).pipe(Effect.filterOrDieMessage((r) => r._tag === 'advance', 'Expected advance from local-push merge'))
 

--- a/packages/@livestore/common/src/sync/next/test/event-fixtures.ts
+++ b/packages/@livestore/common/src/sync/next/test/event-fixtures.ts
@@ -146,7 +146,7 @@ export const toEventNodes = (
     const eventDef = eventDefs[partialEvent.name]!
     const eventNum = EventSequenceNumber.Client.nextPair({
       seqNum: currentEventSequenceNumber,
-      isClient: eventDef.options.clientOnly,
+      isClientOnly: eventDef.options.clientOnly,
     }).seqNum
     currentEventSequenceNumber = eventNum
 

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -9,13 +9,13 @@ import * as SyncState from './syncstate.ts'
 
 class TestEvent extends LiveStoreEvent.Client.EncodedWithMeta {
   public payload = 'uninitialized'
-  public isClient = false
+  public isClientOnly = false
 
   static new = (
     seqNum: EventSequenceNumber.Client.CompositeInput,
     parentSeqNum: EventSequenceNumber.Client.CompositeInput,
     payload: string,
-    isClient: boolean,
+    isClientOnly: boolean,
   ) => {
     const event = new TestEvent({
       seqNum: EventSequenceNumber.Client.Composite.make(seqNum),
@@ -26,12 +26,12 @@ class TestEvent extends LiveStoreEvent.Client.EncodedWithMeta {
       sessionId: 'static-session-id',
     })
     event.payload = payload
-    event.isClient = isClient
+    event.isClientOnly = isClientOnly
     return event
   }
 
   rebase_ = (parentSeqNum: EventSequenceNumber.Client.Composite, rebaseGeneration: number) => {
-    return this.rebase({ parentSeqNum, isClient: this.isClient, rebaseGeneration })
+    return this.rebase({ parentSeqNum, isClientOnly: this.isClientOnly, rebaseGeneration })
   }
 
   // Only used for Vitest printing
@@ -49,19 +49,19 @@ const e2_1 = TestEvent.new({ global: 2, client: 1 }, e2_0.seqNum, 'a', true)
 
 const isEqualEvent = LiveStoreEvent.Client.isEqualEncoded
 
-const isClientEvent = (event: LiveStoreEvent.Client.EncodedWithMeta) => (event as TestEvent).isClient
+const isClientOnlyEvent = (event: LiveStoreEvent.Client.EncodedWithMeta) => (event as TestEvent).isClientOnly
 
 Vitest.describe('syncstate', () => {
   Vitest.describe('merge', () => {
     const merge = ({
       syncState,
       payload,
-      ignoreClientEvents = false,
+      ignoreClientOnlyEvents = false,
     }: {
       syncState: SyncState.SyncState
       payload: typeof SyncState.Payload.Type
-      ignoreClientEvents?: boolean
-    }) => SyncState.merge({ syncState, payload, isClientEvent, isEqualEvent, ignoreClientEvents })
+      ignoreClientOnlyEvents?: boolean
+    }) => SyncState.merge({ syncState, payload, isClientOnlyEvent, isEqualEvent, ignoreClientOnlyEvents })
 
     Vitest.describe('upstream-rebase', () => {
       Vitest.it.effect('should rollback until start', () =>
@@ -305,7 +305,7 @@ Vitest.describe('syncstate', () => {
           const result = yield* merge({
             syncState,
             payload: { _tag: 'upstream-advance', newEvents: [e1_0] },
-            ignoreClientEvents: true,
+            ignoreClientOnlyEvents: true,
           })
           expectAdvance(result)
           expectEventArraysEqual(result.newSyncState.pending, [])
@@ -326,7 +326,7 @@ Vitest.describe('syncstate', () => {
           const result = yield* merge({
             syncState,
             payload: { _tag: 'upstream-advance', newEvents: [e1_0] },
-            ignoreClientEvents: true,
+            ignoreClientOnlyEvents: true,
           })
           expectAdvance(result)
           expectEventArraysEqual(result.newSyncState.pending, [e2_0])
@@ -347,7 +347,7 @@ Vitest.describe('syncstate', () => {
           const result = yield* merge({
             syncState,
             payload: { _tag: 'upstream-advance', newEvents: [e1_0, e2_0] },
-            ignoreClientEvents: true,
+            ignoreClientOnlyEvents: true,
           })
 
           expectAdvance(result)
@@ -570,7 +570,7 @@ Vitest.describe('syncstate', () => {
               const result = yield* merge({
                 syncState,
                 payload: SyncState.PayloadLocalPush.make({ newEvents: [e0_1] }),
-                ignoreClientEvents: true,
+                ignoreClientOnlyEvents: true,
               })
 
               expectAdvance(result)
@@ -592,7 +592,7 @@ Vitest.describe('syncstate', () => {
               const result = yield* merge({
                 syncState,
                 payload: SyncState.PayloadLocalPush.make({ newEvents: [e0_1, e1_0] }),
-                ignoreClientEvents: true,
+                ignoreClientOnlyEvents: true,
               })
 
               expectAdvance(result)

--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -187,9 +187,9 @@ TODO: possibly even keep the client events in a separate table in the client lea
 export const merge = Effect.fnUntraced(function* ({
   syncState,
   payload,
-  isClientEvent,
+  isClientOnlyEvent,
   isEqualEvent,
-  ignoreClientEvents = false,
+  ignoreClientOnlyEvents = false,
 }: {
   syncState: SyncState
   payload: typeof Payload.Type
@@ -199,7 +199,7 @@ export const merge = Effect.fnUntraced(function* ({
    * can preserve the correct sequence-number shape when rebasing: client-only
    * events advance the client component, synced events advance the global component.
    */
-  isClientEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
+  isClientOnlyEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
   /**
    * Pending events are confirmed by comparing their logical encoded identity with
    * upstream events. This is caller-supplied because comparing encoded args may
@@ -211,7 +211,7 @@ export const merge = Effect.fnUntraced(function* ({
    * This is used in the leader which should ignore client events when
    * receiving an upstream-advance payload
    */
-  ignoreClientEvents?: boolean
+  ignoreClientOnlyEvents?: boolean
 }) {
   yield* validateSyncState(syncState)
   yield* validatePayload(payload)
@@ -229,7 +229,7 @@ export const merge = Effect.fnUntraced(function* ({
       const rebasedPending = rebaseEvents({
         events: syncState.pending,
         baseEventSequenceNumber: newUpstreamHead,
-        isClientEvent,
+        isClientOnlyEvent,
       })
 
       return yield* validateMergeResult(
@@ -293,8 +293,8 @@ export const merge = Effect.fnUntraced(function* ({
         existingEvents: syncState.pending,
         incomingEvents: payload.newEvents,
         isEqualEvent,
-        isClientEvent,
-        ignoreClientEvents,
+        isClientOnlyEvent,
+        ignoreClientOnlyEvents,
       })
 
       // No divergent pending events, thus we can just advance (some of) the pending events
@@ -315,7 +315,7 @@ export const merge = Effect.fnUntraced(function* ({
         const [pendingMatching, pendingRemaining] = ReadonlyArray.splitWhere(
           syncState.pending,
           (pendingEvent, index) => {
-            if (ignoreClientEvents === true && isClientEvent(pendingEvent) === true) {
+            if (ignoreClientOnlyEvents === true && isClientOnlyEvent(pendingEvent) === true) {
               clientIndexOffset++
               return false
             }
@@ -347,15 +347,15 @@ export const merge = Effect.fnUntraced(function* ({
         const rebasedPending = rebaseEvents({
           events: divergentPending,
           baseEventSequenceNumber: newUpstreamHead,
-          isClientEvent,
+          isClientOnlyEvent: isClientOnlyEvent,
         })
 
         const divergentNewEventsIndex = findDivergencePoint({
           existingEvents: payload.newEvents,
           incomingEvents: syncState.pending,
           isEqualEvent,
-          isClientEvent,
-          ignoreClientEvents,
+          isClientOnlyEvent: isClientOnlyEvent,
+          ignoreClientOnlyEvents: ignoreClientOnlyEvents,
         })
 
         return yield* validateMergeResult(
@@ -398,7 +398,7 @@ export const merge = Effect.fnUntraced(function* ({
       if (invalidEventSequenceNumber === true) {
         const expectedMinimumId = EventSequenceNumber.Client.nextPair({
           seqNum: syncState.localHead,
-          isClient: true,
+          isClientOnly: true,
         }).seqNum
         return yield* validateMergeResult(
           MergeResultReject.make({
@@ -408,9 +408,11 @@ export const merge = Effect.fnUntraced(function* ({
           }),
         )
       } else {
-        const nonClientEvents =
-          ignoreClientEvents === true ? payload.newEvents.filter((event) => !isClientEvent(event)) : payload.newEvents
-        const newPending = [...syncState.pending, ...nonClientEvents]
+        const nonClientOnlyEvents =
+          ignoreClientOnlyEvents === true
+            ? payload.newEvents.filter((event) => !isClientOnlyEvent(event))
+            : payload.newEvents
+        const newPending = [...syncState.pending, ...nonClientOnlyEvents]
         const newLocalHead =
           newPending.at(-1)?.seqNum ?? EventSequenceNumber.Client.max(syncState.localHead, syncState.upstreamHead)
 
@@ -443,28 +445,28 @@ export const findDivergencePoint = ({
   existingEvents,
   incomingEvents,
   isEqualEvent,
-  isClientEvent,
-  ignoreClientEvents,
+  isClientOnlyEvent,
+  ignoreClientOnlyEvents,
 }: {
   existingEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
   incomingEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
   isEqualEvent: (a: LiveStoreEvent.Client.EncodedWithMeta, b: LiveStoreEvent.Client.EncodedWithMeta) => boolean
-  isClientEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
-  ignoreClientEvents: boolean
+  isClientOnlyEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
+  ignoreClientOnlyEvents: boolean
 }): number => {
-  if (ignoreClientEvents === true) {
-    const filteredExistingEvents = existingEvents.filter((event) => !isClientEvent(event))
-    const divergencePointWithoutClientEvents = findDivergencePoint({
+  if (ignoreClientOnlyEvents === true) {
+    const filteredExistingEvents = existingEvents.filter((event) => !isClientOnlyEvent(event))
+    const divergencePointWithoutClientOnlyEvents = findDivergencePoint({
       existingEvents: filteredExistingEvents,
       incomingEvents,
       isEqualEvent,
-      isClientEvent,
-      ignoreClientEvents: false,
+      isClientOnlyEvent,
+      ignoreClientOnlyEvents: false,
     })
 
-    if (divergencePointWithoutClientEvents === -1) return -1
+    if (divergencePointWithoutClientOnlyEvents === -1) return -1
 
-    const divergencePointEventSequenceNumber = existingEvents[divergencePointWithoutClientEvents]!.seqNum
+    const divergencePointEventSequenceNumber = existingEvents[divergencePointWithoutClientOnlyEvents]!.seqNum
     // Now find the divergence point in the original array
     return existingEvents.findIndex((event) =>
       EventSequenceNumber.Client.isEqual(event.seqNum, divergencePointEventSequenceNumber),
@@ -481,21 +483,20 @@ export const findDivergencePoint = ({
 const rebaseEvents = ({
   events,
   baseEventSequenceNumber,
-  isClientEvent,
+  isClientOnlyEvent,
 }: {
   events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
   baseEventSequenceNumber: EventSequenceNumber.Client.Composite
-  isClientEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
+  isClientOnlyEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean
 }): ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta> => {
   let prevEventSequenceNumber = baseEventSequenceNumber
   const rebaseGeneration = baseEventSequenceNumber.rebaseGeneration + 1
   return events.map((event) => {
     // Rebasing must preserve whether an event is client-only: client-only
     // events become eN.1/eN.2, while synced events become eN+1.
-    const isClient = isClientEvent(event)
     const newEvent = event.rebase({
       parentSeqNum: prevEventSequenceNumber,
-      isClient,
+      isClientOnly: isClientOnlyEvent(event),
       rebaseGeneration,
     })
     prevEventSequenceNumber = newEvent.seqNum

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -136,7 +136,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       const syncState = yield* leaderThreadCtx.syncProcessor.syncState.get
       const nextPair = EventSequenceNumber.Client.nextPair({
         seqNum: syncState.localHead,
-        isClient: false,
+        isClientOnly: false,
       })
 
       const localEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
@@ -185,7 +185,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       const syncState = yield* leaderThreadCtx.syncProcessor.syncState.get
       const nextPair = EventSequenceNumber.Client.nextPair({
         seqNum: syncState.localHead,
-        isClient: false,
+        isClientOnly: false,
       })
 
       const localEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
@@ -250,7 +250,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       const syncState = yield* leaderThreadCtx.syncProcessor.syncState.get
       const nextPair = EventSequenceNumber.Client.nextPair({
         seqNum: syncState.localHead,
-        isClient: false,
+        isClientOnly: false,
       })
 
       const localEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
@@ -562,7 +562,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       const syncStateBefore = yield* leaderThreadCtx.syncProcessor.syncState.get
       const nextPair = EventSequenceNumber.Client.nextPair({
         seqNum: syncStateBefore.localHead,
-        isClient: true,
+        isClientOnly: true,
         rebaseGeneration: syncStateBefore.localHead.rebaseGeneration + 1,
       })
 

--- a/tests/package-common/src/leader-thread/stream-events.test.ts
+++ b/tests/package-common/src/leader-thread/stream-events.test.ts
@@ -99,7 +99,7 @@ const makeClientOnlyEvent = ({
 } => {
   const nextPair = EventSequenceNumber.Client.nextPair({
     seqNum: base,
-    isClient: true,
+    isClientOnly: true,
     rebaseGeneration: base.rebaseGeneration,
   })
 


### PR DESCRIPTION
## Problem

- The sync path used a generic `isClientEvent` naming in multiple places, which made intent less clear for event classification.
- Sync state merging and leader queue handling had repeated inline checks for client-only events, making behavior harder to reason about and maintain consistently.

## Solution

- Renamed client-only event naming from `isClient`/`isClientEvent` to explicit `isClientOnly`/`isClientOnlyEvent` across event sequencing, event rebase, and sync state merge APIs.
- Updated related tests and fixtures to reflect the new naming and avoid ambiguous semantics.
- Simplified `LeaderSyncProcessor` filtering by reusing `isClientOnlyEvent` in all queue/materialization/restart paths instead of duplicate schema lookups, which makes filtering behavior more consistent and centralized.
- This is a refactor-only change; behavior for unknown event definitions remains unchanged (treated as non-client-only for push filtering).

## Validation

- Not run (not requested in this PR open request).

### Demo (optional)

Not run.

## Related issues

- #...