### PR TITLE
chore(webmesh)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/utils/src/browser/WebChannelBrowser.ts
+++ b/packages/@livestore/utils/src/browser/WebChannelBrowser.ts
@@ -1,4 +1,4 @@
-import { Cause, Deferred, Exit, Scope } from 'effect'
+import { Cause, Deferred, Exit, Queue, Scope } from 'effect'
 
 import * as Effect from '../effect/Effect.ts'
 import * as Schema from '../effect/Schema/index.ts'
@@ -98,6 +98,15 @@ export const windowChannel = <MsgListen, MsgSend, MsgListenEncoded, MsgSendEncod
         to: Schema.Literal(ids.other),
       }).annotate({ title: 'webmesh.WindowMessageSend' })
 
+      // `window.postMessage` can fire before a lazily-started stream has installed its listener.
+      // Buffer events from channel construction time so Effect v4 scheduling cannot drop them.
+      const messageQueue = yield* Effect.acquireRelease(Queue.unbounded<MessageEvent>(), Queue.shutdown)
+      const handler = (event: MessageEvent) => {
+        Queue.offerUnsafe(messageQueue, event)
+      }
+      listenWindow.addEventListener('message', handler)
+      yield* Effect.addFinalizer(() => Effect.sync(() => listenWindow.removeEventListener('message', handler)))
+
       const send = (message: MsgSend) =>
         Effect.gen(function* () {
           debugInfo.sendTotal++
@@ -110,7 +119,7 @@ export const windowChannel = <MsgListen, MsgSend, MsgListenEncoded, MsgSendEncod
           sendWindow.postMessage(messageEncoded, targetOrigin, transferables)
         })
 
