### PR TITLE
DO hibernation, end to end: idle sync-DO hibernation + DO-RPC live-pull survival

### DIFF
--- a/examples/cloudflare-todomvc/src/live-store-client-do.ts
+++ b/examples/cloudflare-todomvc/src/live-store-client-do.ts
@@ -1,5 +1,4 @@
 import { DurableObject } from 'cloudflare:workers'
-import type { AlarmInvocationInfo } from '@cloudflare/workers-types'
 
 import { type ClientDoWithRpcCallback, createStoreDoPromise } from '@livestore/adapter-cloudflare'
 import { nanoid } from '@livestore/livestore'
@@ -65,15 +64,11 @@ export class LiveStoreClientDO extends DurableObject<Env> implements ClientDoWit
         console.log(`todos for store (${this.storeId})`, todos)
       })
     }
-
-    await this.ctx.storage.setAlarm(Date.now() + 1000)
-  }
-
-  alarm(_alarmInfo?: AlarmInvocationInfo): void | Promise<void> {
-    this.subscribeToStore()
   }
 
   async syncUpdateRpc(payload: unknown) {
-    await handleSyncUpdateRpc(payload)
+    // Store gone (hibernated): ask the sync DO to drop this subscription; it recovers on next use.
+    if (this.hasCachedStore === false) return true
+    return handleSyncUpdateRpc(payload)
   }
 }

--- a/examples/web-email-client/src/cf-worker/MailboxClientDO.ts
+++ b/examples/web-email-client/src/cf-worker/MailboxClientDO.ts
@@ -120,7 +120,8 @@ export class MailboxClientDO extends DurableObject<Env> implements ClientDoWithR
   }
 
   async syncUpdateRpc(payload: unknown) {
-    // Make sure to wake up the store before processing the sync update
-    await handleSyncUpdateRpc(payload)
+    // Store gone (hibernated): ask the sync DO to drop this subscription; it recovers on next use.
+    if (this.hasStore === false) return true
+    return handleSyncUpdateRpc(payload)
   }
 }

--- a/examples/web-email-client/src/cf-worker/ThreadClientDO.ts
+++ b/examples/web-email-client/src/cf-worker/ThreadClientDO.ts
@@ -141,14 +141,9 @@ export class ThreadClientDO extends DurableObject<Env> implements ClientDoWithRp
     }
   }
 
-  alarm(): void | Promise<void> {
-    // Re-initialize subscriptions after potential hibernation
-    return this.subscribeToStore()
-  }
-
   async syncUpdateRpc(payload: unknown) {
-    // Make sure to wake up the store before processing the sync update
-    await this.subscribeToStore()
-    await handleSyncUpdateRpc(payload)
+    // Store gone (hibernated): ask the sync DO to drop this subscription; it recovers on next use.
+    if (this.hasStore === false) return true
+    return handleSyncUpdateRpc(payload)
   }
 }

--- a/packages/@livestore/common-cf/src/do-rpc/client.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.ts
@@ -1,4 +1,5 @@
 import {
+  type Context,
   Effect,
   Fiber,
   FiberMap,
@@ -66,7 +67,7 @@ export const layerProtocolDurableObject = (args: MakeDoRpcProtocolArgs): Layer.L
 const makeProtocolDurableObject = ({
   callRpc,
 }: MakeDoRpcProtocolArgs): Effect.Effect<RpcClient.Protocol['Type'], never, Scope.Scope> =>
-  RpcClient.Protocol.make(
+  makeProtocol(
     Effect.fnUntraced(function* (writeResponse) {
       // Not using an actual `FiberMap` here because it seems to shutdown to early
       // const fiberMap = new Map<string, Fiber.RuntimeFiber<void, never>>()
@@ -137,3 +138,46 @@ const makeProtocolDurableObject = ({
       }
     }),
   )
+
+/**
+ * Like `@effect/rpc`'s `RpcClient.Protocol.make` (`withRun`), but parks on the timer-less {@link holdForever}
+ * instead of `Effect.never` — whose `setInterval` keepalive would stop a DO-resident client from ever
+ * hibernating (the client analogue of the sync-server `makeSocketProtocol` fix, #1328 ③).
+ */
+const makeProtocol = <EX, RX>(
+  f: (
+    write: (data: RpcMessage.FromServerEncoded) => Effect.Effect<void>,
+  ) => Effect.Effect<Omit<RpcClient.Protocol['Type'], 'run'>, EX, RX>,
+): Effect.Effect<RpcClient.Protocol['Type'], EX, RX> =>
+  Effect.suspend(() => {
+    const semaphore = Effect.unsafeMakeSemaphore(1)
+    let buffer: Array<[data: RpcMessage.FromServerEncoded, context: Context.Context<never>]> = []
+    let write = (data: RpcMessage.FromServerEncoded): Effect.Effect<void> =>
+      Effect.contextWith((context) => {
+        buffer.push([data, context])
+      })
+
+    return f((data) => write(data)).pipe(
+      Effect.map((protocol) => ({
+        ...protocol,
+        run: (realWrite: (data: RpcMessage.FromServerEncoded) => Effect.Effect<void>) =>
+          semaphore.withPermits(1)(
+            Effect.gen(function* () {
+              const prev = write
+              write = realWrite
+              for (const [data, context] of buffer) {
+                yield* Effect.provide(write(data), context)
+              }
+              buffer = []
+              return yield* Effect.onExit(holdForever, () => {
+                write = prev
+                return Effect.void
+              })
+            }),
+          ),
+      })),
+    )
+  })
+
+/** Never-resolving, interruptible park with no `setInterval` (unlike `Effect.never`), so a DO-resident client can hibernate. See #1328. */
+const holdForever = Effect.async<never>(() => {})

--- a/packages/@livestore/common-cf/src/do-rpc/mod.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/mod.ts
@@ -1,3 +1,8 @@
 // Re-export client and server implementations for backward compatibility
 export { layerProtocolDurableObject } from './client.ts'
-export { type ClientDoWithRpcCallback, emitStreamResponse, toDurableObjectHandler } from './server.ts'
+export {
+  type ClientDoWithRpcCallback,
+  emitStreamResponse,
+  type SyncUpdateRpcResult,
+  toDurableObjectHandler,
+} from './server.ts'

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -18,9 +18,16 @@ import {
 
 import type * as CfTypes from '../cf-types.ts'
 
+/**
+ * `true` asks the sync DO to reap this subscription (the client's store is gone); `void`/`false` keeps it.
+ * Primitive, not an object: CF's DO-RPC stub wraps object returns in `& Disposable`, which the producer's
+ * `Effect.tryPromise` can't consume.
+ */
+export type SyncUpdateRpcResult = void | boolean
+
 export interface ClientDoWithRpcCallback {
   __DURABLE_OBJECT_BRAND: never
-  syncUpdateRpc: (payload: RpcMessage.ResponseChunkEncoded) => Promise<void>
+  syncUpdateRpc: (payload: RpcMessage.ResponseChunkEncoded) => Promise<SyncUpdateRpcResult>
 }
 
 /**
@@ -163,7 +170,7 @@ export const toDurableObjectHandler =
       return encoded
     }).pipe(Effect.provide(options.layer), Effect.scoped, Effect.orDie)
 
-/** Out-of-band RPC stream response emission back to the caller DO */
+/** Emits a reverse-RPC chunk to the caller DO; returns its {@link SyncUpdateRpcResult} reap verdict. */
 export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(function* ({
   callerContext,
   env,
@@ -188,7 +195,10 @@ export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(functio
 
   const res: RpcMessage.ResponseChunkEncoded = { _tag: 'Chunk', requestId, values }
 
-  yield* Effect.tryPromise(() => clientDo.syncUpdateRpc(res))
+  // The annotation collapses CF's union-of-promises stub return so `Effect.tryPromise` can infer it.
+  const verdict = yield* Effect.tryPromise((): Promise<void | boolean> => clientDo.syncUpdateRpc(res))
+
+  return verdict === true
 })
 
 /**

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-e2e.test.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-e2e.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview End-to-end reproduction of the DO hibernation disqualifier in a real workerd isolate.
+ *
+ * Runs the actual `@livestore/sync-cf`-style WS-RPC server inside `wrangler dev` (workerd/miniflare)
+ * and measures, from inside the DO isolate, the number of pending long-period `setInterval` timers —
+ * the exact condition Cloudflare checks before hibernating a DO.
+ *
+ * An idle connected client with one live pull holds 3 such timers:
+ *   - `Layer.launch(ServerLive)`      (common-cf  ws-rpc-server.ts)
+ *   - `Stream.concat(Stream.never)`   (sync-cf    live Pull handler — emulated here by `Live`)
+ *   - `withRun`'s `Effect.onExit(Effect.never, …)` (@effect/rpc RpcServer run park)
+ *
+ * Because any pending timer > 0 disqualifies hibernation, this test pins the bug runtime-faithfully
+ * without relying on observing eviction (which workerd does not surface reliably).
+ *
+ * See `hibernation-timers.test.ts` for the fast, in-process decomposition of the same parks.
+ */
+import { expect } from 'vitest'
+
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { WranglerDevServerService } from '@livestore/utils-dev/wrangler'
+import {
+  Effect,
+  Fiber,
+  FetchHttpClient,
+  Layer,
+  Logger,
+  LogLevel,
+  RpcClient,
+  RpcSerialization,
+  Socket,
+  Stream,
+} from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+import { TestRpcs } from './test-fixtures/rpc-schema.ts'
+
+const testTimeout = 60_000
+
+const withWranglerTest = Vitest.makeWithTestCtx({
+  timeout: testTimeout,
+  makeLayer: () =>
+    WranglerDevServerService.Default({
+      cwd: `${import.meta.dirname}/test-fixtures`,
+    }).pipe(
+      Layer.provide(
+        Layer.mergeAll(PlatformNode.NodeContext.layer, FetchHttpClient.layer, Logger.minimumLogLevel(LogLevel.Debug)),
+      ),
+    ),
+})
+
+const ProtocolLive = Layer.suspend(() =>
+  Effect.gen(function* () {
+    const server = yield* WranglerDevServerService
+    return RpcClient.layerProtocolSocket().pipe(
+      Layer.provide(Socket.layerWebSocket(`ws://localhost:${server.port}`)),
+      Layer.provide(Socket.layerWebSocketConstructorGlobal),
+      Layer.provide(RpcSerialization.layerJson),
+    )
+  }).pipe(Layer.unwrapEffect),
+)
+
+Vitest.describe('DO WebSocket hibernation — real workerd, post-fix is timer-less', { timeout: testTimeout }, () => {
+  Vitest.scopedLive('idle live connection leaves 0 pending long-period timers (hibernatable)', (test) =>
+    Effect.gen(function* () {
+      const client = yield* RpcClient.make(TestRpcs)
+
+      // 1. Establish the connection / launch the WS-RPC server.
+      yield* client.Ping({ message: 'launch' })
+      yield* Effect.sleep(300)
+
+      const baseline = yield* client.GetLongTimerCount({})
+      expect(baseline.count).toBe(0)
+
+      // 2. Open a live pull and keep it open in the background (emits backlog, then holds timer-lessly).
+      const liveFiber = yield* client.Live({}).pipe(Stream.runDrain, Effect.forkScoped)
+      yield* Effect.sleep(500)
+
+      const withLive = yield* client.GetLongTimerCount({})
+      expect(withLive.count).toBe(0)
+
+      // 3. Cleanly closes; still 0.
+      yield* Fiber.interrupt(liveFiber)
+      yield* Effect.sleep(500)
+      const afterClose = yield* client.GetLongTimerCount({})
+      expect(afterClose.count).toBe(0)
+    }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
+  )
+})

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/worker.ts
@@ -57,7 +57,7 @@ export class TimerDO extends DurableObject<Env, unknown> {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
-    const ns = url.pathname.startsWith('/timer') ? env.TIMER_DO : env.CONTROL_DO
+    const ns = url.pathname.startsWith('/timer') === true ? env.TIMER_DO : env.CONTROL_DO
     return ns.get(ns.idFromName('probe')).fetch(request)
   },
 }

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/worker.ts
@@ -1,0 +1,63 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { DurableObject } from 'cloudflare:workers'
+
+export interface Env {
+  CONTROL_DO: DurableObjectNamespace<ControlDO>
+  TIMER_DO: DurableObjectNamespace<TimerDO>
+}
+
+/**
+ * Empirical probe for whether local `wrangler dev`/miniflare actually evicts hibernatable DOs.
+ *
+ * Each DO exposes a per-INSTANCE uuid (`instanceId`, set in the constructor, NOT persisted). If the
+ * DO hibernates (is evicted from memory), the next inbound message reconstructs it and the constructor
+ * re-runs → a NEW uuid. So `instanceId` changing across an idle gap == hibernation actually happened.
+ *
+ * - `ControlDO`: a faithful hibernatable WS server with zero pending timers → SHOULD hibernate.
+ * - `TimerDO`:   identical, but holds one pending `setInterval(2**31-1)` (the exact thing `Effect.never`
+ *                registers) → should NOT hibernate IF the runtime enforces the pending-timer gate.
+ *
+ * The raw-WS test client sends nothing during the idle window, so there is no application-ping confound.
+ */
+export class ControlDO extends DurableObject<Env, unknown> {
+  instanceId = crypto.randomUUID()
+
+  override async fetch(_request: Request): Promise<Response> {
+    const { 0: client, 1: server } = new WebSocketPair()
+    this.ctx.acceptWebSocket(server)
+    return new Response(null, { status: 101, webSocket: client })
+  }
+
+  override webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+    if (message === 'id') ws.send(this.instanceId)
+  }
+}
+
+export class TimerDO extends DurableObject<Env, unknown> {
+  instanceId = crypto.randomUUID()
+
+  constructor(state: DurableObjectState, env: Env) {
+    super(state, env)
+    // Mimic the `Effect.never` keepalive: a single pending long-period timer in the isolate.
+    setInterval(() => {}, 2 ** 31 - 1)
+  }
+
+  override async fetch(_request: Request): Promise<Response> {
+    const { 0: client, 1: server } = new WebSocketPair()
+    this.ctx.acceptWebSocket(server)
+    return new Response(null, { status: 101, webSocket: client })
+  }
+
+  override webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+    if (message === 'id') ws.send(this.instanceId)
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    const ns = url.pathname.startsWith('/timer') ? env.TIMER_DO : env.CONTROL_DO
+    return ns.get(ns.idFromName('probe')).fetch(request)
+  },
+}

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/wrangler.toml
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/wrangler.toml
@@ -1,0 +1,13 @@
+name = "hibernation-probe"
+main = "worker.ts"
+compatibility_date = "2024-04-03"
+
+[durable_objects]
+bindings = [
+  { name = "CONTROL_DO", class_name = "ControlDO" },
+  { name = "TIMER_DO", class_name = "TimerDO" },
+]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ControlDO", "TimerDO"]

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/wrangler.toml
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe-fixtures/wrangler.toml
@@ -3,10 +3,7 @@ main = "worker.ts"
 compatibility_date = "2024-04-03"
 
 [durable_objects]
-bindings = [
-  { name = "CONTROL_DO", class_name = "ControlDO" },
-  { name = "TIMER_DO", class_name = "TimerDO" },
-]
+bindings = [{ name = "CONTROL_DO", class_name = "ControlDO" }, { name = "TIMER_DO", class_name = "TimerDO" }]
 
 [[migrations]]
 tag = "v1"

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe.test.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-probe.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview EMPIRICAL SPIKE — does local miniflare actually hibernate (evict) a hibernatable DO,
+ * and does it enforce the pending-timer gate? Answers whether direct hibernation observation is even
+ * possible locally, or whether we must rely on the timer-count proxy + production analytics.
+ *
+ * See `hibernation-probe-fixtures/worker.ts` for the two probe DOs.
+ */
+import { expect } from 'vitest'
+
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { WranglerDevServerService } from '@livestore/utils-dev/wrangler'
+import { Effect, FetchHttpClient, Layer, Logger, LogLevel } from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+const testTimeout = 60_000
+const IDLE_MS = 13_000 // production hibernates after ~10s idle
+
+const withWranglerTest = Vitest.makeWithTestCtx({
+  timeout: testTimeout,
+  makeLayer: () =>
+    WranglerDevServerService.Default({
+      cwd: `${import.meta.dirname}/hibernation-probe-fixtures`,
+    }).pipe(
+      Layer.provide(
+        Layer.mergeAll(PlatformNode.NodeContext.layer, FetchHttpClient.layer, Logger.minimumLogLevel(LogLevel.Debug)),
+      ),
+    ),
+})
+
+/** Opens one raw WebSocket and lets us ask the DO for its in-memory instanceId. */
+const connect = (url: string) =>
+  new Promise<{ ask: () => Promise<string>; close: () => void }>((resolve, reject) => {
+    const ws = new WebSocket(url)
+    const waiters: Array<(v: string) => void> = []
+    ws.addEventListener('message', (e) => {
+      const data = typeof e.data === 'string' ? e.data : new TextDecoder().decode(e.data as ArrayBuffer)
+      waiters.shift()?.(data)
+    })
+    ws.addEventListener('open', () =>
+      resolve({
+        ask: () =>
+          new Promise<string>((res) => {
+            waiters.push(res)
+            ws.send('id')
+          }),
+        close: () => ws.close(),
+      }),
+    )
+    ws.addEventListener('error', (e) => reject(e))
+  })
+
+const probeReconstruction = (port: number, path: string) =>
+  Effect.gen(function* () {
+    const conn = yield* Effect.promise(() => connect(`ws://localhost:${port}${path}`))
+    const id1 = yield* Effect.promise(() => conn.ask())
+    yield* Effect.sleep(IDLE_MS)
+    const id2 = yield* Effect.promise(() => conn.ask())
+    conn.close()
+    return { id1, id2, reconstructed: id1 !== id2 }
+  })
+
+Vitest.describe('SPIKE: can we observe DO hibernation locally?', { timeout: testTimeout }, () => {
+  Vitest.scopedLive('control DO (no timers) reconstructs after idle → local DOES hibernate', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServerService
+      const r = yield* probeReconstruction(server.port, '/control')
+      console.log('[probe] control (no timers):', r)
+      expect(r.reconstructed).toBe(true)
+    }).pipe(withWranglerTest(test)),
+  )
+
+  Vitest.scopedLive('timer DO (1 pending setInterval) stays resident after idle → gate enforced', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServerService
+      const r = yield* probeReconstruction(server.port, '/timer')
+      console.log('[probe] timer (1 pending long setInterval):', r)
+      expect(r.reconstructed).toBe(false)
+    }).pipe(withWranglerTest(test)),
+  )
+})

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/rpc-schema.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/rpc-schema.ts
@@ -1,0 +1,9 @@
+import { Rpc, RpcGroup, Schema } from '@livestore/utils/effect'
+
+/** Minimal RPC surface for the hibernation-outcome tests against the real WS-RPC server. */
+export class HibRpcs extends RpcGroup.make(
+  Rpc.make('Ping', { payload: Schema.Struct({}), success: Schema.Struct({}) }),
+  /** Returns the DO's per-instance uuid — changes iff the DO was evicted and reconstructed (i.e. hibernated). */
+  Rpc.make('InstanceId', { payload: Schema.Struct({}), success: Schema.Struct({ id: Schema.String }) }),
+  Rpc.make('Live', { payload: Schema.Struct({}), success: Schema.Number, stream: true }),
+) {}

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/worker.ts
@@ -77,7 +77,7 @@ export class SentinelRpcDO extends DurableObject<Env, unknown> {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
-    const ns = url.pathname.startsWith('/sentinel') ? env.SENTINEL_RPC_DO : env.REAL_RPC_DO
+    const ns = url.pathname.startsWith('/sentinel') === true ? env.SENTINEL_RPC_DO : env.REAL_RPC_DO
     return ns.get(ns.idFromName('rpc')).fetch(request)
   },
 }

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/worker.ts
@@ -1,0 +1,83 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import { DurableObject } from 'cloudflare:workers'
+
+import { Effect, Layer, RpcMessage, RpcServer, Stream } from '@livestore/utils/effect'
+
+import type * as CfTypes from '../../cf-types.ts'
+import { setupDurableObjectWebSocketRpc } from '../ws-rpc-server.ts'
+import { HibRpcs } from './rpc-schema.ts'
+
+export interface Env {
+  REAL_RPC_DO: DurableObjectNamespace<RealRpcDO>
+  SENTINEL_RPC_DO: DurableObjectNamespace<SentinelRpcDO>
+}
+
+/** Wires the REAL (now timer-less) `setupDurableObjectWebSocketRpc` server onto `self`. */
+const setupServer = (self: DurableObject, instanceId: string) => {
+  const handlersLayer = HibRpcs.toLayer({
+    Ping: () => Effect.succeed({}),
+    InstanceId: () => Effect.succeed({ id: instanceId }),
+    Live: () => Stream.make(1, 2, 3).pipe(Stream.concat(Stream.fromEffect(Effect.async<never>(() => {})))),
+  })
+  const ServerLive = RpcServer.layer(HibRpcs).pipe(Layer.provide(handlersLayer))
+  setupDurableObjectWebSocketRpc({
+    doSelf: self as unknown as CfTypes.DurableObject,
+    rpcLayer: ServerLive,
+    webSocketMode: 'hibernate',
+  })
+}
+
+const acceptWs = (ctx: DurableObjectState): Response => {
+  const { 0: client, 1: server } = new WebSocketPair()
+  ctx.acceptWebSocket(server)
+  // Model real sync-cf: auto-respond to Effect-RPC pings so idle keepalive pings don't wake the DO.
+  // (Without this, client pings arrive as webSocketMessage and reset the hibernation idle timer.)
+  ctx.setWebSocketAutoResponse(
+    new WebSocketRequestResponsePair(JSON.stringify(RpcMessage.constPing), JSON.stringify(RpcMessage.constPong)),
+  )
+  return new Response(null, { status: 101, webSocket: client })
+}
+
+/** The real, fixed WS-RPC server: its connection-holding parks are timer-less, so it hibernates at idle. */
+export class RealRpcDO extends DurableObject<Env, unknown> {
+  instanceId = crypto.randomUUID()
+
+  constructor(state: DurableObjectState, env: Env) {
+    super(state, env)
+    this.ctx = state
+    setupServer(this, this.instanceId)
+  }
+
+  override async fetch(): Promise<Response> {
+    return acceptWs(this.ctx)
+  }
+}
+
+/**
+ * Regression sentinel: the same real server, but re-introduces one long-period `setInterval` — exactly the
+ * disqualifier `Effect.never` used to register. It must NOT hibernate. This proves the test still detects a
+ * timer regression (so a future reintroduction can't pass silently) and documents the pre-fix behavior.
+ */
+export class SentinelRpcDO extends DurableObject<Env, unknown> {
+  instanceId = crypto.randomUUID()
+
+  constructor(state: DurableObjectState, env: Env) {
+    super(state, env)
+    this.ctx = state
+    setInterval(() => {}, 2 ** 31 - 1)
+    setupServer(this, this.instanceId)
+  }
+
+  override async fetch(): Promise<Response> {
+    return acceptWs(this.ctx)
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    const ns = url.pathname.startsWith('/sentinel') ? env.SENTINEL_RPC_DO : env.REAL_RPC_DO
+    return ns.get(ns.idFromName('rpc')).fetch(request)
+  },
+}

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/worker.ts
@@ -14,7 +14,7 @@ export interface Env {
 }
 
 /** Wires the REAL (now timer-less) `setupDurableObjectWebSocketRpc` server onto `self`. */
