### PR TITLE
fix(docs): deploy SSR functions via shared netlify task (fix prod 502)

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -24,16 +24,16 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1780483804,
-        "narHash": "sha256-ZhB/0NiJS7PvDXUU3DFwSBVFf4TMzC/MQvXEbs9M+RA=",
+        "lastModified": 1781278520,
+        "narHash": "sha256-1cdv/BP9CGg8S3e6Vw1FHEZGaqVs5snHYwA+ev9R120=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "b5e983b0be87c4ae5c06d64bbd6852c9518a77c3",
+        "rev": "d6c3ea0e55886832be8591228c368f657d0a4369",
         "type": "github"
       },
       "original": {
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "ref": "schickling-assistant/2026-06-12-netlify-ssr-deploy",
         "repo": "effect-utils",
         "type": "github"
       }
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780125817,
-        "narHash": "sha256-A44psESF9sRBg5kkkYwPPKcDakheLDnpwWMguKpA2xw=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cc8609d47cd9ddda67f70bd4729b0c1dfb2e7f21",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -285,6 +285,30 @@ in
       tsconfigFile = "tsconfig.dev.json";
     })
     (taskModules.pnpm { packages = pnpmPackages; })
+    # Docs deploy to Netlify via the shared SSR-capable task. The docs site is
+    # function-bearing (Astro SSR: /api/search, on-demand OG images, the static
+    # 404 fallback), so it uses `ssr = true`: `netlify deploy --no-build` without
+    # `--dir`, shipping the bundled serverless + edge functions produced by the
+    # `mono docs build --netlify` step. A `--dir` deploy is publish-only and
+    # drops every function — the docs.livestore.dev 502 outage.
+    # Provides `dt netlify:deploy:docs [--input type=prod|pr --input pr=N]`.
+    (taskModules.netlify {
+      siteName = "livestore-docs";
+      siteId = "abeae053-d336-480a-a0fe-f0aaaacaa74e";
+      deployments = [
+        {
+          name = "docs";
+          staticDir = "docs/dist";
+          # The build (snippets/diagrams + `netlify build`) runs in the docs
+          # build phase; this task only ships the already-bundled output.
+          afterTask = null;
+          ssr = true;
+          # docs owns its Netlify site, so `type=prod` publishes to the
+          # production domain (docs.livestore.dev) rather than a `prod` alias.
+          prodAlias = false;
+        }
+      ];
+    })
     # Setup task (auto-runs in enterShell)
     (taskModules.setup {
       requiredTasks = [ ];

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -12,4 +12,7 @@ inputs:
       nixpkgs:
         follows: nixpkgs
   effect-utils:
-    url: github:overengineeringstudio/effect-utils/main
+    # TEMPORARY: points at the effect-utils PR branch that adds netlify `ssr` +
+    # `prodAlias` deploy modes (overengineeringstudio/effect-utils#783). Retarget
+    # to `main` once that PR merges.
+    url: github:overengineeringstudio/effect-utils?ref=schickling-assistant/2026-06-12-netlify-ssr-deploy

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,9 +1,12 @@
-# Netlify configuration for docs deployment
+# Netlify configuration for docs deployment.
 #
-# IMPORTANT: Netlify CLI resolves config paths relative to the git repository
-# root, not relative to this file. The deploy script passes --dir with an
-# absolute path for publish, but edge_functions must use the git-root-relative
-# path here.
+# Build + deploy run from this directory (`docs/`), so Netlify treats it as the
+# base and every path below is resolved relative to `docs/` — NOT the git root.
+# `netlify build` runs the `[build] command`, bundles the Astro SSR serverless
+# function and the edge function, and writes the result under `docs/.netlify/`;
+# `netlify deploy --no-build` (no `--dir`) then ships that full output so the
+# functions ride along. A `--dir` deploy is publish-only and would drop every
+# function (the 502-on-every-on-demand-route failure mode).
 #
 # This file also configures Netlify's Image CDN to allow remote image
 # transformations from the hosted asset service used for example screenshots.
@@ -14,13 +17,14 @@
 # The domain is double-escaped as required by Netlify's regex configuration
 remote_images = ["https://gitbucket\\.schickling\\.dev/.*"]
 
-# Build & publish
-# Astro's static build produces docs/dist/. The deploy script runs with --no-build
-# and passes --dir explicitly, so `publish` here is only a fallback.
 [build]
+# `netlify build` runs this; `mono docs build --netlify` invokes it after the
+# snippet/diagram pre-build steps. Astro's build emits the static site to
+# `docs/dist/` plus the un-bundled SSR function under `docs/.netlify/v1/`, which
+# Netlify's Functions/Edge bundling step then packages.
+command = "pnpm astro build"
 publish = "dist"
-# Path relative to git root (Netlify CLI resolves from repo root, not this file)
-edge_functions = "docs/netlify/edge-functions"
+edge_functions = "netlify/edge-functions"
 
 # Edge Function configuration. The Edge runtime bundles the file(s) below and
 # attaches them at the CDN layer during the Netlify deploy phase.

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -263,28 +263,33 @@ in
           kill "$HEARTBEAT_PID" 2>/dev/null || true
         }
         trap cleanup EXIT
-        timeout --signal=TERM --kill-after=2m 20m mono docs build --api-docs --skip-deps 2>&1 | tee tmp/ci-docs-prod/03-astro-build.log
+        # `--netlify` builds via `netlify build`, which runs the same Astro build
+        # and then bundles the SSR serverless + edge functions so the output is
+        # deploy-ready. A plain `astro build` emits an un-bundled function that
+        # 502s once deployed.
+        timeout --signal=TERM --kill-after=2m 20m mono docs build --api-docs --skip-deps --netlify 2>&1 | tee tmp/ci-docs-prod/03-astro-build.log
       '';
     };
 
     "docs:deploy:prod:phase:upload" = {
-      description = "Upload prod docs build to Netlify (CI phase, writes state file)";
+      description = "Publish prod docs to Netlify via the shared netlify task (CI phase, writes state file)";
       exec = ''
         set -euo pipefail
         mkdir -p tmp/ci-docs-prod
-        (
-          while true; do
-            echo "[docs-prod-heartbeat] $(date -u +%Y-%m-%dT%H:%M:%SZ) netlify upload in progress"
-            pgrep -af 'netlify|node|bun|mono' || true
-            sleep 30
-          done
-        ) > tmp/ci-docs-prod/04-upload-heartbeat.log 2>&1 &
-        HEARTBEAT_PID=$!
-        cleanup() {
-          kill "$HEARTBEAT_PID" 2>/dev/null || true
-        }
-        trap cleanup EXIT
-        timeout --signal=TERM --kill-after=2m 20m mono docs deploy --prod --step=upload 2>&1 | tee tmp/ci-docs-prod/04-upload.log
+        # Publish the bundled docs build (from the astro `--netlify` phase) to the
+        # production domain via the shared effect-utils netlify task. ssr +
+        # prodAlias=false → `netlify deploy --no-build --prod`, shipping the
+        # bundled serverless + edge functions. `--input type=prod` selects the
+        # production publish.
+        timeout --signal=TERM --kill-after=2m 20m dt netlify:deploy:docs --input type=prod 2>&1 | tee tmp/ci-docs-prod/04-upload.log
+        # Record deploy identifiers for the verify/purge phases. A prod publish
+        # targets the known production domain; the unique per-deploy URL is in the
+        # upload log above.
+        full_sha="$(git rev-parse HEAD)"
+        short_sha="$(git rev-parse --short HEAD)"
+        branch_name="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
+        printf '{"site":"livestore-docs","siteId":"abeae053-d336-480a-a0fe-f0aaaacaa74e","deployId":"prod","deployUrl":"https://docs.livestore.dev","branchName":"%s","shortSha":"%s","fullSha":"%s"}\n' \
+          "$branch_name" "$short_sha" "$full_sha" > tmp/ci-docs-prod/deploy-state.json
       '';
     };
 

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -215,8 +215,14 @@ const docsBuildCommand = Cli.Command.make(
       Cli.Options.withDefault(false),
       Cli.Options.withDescription('Skip building snippets and diagrams'),
     ),