-      const listen = Stream.fromEventListener<MessageEvent>(listenWindow, 'message').pipe(
+      const listen = Stream.fromQueue(messageQueue).pipe(
         Stream.filter((_) => Schema.is(Schema.toEncoded(WindowMessageListen))(_.data)),
         Stream.map((_) => {
           debugInfo.listenTotal++

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
@@ -48,13 +48,23 @@ export const messagePortChannel: <MsgListen, MsgSend, MsgListenEncoded, MsgSendE
 
       const label = debugId === undefined ? 'messagePort' : `messagePort:${debugId}`
 
+      // In Effect v4, forking a consumer is not a readiness handshake. Install the MessagePort
+      // listener while constructing the channel and buffer into a scoped queue so early messages
+      // are not lost before `listen` is pulled.
+      const messageQueue = yield* Effect.acquireRelease(Queue.unbounded<MessageEvent>(), Queue.shutdown)
+      const handler = (event: MessageEvent) => {
+        Queue.offerUnsafe(messageQueue, event)
+      }
+      port.addEventListener('message', handler)
+      yield* Effect.addFinalizer(() => Effect.sync(() => port.removeEventListener('message', handler)))
+
       const send = (message: any) =>
         Effect.gen(function* () {
           const [messageEncoded, transferables] = yield* Schema.encodeWithTransferables(schema.send)(message)
           port.postMessage(messageEncoded, transferables)
         })
 
-      const listen = Stream.fromEventListener<MessageEvent>(port, 'message').pipe(
+      const listen = Stream.fromQueue(messageQueue).pipe(
         // Stream.tap((_) => Effect.log(`${label}:message`, _.data)),
         Stream.map((_) => Schema.decodeResult(schema.listen)(_.data)),
         listenToDebugPing(label),
@@ -155,6 +165,15 @@ export const messagePortChannelWithAck: <MsgListen, MsgSend, MsgListenEncoded, M
         id: debugId,
       }
 
+      // The ack channel sends protocol messages during setup. Buffer MessagePort events eagerly so
+      // the initial ping/pong cannot race a lazily-started `listen` stream under Effect v4.
+      const messageQueue = yield* Effect.acquireRelease(Queue.unbounded<MessageEvent>(), Queue.shutdown)
+      const handler = (event: MessageEvent) => {
+        Queue.offerUnsafe(messageQueue, event)
+      }
+      port.addEventListener('message', handler)
+      yield* Effect.addFinalizer(() => Effect.sync(() => port.removeEventListener('message', handler)))
+
       const send = (message: any) =>
         Effect.gen(function* () {
           debugInfo.sendTotal++
@@ -179,9 +198,7 @@ export const messagePortChannelWithAck: <MsgListen, MsgSend, MsgListenEncoded, M
           debugInfo.sendPending--
         })
 
-      // TODO re-implement this via `port.onmessage`
-      // https://github.com/livestorejs/livestore/issues/262
-      const listen = Stream.fromEventListener<MessageEvent>(port, 'message').pipe(
+      const listen = Stream.fromQueue(messageQueue).pipe(
         // Stream.onStart(Effect.log(`${label}:listen:start`)),
         // Stream.tap((_) => Effect.log(`${label}:message`, _.data)),
         Stream.map((_) => Schema.decodeResult(ChannelMessage)(_.data)),

--- a/packages/@livestore/utils/src/effect/WebChannel/broadcastChannelWithAck.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/broadcastChannelWithAck.ts
@@ -40,7 +40,9 @@ export const broadcastChannelWithAck = <MsgListen, MsgSend, MsgListenEncoded, Ms
   Effect.scopeWithCloseable((scope) =>
     Effect.gen(function* () {
       const channel = new BroadcastChannel(channelName)
-      const messageQueue = yield* Queue.unbounded<MsgSend>()
+      // BroadcastChannel messages are dropped unless a listener is already registered. Effect v4
+      // makes stream startup ordering explicit, so buffer events from channel construction time.
+      const messageQueue = yield* Effect.acquireRelease(Queue.unbounded<MessageEvent>(), Queue.shutdown)
       const connectionId = crypto.randomUUID()
       const schema = mapSchema(inputSchema)
 
@@ -50,6 +52,12 @@ export const broadcastChannelWithAck = <MsgListen, MsgSend, MsgListenEncoded, Ms
 
       const postMessage = (msg: typeof Message.Type) => channel.postMessage(Schema.encodeSync(Message)(msg))
 
+      const handler = (event: MessageEvent) => {
+        Queue.offerUnsafe(messageQueue, event)
+      }
+      channel.addEventListener('message', handler)
+      yield* Effect.addFinalizer(() => Effect.sync(() => channel.removeEventListener('message', handler)))
+
       const send = (message: MsgSend) =>
         Effect.gen(function* () {
           yield* connectedLatch.await
@@ -58,7 +66,7 @@ export const broadcastChannelWithAck = <MsgListen, MsgSend, MsgListenEncoded, Ms
           postMessage(PayloadMessage.make({ from: connectionId, to: peerIdRef.current!, payload }))
         })
 
-      const listen = Stream.fromEventListener<MessageEvent>(channel, 'message').pipe(
+      const listen = Stream.fromQueue(messageQueue).pipe(
         Stream.map(({ data }) => data),
         Stream.filterMap(Filter.fromPredicateOption(Schema.decodeUnknownOption(Message))),
         Stream.mapEffect((data) =>
@@ -110,7 +118,6 @@ export const broadcastChannelWithAck = <MsgListen, MsgSend, MsgListenEncoded, Ms
         Effect.gen(function* () {
           postMessage(DisconnectMessage.make({ from: connectionId }))
           channel.close()
-          yield* Queue.shutdown(messageQueue)
         }),
       )
 

--- a/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
@@ -298,22 +298,6 @@ export const makeDirectChannelInternal = ({
         }),
       )
 
-    yield* Effect.gen(function* () {
-      while (true) {
-        const packet = yield* Queue.take(incomingPacketsQueue)
-        const res = yield* processMessagePacket(packet)
-        // We want to give requests another chance to be processed
-        if (res === 'close') {
-          return
-        }
-      }
-    }).pipe(
-      Effect.interruptible,
-      Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
-
     const channelState = channelStateRef.current
 
     if (channelState._tag !== 'Initial') {
@@ -346,6 +330,25 @@ export const makeDirectChannelInternal = ({
     })
 
     yield* edgeRequest
+
+    // Start draining only after `edgeRequest` moved the channel to `RequestSent`. Under Effect v4
+    // an eagerly forked processor can otherwise handle an already-buffered packet while still
+    // `Initial`.
+    yield* Effect.gen(function* () {
+      while (true) {
+        const packet = yield* Queue.take(incomingPacketsQueue)
+        const res = yield* processMessagePacket(packet)
+        // We want to give requests another chance to be processed
+        if (res === 'close') {
+          return
+        }
+      }
+    }).pipe(
+      Effect.interruptible,
+      Effect.tapCauseLogPretty,
+      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+    )
 
     const channel = yield* Deferred.await(deferred)
 

--- a/packages/@livestore/webmesh/src/channel/direct-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel.ts
@@ -7,6 +7,7 @@ import {
   Exit,
   Option,
   Queue,
+  References,
   Schema,
   Scope,
   Stream,
@@ -122,7 +123,7 @@ export const makeDirectChannel = ({
             Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
             // Given we only call `Effect.exit` later when joining the fiber,
             // we don't want Effect to produce a "unhandled error" log message
-            Effect.withUnhandledErrorLogLevel(Option.none()),
+            Effect.provideService(References.UnhandledLogLevel, undefined),
           )
 
           const raceResult = yield* Effect.raceFirst(makeChannel, waitForNewEdgeFiber.pipe(Effect.disconnect))

--- a/packages/@livestore/webmesh/src/channel/direct-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel.ts
@@ -121,18 +121,18 @@ export const makeDirectChannel = ({
             Scope.provide(makeDirectChannelScope),
             // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
-            // Given we only call `Effect.exit` later when joining the fiber,
+            // Given we only await the exit later when observing the fiber,
             // we don't want Effect to produce a "unhandled error" log message
             Effect.provideService(References.UnhandledLogLevel, undefined),
           )
 
-          const raceResult = yield* Effect.raceFirst(makeChannel, waitForNewEdgeFiber.pipe(Effect.disconnect))
+          const raceResult = yield* Effect.raceFirst(makeChannel, Fiber.join(waitForNewEdgeFiber))
 
           if (raceResult === 'new-edge') {
             yield* Scope.close(makeDirectChannelScope, Exit.fail('new-edge'))
             // We'll try again
           } else {
-            const channelExit = yield* raceResult.pipe(Effect.exit)
+            const channelExit = yield* Fiber.await(raceResult)
             if (channelExit._tag === 'Failure') {
               yield* Scope.close(makeDirectChannelScope, channelExit)
 

--- a/packages/@livestore/webmesh/src/channel/proxy-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/proxy-channel.ts
@@ -131,6 +131,10 @@ export const makeProxyChannel = ({
       const channelSpan = yield* Effect.currentSpan.pipe(Effect.orDie)
 
       const connectedStateRef = yield* SubscriptionRef.make<ProxiedChannelStateEstablished | false>(false)
+      // Incoming packets can be processed as soon as the queue-draining fiber starts, so state
+      // referenced by established channels must exist before that processor is forked.
+      const listenQueue = yield* Queue.unbounded<any>()
+      const ackMap = new Map<string, Deferred.Deferred<void>>()
 
       const waitForEstablished = Effect.gen(function* () {
         const state = yield* SubscriptionRef.waitUntil(connectedStateRef, (state) => state !== false)
@@ -375,19 +379,7 @@ export const makeProxyChannel = ({
           }),
         )
 
-      yield* Stream.fromQueue(queue).pipe(
-        Stream.tap(processProxyPacket),
-        Stream.runDrain,
-        Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
-
-      const listenQueue = yield* Queue.unbounded<any>()
-
       yield* Effect.spanEvent(`Connecting`)
-
-      const ackMap = new Map<string, Deferred.Deferred<void>>()
 
       // check if already established via incoming `ProxyChannelRequest` from other side
       // which indicates we already have a edge to the target node
@@ -404,6 +396,16 @@ export const makeProxyChannel = ({
         const retryOnNewEdgeFiber = yield* Stream.fromPubSub(newEdgeAvailablePubSub).pipe(
           Stream.tap(() => edgeRequest),
           Stream.runDrain,
+          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        )
+
+        // Drain queued proxy packets only after the local side entered `Pending` and sent its
+        // request. Otherwise an already-buffered response can race initialization.
+        yield* Stream.fromQueue(queue).pipe(
+          Stream.tap(processProxyPacket),
+          Stream.runDrain,
+          Effect.tapCauseLogPretty,
           // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )

--- a/packages/@livestore/webmesh/src/channel/proxy-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/proxy-channel.ts
@@ -282,7 +282,7 @@ export const makeProxyChannel = ({
                   const decodedMessage = yield* Schema.decodeUnknownEffect(establishedState.listenSchema)(
                     bufferedPacket.payload,
                   )
-                  yield* establishedState.listenQueue.pipe(Queue.offer(decodedMessage))
+                  yield* Queue.offer(establishedState.listenQueue, decodedMessage)
                 }
               } else {
                 yield* Effect.logError(
@@ -333,7 +333,7 @@ export const makeProxyChannel = ({
 
               if (channelState._tag === 'Established') {
                 const decodedMessage = yield* Schema.decodeUnknownEffect(channelState.listenSchema)(packet.payload)
-                yield* channelState.listenQueue.pipe(Queue.offer(decodedMessage))
+                yield* Queue.offer(channelState.listenQueue, decodedMessage)
 
                 // Simulation point: delay after adding to listen queue
                 yield* simSleep('onPayload', 'afterListenQueueOffer')

--- a/packages/@livestore/webmesh/src/node.test.ts
+++ b/packages/@livestore/webmesh/src/node.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'vitest'
 
 import { IS_CI, omitUndefineds } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Chunk, Deferred, Effect, Exit, Fiber, Schema, Scope, Stream, WebChannel } from '@livestore/utils/effect'
+import { Deferred, Effect, Exit, Fiber, Schema, Scope, Stream, WebChannel } from '@livestore/utils/effect'
 
 import { Packet } from './mesh-schema.ts'
 import type { MeshNode } from './node.ts'
@@ -416,7 +416,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
 
                 // send 10 times A1
                 yield* Effect.forEach(
-                  Chunk.makeBy(count, (i) => ({ message: `A${i}` })),
+                  Array.from({ length: count }, (_, i) => ({ message: `A${i}` })),
                   channelAToB.send,
                   { concurrency: 'unbounded' },
                 )
@@ -427,7 +427,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
                     Stream.take(count),
                     Stream.runCollect,
                   ),
-                ).toEqual(Chunk.makeBy(count, (i) => ({ message: `B${i}` })))
+                ).toEqual(Array.from({ length: count }, (_, i) => ({ message: `B${i}` })))
                 // expect(yield* getFirstMessage(channelAToB)).toEqual({ message: 'A2' })
               })
 
@@ -436,7 +436,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
 
                 // send 10 times B1
                 yield* Effect.forEach(
-                  Chunk.makeBy(count, (i) => ({ message: `B${i}` })),
+                  Array.from({ length: count }, (_, i) => ({ message: `B${i}` })),
                   channelBToA.send,
                   { concurrency: 'unbounded' },
                 )
@@ -447,7 +447,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
                     Stream.take(count),
                     Stream.runCollect,
                   ),
-                ).toEqual(Chunk.makeBy(count, (i) => ({ message: `A${i}` })))
+                ).toEqual(Array.from({ length: count }, (_, i) => ({ message: `A${i}` })))
               })
 
               yield* Effect.all([nodeACode, nodeBCode, connectNodes(nodeA, nodeB).pipe(Effect.delay(100))], {
@@ -672,7 +672,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
           const channelAToC = yield* createChannel(nodeA, 'C', { mode: 'proxy' })
           // Send multiple messages concurrently
           yield* Effect.forEach(
-            Chunk.makeBy(messageCount, (i) => ({ message: `A${i}` })),
+            Array.from({ length: messageCount }, (_, i) => ({ message: `A${i}` })),
             channelAToC.send,
             { concurrency: 'unbounded' },
           )
@@ -689,7 +689,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
           const channelCToA = yield* createChannel(nodeC, 'A', { mode: 'proxy' })
           // Send multiple messages concurrently
           yield* Effect.forEach(
-            Chunk.makeBy(messageCount, (i) => ({ message: `C${i}` })),
+            Array.from({ length: messageCount }, (_, i) => ({ message: `C${i}` })),
             channelCToA.send,
             { concurrency: 'unbounded' },
           )
@@ -758,7 +758,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
             // With forked ACKs, all messages get processed immediately at receiver
             // With blocking ACKs, messages would be processed one at a time with delays
             yield* Effect.forEach(
-              Chunk.makeBy(MESSAGE_COUNT, (i) => ({ message: `msg${i}` })),
+              Array.from({ length: MESSAGE_COUNT }, (_, i) => ({ message: `msg${i}` })),
               channelAToB.send,
               { concurrency: 'unbounded' },
             )
@@ -850,7 +850,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
 
             // Send all messages concurrently
             yield* Effect.forEach(
-              Chunk.makeBy(MESSAGE_COUNT, (i) => ({ message: `msg${i}` })),
+              Array.from({ length: MESSAGE_COUNT }, (_, i) => ({ message: `msg${i}` })),
               channelAToB.send,
               { concurrency: 'unbounded' },
             )

--- a/packages/@livestore/webmesh/src/node.ts
+++ b/packages/@livestore/webmesh/src/node.ts
@@ -6,7 +6,6 @@ import {
   Effect,
   Exit,
   Fiber,
-  Option,
   PubSub,
   Queue,
   Schema,
@@ -676,7 +675,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
             '    ',
             value.debugInfo?.channel,
             '\n',
-            indent(`Queue: ${value.queue.unsafeSize().pipe(Option.getOrUndefined)}`, 4),
+            indent(`Queue: ${Queue.sizeUnsafe(value.queue)}`, 4),
             value.queue,
           )
         }

--- a/packages/@livestore/webmesh/src/utils.ts
+++ b/packages/@livestore/webmesh/src/utils.ts
@@ -6,7 +6,7 @@ import { Duration, Effect } from '@livestore/utils/effect'
  */
 export class TimeoutSet<V> {
   private values = new Map<V, number>()
-  private timeoutHandle: NodeJS.Timeout | undefined
+  private timeoutHandle: ReturnType<typeof setTimeout> | undefined
   private readonly timeoutMs: number
 
   private constructor({ timeout }: { timeout: Duration.Input }) {

--- a/packages/@livestore/webmesh/src/websocket-edge.test.ts
+++ b/packages/@livestore/webmesh/src/websocket-edge.test.ts
@@ -70,7 +70,7 @@ Vitest.describe('websocket-edge', () => {
 
       // WebChannel.Ping should be decodable via the wrapped listen schema
       const pingPayload = { _tag: 'WebChannel.Ping' as const, requestId: 'test-123' }
-      const result = Schema.decodeUnknownExit(schema.listen)(pingPayload)
+      const result = Schema.decodeUnknownResult(schema.listen)(pingPayload)
 
       // mapSchema adds WebChannel messages to the schema
       expect(Result.isSuccess(result)).toBe(true)

--- a/packages/@livestore/webmesh/src/websocket-edge.ts
+++ b/packages/@livestore/webmesh/src/websocket-edge.ts
@@ -105,10 +105,10 @@ export const makeWebSocketEdge = ({
 
       const closedDeferred = yield* Effect.acquireRelease(Deferred.make<void>(), Deferred.done(Exit.void))
 
-      const retryOpenTimeoutSchedule = Schedule.exponential(100).pipe(
-        Schedule.modifyDelay((_, delay) => Duration.min(delay, Duration.millis(5000))),
+      const retryOpenErrorSchedule = Schedule.exponential(100).pipe(
+        Schedule.modifyDelay((_, delay) => Effect.succeed(Duration.min(delay, Duration.millis(5000)))),
         Schedule.setInputType<Socket.SocketError>(),
-        Schedule.while(({ input }) => input.reason === 'OpenTimeout' || input.reason === 'Open'),
+        Schedule.while(({ input }) => input.reason._tag === 'SocketOpenError'),
       )
 
       const sendToSocket = yield* socket.writer
@@ -117,19 +117,22 @@ export const makeWebSocketEdge = ({
         Stream.pipeThroughChannel(Socket.toChannel(socket)),
         Stream.catchTag(
           'SocketError',
-          Effect.fnUntraced(function* (error) {
-            // In the case of the socket being closed, we're interrupting the stream
-            // and close the WebChannel (which can be observed from the outside)
-            if (error.reason === 'Close') {
-              yield* Deferred.succeed(closedDeferred, undefined)
-              yield* isConnectedLatch.close
-              return yield* Effect.interrupt
-            } else {
-              return yield* error
+          (error) => {
+            // In the case of the socket being closed, close the WebChannel
+            // which can be observed from the outside.
+            if (error.reason._tag === 'SocketCloseError') {
+              return Stream.fromEffectDrain(
+                Effect.gen(function* () {
+                  yield* Deferred.succeed(closedDeferred, undefined)
+                  yield* isConnectedLatch.close
+                }),
+              )
             }
-          }),
+
+            return Stream.fail(error)
+          },
         ),
-        Stream.retry(retryOpenTimeoutSchedule),
+        Stream.retry(retryOpenErrorSchedule),
         Stream.tap(
           Effect.fn(function* (bytes) {
             const msg = yield* Schema.decodeEffect(MessageMsgpack)(new Uint8Array(bytes))

--- a/packages/@livestore/webmesh/src/worker/mod.ts
+++ b/packages/@livestore/webmesh/src/worker/mod.ts
@@ -1,5 +1,5 @@
 import { LS_DEV } from '@livestore/utils'
-import { Context, Deferred, Effect, Layer, Stream, WebChannel, type Worker } from '@livestore/utils/effect'
+import { Context, Deferred, Effect, Layer, Queue, Stream, WebChannel } from '@livestore/utils/effect'
 
 import * as WebmeshSchema from '../mesh-schema.ts'
 import type { MeshNode } from '../node.ts'
@@ -38,7 +38,10 @@ export const CreateConnection = ({ from, port }: typeof WorkerSchema.CreateConne
         yield* Effect.logDebug(`@livestore/webmesh:worker: accepted edge: ${node.nodeName} <- ${from}`)
       }
 
-      emit.single({})
+      // `Stream.callback` exposes a queue-like emitter in Effect v4. Emit the single success value
+      // and then end the stream to preserve the old one-response worker command behavior.
+      yield* Queue.offer(emit, {})
+      yield* Queue.end(emit)
 
       yield* Effect.spanEvent({ connectedTo: [...node.edgeKeys] })
     }).pipe(Effect.orDie),
@@ -51,7 +54,9 @@ export const connectViaWorker = ({
 }: {
   node: MeshNode
   target: string
-  worker: Worker.SerializedWorkerPool<typeof WorkerSchema.Request.Type>
+  // Effect v4 removed the serialized worker pool type this package used to reference. Webmesh only
+  // needs this structural `execute` contract; adapter code can provide any compatible pool.
+  worker: { execute: (request: typeof WorkerSchema.Request.Type) => Stream.Stream<{}> }
 }) =>
   Effect.gen(function* () {
     const mc = new MessageChannel()

--- a/packages/@livestore/webmesh/src/worker/schema.ts
+++ b/packages/@livestore/webmesh/src/worker/schema.ts
@@ -1,12 +1,8 @@
 import { Schema, Transferable } from '@livestore/utils/effect'
 
-export class CreateConnection extends Schema.TaggedRequest<CreateConnection>()('WebmeshWorker.CreateConnection', {
-  payload: {
-    from: Schema.String,
-    port: Transferable.MessagePort,
-  },
-  success: Schema.Struct({}),
-  failure: Schema.Never,
-}) {}
+export const CreateConnection = Schema.TaggedStruct('WebmeshWorker.CreateConnection', {
+  from: Schema.String,
+  port: Transferable.MessagePort,
+})
 
 export const Request = Schema.Union([CreateConnection])

--- a/packages/@livestore/webmesh/tsconfig.json
+++ b/packages/@livestore/webmesh/tsconfig.json
@@ -3,7 +3,7 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024"],
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "NodeNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,

--- a/packages/@livestore/webmesh/tsconfig.json.genie.ts
+++ b/packages/@livestore/webmesh/tsconfig.json.genie.ts
@@ -1,5 +1,6 @@
 import {
   baseTsconfigCompilerOptions,
+  domLib,
   packageTsconfigCompilerOptions,
   packageTsconfigExclude,
   refs,
@@ -10,6 +11,7 @@ export default tsconfigJson({
   compilerOptions: {
     ...baseTsconfigCompilerOptions,
     ...packageTsconfigCompilerOptions,
+    lib: [...domLib],
     resolveJsonModule: true,
   },
   include: ['./src'],


### PR DESCRIPTION
## Problem

Part of #1319 under the Effect v4 migration stack (#1310). `@livestore/webmesh` sits between the shared utils migration and downstream packages such as `@livestore/common` and `@livestore/adapter-web`, so its worker/channel APIs need to move to the Effect v4 surface before those packages can be reviewed cleanly.

## Solution

- Migrates webmesh direct, proxy, worker, and WebSocket edge channel code to the Effect v4 APIs.
- Updates affected `WebChannel` helpers in `@livestore/utils` where the webmesh migration requires the v4 shape.
- Fixes queue/fiber/race/log-level usage and test decode helpers for the v4 API surface.
- Adds DOM lib coverage to the webmesh TypeScript config needed by the migrated worker/channel code.

## Trade-offs / follow-up

This PR is scoped to `@livestore/webmesh` and directly required utility helper adjustments. Downstream package fixes remain in the following stack branches.

## Validation

Not run in this PR creation pass. The branch diff is limited to the webmesh package plus directly required web channel helpers.

Closes #1319
Part of #1310