-const setupServer = (self: DurableObject, instanceId: string) => {
+const setupServer = (self: DurableObject<Env, unknown>, instanceId: string) => {
   const handlersLayer = HibRpcs.toLayer({
     Ping: () => Effect.succeed({}),
     InstanceId: () => Effect.succeed({ id: instanceId }),

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/wrangler.toml
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc-fixtures/wrangler.toml
@@ -1,0 +1,16 @@
+name = "hibernation-rpc"
+main = "worker.ts"
+compatibility_date = "2024-04-03"
+compatibility_flags = [
+  "enable_request_signal", # Needed for HTTP RPC streams
+]
+
+[durable_objects]
+bindings = [
+  { name = "REAL_RPC_DO", class_name = "RealRpcDO" },
+  { name = "SENTINEL_RPC_DO", class_name = "SentinelRpcDO" },
+]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["RealRpcDO", "SentinelRpcDO"]

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc.test.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Capstone — observes the ACTUAL hibernation OUTCOME of the real (now timer-less) WS-RPC
+ * server, in a faithful local workerd runtime that (per `hibernation-probe.test.ts`) hibernates and
+ * enforces the pending-timer gate exactly like production.
+ *
+ * Unlike the timer-count proxy, this measures the real-world result and therefore accounts for ALL
+ * hibernation gating conditions at once (timers, pending I/O, in-flight requests, hibernatable API):
+ *
+ *   - `RealRpcDO`     — the real, fixed server → DOES hibernate at idle and still serves RPC after wake.
+ *   - `SentinelRpcDO` — identical, but re-introduces one `setInterval(2**31-1)` → does NOT hibernate.
+ *                       Proves the test still catches a timer regression (the fix can't silently rot).
+ *
+ * `instanceId` is a per-construction uuid; it changes iff the DO was evicted and reconstructed.
+ */
+import { expect } from 'vitest'
+
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { WranglerDevServerService } from '@livestore/utils-dev/wrangler'
+import {
+  Effect,
+  FetchHttpClient,
+  Layer,
+  Logger,
+  LogLevel,
+  RpcClient,
+  RpcSerialization,
+  Socket,
+  Stream,
+} from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+import { HibRpcs } from './hibernation-rpc-fixtures/rpc-schema.ts'
+
+const testTimeout = 60_000
+const IDLE_MS = 13_000 // production hibernates after ~10s idle
+
+const withWranglerTest = Vitest.makeWithTestCtx({
+  timeout: testTimeout,
+  makeLayer: () =>
+    WranglerDevServerService.Default({
+      cwd: `${import.meta.dirname}/hibernation-rpc-fixtures`,
+    }).pipe(
+      Layer.provide(
+        Layer.mergeAll(PlatformNode.NodeContext.layer, FetchHttpClient.layer, Logger.minimumLogLevel(LogLevel.Debug)),
+      ),
+    ),
+})
+
+const protocolFor = (path: string) =>
+  Layer.suspend(() =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServerService
+      return RpcClient.layerProtocolSocket().pipe(
+        Layer.provide(Socket.layerWebSocket(`ws://localhost:${server.port}${path}`)),
+        Layer.provide(Socket.layerWebSocketConstructorGlobal),
+        Layer.provide(RpcSerialization.layerJson),
+      )
+    }).pipe(Layer.unwrapEffect),
+  )
+
+/** Launch the real server, optionally keep a live pull open, idle, and report whether the DO reconstructed. */
+const observeHibernation = ({ path, withLivePull }: { path: string; withLivePull: boolean }) =>
+  Effect.gen(function* () {
+    const client = yield* RpcClient.make(HibRpcs)
+    yield* client.Ping({})
+    if (withLivePull) {
+      yield* client.Live({}).pipe(Stream.runDrain, Effect.forkScoped)
+      yield* Effect.sleep(500)
+    }
+    const { id: id1 } = yield* client.InstanceId({})
+    yield* Effect.sleep(IDLE_MS)
+    const { id: id2 } = yield* client.InstanceId({}) // wakes the DO; reconstructed ⇒ new id
+    return { id1, id2, hibernated: id1 !== id2 }
+  }).pipe(Effect.provide(protocolFor(path)))
+
+Vitest.describe('real WS-RPC server hibernation OUTCOME (post-fix)', { timeout: testTimeout }, () => {
+  Vitest.scopedLive('the fixed real server hibernates at idle and still serves RPC after wake', (test) =>
+    Effect.gen(function* () {
+      const r = yield* observeHibernation({ path: '/real', withLivePull: false })
+      console.log('[hibernation-rpc] real (fixed):', r)
+      // The DO was evicted and reconstructed across the idle window, yet the post-idle RPC succeeded.
+      expect(r.hibernated).toBe(true)
+    }).pipe(withWranglerTest(test)),
+  )
+
+  Vitest.scopedLive('regression sentinel (re-introduced timer) stays resident at idle', (test) =>
+    Effect.gen(function* () {
+      const r = yield* observeHibernation({ path: '/sentinel', withLivePull: false })
+      console.log('[hibernation-rpc] sentinel (timer reintroduced):', r)
+      // One pending long timer is enough to block hibernation: same instance handled both calls.
+      expect(r.hibernated).toBe(false)
+    }).pipe(withWranglerTest(test)),
+  )
+})

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc.test.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-rpc.test.ts
@@ -63,7 +63,7 @@ const observeHibernation = ({ path, withLivePull }: { path: string; withLivePull
   Effect.gen(function* () {
     const client = yield* RpcClient.make(HibRpcs)
     yield* client.Ping({})
-    if (withLivePull) {
+    if (withLivePull === true) {
       yield* client.Live({}).pipe(Stream.runDrain, Effect.forkScoped)
       yield* Effect.sleep(500)
     }

--- a/packages/@livestore/common-cf/src/ws-rpc/hibernation-timers.test.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/hibernation-timers.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview Reproduces the Durable Object hibernation disqualifier in isolation.
+ *
+ * Cloudflare DO WebSocket Hibernation is suppressed while the isolate has *any* pending
+ * `setTimeout`/`setInterval` (per CF docs: "No setTimeout/setInterval scheduled callbacks
+ * are set, since there would be no way to recreate the callback after hibernating").
+ *
+ * `effect`'s `Effect.never` is implemented as `asyncInterrupt(() => { setInterval(()=>{}, 2**31-1) })`
+ * — a Node-only event-loop keepalive. Every connection-holding park that bottoms out in
+ * `Effect.never` therefore registers a pending long-period `setInterval`, which keeps the DO
+ * resident (billed for full wall-clock) instead of hibernating between messages.
+ *
+ * These tests count pending long-period `setInterval` timers — the exact, runtime-independent
+ * disqualifier — without needing wrangler/miniflare. A non-zero count on an idle connection ==
+ * "cannot hibernate".
+ */
+import { afterEach, beforeEach, expect } from 'vitest'
+
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import {
+  Context,
+  Effect,
+  Fiber,
+  Layer,
+  Rpc,
+  RpcGroup,
+  RpcSerialization,
+  RpcServer,
+  Schema,
+  Stream,
+} from '@livestore/utils/effect'
+
+import type * as CfTypes from '../cf-types.ts'
+import { setupDurableObjectWebSocketRpc } from './ws-rpc-server.ts'
+
+// The `Effect.never` timer uses `2 ** 31 - 1` ms. Count only long-period timers so we don't
+// catch unrelated short Effect/runtime timers (schedules, ping intervals, etc.).
+const NEVER_PERIOD_MS = 2 ** 31 - 1
+const LONG_MS = 1_000_000
+
+let realSetInterval: typeof globalThis.setInterval
+let realClearInterval: typeof globalThis.clearInterval
+const liveLongTimers = new Map<ReturnType<typeof setInterval>, number>()
+
+const longTimerCount = () => liveLongTimers.size
+const longTimerPeriods = () => [...liveLongTimers.values()]
+
+/** Wait `ms` using the REAL (un-instrumented) timer so forked fibers can park. */
+const realDelay = (ms: number) => new Promise<void>((resolve) => realSetInterval(() => resolve(), ms))
+
+beforeEach(() => {
+  realSetInterval = globalThis.setInterval
+  realClearInterval = globalThis.clearInterval
+  liveLongTimers.clear()
+  globalThis.setInterval = ((cb: any, ms?: number, ...args: any[]) => {
+    const id = realSetInterval(cb, ms as any, ...args)
+    if ((ms ?? 0) > LONG_MS) liveLongTimers.set(id, ms!)
+    return id
+  }) as typeof globalThis.setInterval
+  globalThis.clearInterval = ((id?: any) => {
+    if (id !== undefined) liveLongTimers.delete(id)
+    realClearInterval(id)
+  }) as typeof globalThis.clearInterval
+})
+
+afterEach(() => {
+  globalThis.setInterval = realSetInterval
+  globalThis.clearInterval = realClearInterval
+})
+
+Vitest.describe('hibernation disqualifier — root mechanic (effect only)', () => {
+  Vitest.test('Effect.never registers exactly one setInterval(2**31-1)', async () => {
+    const fiber = Effect.runFork(Effect.never)
+    await realDelay(50)
+    expect(longTimerCount()).toBe(1)
+    expect(longTimerPeriods()).toEqual([NEVER_PERIOD_MS])
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    await realDelay(20)
+    expect(longTimerCount()).toBe(0)
+  })
+
+  Vitest.test('Stream.never registers one long-period timer (via Effect.never)', async () => {
+    const fiber = Effect.runFork(Stream.runDrain(Stream.never))
+    await realDelay(50)
+    expect(longTimerCount()).toBe(1)
+    expect(longTimerPeriods()).toEqual([NEVER_PERIOD_MS])
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    await realDelay(20)
+    expect(longTimerCount()).toBe(0)
+  })
+
+  Vitest.test('Layer.launch registers one long-period timer (via Effect.never)', async () => {
+    class SomeTag extends Context.Tag('SomeTag')<SomeTag, { readonly x: number }>() {}
+    const fiber = Effect.runFork(Layer.launch(Layer.succeed(SomeTag, { x: 1 })))
+    await realDelay(50)
+    expect(longTimerCount()).toBe(1)
+    expect(longTimerPeriods()).toEqual([NEVER_PERIOD_MS])
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    await realDelay(20)
+    expect(longTimerCount()).toBe(0)
+  })
+
+  // The fix direction: a timer-less "park forever" that still never resolves and stays interruptible.
+  // This is what the parks above should be replaced with to make the DO hibernatable.
+  Vitest.test('Effect.async<never> (proposed timer-less park) registers no long-period timer', async () => {
+    const fiber = Effect.runFork(Effect.async<never>(() => {}))
+    await realDelay(50)
+    expect(longTimerCount()).toBe(0)
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    await realDelay(20)
+    expect(longTimerCount()).toBe(0)
+  })
+})
+
+// Minimal RPC surface to launch the real WS-RPC server. `Live` returns `Stream.concat(Stream.never)`,
+// mirroring `@livestore/sync-cf`'s live-pull handler.
+class HibRpcs extends RpcGroup.make(
+  Rpc.make('Ping', { payload: Schema.Struct({}), success: Schema.Struct({}) }),
+  Rpc.make('Live', { payload: Schema.Struct({}), success: Schema.Number, stream: true }),
+) {}
+
+const handlersLayer = HibRpcs.toLayer({
+  Ping: () => Effect.succeed({}),
+  // Mirrors sync-cf live pull: emit a backlog then hold the stream open forever via Stream.never.
+  Live: () => Stream.make(1, 2, 3).pipe(Stream.concat(Stream.never)),
+})
+
+const makeServer = () => {
+  const ServerLive = RpcServer.layer(HibRpcs).pipe(Layer.provide(handlersLayer))
+  const sent: Array<string | Uint8Array> = []
+  // Minimal fake WebSocket — `setupDurableObjectWebSocketRpc` only needs `send` for this RPC surface.
+  const ws = { send: (data: string | Uint8Array) => sent.push(data) } as unknown as CfTypes.WebSocket
+  // Minimal fake DO — only used as an assignment target for the webSocket* handlers.
+  const doSelf = {} as unknown as CfTypes.DurableObject
+  const handlers = setupDurableObjectWebSocketRpc({ doSelf, rpcLayer: ServerLive, webSocketMode: 'hibernate' })
+  return { ws, sent, ...handlers }
+}
+
+Vitest.describe('hibernation fix — real setupDurableObjectWebSocketRpc path is timer-less', () => {
+  Vitest.test('launching the WS-RPC server holds 0 long-period timers', async () => {
+    const { ws, webSocketMessage, webSocketClose } = makeServer()
+    expect(longTimerCount()).toBe(0)
+
+    // First inbound message launches the server (empty JSON batch is a decode no-op).
+    await webSocketMessage(ws, '[]')
+    await realDelay(150)
+
+    expect(longTimerCount()).toBe(0)
+    expect(longTimerPeriods()).toEqual([])
+
+    await webSocketClose(ws, 1000, 'test', true)
+    await realDelay(50)
+    expect(longTimerCount()).toBe(0)
+  })
+})

--- a/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/rpc-schema.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/rpc-schema.ts
@@ -45,5 +45,14 @@ export class TestRpcs extends RpcGroup.make(
     success: Schema.Number,
     stream: true,
   }),
+  Rpc.make('Live', {
+    payload: Schema.Struct({}),
+    success: Schema.Number,
+    stream: true,
+  }),
+  Rpc.make('GetLongTimerCount', {
+    payload: Schema.Struct({}),
+    success: Schema.Struct({ count: Schema.Number }),
+  }),
 ) {}
 export type TestRpcsI = RpcGroup.Rpcs<typeof TestRpcs>

--- a/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/worker.ts
@@ -27,7 +27,7 @@ let liveLongTimers = 0
     return id
   }) as typeof globalThis.setInterval
   globalThis.clearInterval = ((id?: any) => {
-    if (id !== undefined && ids.delete(id)) liveLongTimers = ids.size
+    if (id !== undefined && ids.delete(id) === true) liveLongTimers = ids.size
     realClearInterval(id)
   }) as typeof globalThis.clearInterval
 }

--- a/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/worker.ts
@@ -12,6 +12,26 @@ export interface Env {
   TEST_RPC_DO: DurableObjectNamespace<TestRpcDurableObject>
 }
 
+let liveLongTimers = 0
+{
+  const LONG_MS = 1_000_000 // the Effect.never timer is 2_147_483_647
+  const realSetInterval = globalThis.setInterval
+  const realClearInterval = globalThis.clearInterval
+  const ids = new Set<ReturnType<typeof setInterval>>()
+  globalThis.setInterval = ((cb: any, ms?: number, ...args: any[]) => {
+    const id = realSetInterval(cb, ms as any, ...args)
+    if ((ms ?? 0) > LONG_MS) {
+      ids.add(id)
+      liveLongTimers = ids.size
+    }
+    return id
+  }) as typeof globalThis.setInterval
+  globalThis.clearInterval = ((id?: any) => {
+    if (id !== undefined && ids.delete(id)) liveLongTimers = ids.size
+    realClearInterval(id)
+  }) as typeof globalThis.clearInterval
+}
+
 export class TestRpcDurableObject extends DurableObject<Env, unknown> {
   override __DURABLE_OBJECT_BRAND = 'TestRpcDurableObject' as never
 
@@ -50,6 +70,8 @@ export class TestRpcDurableObject extends DurableObject<Env, unknown> {
           Stream.map((n) => n),
           Stream.schedule(Schedule.spaced(delay)),
         ),
+      Live: () => Stream.make(1, 2, 3).pipe(Stream.concat(Stream.fromEffect(Effect.async<never>(() => {})))),
+      GetLongTimerCount: () => Effect.sync(() => ({ count: liveLongTimers })),
     })
 
     const ServerLive = RpcServer.layer(TestRpcs).pipe(Layer.provide(handlersLayer))

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -175,7 +175,7 @@ export const setupDurableObjectWebSocketRpc = ({
 
       const ServerLive = rpcLayer.pipe(Layer.provide(ProtocolLive))
 
-      yield* Layer.launch(ServerLive).pipe(Effect.tapCauseLogPretty, Effect.forkIn(scope))
+      yield* Layer.buildWithScope(ServerLive, scope).pipe(Effect.tapCauseLogPretty)
 
       const runtime = yield* Effect.runtime()
 
@@ -273,8 +273,6 @@ const makeSocketProtocol = ({ incomingQueue, ws, onMessage }: WsRpcServerArgs) =
 
     const writeRaw = (msg: Uint8Array | string) => Effect.succeed(ws.send(msg))
 
-    let writeRequest!: (clientId: number, message: RpcMessage.FromClientEncoded) => Effect.Effect<void>
-
     const parser = serialization.unsafeMake()
     const id = 0
 
@@ -290,51 +288,42 @@ const makeSocketProtocol = ({ incomingQueue, ws, onMessage }: WsRpcServerArgs) =
       }
     }
 
-    const protocol = yield* RpcServer.Protocol.make((writeRequest_) => {
-      writeRequest = writeRequest_
-
-      // Start processing messages now that writeRequest is available
-      const startProcessing = Mailbox.toStream(incomingQueue).pipe(
-        Stream.tap((data) => {
-          try {
-            const decoded = parser.decode(data) as ReadonlyArray<RpcMessage.FromClientEncoded>
-            if (decoded.length === 0) return Effect.void
-            let i = 0
-            return Effect.whileLoop({
-              while: () => i < decoded.length,
-              body: () => {
-                const request = decoded[i++]!
-                if (onMessage !== undefined) {
-                  onMessage(request, ws)
-                }
-                return writeRequest(id, request)
-              },
-              step: constVoid,
-            })
-          } catch (cause) {
-            return Effect.orDie(writeRaw(parser.encode(RpcMessage.ResponseDefectEncoded(cause))!))
-          }
-        }),
-        Stream.runDrain,
-        Effect.tapCauseLogPretty,
-        Effect.fork,
-      )
-
-      // Start the message processing
-      return Effect.map(startProcessing, () => ({
-        disconnects,
-        send: (_clientId, response) => Effect.orDie(write(response)),
-        end(_clientId) {
-          return Effect.void
-        },
-        // Always just one client
-        clientIds: Effect.sync(() => new Set([id]) as ReadonlySet<number>),
-        initialMessage: Effect.succeedNone,
-        supportsAck: true,
-        supportsTransferables: false,
-        supportsSpanPropagation: true,
-      }))
-    })
-
-    return protocol
+    return {
+      disconnects,
+      send: (_clientId: number, response: RpcMessage.FromServerEncoded) => Effect.orDie(write(response)),
+      end: (_clientId: number) => Effect.void,
+      // Always just one client
+      clientIds: Effect.sync(() => new Set([id]) as ReadonlySet<number>),
+      initialMessage: Effect.succeedNone,
+      supportsAck: true,
+      supportsTransferables: false,
+      supportsSpanPropagation: true,
+      run: (handleRequest: (clientId: number, message: RpcMessage.FromClientEncoded) => Effect.Effect<void>) =>
+        Mailbox.toStream(incomingQueue).pipe(
+          Stream.runForEach((data) => {
+            try {
+              const decoded = parser.decode(data) as ReadonlyArray<RpcMessage.FromClientEncoded>
+              if (decoded.length === 0) return Effect.void
+              let i = 0
+              return Effect.whileLoop({
+                while: () => i < decoded.length,
+                body: () => {
+                  const request = decoded[i++]!
+                  if (onMessage !== undefined) {
+                    onMessage(request, ws)
+                  }
+                  return handleRequest(id, request)
+                },
+                step: constVoid,
+              })
+            } catch (cause) {
+              return Effect.orDie(writeRaw(parser.encode(RpcMessage.ResponseDefectEncoded(cause))!))
+            }
+          }),
+          Effect.tapCauseLogPretty,
+          Effect.zipRight(holdForever),
+        ),
+    }
   })
+
+const holdForever = Effect.async<never>(() => {})

--- a/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
@@ -165,9 +165,9 @@ const makeRpcSubscriptions = (ctx: CfTypes.DurableObjectState): RpcSubscriptions
         nextGeneration(),
       ),
     all: () => {
-      const rows = ctx.storage.sql
-        .exec(`SELECT * FROM "${table}"`)
-        .toArray() as Array<typeof rpcSubscriptionTable.rowSchema.Type>
+      const rows = ctx.storage.sql.exec(`SELECT * FROM "${table}"`).toArray() as Array<
+        typeof rpcSubscriptionTable.rowSchema.Type
+      >
       return rows.map(
         (row): RpcSubscription => ({
           storeId: row.storeId,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
@@ -6,8 +6,16 @@ import { Effect, Predicate } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 
 import type { Env, MakeDurableObjectClassOptions, RpcSubscription } from '../shared.ts'
-import { contextTable, eventlogTable } from './sqlite.ts'
+import { contextTable, eventlogTable, rpcSubscriptionTable } from './sqlite.ts'
 import { makeStorage } from './sync-storage.ts'
+
+/** SQLite-backed DO-RPC live-pull subscription registry. */
+export interface RpcSubscriptions {
+  readonly set: (subscription: Omit<RpcSubscription, 'generation'>) => void
+  readonly all: () => ReadonlyArray<RpcSubscription>
+  /** Match on `generation` so a newer re-subscribe isn't clobbered. */
+  readonly remove: (durableObjectId: string, generation: number) => void
+}
 
 const CacheSymbol = Symbol('Cache')
 
@@ -73,6 +81,12 @@ export class DoCtx extends Effect.Service<DoCtx>()('DoCtx', {
         const colSpec = State.SQLite.makeColumnSpec(contextTable.sqliteDef.ast)
         doSelf.ctx.storage.sql.exec(`CREATE TABLE IF NOT EXISTS "${contextTable.sqliteDef.name}" (${colSpec}) strict`)
       }
+      {
+        const colSpec = State.SQLite.makeColumnSpec(rpcSubscriptionTable.sqliteDef.ast)
+        doSelf.ctx.storage.sql.exec(
+          `CREATE TABLE IF NOT EXISTS "${rpcSubscriptionTable.sqliteDef.name}" (${colSpec}) strict`,
+        )
+      }
 
       const storageRow = doSelf.ctx.storage.sql
         .exec(`SELECT * FROM "${contextTable.sqliteDef.name}" WHERE storeId = ?`, storeId)
@@ -100,7 +114,7 @@ export class DoCtx extends Effect.Service<DoCtx>()('DoCtx', {
         doSelf[CacheSymbol].currentHeadRef = { current: currentHead }
       }
 
-      const rpcSubscriptions = new Map<string, RpcSubscription>()
+      const rpcSubscriptions = makeRpcSubscriptions(doSelf.ctx)
 
       const storageCache = {
         storeId,
@@ -127,3 +141,48 @@ export class DoCtx extends Effect.Service<DoCtx>()('DoCtx', {
     Effect.withSpan('@livestore/sync-cf:durable-object:makeDoCtx'),
   ),
 }) {}
+
+const makeRpcSubscriptions = (ctx: CfTypes.DurableObjectState): RpcSubscriptions => {
+  const table = rpcSubscriptionTable.sqliteDef.name
+
+  // Monotonic compare-and-delete token (NOT a timestamp); seeded from the persisted max to stay increasing
+  // across hibernation, so same-turn re-subscribes get distinct tokens and a stale reap can't clobber.
+  const seed = ctx.storage.sql
+    .exec(`SELECT MAX(generation) AS maxGeneration FROM "${table}"`)
+    .toArray()[0] as unknown as { maxGeneration: number | null } | undefined
+  let lastGeneration = seed?.maxGeneration ?? 0
+  const nextGeneration = () => (lastGeneration += 1)
+
+  return {
+    set: (subscription) =>
+      ctx.storage.sql.exec(
+        `INSERT OR REPLACE INTO "${table}" (durableObjectId, bindingName, requestId, storeId, payload, generation) VALUES (?, ?, ?, ?, ?, ?)`,
+        subscription.callerContext.durableObjectId,
+        subscription.callerContext.bindingName,
+        subscription.requestId,
+        subscription.storeId,
+        subscription.payload === undefined ? null : JSON.stringify(subscription.payload),
+        nextGeneration(),
+      ),
+    all: () => {
+      const rows = ctx.storage.sql
+        .exec(`SELECT * FROM "${table}"`)
+        .toArray() as Array<typeof rpcSubscriptionTable.rowSchema.Type>
+      return rows.map(
+        (row): RpcSubscription => ({
+          storeId: row.storeId,
+          requestId: row.requestId,
+          generation: row.generation,
+          callerContext: { bindingName: row.bindingName, durableObjectId: row.durableObjectId },
+          ...(row.payload !== null ? { payload: JSON.parse(row.payload) } : {}),
+        }),
+      )
+    },
+    remove: (durableObjectId, generation) =>
+      ctx.storage.sql.exec(
+        `DELETE FROM "${table}" WHERE durableObjectId = ? AND generation = ?`,
+        durableObjectId,
+        generation,
+      ),
+  }
+}

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -177,7 +177,12 @@ export const makePush =
                 env,
                 requestId: subscription.requestId,
                 values: [encoded],
-              }).pipe(Effect.disconnect, Effect.timeout(RPC_SUBSCRIBER_CALL_TIMEOUT), Effect.tapCauseLogPretty, Effect.exit)
+              }).pipe(
+                Effect.disconnect,
+                Effect.timeout(RPC_SUBSCRIBER_CALL_TIMEOUT),
+                Effect.tapCauseLogPretty,
+                Effect.exit,
+              )
 
               if (Exit.isFailure(exit)) break // Transient — keep the subscription, retry next push.
 

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -1,7 +1,7 @@
 import { BackendIdMismatchError, ServerAheadError, SyncBackend, UnknownError } from '@livestore/common'
 import { type CfTypes, emitStreamResponse } from '@livestore/common-cf'
 import { splitChunkBySize } from '@livestore/common/sync'
-import { Chunk, Effect, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
+import { Chunk, Duration, Effect, Exit, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
 
 import { MAX_PUSH_EVENTS_PER_REQUEST, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SyncMessage } from '../../common/mod.ts'
@@ -17,6 +17,9 @@ import { DoCtx } from './layer.ts'
 const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
 const jsonStringify = Schema.encodeSync(Schema.parseJson())
 type PullBatchItem = SyncMessage.PullResponse['batch'][number]
+
+/** Bounds each reverse-RPC so a hung client can't pin this DO resident and defeat hibernation. */
+const RPC_SUBSCRIBER_CALL_TIMEOUT = Duration.seconds(5)
 
 export const makePush =
   ({
@@ -159,20 +162,41 @@ export const makePush =
           yield* Effect.logDebug(`Broadcasted to ${connectedClients.length} WebSocket clients`)
         }
 
-        // RPC broadcasting would require reconstructing client stubs from clientIds
-        if (rpcSubscriptions.size > 0) {
-          for (const subscription of rpcSubscriptions.values()) {
+        // A subscriber's own `true` verdict is the ONLY reap signal — the producer can't detect a dead client
+        // (a reverse-RPC resurrects a hibernated one), so an RPC error/timeout is transient (keep the row).
+        // `Effect.disconnect` lets the per-call timeout abandon a slow client without making the
+        // uninterruptible loop interruptible.
+        const subscriptions = rpcSubscriptions.all()
+        if (subscriptions.length > 0) {
+          for (const subscription of subscriptions) {
+            let unsubscribe = false
+
             for (const { encoded } of responses) {
-              yield* emitStreamResponse({
+              const exit = yield* emitStreamResponse({
                 callerContext: subscription.callerContext,
                 env,
                 requestId: subscription.requestId,
                 values: [encoded],
-              }).pipe(Effect.tapCauseLogPretty, Effect.exit)
+              }).pipe(Effect.disconnect, Effect.timeout(RPC_SUBSCRIBER_CALL_TIMEOUT), Effect.tapCauseLogPretty, Effect.exit)
+
+              if (Exit.isFailure(exit)) break // Transient — keep the subscription, retry next push.
+
+              if (exit.value === true) {
+                unsubscribe = true
+                break
+              }
+            }
+
+            // Match on `generation` so a newer same-DO re-subscribe isn't clobbered.
+            if (unsubscribe === true) {
+              rpcSubscriptions.remove(subscription.callerContext.durableObjectId, subscription.generation)
+              yield* Effect.logDebug(
+                `Reaped DO-RPC subscription ${subscription.callerContext.durableObjectId} (client reported store gone)`,
+              )
             }
           }
 
-          yield* Effect.logDebug(`Broadcasted to ${rpcSubscriptions.size} RPC clients`)
+          yield* Effect.logDebug(`Broadcasted to ${subscriptions.length} RPC clients`)
         }
       }).pipe(
         Effect.tapCauseLogPretty,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -1,7 +1,7 @@
 import { BackendIdMismatchError, ServerAheadError, SyncBackend, UnknownError } from '@livestore/common'
 import { type CfTypes, emitStreamResponse } from '@livestore/common-cf'
 import { splitChunkBySize } from '@livestore/common/sync'
-import { Chunk, Duration, Effect, Exit, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
+import { Chunk, Duration, Effect, Option, type RpcMessage, Schema } from '@livestore/utils/effect'
 
 import { MAX_PUSH_EVENTS_PER_REQUEST, MAX_WS_MESSAGE_BYTES } from '../../common/constants.ts'
 import { SyncMessage } from '../../common/mod.ts'
@@ -184,7 +184,7 @@ export const makePush =
                 Effect.exit,
               )
 
-              if (Exit.isFailure(exit)) break // Transient — keep the subscription, retry next push.
+              if (exit._tag === 'Failure') break // Transient — keep the subscription, retry next push.
 
               if (exit.value === true) {
                 unsubscribe = true

--- a/packages/@livestore/sync-cf/src/cf-worker/do/sqlite.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/sqlite.ts
@@ -36,3 +36,21 @@ export const contextTable = State.SQLite.table({
     backendId: State.SQLite.text({}),
   },
 })
+
+/**
+ * Persisted DO-RPC live-pull subscriptions — one row per subscribing caller DO.
+ *
+ * ⚠️  IMPORTANT: Any changes to this schema require bumping PERSISTENCE_FORMAT_VERSION in shared.ts
+ */
+export const rpcSubscriptionTable = State.SQLite.table({
+  name: `rpc_subscription_${PERSISTENCE_FORMAT_VERSION}`,
+  columns: {
+    durableObjectId: State.SQLite.text({ primaryKey: true }),
+    bindingName: State.SQLite.text({}),
+    requestId: State.SQLite.text({}),
+    storeId: State.SQLite.text({}),
+    payload: State.SQLite.text({ nullable: true }),
+    /** Compare-and-delete token (not a timestamp); see `makeRpcSubscriptions`. */
+    generation: State.SQLite.integer({}),
+  },
+})

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -41,9 +41,8 @@ export const createDoRpcHandler = (
 
           // TODO rename `req.rpcContext` to something more appropriate
           if (req.rpcContext !== undefined) {
-            rpcSubscriptions.set(req.storeId, {
+            rpcSubscriptions.set({
               storeId: req.storeId,
-              subscribedAt: Date.now(),
               requestId: Headers.get(headers, 'x-rpc-request-id').pipe(Option.getOrThrow),
               callerContext: req.rpcContext.callerContext,
               ...(req.payload !== undefined ? { payload: req.payload } : {}),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -15,7 +15,7 @@ export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtxInput, 'from'>) =
         const headers = yield* getForwardedHeaders
         return makeEndingPullStream({ req, payload: req.payload, headers }).pipe(
           // Needed to keep the stream alive on the client side for phase 2 (i.e. not send the `Exit` stream RPC message)
-          req.live === true ? Stream.concat(Stream.never) : identity,
+          req.live === true ? Stream.concat(Stream.fromEffect(Effect.async<never>(() => {}))) : identity,
           Stream.provideLayer(DoCtx.Default({ doSelf, doOptions, from: { storeId: req.storeId } })),
           Stream.mapError((cause) =>
             cause._tag === 'UnknownError' || cause._tag === 'BackendIdMismatchError'

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -119,7 +119,7 @@ export type DurableObjectId = string
  * CRITICAL: Increment this version whenever you modify the database schema structure.
  *
  * Bump required when:
- * - Adding/removing/renaming columns in eventlogTable or contextTable (see sqlite.ts)
+ * - Adding/removing/renaming columns in eventlogTable, contextTable, or rpcSubscriptionTable (see sqlite.ts)
  * - Changing column types or constraints
  * - Modifying primary keys or indexes
  *
@@ -157,7 +157,7 @@ export const matchSyncRequest = (request: CfTypes.Request): SearchParams | undef
 export type RpcSubscription = {
   storeId: StoreId
   payload?: Schema.JsonValue
-  subscribedAt: number
+  generation: number
   /** Effect RPC request ID */
   requestId: string
   callerContext: {

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -24,7 +24,7 @@ import type { SyncMetadata } from '../../common/sync-message-types.ts'
 
 export interface SyncBackendRpcStub extends CfTypes.DurableObjectStub, SyncBackendRpcInterface {}
 
-// TODO we probably need better scoping for the requestIdMailboxMap (i.e. support multiple stores, ...)
+// requestIds are isolate-unique (`@effect/rpc` module-level counter), so one map routes correctly across stores.
 type EffectRpcRequestId = string // 0, 1, 2, ...
 const requestIdMailboxMap = new Map<EffectRpcRequestId, Mailbox.Mailbox<SyncMessage.PullResponse>>()
 
@@ -82,11 +82,16 @@ export const makeDoRpcSync =
                   if (res._tag === 'None')
                     return shouldNeverHappen('There should at least be a no-more page info response')
 
+                  const rpcRequestId = res.value.rpcRequestId
+
                   const mailbox = yield* Mailbox.make<SyncMessage.PullResponse>().pipe(
-                    Effect.acquireRelease((mailbox) => mailbox.shutdown),
+                    // On scope close, drop the map entry so a closed client leaves no stale route.
+                    Effect.acquireRelease((mailbox) =>
+                      mailbox.shutdown.pipe(Effect.zipRight(Effect.sync(() => requestIdMailboxMap.delete(rpcRequestId)))),
+                    ),
                   )
 
-                  requestIdMailboxMap.set(res.value.rpcRequestId, mailbox)
+                  requestIdMailboxMap.set(rpcRequestId, mailbox)
 
                   return Mailbox.toStream(mailbox)
                 }).pipe(Stream.unwrapScoped),
@@ -159,17 +164,14 @@ export const makeDoRpcSync =
     }).pipe(Effect.withSpan('rpc-sync-client:makeDoRpcSync'))
 
 /**
+ * Routes a reverse-RPC chunk into the matching live pull stream. A client DO implementing `syncUpdateRpc`
+ * must gate on its own store liveness — return `true` when the store is gone so the sync DO reaps the
+ * subscription (recovery is a normal catch-up pull on next use, ≈ WebSocket reconnect).
  *
  * ```ts
- * import { DurableObject } from 'cloudflare:workers'
- * import { ClientDoWithRpcCallback } from '@livestore/common-cf'
- *
- * export class MyDurableObject extends DurableObject implements ClientDoWithRpcCallback {
- *   // ...
- *
- *   async syncUpdateRpc(payload: RpcMessage.ResponseChunkEncoded) {
- *     return handleSyncUpdateRpc(payload)
- *   }
+ * async syncUpdateRpc(payload: RpcMessage.ResponseChunkEncoded): Promise<SyncUpdateRpcResult> {
+ *   if (this.#store === undefined) return true
+ *   return handleSyncUpdateRpc(payload)
  * }
  * ```
  */
@@ -181,10 +183,9 @@ export const handleSyncUpdateRpc = (payload: unknown) =>
     const pullStreamMailbox = requestIdMailboxMap.get(decodedPayload.requestId)
 
     if (pullStreamMailbox === undefined) {
-      // Case: DO was hibernated, so we need to manually update the store
-      yield* Effect.log(`No mailbox found for ${decodedPayload.requestId}`)
+      // Transient: live pull not (re)registered yet. Drop the chunk; the next pull catches up from the cursor.
+      yield* Effect.logDebug(`No mailbox for requestId ${decodedPayload.requestId}; dropping chunk (transient)`)
     } else {
-      // Case: DO was still alive, so the existing `pull` will pick up the new events
       yield* pullStreamMailbox.offer(decoded)
     }
   }).pipe(Effect.withSpan('rpc-sync-client:rpcCallback'), Effect.tapCauseLogPretty, Effect.runPromise)

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -87,7 +87,9 @@ export const makeDoRpcSync =
                   const mailbox = yield* Mailbox.make<SyncMessage.PullResponse>().pipe(
                     // On scope close, drop the map entry so a closed client leaves no stale route.
                     Effect.acquireRelease((mailbox) =>
-                      mailbox.shutdown.pipe(Effect.zipRight(Effect.sync(() => requestIdMailboxMap.delete(rpcRequestId)))),
+                      mailbox.shutdown.pipe(
+                        Effect.zipRight(Effect.sync(() => requestIdMailboxMap.delete(rpcRequestId))),
+                      ),
                     ),
                   )
 

--- a/tests/integration/src/tests/adapter-cloudflare/client-host-hibernation.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/client-host-hibernation.test.ts
@@ -77,9 +77,7 @@ const makeHelpers = (serverUrl: string, storeId: string) =>
     return {
       /** Cheap probe: per-instance uuid + current long-period timer count. Does NOT boot the store. */
       getInstance: () =>
-        client
-          .get('/store/instance')
-          .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(InstanceSchema))),
+        client.get('/store/instance').pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(InstanceSchema))),
 
       /**
        * Boots the full Store inside the DO (DO-RPC sync to SyncBackendDO) and commits one event.

--- a/tests/integration/src/tests/adapter-cloudflare/client-host-hibernation.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/client-host-hibernation.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Regression guard for client-host DO hibernation.
+ *
+ * A Durable Object that *runs* a livestore client (`createStoreDoPromise` + DO-RPC sync) must not
+ * pin itself resident. The sole steady-state park was the DO-RPC client transport's run-loop, which
+ * `@effect/rpc`'s `withRun` held open with `Effect.never` — registering a pending `setInterval(2**31-1)`,
+ * the exact disqualifier for Cloudflare DO hibernation/eviction. So the DO stayed resident and billed for
+ * wall-clock forever. Client-side mirror of the sync-DO bug (#1328): same `Effect.never` root, different DO.
+ *
+ * The fix (`@livestore/common-cf` `layerProtocolDurableObject` -> `makeProtocol`) parks that run-loop on a
+ * timer-less `Effect.async<never>` instead, so an idle DO-resident client holds 0 pending long-period
+ * timers and can hibernate. (NB: `StoreRegistry.retain`'s `Effect.never` is NOT on this path — the CF
+ * adapter `createStoreDo` calls `createStore` directly, not the registry.)
+ *
+ * We assert this runtime-faithfully (no flaky eviction observation) by counting pending long-period timers
+ * from inside the isolate, before vs after booting the store. A non-zero count would mean "cannot hibernate"
+ * and fail this test — guarding against a re-introduced `Effect.never`/`setInterval` park.
+ *
+ * @see ../../../../@livestore/common-cf/src/ws-rpc/hibernation-e2e.test.ts — the sync-server analogue.
+ */
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect } from 'vitest'
+
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import {
+  Duration,
+  Effect,
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  Layer,
+  Schema,
+} from '@livestore/utils/effect'
+import { nanoid } from '@livestore/utils/nanoid'
+import { PlatformNode } from '@livestore/utils/node'
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const fixturesDir = path.join(testDir, 'fixtures')
+const testTimeout = Duration.toMillis(Duration.seconds(60))
+
+// Wrangler refuses to start when proxy environment variables are set, which can happen in CI.
+delete process.env.HTTP_PROXY
+delete process.env.http_proxy
+delete process.env.HTTPS_PROXY
+delete process.env.https_proxy
+delete process.env.ALL_PROXY
+delete process.env.all_proxy
+
+const { WranglerDevServerService } = await import('@livestore/utils-dev/wrangler')
+
+const withTestCtx = Vitest.makeWithTestCtx({
+  timeout: testTimeout,
+  makeLayer: () =>
+    Layer.mergeAll(
+      WranglerDevServerService.Default({
+        cwd: fixturesDir,
+        readiness: { connectTimeout: Duration.seconds(15) },
+      }).pipe(Layer.provide(Layer.mergeAll(PlatformNode.NodeContext.layer, FetchHttpClient.layer))),
+      FetchHttpClient.layer,
+    ),
+})
+
+const InstanceSchema = Schema.Struct({ instanceId: Schema.String, longTimers: Schema.Number })
+
+const makeHelpers = (serverUrl: string, storeId: string) =>
+  Effect.gen(function* () {
+    const client = (yield* HttpClient.HttpClient).pipe(
+      HttpClient.mapRequest((req) =>
+        req.pipe(HttpClientRequest.prependUrl(serverUrl), HttpClientRequest.setUrlParam('storeId', storeId)),
+      ),
+      HttpClient.filterStatusOk,
+    )
+
+    return {
+      /** Cheap probe: per-instance uuid + current long-period timer count. Does NOT boot the store. */
+      getInstance: () =>
+        client
+          .get('/store/instance')
+          .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(InstanceSchema))),
+
+      /**
+       * Boots the full Store inside the DO (DO-RPC sync to SyncBackendDO) and commits one event.
+       * `livePull: true` mirrors the app's reactive client (reverse-RPC subscription via `syncUpdateRpc`).
+       */
+      createTodo: (id: string, title: string) =>
+        HttpClientRequest.post('/store/todos').pipe(
+          HttpClientRequest.setUrlParam('livePull', 'true'),
+          HttpClientRequest.bodyJson({ id, title }),
+          Effect.flatMap(client.execute),
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(Schema.Struct({ id: Schema.String }))),
+        ),
+    }
+  })
+
+Vitest.describe('adapter-cloudflare — client-host hibernation', { timeout: testTimeout }, () => {
+  Vitest.live('DO running a livestore client holds NO pending long-period timers at idle (can hibernate)', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServerService
+      const storeId = `cf-client-hibernation-${nanoid(6)}`
+      const { getInstance, createTodo } = yield* makeHelpers(server.url, storeId)
+
+      // 1. Baseline — DO constructed but no store booted yet. No pending long-period timers.
+      const baseline = yield* getInstance()
+      expect(baseline.longTimers).toBe(0)
+
+      // 2. Boot the full Store (this establishes the DO-RPC sync RpcClient connection).
+      yield* createTodo('todo-1', 'first item')
+
+      // 3. Let boot transients settle so we measure the STEADY-STATE idle park count.
+      yield* Effect.sleep('3 seconds')
+
+      const withStore = yield* getInstance()
+
+      // The DO never evicted between these rapid calls — sanity check that the probe is stable.
+      expect(withStore.instanceId).toBe(baseline.instanceId)
+
+      yield* Effect.promise(() =>
+        test.annotate(
+          `long-period timers at idle: baseline=${baseline.longTimers}, with store=${withStore.longTimers}. ` +
+            `Any > 0 == the client-host DO cannot hibernate (pending setInterval disqualifier).`,
+        ),
+      )
+
+      // The DO-RPC sync `RpcClient` transport's run-loop is the only steady-state park here. Before the fix
+      // it parked on `@effect/rpc`'s `withRun` `Effect.never` (a `setInterval(2**31-1)`); now it parks on a
+      // timer-less `Effect.async<never>` via `layerProtocolDurableObject` -> `makeProtocol` (client analogue
+      // of the sync-server #1328 ③ fix). So an idle DO-resident client leaves 0 pending long-period timers
+      // and can hibernate. A re-introduced `Effect.never`/`setInterval` park would bump this above 0 and fail.
+      //
+      // (`StoreRegistry.retain`'s `Effect.never` is NOT on this path — `createStoreDo` uses `createStore`
+      // directly; and the `livePull: true` reverse-RPC subscription is held open with `Mailbox.toStream`,
+      // which is timer-less — so neither contributes a long-period timer.)
+      expect(withStore.longTimers).toBe(0)
+    }).pipe(withTestCtx(test)),
+  )
+})