+    netlify: Cli.Options.boolean('netlify').pipe(
+      Cli.Options.withDefault(false),
+      Cli.Options.withDescription(
+        'Build via `netlify build` so the SSR serverless + edge functions are bundled (deploy-ready). A plain `astro build` emits an un-bundled function that 502s once deployed via netlify deploy.',
+      ),
+    ),
   },
-  Effect.fn('docs.build')(function* ({ apiDocs, clean, skipDeps }) {
+  Effect.fn('docs.build')(function* ({ apiDocs, clean, skipDeps, netlify }) {
     if (clean === true) {
       // Wipe Astro output plus cached diagram/snippet artefacts to avoid stale renders between builds.
       yield* cmd(
@@ -237,9 +243,18 @@ const docsBuildCommand = Cli.Command.make(
       yield* cleanupChromiumChildren()
     }
 
-    // Local/CI prebuild uses Astro directly. The deploy step performs the
-    // Netlify build (single build overall), which handles Edge bundling.
-    yield* cmd('pnpm astro build', {
+    // Two build paths, same Astro build underneath:
+    // - default `pnpm astro build`: emits the static site to `dist/` plus the
+    //   un-bundled SSR function under `.netlify/v1/`. Fine for local/dev.
+    // - `--netlify` → `netlify build`: runs the same `astro build` (via the
+    //   `[build] command` in netlify.toml) and then bundles the serverless +
+    //   edge functions with their deps, producing a deploy-ready output. This
+    //   is what the deploy must use — a plain `astro build` deploy ships an
+    //   un-bundled function that fails at runtime with ERR_MODULE_NOT_FOUND and
+    //   returns a 502 on every on-demand route and the 404 fallback.
+    //   `--offline` keeps the bundling step from requiring Netlify auth/link.
+    const buildCommand = netlify === true ? 'bunx netlify-cli build --offline' : 'pnpm astro build'
+    yield* cmd(buildCommand, {
       env: {
         STARLIGHT_INCLUDE_API_DOCS: apiDocs === true ? '1' : undefined,
         // Building the docs sometimes runs out of memory, so we give it more


### PR DESCRIPTION
## Problem

docs.livestore.dev returns a **502 on every on-demand route** (`/api/search`,
on-demand OG images, `/_image`) **and on every missing page** (the 404 fallback,
e.g. `/misc/sponsoring`). Static prerendered pages are fine.

Root cause (verified from prod Netlify function logs):

```
ssr ERROR Invoke Error  Cannot find package '@astrojs/netlify'
  imported from /var/task/.netlify/build/entry.mjs  (ERR_MODULE_NOT_FOUND)
```

The deploy uploaded the static `dist/` with `netlify deploy --dir --no-build`,
which is a **publish-only** deploy: it drops the Astro SSR serverless function and
the `markdown-negotiation` edge function. Because the adapter registers a `/*`
catch-all to that function (it renders SSR routes *and* the 404), every on-demand
route + the 404 fallback hit a function that fails at runtime → 502. (The site
also had `has_edge: false` — the edge function never deployed either.)

## Fix — deploy the bundled functions via the shared `netlify` task

Uses the new SSR mode of the shared effect-utils `netlify` devenv task
(overengineeringstudio/effect-utils#783):

- **Build** (`docs:deploy:prod:phase:astro`) now runs `mono docs build --netlify`
  → `netlify build`, which runs the same Astro build and then bundles the
  serverless + edge functions (with deps) into a deploy-ready output.
- **Upload** (`docs:deploy:prod:phase:upload`) now runs
  `dt netlify:deploy:docs --input type=prod` → `netlify deploy --no-build --prod`
  (ssr + `prodAlias=false`, **no `--dir`**), shipping the bundled functions to
  the production domain. It records deploy state for the existing verify/purge
  phases.
- `docs/netlify.toml`: build/deploy run from `docs/`, so paths are site-relative
  (`publish`, `edge_functions`) and `[build] command` drives `netlify build`.

## Verified locally

- `devenv tasks list` shows `netlify:deploy:docs` (config evaluates against the
  effect-utils branch); `nixfmt --check` clean; `oxlint` clean; `netlify.toml`
  parses.
- The `netlify build` → `netlify deploy --no-build` sequence was proven e2e
  against a faithful minimal repro (adapter 6.5.9, git-root ≠ site dir, edge fn
  on `/*`, a `prerender=false` route): SSR route → 200, missing path → real 404;
  the old `--dir --no-build` path drops the function.

## CI validates (not runnable locally)

The full docs build (`netlify build --offline` with typedoc/d2/chromium + Deno
edge bundling) and the production deploy run only in CI. Notably the upload step
invokes `dt netlify:deploy:docs` and the edge bundler needs Deno (available on CI
runners; blocked only in the local sandbox).

## Dependency / follow-ups

- Depends on overengineeringstudio/effect-utils#783. `devenv.yaml`/`devenv.lock`
  are **temporarily pinned** to that PR branch — retarget to `main` once it merges.
- PR-preview docs deploys (`mono docs deploy`, ci.yml) still use the old bespoke
  path and remain a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🫑 cl1-sorrel |
| `agent_session_id` | c5481079-88d4-4406-b2bf-d31ff5588e67 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.165 |
| `agent_runtime` | Claude Code 2.1.165 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/ffppqrb9xkq0jamayzc05dwlm86yi5yk-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/f4bp1wnsfzypdxckkp0vyqcgw5xq4yp1-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-06-12-docs-netlify-ssr-deploy |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b39be89 |
</details>
<!-- agent-footer:end -->