--- a/tests/integration/src/tests/adapter-cloudflare/do-rpc-client-hibernation.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/do-rpc-client-hibernation.test.ts
@@ -108,8 +108,7 @@ const makeHelpers = (serverUrl: string, storeId: string) =>
       getEventlog: () =>
         client.get('/store/eventlog').pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(EventlogSchema))),
       /** Control: boots the store (catch-up pull) and returns the materialized todos. */
-      getTodos: () =>
-        client.get('/store/todos').pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(TodosSchema))),
+      getTodos: () => client.get('/store/todos').pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(TodosSchema))),
     }
   })
 
@@ -181,7 +180,9 @@ Vitest.describe('adapter-cloudflare — client-host hibernation (live-pull deliv
       )
 
       // Preconditions: live delivery worked while resident, and the store DO actually hibernated.
-      expect(afterBefore.eventlogCount, 'before-evict should be delivered live while resident').toBeGreaterThanOrEqual(1)
+      expect(afterBefore.eventlogCount, 'before-evict should be delivered live while resident').toBeGreaterThanOrEqual(
+        1,
+      )
       expect(afterEvict.instanceId, 'store DO should have evicted+reconstructed during the idle window').not.toBe(
         instance1,
       )

--- a/tests/integration/src/tests/adapter-cloudflare/do-rpc-client-hibernation.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/do-rpc-client-hibernation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @fileoverview Regression guard for the DO-RPC client-host hibernation CONTRACT (livestorejs/livestore#1328,
+ * #2/#4): a DO-resident livestore client's live pull is live ONLY while its store is resident (≈ a WebSocket
+ * connection). Once the client-host DO hibernates, the next reverse-RPC update finds no live store, so the
+ * client reports `syncUpdateRpc -> true` and the SyncBackendDO REAPS the subscription — the update is NOT
+ * delivered live. Recovery is on next use: booting the store runs a catch-up pull from the cursor, so no
+ * event is lost (there is deliberately no boot-on-wake auto-recovery).
+ *
+ * Topology — the external "browser" client is the SOLE writer; the store DO is a pure live-pull reader:
+ *
+ *   ┌──────────┐  WS push  ┌────────────────┐  reverse syncUpdateRpc  ┌──────────────┐
+ *   │  vitest  │ ────────▶ │  SyncBackendDO │ ──────────────────────▶ │  TestStoreDo │
+ *   │ (direct) │           └────────────────┘   (DO-to-DO RPC)        │ (livePull)   │
+ *   └──────────┘                                                       └──────────────┘
+ *
+ * Live delivery is observed via the DO's NATIVE persisted `eventlog` row count, read WITHOUT booting the store
+ * (`/store/eventlog`) — booting would trigger a catch-up pull that masks whether the LIVE path delivered.
+ *
+ * @see ./client-host-hibernation.test.ts — proves the client-host DO holds 0 long-period timers (can hibernate).
+ * @see ../../../../../tests/sync-provider/src/do-rpc-hibernation.test.ts — the sync-DO-eviction + reap analogue.
+ */
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect } from 'vitest'
+
+import { EventFactory } from '@livestore/common/testing'
+import { makeWsSync } from '@livestore/sync-cf/client'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import {
+  Duration,
+  Effect,
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  KeyValueStore,
+  Layer,
+  Option,
+  Schedule,
+  Schema,
+  Stream,
+} from '@livestore/utils/effect'
+import { nanoid } from '@livestore/utils/nanoid'
+import { PlatformNode } from '@livestore/utils/node'
+
+import { events } from './schema.ts'
+
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const fixturesDir = path.join(testDir, 'fixtures')
+const testTimeout = Duration.toMillis(Duration.seconds(90))
+
+/** Production hibernates after ~10s idle; idle the client-host DO well past that. */
+const CLIENT_IDLE_MS = 15_000
+
+// Wrangler refuses to start when proxy environment variables are set, which can happen in CI.
+delete process.env.HTTP_PROXY
+delete process.env.http_proxy
+delete process.env.HTTPS_PROXY
+delete process.env.https_proxy
+delete process.env.ALL_PROXY
+delete process.env.all_proxy
+
+const { WranglerDevServerService } = await import('@livestore/utils-dev/wrangler')
+
+const withTestCtx = Vitest.makeWithTestCtx({
+  timeout: testTimeout,
+  makeLayer: () =>
+    Layer.mergeAll(
+      WranglerDevServerService.Default({
+        cwd: fixturesDir,
+        readiness: { connectTimeout: Duration.seconds(15) },
+      }).pipe(Layer.provide(Layer.mergeAll(PlatformNode.NodeContext.layer, FetchHttpClient.layer))),
+      FetchHttpClient.layer,
+      // The direct `makeWsSync` sync backend (its backend-id helper) needs a KeyValueStore.
+      KeyValueStore.layerMemory,
+    ),
+})
+
+const EventlogSchema = Schema.Struct({
+  instanceId: Schema.String,
+  eventlogCount: Schema.Number,
+})
+const BootSchema = Schema.Struct({ instanceId: Schema.String })
+const TodosSchema = Schema.Array(Schema.Struct({ id: Schema.String, title: Schema.String }))
+
+const writer = EventFactory.clientIdentity('browser-client', 'browser-session')
+const makeFactory = EventFactory.makeFactory(events)
+
+const makeHelpers = (serverUrl: string, storeId: string) =>
+  Effect.gen(function* () {
+    const client = (yield* HttpClient.HttpClient).pipe(
+      HttpClient.mapRequest((req) =>
+        req.pipe(HttpClientRequest.prependUrl(serverUrl), HttpClientRequest.setUrlParam('storeId', storeId)),
+      ),
+      HttpClient.filterStatusOk,
+    )
+
+    return {
+      /** Boots the store DO as a pure-reader live-pull subscriber. Does NOT commit. */
+      bootStore: () =>
+        HttpClientRequest.post('/store/boot').pipe(
+          HttpClientRequest.setUrlParam('livePull', 'true'),
+          client.execute,
+          Effect.flatMap(HttpClientResponse.schemaBodyJson(BootSchema)),
+        ),
+      /** Non-booting probe: per-instance uuid (eviction signal) + persisted native eventlog row count. */
+      getEventlog: () =>
+        client.get('/store/eventlog').pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(EventlogSchema))),
+      /** Control: boots the store (catch-up pull) and returns the materialized todos. */
+      getTodos: () =>
+        client.get('/store/todos').pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(TodosSchema))),
+    }
+  })
+
+Vitest.describe('adapter-cloudflare — client-host hibernation (live-pull delivery)', { timeout: testTimeout }, () => {
+  Vitest.live('live pull stops when the client-host DO hibernates; recovers via catch-up pull on next use', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServerService
+      const storeId = `cf-client-hib-delivery-${nanoid(6)}`
+      const { bootStore, getEventlog, getTodos } = yield* makeHelpers(server.url, storeId)
+
+      // 1. Boot the store DO as a pure-reader live-pull subscriber (registers the reverse-RPC subscription).
+      const boot = yield* bootStore()
+      const instance1 = boot.instanceId
+      // Give the leader's initial live pull a moment to register its subscription on the SyncBackendDO.
+      yield* Effect.sleep('1 second')
+
+      // 2. Direct "browser" writer — a second, independent WS sync connection straight to the SyncBackendDO.
+      //    This is the SOLE writer, so it owns the eventlog sequence cleanly (no multi-writer conflicts).
+      const directBackend = yield* makeWsSync({ url: server.url })({
+        storeId,
+        clientId: 'browser-client',
+        payload: undefined,
+      })
+      yield* directBackend.connect
+      // Drain the (empty) backlog once to establish the backendId used by subsequent pushes.
+      yield* directBackend.pull(Option.none(), { live: false }).pipe(Stream.runDrain)
+
+      const factory = makeFactory({ client: writer, startSeq: 1, initialParent: 'root' })
+
+      // 3. Push `before-evict` and confirm it is delivered LIVE while the store DO is resident
+      //    (the eventlog grows without us booting the store).
+      yield* directBackend.push([factory.todoCreated.next({ id: 'before-evict', title: 'before' })])
+      const afterBefore = yield* getEventlog().pipe(
+        Effect.flatMap((r) =>
+          r.eventlogCount >= 1 ? Effect.succeed(r) : Effect.fail(new Error(`eventlog ${r.eventlogCount} < 1`)),
+        ),
+        Effect.retry(Schedule.spaced('300 millis')),
+        Effect.timeout('15 seconds'),
+      )
+
+      // 4. Idle the store DO past the eviction window WITHOUT touching any /store route. Keep only the
+      //    direct WS warm (pings hit the SyncBackendDO, never the store DO), so the store DO evicts.
+      yield* directBackend.ping.pipe(Effect.delay('3 seconds'), Effect.repeat(Schedule.recurs(4)))
+      yield* Effect.sleep(`${CLIENT_IDLE_MS - 12_000} millis`)
+
+      // 5. Prove the precondition: the store DO evicted+reconstructed (instanceId changed), and the
+      //    persisted eventlog from before survived (count still 1).
+      const afterEvict = yield* getEventlog()
+
+      // 6. Push `after-evict` while the store DO is hibernated. The SyncBackendDO reverse-RPCs `syncUpdateRpc`
+      //    to the reconstructed (storeless) DO, which returns `true` → the subscription is reaped and the
+      //    event is NOT delivered live.
+      yield* directBackend.push([factory.todoCreated.next({ id: 'after-evict', title: 'after' })])
+
+      // 7. Give live delivery ample time, then confirm the eventlog did NOT grow on its own (no auto-recovery).
+      yield* Effect.sleep('5 seconds')
+      const afterAfter = yield* getEventlog()
+
+      // 8. Control — booting the store (a catch-up pull) recovers `after-evict`, proving recovery-on-next-use.
+      const todos = yield* getTodos()
+      const todoIds = todos.map((t) => t.id)
+
+      yield* Effect.promise(() =>
+        test.annotate(
+          `instance: boot=${instance1} afterEvict=${afterEvict.instanceId} (evicted=${afterEvict.instanceId !== instance1}). ` +
+            `eventlogCount: afterBefore=${afterBefore.eventlogCount} afterEvict=${afterEvict.eventlogCount} ` +
+            `afterAfter=${afterAfter.eventlogCount}. control todos=${JSON.stringify(todoIds)}.`,
+        ),
+      )
+
+      // Preconditions: live delivery worked while resident, and the store DO actually hibernated.
+      expect(afterBefore.eventlogCount, 'before-evict should be delivered live while resident').toBeGreaterThanOrEqual(1)
+      expect(afterEvict.instanceId, 'store DO should have evicted+reconstructed during the idle window').not.toBe(
+        instance1,
+      )
+
+      // The contract: after-evict was pushed while hibernated → reaped, NOT delivered live. The eventlog
+      // stays at its pre-hibernation count (no boot-on-wake auto-recovery).
+      expect(
+        afterAfter.eventlogCount,
+        'after-evict must NOT be delivered live to a hibernated client (subscription reaped)',
+      ).toBe(afterEvict.eventlogCount)
+
+      // Recover-on-next-use: booting the store catches up via its initial pull, so no event is lost.
+      expect(todoIds, 'control: booting the store recovers both events (catch-up pull)').toEqual(
+        expect.arrayContaining(['before-evict', 'after-evict']),
+      )
+    }).pipe(withTestCtx(test)),
+  )
+})

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -17,6 +17,27 @@ import { shouldNeverHappen } from '@livestore/utils'
 
 import { events, schema, tables } from '../schema.ts'
 
+/** Counts pending long-period `setInterval` timers — the exact CF DO hibernation disqualifier `Effect.never` registers. */
+let liveLongTimers = 0
+{
+  const LONG_MS = 1_000_000 // the Effect.never timer is 2_147_483_647
+  const realSetInterval = globalThis.setInterval
+  const realClearInterval = globalThis.clearInterval
+  const ids = new Set<ReturnType<typeof setInterval>>()
+  globalThis.setInterval = ((cb: any, ms?: number, ...args: any[]) => {
+    const id = realSetInterval(cb, ms as any, ...args)
+    if ((ms ?? 0) > LONG_MS) {
+      ids.add(id)
+      liveLongTimers = ids.size
+    }
+    return id
+  }) as typeof globalThis.setInterval
+  globalThis.clearInterval = ((id?: any) => {
+    if (id !== undefined && ids.delete(id)) liveLongTimers = ids.size
+    realClearInterval(id)
+  }) as typeof globalThis.clearInterval
+}
+
 /**
  * Bridge Cloudflare's worker `Response` constructor back to the worker type in this mixed DOM/worker TS program.
  */
@@ -94,6 +115,8 @@ const wrapSqlForTracking = (sql: CfTypes.SqlStorage) => {
 
 export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCallback {
   __DURABLE_OBJECT_BRAND = 'TestStoreDo' as never
+  /** Per-instance uuid (not persisted): a stable value across an idle gap == the DO never evicted. */
+  readonly instanceId = crypto.randomUUID()
   private cachedStore: Store<typeof schema> | undefined
   private cachedStoreId: string | undefined
   /** Captures the VFS counts immediately before/after a reset so tests can assert the deletion actually happened. */
@@ -108,11 +131,46 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
       return makeCfResponse('storeId is required', { status: 400 })
     }
 
+    if (url.pathname === '/store/instance' && request.method === 'GET') {
+      // Pure read — does NOT boot the store. Returns the per-instance uuid (eviction probe) and the
+      // current count of pending long-period timers in this isolate (the hibernation disqualifier).
+      // Calling this before vs after booting the store gives the store's steady-state park count.
+      return makeCfResponse(JSON.stringify({ instanceId: this.instanceId, longTimers: liveLongTimers }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    if (url.pathname === '/store/eventlog' && request.method === 'GET') {
+      // Pure read of the native `eventlog` table (no store boot — booting would trigger a catch-up pull
+      // that masks whether live delivery happened). `instanceId` doubles as the eviction probe.
+      return makeCfResponse(
+        JSON.stringify({
+          instanceId: this.instanceId,
+          eventlogCount: this.countEventlogRows().count,
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    }
+
+    if (url.pathname === '/store/boot' && request.method === 'POST') {
+      // Boots the Store as a pure-reader live-pull subscriber WITHOUT committing anything, so an external
+      // writer can own the eventlog sequence cleanly. `?livePull=true` establishes the reverse-RPC
+      // subscription on the SyncBackendDO (the path that breaks across client-host hibernation).
+      const livePull = url.searchParams.get('livePull') === 'true'
+      await this.ensureStore({ storeId, resetPersistence: false, livePull })
+
+      return makeCfResponse(JSON.stringify({ instanceId: this.instanceId }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
     if (url.pathname === '/store/todos') {
       if (request.method === 'POST') {
         const payload = await request.json<{ id?: string; title: string }>()
         const id = payload.id ?? crypto.randomUUID()
-        const store = await this.ensureStore({ storeId, resetPersistence: false })
+        // `?livePull=true` mirrors the app's reactive DO-RPC client (reverse-RPC subscription).
+        const livePull = url.searchParams.get('livePull') === 'true'
+        const store = await this.ensureStore({ storeId, resetPersistence: false, livePull })
 
         store.commit(events.todoCreated({ id, title: payload.title }))
 
@@ -204,7 +262,9 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
   }
 
   async syncUpdateRpc(payload: unknown) {
-    await handleSyncUpdateRpc(payload)
+    // Store gone (hibernated): ask the sync DO to drop this subscription; it recovers on next use.
+    if (this.cachedStore === undefined) return true
+    return handleSyncUpdateRpc(payload)
   }
 
   private ensureSqlTracking() {
@@ -224,9 +284,11 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
   private async ensureStore({
     storeId,
     resetPersistence,
+    livePull = false,
   }: {
     storeId: string
     resetPersistence: boolean
+    livePull?: boolean
   }): Promise<Store<typeof schema>> {
     this.ensureSqlTracking()
 
@@ -248,6 +310,7 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
           durableObject: { ctx: this.ctx, env: this.env, bindingName: 'TEST_STORE_DO' },
           syncBackendStub: this.env.SYNC_BACKEND_DO.get(this.env.SYNC_BACKEND_DO.idFromName(storeId)),
           resetPersistence,
+          livePull,
         })
 
       let snapshotDuringReset: ResetPersistenceSnapshot | undefined

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -33,7 +33,7 @@ let liveLongTimers = 0
     return id
   }) as typeof globalThis.setInterval
   globalThis.clearInterval = ((id?: any) => {
-    if (id !== undefined && ids.delete(id)) liveLongTimers = ids.size
+    if (id !== undefined && ids.delete(id) === true) liveLongTimers = ids.size
     realClearInterval(id)
   }) as typeof globalThis.clearInterval
 }

--- a/tests/sync-provider/src/do-rpc-hibernation.test.ts
+++ b/tests/sync-provider/src/do-rpc-hibernation.test.ts
@@ -74,99 +74,95 @@ Vitest.describe('DO-RPC live pull across sync-DO hibernation', { timeout: testTi
 
   Vitest.afterAll(async () => await runtime.dispose())
 
-  Vitest.scopedLive(
-    'resident DO-RPC client stops receiving live events after the sync DO evicts',
-    (test) =>
-      Effect.gen(function* () {
-        const { makeProvider, port } = yield* SyncProviderImpl.pipe(
-          Effect.map((_) => ({ makeProvider: _.makeProvider, port: _.providerSpecific.port as number })),
-        )
+  Vitest.scopedLive('resident DO-RPC client stops receiving live events after the sync DO evicts', (test) =>
+    Effect.gen(function* () {
+      const { makeProvider, port } = yield* SyncProviderImpl.pipe(
+        Effect.map((_) => ({ makeProvider: _.makeProvider, port: _.providerSpecific.port as number })),
+      )
 
-        // Unique per run so persisted DO state from a prior run can't poison the head (ServerAheadError).
-        const storeId = `do-rpc-hibernation-${nanoid()}`
-        const factory = makeFactory({ client, startSeq: 1, initialParent: 'root' })
-        const base = `http://localhost:${port}`
-        const getJson = (path: string) =>
-          Effect.promise(() => fetch(`${base}${path}`).then((r) => r.json() as Promise<any>))
+      // Unique per run so persisted DO state from a prior run can't poison the head (ServerAheadError).
+      const storeId = `do-rpc-hibernation-${nanoid()}`
+      const factory = makeFactory({ client, startSeq: 1, initialParent: 'root' })
+      const base = `http://localhost:${port}`
+      const getJson = (path: string): Effect.Effect<any> =>
+        Effect.promise(() => fetch(`${base}${path}`).then((r) => r.json()))
 
-        const syncBackend = yield* makeProvider({ storeId, clientId: client.clientId, payload: undefined })
+      const syncBackend = yield* makeProvider({ storeId, clientId: client.clientId, payload: undefined })
 
-        // Collect every todo id the live pull delivers, into a shared array.
-        const received: string[] = []
-        yield* syncBackend
-          .pull(Option.none(), { live: true })
-          .pipe(
-            Stream.runForEach((res) =>
-              Effect.sync(() => {
-                for (const item of res.batch) {
-                  const id = todoId(item)
-                  if (id !== undefined) received.push(id)
-                }
-              }),
-            ),
-            Effect.forkScoped,
-          )
-
-        // Let the initial (live) pull register its subscription on the sync DO before pushing.
-        yield* Effect.sleep('1 second')
-
-        // 1. Baseline — push an event and confirm it IS delivered live (the subscription channel works).
-        yield* syncBackend.push([factory.todoCreated.next({ id: 'before-evict', text: 'before', completed: false })])
-        yield* Effect.sync(() => received.includes('before-evict')).pipe(
-          Effect.flatMap((ok) => (ok ? Effect.void : Effect.fail(new Error('not yet delivered')))),
-          Effect.retry(Schedule.spaced('300 millis')),
-          Effect.timeout('10 seconds'),
-        )
-
-        // 2. Snapshot instance ids (precondition baseline).
-        const serverId1 = (yield* getJson(`/instance/sync?storeId=${storeId}`)).instanceId as string
-        const clientId1 = (yield* getJson('/instance/client')).instanceId as string
-
-        // 3. Idle the SYNC DO past the eviction window, while keeping the CLIENT DO warm
-        //    (ping /instance/client — a local no-op that never touches the sync DO).
-        yield* getJson('/instance/client').pipe(Effect.delay('3 seconds'), Effect.repeat(Schedule.recurs(4)))
-        yield* Effect.sleep(`${SERVER_IDLE_MS - 12_000} millis`)
-
-        // 4. PROVE the precondition: sync DO reconstructed (evicted), client DO stayed resident.
-        const serverId2 = (yield* getJson(`/instance/sync?storeId=${storeId}`)).instanceId as string
-        const clientId2 = (yield* getJson('/instance/client')).instanceId as string
-        expect(serverId2, 'sync DO should have evicted+reconstructed (new instance id)').not.toBe(serverId1)
-        expect(clientId2, 'client DO should have stayed resident (same instance id)').toBe(clientId1)
-
-        // 5. Push a new event AFTER the sync DO evicted.
-        yield* syncBackend.push([factory.todoCreated.next({ id: 'after-evict', text: 'after', completed: false })])
-
-        // 6. Give live delivery ample time (baseline took <1s).
-        yield* Effect.sleep('4 seconds')
-
-        // 7. Control — the server DID store the post-eviction event (a fresh non-live pull returns it),
-        //    so the ONLY thing that failed is live delivery over the lost subscription.
-        const stored = yield* syncBackend.pull(Option.none(), { live: false }).pipe(
-          Stream.runFold([] as string[], (acc, res) => {
+      // Collect every todo id the live pull delivers, into a shared array.
+      const received: string[] = []
+      yield* syncBackend.pull(Option.none(), { live: true }).pipe(
+        Stream.runForEach((res) =>
+          Effect.sync(() => {
             for (const item of res.batch) {
               const id = todoId(item)
-              if (id !== undefined) acc.push(id)
+              if (id !== undefined) received.push(id)
             }
-            return acc
           }),
-        )
-        expect(stored, 'server should have stored both events').toEqual(
-          expect.arrayContaining(['before-evict', 'after-evict']),
-        )
+        ),
+        Effect.forkScoped,
+      )
 
-        yield* Effect.logInfo('[do-rpc-hibernation] repro evidence', {
-          serverEvicted: serverId1 !== serverId2,
-          clientResident: clientId1 === clientId2,
-          liveReceived: received,
-          storedOnServer: stored,
-        })
+      // Let the initial (live) pull register its subscription on the sync DO before pushing.
+      yield* Effect.sleep('1 second')
 
-        // 8. The bug: the resident DO-RPC client received the pre-eviction event but NOT the post-eviction one.
-        expect(received, 'live pull received the pre-eviction event').toContain('before-evict')
-        expect(received, 'live pull should have received the post-eviction event (currently lost)').toContain(
-          'after-evict',
-        )
-      }).pipe(Effect.provide(runtime)),
+      // 1. Baseline — push an event and confirm it IS delivered live (the subscription channel works).
+      yield* syncBackend.push([factory.todoCreated.next({ id: 'before-evict', text: 'before', completed: false })])
+      yield* Effect.sync(() => received.includes('before-evict')).pipe(
+        Effect.flatMap((ok) => (ok ? Effect.void : Effect.fail(new Error('not yet delivered')))),
+        Effect.retry(Schedule.spaced('300 millis')),
+        Effect.timeout('10 seconds'),
+      )
+
+      // 2. Snapshot instance ids (precondition baseline).
+      const serverId1 = (yield* getJson(`/instance/sync?storeId=${storeId}`)).instanceId as string
+      const clientId1 = (yield* getJson('/instance/client')).instanceId as string
+
+      // 3. Idle the SYNC DO past the eviction window, while keeping the CLIENT DO warm
+      //    (ping /instance/client — a local no-op that never touches the sync DO).
+      yield* getJson('/instance/client').pipe(Effect.delay('3 seconds'), Effect.repeat(Schedule.recurs(4)))
+      yield* Effect.sleep(`${SERVER_IDLE_MS - 12_000} millis`)
+
+      // 4. PROVE the precondition: sync DO reconstructed (evicted), client DO stayed resident.
+      const serverId2 = (yield* getJson(`/instance/sync?storeId=${storeId}`)).instanceId as string
+      const clientId2 = (yield* getJson('/instance/client')).instanceId as string
+      expect(serverId2, 'sync DO should have evicted+reconstructed (new instance id)').not.toBe(serverId1)
+      expect(clientId2, 'client DO should have stayed resident (same instance id)').toBe(clientId1)
+
+      // 5. Push a new event AFTER the sync DO evicted.
+      yield* syncBackend.push([factory.todoCreated.next({ id: 'after-evict', text: 'after', completed: false })])
+
+      // 6. Give live delivery ample time (baseline took <1s).
+      yield* Effect.sleep('4 seconds')
+
+      // 7. Control — the server DID store the post-eviction event (a fresh non-live pull returns it),
+      //    so the ONLY thing that failed is live delivery over the lost subscription.
+      const stored = yield* syncBackend.pull(Option.none(), { live: false }).pipe(
+        Stream.runFold([] as string[], (acc, res) => {
+          for (const item of res.batch) {
+            const id = todoId(item)
+            if (id !== undefined) acc.push(id)
+          }
+          return acc
+        }),
+      )
+      expect(stored, 'server should have stored both events').toEqual(
+        expect.arrayContaining(['before-evict', 'after-evict']),
+      )
+
+      yield* Effect.logInfo('[do-rpc-hibernation] repro evidence', {
+        serverEvicted: serverId1 !== serverId2,
+        clientResident: clientId1 === clientId2,
+        liveReceived: received,
+        storedOnServer: stored,
+      })
+
+      // 8. The bug: the resident DO-RPC client received the pre-eviction event but NOT the post-eviction one.
+      expect(received, 'live pull received the pre-eviction event').toContain('before-evict')
+      expect(received, 'live pull should have received the post-eviction event (currently lost)').toContain(
+        'after-evict',
+      )
+    }).pipe(Effect.provide(runtime)),
   )
 
   // Reaping (#2/#4): once the client reports its store is gone, the sync DO must drop the persisted
@@ -182,8 +178,8 @@ Vitest.describe('DO-RPC live pull across sync-DO hibernation', { timeout: testTi
         const storeId = `do-rpc-reap-${nanoid()}`
         const factory = makeFactory({ client, startSeq: 1, initialParent: 'root' })
         const base = `http://localhost:${port}`
-        const getJson = (path: string) =>
-          Effect.promise(() => fetch(`${base}${path}`).then((r) => r.json() as Promise<any>))
+        const getJson = (path: string): Effect.Effect<any> =>
+          Effect.promise(() => fetch(`${base}${path}`).then((r) => r.json()))
         const subCount = () =>
           getJson(`/rpc-subscriptions/count?storeId=${storeId}`).pipe(Effect.map((r) => r.count as number))
 
@@ -192,19 +188,17 @@ Vitest.describe('DO-RPC live pull across sync-DO hibernation', { timeout: testTi
         const syncBackend = yield* makeProvider({ storeId, clientId: client.clientId, payload: undefined })
 
         const received: string[] = []
-        yield* syncBackend
-          .pull(Option.none(), { live: true })
-          .pipe(
-            Stream.runForEach((res) =>
-              Effect.sync(() => {
-                for (const item of res.batch) {
-                  const id = todoId(item)
-                  if (id !== undefined) received.push(id)
-                }
-              }),
-            ),
-            Effect.forkScoped,
-          )
+        yield* syncBackend.pull(Option.none(), { live: true }).pipe(
+          Stream.runForEach((res) =>
+            Effect.sync(() => {
+              for (const item of res.batch) {
+                const id = todoId(item)
+                if (id !== undefined) received.push(id)
+              }
+            }),
+          ),
+          Effect.forkScoped,
+        )
 
         yield* Effect.sleep('1 second') // let the live pull register its subscription
 

--- a/tests/sync-provider/src/do-rpc-hibernation.test.ts
+++ b/tests/sync-provider/src/do-rpc-hibernation.test.ts
@@ -109,7 +109,7 @@ Vitest.describe('DO-RPC live pull across sync-DO hibernation', { timeout: testTi
       // 1. Baseline — push an event and confirm it IS delivered live (the subscription channel works).
       yield* syncBackend.push([factory.todoCreated.next({ id: 'before-evict', text: 'before', completed: false })])
       yield* Effect.sync(() => received.includes('before-evict')).pipe(
-        Effect.flatMap((ok) => (ok ? Effect.void : Effect.fail(new Error('not yet delivered')))),
+        Effect.flatMap((ok) => (ok === true ? Effect.void : Effect.fail(new Error('not yet delivered')))),
         Effect.retry(Schedule.spaced('300 millis')),
         Effect.timeout('10 seconds'),
       )
@@ -204,7 +204,7 @@ Vitest.describe('DO-RPC live pull across sync-DO hibernation', { timeout: testTi
 
         yield* syncBackend.push([factory.todoCreated.next({ id: 'live-1', text: 'one', completed: false })])
         yield* Effect.sync(() => received.includes('live-1')).pipe(
-          Effect.flatMap((ok) => (ok ? Effect.void : Effect.fail(new Error('not yet delivered')))),
+          Effect.flatMap((ok) => (ok === true ? Effect.void : Effect.fail(new Error('not yet delivered')))),
           Effect.retry(Schedule.spaced('300 millis')),
           Effect.timeout('10 seconds'),
         )

--- a/tests/sync-provider/src/do-rpc-hibernation.test.ts
+++ b/tests/sync-provider/src/do-rpc-hibernation.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @fileoverview Isolated, unbiased reproduction of the DO-RPC live-pull subscription loss across
+ * sync-DO hibernation (follow-up to livestorejs/livestore#1328).
+ *
+ * The bug: a livestore client running inside another DO that subscribes to the sync backend via
+ * DO-to-DO RPC live pull stops receiving events once the sync DO goes idle and evicts — because the
+ * sync DO's subscription registry (`rpcSubscriptions`) is in-memory only and is wiped on eviction,
+ * unlike the WebSocket path which re-enumerates `ctx.getWebSockets()` after wake.
+ *
+ * Topology (the existing DO-RPC provider proxy):
+ *
+ *   ┌──────────┐  WS RPC   ┌────────────────┐  DO RPC   ┌────────────────┐
+ *   │  vitest  │ ────────▶ │  TestClientDo  │ ────────▶ │  SyncBackendDO │
+ *   └──────────┘  (pull)   └────────────────┘  ◀ syncUpdateRpc (reverse) ┘
+ *
+ * This test PROVES the precondition rather than assuming it: a non-persisted per-instance id on each
+ * DO shows the sync DO actually reconstructed (evicted) while the client DO stayed resident. A fresh
+ * non-live pull is used as a control to show the server really stored the post-eviction event — so the
+ * only thing that failed is live delivery over the (lost) subscription.
+ */
+import { expect } from 'vitest'
+
+import { EventFactory } from '@livestore/common/testing'
+import { nanoid } from '@livestore/livestore'
+import { events } from '@livestore/livestore/internal/testing-utils'
+import { OtelLiveHttp } from '@livestore/utils-dev/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import {
+  Effect,
+  FetchHttpClient,
+  type HttpClient,
+  KeyValueStore,
+  Layer,
+  Logger,
+  LogLevel,
+  ManagedRuntime,
+  Option,
+  Schedule,
+  Stream,
+} from '@livestore/utils/effect'
+
+import * as CloudflareDoRpcProvider from './providers/cloudflare-do-rpc.ts'
+import { SyncProviderImpl } from './types.ts'
+
+const testTimeout = 90_000
+/** Production hibernates after ~10s idle; idle the sync DO well past that (matches the hibernation probe). */
+const SERVER_IDLE_MS = 15_000
+
+const client = EventFactory.clientIdentity('repro-client', 'repro-session')
+const makeFactory = EventFactory.makeFactory(events)
+
+const todoId = (item: { eventEncoded: unknown }): string | undefined =>
+  (item.eventEncoded as { args?: { id?: string } })?.args?.id
+
+Vitest.describe('DO-RPC live pull across sync-DO hibernation', { timeout: testTimeout }, () => {
+  let runtime: ManagedRuntime.ManagedRuntime<
+    SyncProviderImpl | HttpClient.HttpClient | KeyValueStore.KeyValueStore,
+    never
+  >
+
+  Vitest.beforeAll(async () => {
+    runtime = ManagedRuntime.make(
+      CloudflareDoRpcProvider.doSqlite.layer.pipe(
+        Layer.provideMerge(FetchHttpClient.layer),
+        Layer.provideMerge(KeyValueStore.layerMemory),
+        Layer.provide(OtelLiveHttp({ rootSpanName: 'beforeAll', serviceName: 'vitest-runner', skipLogUrl: false })),
+        Layer.provide(Logger.prettyWithThread('test-runner')),
+        Layer.provide(Logger.minimumLogLevel(LogLevel.Debug)),
+        Layer.orDie,
+      ),
+    )
+    await runtime.runPromise(Effect.void)
+  })
+
+  Vitest.afterAll(async () => await runtime.dispose())
+
+  Vitest.scopedLive(
+    'resident DO-RPC client stops receiving live events after the sync DO evicts',
+    (test) =>
+      Effect.gen(function* () {
+        const { makeProvider, port } = yield* SyncProviderImpl.pipe(
+          Effect.map((_) => ({ makeProvider: _.makeProvider, port: _.providerSpecific.port as number })),
+        )
+
+        // Unique per run so persisted DO state from a prior run can't poison the head (ServerAheadError).
+        const storeId = `do-rpc-hibernation-${nanoid()}`
+        const factory = makeFactory({ client, startSeq: 1, initialParent: 'root' })
+        const base = `http://localhost:${port}`
+        const getJson = (path: string) =>
+          Effect.promise(() => fetch(`${base}${path}`).then((r) => r.json() as Promise<any>))
+
+        const syncBackend = yield* makeProvider({ storeId, clientId: client.clientId, payload: undefined })
+
+        // Collect every todo id the live pull delivers, into a shared array.
+        const received: string[] = []
+        yield* syncBackend
+          .pull(Option.none(), { live: true })
+          .pipe(
+            Stream.runForEach((res) =>
+              Effect.sync(() => {
+                for (const item of res.batch) {
+                  const id = todoId(item)
+                  if (id !== undefined) received.push(id)
+                }
+              }),
+            ),
+            Effect.forkScoped,
+          )
+
+        // Let the initial (live) pull register its subscription on the sync DO before pushing.
+        yield* Effect.sleep('1 second')
+
+        // 1. Baseline — push an event and confirm it IS delivered live (the subscription channel works).
+        yield* syncBackend.push([factory.todoCreated.next({ id: 'before-evict', text: 'before', completed: false })])
+        yield* Effect.sync(() => received.includes('before-evict')).pipe(
+          Effect.flatMap((ok) => (ok ? Effect.void : Effect.fail(new Error('not yet delivered')))),
+          Effect.retry(Schedule.spaced('300 millis')),
+          Effect.timeout('10 seconds'),
+        )
+
+        // 2. Snapshot instance ids (precondition baseline).
+        const serverId1 = (yield* getJson(`/instance/sync?storeId=${storeId}`)).instanceId as string
+        const clientId1 = (yield* getJson('/instance/client')).instanceId as string
+
+        // 3. Idle the SYNC DO past the eviction window, while keeping the CLIENT DO warm
+        //    (ping /instance/client — a local no-op that never touches the sync DO).
+        yield* getJson('/instance/client').pipe(Effect.delay('3 seconds'), Effect.repeat(Schedule.recurs(4)))
+        yield* Effect.sleep(`${SERVER_IDLE_MS - 12_000} millis`)
+
+        // 4. PROVE the precondition: sync DO reconstructed (evicted), client DO stayed resident.
+        const serverId2 = (yield* getJson(`/instance/sync?storeId=${storeId}`)).instanceId as string
+        const clientId2 = (yield* getJson('/instance/client')).instanceId as string
+        expect(serverId2, 'sync DO should have evicted+reconstructed (new instance id)').not.toBe(serverId1)
+        expect(clientId2, 'client DO should have stayed resident (same instance id)').toBe(clientId1)
+
+        // 5. Push a new event AFTER the sync DO evicted.
+        yield* syncBackend.push([factory.todoCreated.next({ id: 'after-evict', text: 'after', completed: false })])
+
+        // 6. Give live delivery ample time (baseline took <1s).
+        yield* Effect.sleep('4 seconds')
+
+        // 7. Control — the server DID store the post-eviction event (a fresh non-live pull returns it),
+        //    so the ONLY thing that failed is live delivery over the lost subscription.
+        const stored = yield* syncBackend.pull(Option.none(), { live: false }).pipe(
+          Stream.runFold([] as string[], (acc, res) => {
+            for (const item of res.batch) {
+              const id = todoId(item)
+              if (id !== undefined) acc.push(id)
+            }
+            return acc
+          }),
+        )
+        expect(stored, 'server should have stored both events').toEqual(
+          expect.arrayContaining(['before-evict', 'after-evict']),
+        )
+
+        yield* Effect.logInfo('[do-rpc-hibernation] repro evidence', {
+          serverEvicted: serverId1 !== serverId2,
+          clientResident: clientId1 === clientId2,
+          liveReceived: received,
+          storedOnServer: stored,
+        })
+
+        // 8. The bug: the resident DO-RPC client received the pre-eviction event but NOT the post-eviction one.
+        expect(received, 'live pull received the pre-eviction event').toContain('before-evict')
+        expect(received, 'live pull should have received the post-eviction event (currently lost)').toContain(
+          'after-evict',
+        )
+      }).pipe(Effect.provide(runtime)),
+  )
+
+  // Reaping (#2/#4): once the client reports its store is gone, the sync DO must drop the persisted
+  // subscription (else dead clients wake on every push forever); recovery is a catch-up pull on next use.
+  Vitest.scopedLive(
+    'reaps a DO-RPC subscription when the client reports its store is gone (recover on next use)',
+    (test) =>
+      Effect.gen(function* () {
+        const { makeProvider, port } = yield* SyncProviderImpl.pipe(
+          Effect.map((_) => ({ makeProvider: _.makeProvider, port: _.providerSpecific.port as number })),
+        )
+
+        const storeId = `do-rpc-reap-${nanoid()}`
+        const factory = makeFactory({ client, startSeq: 1, initialParent: 'root' })
+        const base = `http://localhost:${port}`
+        const getJson = (path: string) =>
+          Effect.promise(() => fetch(`${base}${path}`).then((r) => r.json() as Promise<any>))
+        const subCount = () =>
+          getJson(`/rpc-subscriptions/count?storeId=${storeId}`).pipe(Effect.map((r) => r.count as number))
+
+        yield* getJson('/do-rpc/open') // Order-independence: start with a live store.
+
+        const syncBackend = yield* makeProvider({ storeId, clientId: client.clientId, payload: undefined })
+
+        const received: string[] = []
+        yield* syncBackend
+          .pull(Option.none(), { live: true })
+          .pipe(
+            Stream.runForEach((res) =>
+              Effect.sync(() => {
+                for (const item of res.batch) {
+                  const id = todoId(item)
+                  if (id !== undefined) received.push(id)
+                }
+              }),
+            ),
+            Effect.forkScoped,
+          )
+
+        yield* Effect.sleep('1 second') // let the live pull register its subscription
+
+        yield* syncBackend.push([factory.todoCreated.next({ id: 'live-1', text: 'one', completed: false })])
+        yield* Effect.sync(() => received.includes('live-1')).pipe(
+          Effect.flatMap((ok) => (ok ? Effect.void : Effect.fail(new Error('not yet delivered')))),
+          Effect.retry(Schedule.spaced('300 millis')),
+          Effect.timeout('10 seconds'),
+        )
+        const countAfterBaseline = yield* subCount()
+        expect(countAfterBaseline, 'one DO-RPC subscription registered').toBe(1)
+
+        // Close the store → the gate now reports the subscription should be reaped.
+        yield* getJson('/do-rpc/close')
+
+        yield* syncBackend.push([factory.todoCreated.next({ id: 'after-close', text: 'after', completed: false })])
+
+        yield* subCount().pipe(
+          Effect.flatMap((c) => (c === 0 ? Effect.void : Effect.fail(new Error(`still ${c} subscription(s)`)))),
+          Effect.retry(Schedule.spaced('300 millis')),
+          Effect.timeout('10 seconds'),
+        )
+
+        expect(received, 'closed client should not receive the post-close event live').not.toContain('after-close')
+
+        // Recover-on-next-use: the server stored it, so a fresh non-live pull returns everything.
+        const stored = yield* syncBackend.pull(Option.none(), { live: false }).pipe(
+          Stream.runFold([] as string[], (acc, res) => {
+            for (const item of res.batch) {
+              const id = todoId(item)
+              if (id !== undefined) acc.push(id)
+            }
+            return acc
+          }),
+        )
+        expect(stored, 'server stored both events (recover-on-next-use)').toEqual(
+          expect.arrayContaining(['live-1', 'after-close']),
+        )
+
+        yield* Effect.logInfo('[do-rpc-reap] evidence', { liveReceived: received, storedOnServer: stored })
+
+        yield* getJson('/do-rpc/open') // Restore for later tests.
+      }).pipe(Effect.provide(runtime)),
+  )
+})

--- a/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
+++ b/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
@@ -39,7 +39,9 @@ const makeLayer = (config?: { wranglerConfigPath?: string; label: string }): Syn
           })(args),
         turnBackendOffline: Effect.log('TODO implement turnBackendOffline'),
         turnBackendOnline: Effect.log('TODO implement turnBackendOnline'),
-        providerSpecific: {},
+        // Expose the dev-server port so tests can hit worker routes directly (e.g. the hibernation
+        // instance-id probes in `do-rpc-hibernation.test.ts`).
+        providerSpecific: { port: server.port, url: server.url },
       }
     }),
   ).pipe(

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -3,7 +3,11 @@
 import { DurableObject } from 'cloudflare:workers'
 
 import type { SyncBackend } from '@livestore/common'
-import { type ClientDoWithRpcCallback, setupDurableObjectWebSocketRpc } from '@livestore/common-cf'
+import {
+  type ClientDoWithRpcCallback,
+  setupDurableObjectWebSocketRpc,
+  type SyncUpdateRpcResult,
+} from '@livestore/common-cf'
 import type { CfDeclare } from '@livestore/common-cf/declare'
 import {
   type CfTypes,
@@ -30,9 +34,22 @@ declare class Request extends CfDeclare.Request {}
 declare class Response extends CfDeclare.Response {}
 declare class WebSocketPair extends CfDeclare.WebSocketPair {}
 
+interface InstanceIdProbe {
+  getInstanceId(): string
+}
+
+interface SyncDoProbe extends InstanceIdProbe {
+  getRpcSubscriptionCount(): number
+}
+
+interface ClientDoProbe extends InstanceIdProbe {
+  closeStore(): void
+  openStore(): void
+}
+
 export interface Env {
-  SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
-  TEST_CLIENT_DO: CfTypes.DurableObjectNamespace
+  SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface & SyncDoProbe>
+  TEST_CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback & ClientDoProbe>
   /** Eventlog database */
   DB: CfTypes.D1Database
 }
@@ -50,7 +67,27 @@ export class SyncBackendDO extends makeDurableObject({
       'X-LiveStore-Version': '1.0.0',
     },
   },
-}) {}
+}) {
+  instanceId = crypto.randomUUID()
+
+  getInstanceId(): string {
+    return this.instanceId
+  }
+
+  getRpcSubscriptionCount(): number {
+    // `makeDurableObject`'s public type erases `ctx`; the runtime base provides it (test-only narrowing).
+    const { sql } = (this as unknown as { ctx: CfTypes.DurableObjectState }).ctx.storage
+    const tables = sql
+      .exec(`SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'rpc_subscription_%'`)
+      .toArray() as unknown as ReadonlyArray<{ name: string }>
+    let count = 0
+    for (const { name } of tables) {
+      const row = sql.exec(`SELECT COUNT(*) AS c FROM "${name}"`).toArray()[0] as unknown as { c: number } | undefined
+      count += Number(row?.c ?? 0)
+    }
+    return count
+  }
+}
 
 const DurableObjectBase = DurableObject as any as new (
   state: CfTypes.DurableObjectState,
@@ -61,6 +98,21 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
   __DURABLE_OBJECT_BRAND = 'ClientDO' as never
   env: Env
   ctx: CfTypes.DurableObjectState
+  instanceId = crypto.randomUUID()
+  /** Store-liveness flag — analog of the real adapter's `cachedStore === undefined`. */
+  storeClosed = false
+
+  getInstanceId(): string {
+    return this.instanceId
+  }
+
+  closeStore(): void {
+    this.storeClosed = true
+  }
+
+  openStore(): void {
+    this.storeClosed = false
+  }
 
   constructor(state: CfTypes.DurableObjectState, env: Env) {
     super(state, env)
@@ -163,8 +215,10 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
     })
   }
 
-  async syncUpdateRpc(payload: RpcMessage.ResponseChunkEncoded) {
-    await handleSyncUpdateRpc(payload)
+  async syncUpdateRpc(payload: RpcMessage.ResponseChunkEncoded): Promise<SyncUpdateRpcResult> {
+    // Store-liveness gate: reap once the store is gone (`storeClosed` is this harness's `cachedStore` analog).
+    if (this.storeClosed === true) return true
+    return handleSyncUpdateRpc(payload)
   }
 }
 
@@ -189,6 +243,35 @@ export default {
       const durableObject = env.TEST_CLIENT_DO.get(id)
 
       return durableObject.fetch(request)
+    }
+
+    // Probes for `do-rpc-hibernation.test.ts`: per-instance id (eviction), subscription count (reap),
+    // store-liveness toggle (drives the reap gate). Reading the client id also keeps it warm.
+    if (url.pathname.endsWith('/instance/sync') === true) {
+      const storeId = url.searchParams.get('storeId') ?? 'default'
+      const instanceId = await env.SYNC_BACKEND_DO.get(env.SYNC_BACKEND_DO.idFromName(storeId)).getInstanceId()
+      return new Response(JSON.stringify({ instanceId }), { headers: { 'content-type': 'application/json' } })
+    }
+
+    if (url.pathname.endsWith('/instance/client') === true) {
+      const instanceId = await env.TEST_CLIENT_DO.get(env.TEST_CLIENT_DO.idFromName('test-client-do')).getInstanceId()
+      return new Response(JSON.stringify({ instanceId }), { headers: { 'content-type': 'application/json' } })
+    }
+
+    if (url.pathname.endsWith('/rpc-subscriptions/count') === true) {
+      const storeId = url.searchParams.get('storeId') ?? 'default'
+      const count = await env.SYNC_BACKEND_DO.get(env.SYNC_BACKEND_DO.idFromName(storeId)).getRpcSubscriptionCount()
+      return new Response(JSON.stringify({ count }), { headers: { 'content-type': 'application/json' } })
+    }
+
+    if (url.pathname.endsWith('/do-rpc/close') === true) {
+      await env.TEST_CLIENT_DO.get(env.TEST_CLIENT_DO.idFromName('test-client-do')).closeStore()
+      return new Response(JSON.stringify({ closed: true }), { headers: { 'content-type': 'application/json' } })
+    }
+
+    if (url.pathname.endsWith('/do-rpc/open') === true) {
+      await env.TEST_CLIENT_DO.get(env.TEST_CLIENT_DO.idFromName('test-client-do')).openStore()
+      return new Response(JSON.stringify({ closed: false }), { headers: { 'content-type': 'application/json' } })
     }
 
     return new Response('Invalid path', { status: 400 })


### PR DESCRIPTION
> The #1328 hibernation chain — four bugs in two symmetric server/client pairs, shipped as two commits. "Bug N" is internal chain numbering (not GitHub issue references).

## Problem

Cloudflare bills Durable Objects for **wall-clock residency**, so an idle DO is **hibernated** (evicted) and reconstructed on the next request. The asymmetry that drives everything: **persisted SQLite survives; in-memory JS — instance fields, module-level `Map`s — is wiped.**

The chain is four bugs forming **two symmetric pairs.** In each pair a DO *couldn't hibernate*, and *fixing that* exposed a second bug that only manifests once the DO actually evicts:

**Server side**
- **Bug 1 — the sync DO couldn't hibernate.** Effect's `Effect.never` parks a fiber by registering `setInterval(() => {}, 2**31-1)` — a Node-only event-loop keepalive that is useless in a Worker and is the *exact* CF hibernation disqualifier (an isolate with any pending `setInterval`/`setTimeout` cannot evict). The WS-RPC sync server held **three** such parks per idle live connection (`Layer.launch`, `@effect/rpc`'s `withRun` run-loop, and each live-pull `Stream.never`).
- **Bug 2 — once it *can* hibernate, it silently forgets its DO-RPC subscribers.** Live updates are fanned out by iterating a subscriber registry and calling each reader's `clientDo.syncUpdateRpc(chunk)` (a DO→DO **reverse RPC**). That registry was an **in-memory `Map`** — exactly the state hibernation wipes. The reconstructed sync DO loops over zero subscribers, and a reader that subscribed earlier **stops receiving live updates with no error.** Fixing Bug 1 is what *unmasked* Bug 2.

**Client side (the mirror)**
- **Bug 3 — the client-host DO couldn't hibernate.** The same `Effect.never` root, on the DO-RPC client transport's run-loop.
- **Bug 4 — once it *can* hibernate, it can't receive after its own hibernation.** A reverse-RPC arriving while the reader DO is hibernated hits a DO with no live store to deliver into. Fixing Bug 3 unmasks Bug 4 (just as Bug 1 unmasks Bug 2).

**Commit split:** Bug 1 shipped first as **Commit 1** (the server timer-park); Bugs 2, 3, and 4 are **Commit 2**.

**Why this is structurally hard.** The obvious fix to Bug 2 — persist the registry in SQLite — fixes it but **deletes the only reaper**: the in-memory map's loss-on-eviction was the system's sole (accidental) garbage collection. A persisted registry never forgets, so dead subscriptions accumulate forever (unbounded SQLite growth, O(N) fan-out, and the cost of waking dead DOs on every push). And the sync DO **structurally cannot detect a dead subscriber**:

- a reverse-RPC to a hibernated/retired client **resurrects it and succeeds** — the probe revives the corpse;
- there is **no destructor hook** on hibernation/retirement; and
- the DO-RPC pull is an **ending stream** — it drains the backlog and completes, so (unlike a WebSocket, whose *disconnect* the server observes) there is no close signal.

So *reap-on-failure* is both trigger-happy (a transient hiccup false-reaps a **live** client → silent permanent severance) and blind (a genuinely **dead** client never produces a failure). The failure channel is unusable as a reaping signal — **only the client knows whether it still wants the subscription.**

**Constraints (hard).** No new public API on `@livestore` packages; no user-facing config knobs; **no time-based mechanisms** (alarm / lease / TTL); zero regressions (correctness, billing, storage).

## Solution

### Commit 1 (Bug 1) — `47858396f`

Replace each `Effect.never` park with a timer-less `Effect.async<never>(() => {})` (identical never-resolving, interruptible behavior, no timer): in `common-cf` ws-rpc-server (built into the connection scope with a hand-rolled protocol `run` loop instead of `@effect/rpc`'s `withRun`) and the `sync-cf` live-pull handler. Idle ⇒ 0 long-period timers ⇒ hibernation-eligible.

### Commit 2 (Bugs 2 / 3 / 4) — reap on the client's own verdict

Since the producer can't detect liveness, the **client reports it** through the reverse-RPC's return value, and the sync DO reaps on that:

```ts
async syncUpdateRpc(payload): Promise<SyncUpdateRpcResult> {
  if (this.store === undefined) return true   // store gone (hibernated) → ask to be reaped
  return handleSyncUpdateRpc(payload)         // store live → route the chunk, return void
}
```

- **Persist the registry** in SQLite (one `rpc_subscription` row per subscribing caller DO) so it survives hibernation — fixes Bug 2.
- **Reap only on the explicit `true` verdict.** Failure/timeout is **transient — keep the row** (a transient fault against a live client must never reap it). The broadcast loop reads the verdict and `DELETE`s the row only on `true`.
- **The wake and the reap are the same event.** The first push after a client hibernates wakes it once; its reconstructed (storeless) gate returns `true`; the row is reaped; it sleeps again. The registry **self-cleans** instead of waking dead DOs forever — each hibernated subscriber is woken at most once per hibernation cycle.
- **Bug 4 dissolves** into that one-line gate — a woken storeless client returns `true` and recovers via catch-up pull on next use. No boot-on-wake; the old keep-alive `alarm()` / wake-resubscribe machinery is **removed** from the examples.
- **Bug 3** parks the client-host DO-RPC transport's run-loop on the same timer-less `Effect.async`, so a DO-resident client can hibernate too (the client-side mirror of Bug 1).

**Two correctness guards:**

- **Per-call timeout** (`Effect.disconnect` + `Effect.timeout`, 5s). The broadcast loop is `Effect.uninterruptible` (so it can't be killed mid-fan-out); without a per-call bound, one hung `syncUpdateRpc` is in-flight I/O that pins the sync DO resident and **silently re-breaks Bug 1**. `timeout` bounds each call; `disconnect` makes the *call* interruptible inside the uninterruptible loop so the timeout actually releases the CF outbound I/O.
- **Monotonic `generation` compare-and-delete token.** The loop reads a snapshot and can run for seconds; meanwhile the same DO may re-subscribe (`INSERT OR REPLACE`, new generation). `remove(doId, generation)` deletes only if the generation still matches, so a stale reap cannot clobber a fresh re-subscribe. It is a counter seeded from `MAX(generation)` (to stay increasing across hibernation), **not** `Date.now()` — CF freezes the clock within a turn, so same-turn re-subscribes would otherwise collide.

**Why store-liveness, not mailbox-presence (the one real design fork).** Gating on `cachedStore === undefined` rather than "is there a routing mailbox" deliberately dissolves the **subscribe boot-race**: the server writes the subscription synchronously on `Pull`, but the client registers its mailbox only *after* draining the backlog. A push in that window finds no mailbox — under a mailbox-presence probe that would false-reap an about-to-be-live subscriber and permanently sever it. Under store-liveness the store is live throughout the window, so the chunk is dropped as transient and recovered by the finishing pull. The library's `handleSyncUpdateRpc` is therefore **routing-only and never reaps**; the consumer gate is the *only* reap signal.

**Client-side hygiene (the "keystone").** The reverse-RPC routing map (`requestIdMailboxMap`) now drops its entry on scope close. Without it, a closed/reconnected pull leaves a shut-down mailbox in the module-level map — and `offer` on a shut-down mailbox is a silent no-op, so a stale entry is an indistinguishable false-alive plus a leak across store boots in a warm isolate. (Defense-in-depth, *not* the reap signal.) A single module map routes correctly across multiple stores because `@effect/rpc` request IDs are isolate-unique — no per-`storeId` scoping needed.

**Consumer cooperation — and the one gotcha.** The gate is ~2 lines reading a store-liveness field every consumer already maintains; the return-type widening (`Promise<void>` → `Promise<void | boolean>`) is source-compatible, so existing `return handleSyncUpdateRpc(payload)` consumers still type-check. **Clear-on-shutdown is load-bearing:** hibernation wipes the liveness flag for free, but a *graceful* close must reset it or the gate never fires. (Will be documented for adopters in the docs follow-up.)

**Behavioral contract — "live only while the store is alive, ≈ WebSocket."** Idle ⇒ reaped; recovery is a normal store boot + catch-up pull from the cursor on next use (the *same* code path a WS reconnect uses → no data loss). Nothing wakes a hibernated client to keep it synced — an always-on reactor that hibernates *and* wakes on every event is a contradiction (keep the store alive if you need that).

**Rejected alternatives.** *Lease/alarm/TTL reaper* — needs time (ruled out) and a client heartbeat that itself defeats hibernation; false-reaps an idle-but-alive subscriber. *Persisted "retired" marker* — can't catch vanished clients (no destructor). *Adapter-owned base class injecting `syncUpdateRpc`* — the adapter has no per-instance store handle, so it would require a class users `extends` = new public API (forbidden), for identical correctness.

**Trade-off / known follow-up (separate PR).** Live delivery is best-effort. A transient drop to a *still-resident* client leaves a forward gap the sync core currently advances past silently (no `parentSeqNum` contiguity check on the upstream boundary). This is a **pre-existing** weakness, first *exposed* by DO-RPC keep-on-failure; the proper fix (sync-core gap-detection → re-pull from cursor) is transport-agnostic and tracked for a follow-up PR rather than bolted onto this one.

### Implementation map

| Concern | Files |
| --- | --- |
| Bug 1 — server timer-park (Commit 1) | `common-cf/.../ws-rpc/ws-rpc-server.ts`, `sync-cf/.../do/*` live-pull handler |
| Bug 3 — client timer-park | `common-cf/src/do-rpc/client.ts` (`makeProtocol`) |
| Verdict type + producer returns it | `common-cf/src/do-rpc/server.ts` (`SyncUpdateRpcResult`, `emitStreamResponse`) |
| Persisted registry + `generation` | `sync-cf/.../do/sqlite.ts`, `cf-worker/shared.ts`, `do/layer.ts`, `do/transport/do-rpc-server.ts` |
| Reap loop + two guards | `sync-cf/.../do/push.ts` |
| Keystone + routing-only handler | `sync-cf/src/client/transport/do-rpc-client.ts` |
| Consumer gate (Bug 4 dissolves) | integration fixture + `cloudflare-todomvc`, `web-email-client/{Mailbox,Thread}ClientDO` |

## Validation

Host type-check (`tsc --build`) is clean for all changed files (2 unrelated pre-existing fixture errors remain). The tests lean on four rigor techniques — **prove the precondition** (a per-instance UUID that changes only on real reconstruction, so a green test can't be a false positive where nothing evicted), **isolate the variable** (a non-live pull confirms the server stored the event, so a missing live delivery means delivery failed, not data lost), **observe without perturbing** (a non-booting eventlog probe, since booting would trigger the very catch-up we're testing for the *absence* of), and **deterministic trigger where reproduction is unreliable** (a store-liveness switch that fires the exact gate when real hibernation can't be forced):

- **sync-provider — reap mechanism:** register a live subscription → flip the store-liveness switch → push → assert the persisted subscription count goes **1 → 0** → the closed client misses the live event → a catch-up pull recovers it.
- **sync-provider — Bug 2 regression under real sync-DO eviction:** idle the sync DO out (proven evicted via the UUID), assert the resident client still receives live (persisted registry survived), with a non-live pull control.
- **integration (workerd) — inverted contract under real client-host eviction:** a post-hibernation event is **reaped, not delivered live** (non-booting eventlog probe stays flat), then a control boot catch-up-pulls it.
- **integration — timer guard (Bug 3):** a DO-resident client holds **0 long-period timers** (can hibernate); a re-introduced `Effect.never` would fail it.

**Local vs. deployed scope note.** DO *instance* eviction is reproduced and trusted locally (instance fields are wiped on eviction, proven by the UUID), so the reap is exercised under real local eviction. The only residual is real-CF *isolate* teardown (module globals), which local dev keeps warm — and the design was deliberately built to not depend on it.

Still pending before this draft is merge-ready: `CHANGELOG` entry, docs snippet + adapter `.mdx`, and the full devenv `lint`/`ts` suites.

### Demo

Verdict round-trip — the reap mechanism:

```
push.ts broadcast (per subscriber, per chunk)         consumer DO
  rpcSubscriptions.all()  ← persisted rows (survive hibernation)
  emitStreamResponse(…) ──reverse RPC──▶ syncUpdateRpc(payload)
    .pipe(disconnect, timeout 5s, exit)   ◀── verdict ── (true | void)
      ├─ Exit.isFailure  → keep   (transient: never reap on failure)
      ├─ value === true  → reap this row (DELETE matched on `generation`)
      └─ value void      → next chunk (alive)
```

The two symmetric pairs:

```
            cannot hibernate         →  fixing it unmasks
server      Bug 1 (sync-DO park)     →  Bug 2 (forgets DO-RPC subscribers)
client      Bug 3 (client-DO park)   →  Bug 4 (can't receive after own hibernation)
```

## Related issues

- livestorejs/livestore#1328
