### PR TITLE
chore(effect-playwright)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/effect-playwright/src/index.ts
+++ b/packages/@livestore/effect-playwright/src/index.ts
@@ -3,7 +3,7 @@ import process from 'node:process'
 import * as PW from '@playwright/test'
 
 import { envTruish } from '@livestore/utils'
-import { Context, Effect, Layer, Option, Schema, Stream } from '@livestore/utils/effect'
+import { Cause, Context, Effect, Layer, Option, Queue, Schema, Stream } from '@livestore/utils/effect'
 
 export class BrowserContext extends Context.Service<
   BrowserContext,
@@ -196,7 +196,7 @@ export const pageConsole = ({
   label: string
   shouldEvaluateArgs: boolean
 }) =>
-  Stream.callback<typeof ConsoleMessage.Type, SiteError>((emit) =>
+  Stream.callback<typeof ConsoleMessage.Type, SiteError>((queue) =>
     Effect.acquireRelease(
       Effect.sync(() => {
         const errorGroupRef = ref<{ errorMessages: (typeof ConsoleMessage.Type)[] } | undefined>(undefined)
@@ -212,11 +212,14 @@ export const pageConsole = ({
             ) {
               errorGroupRef.current = { errorMessages: [message] }
             } else if (message.type === 'groupEnd' && errorGroupRef.current !== undefined) {
-              emit.fail(
-                new SiteError({
-                  label,
-                  messages: errorGroupRef.current.errorMessages,
-                }),
+              Queue.failCauseUnsafe(
+                queue,
+                Cause.fail(
+                  new SiteError({
+                    label,
+                    messages: errorGroupRef.current.errorMessages,
+                  }),
+                ),
               )
             } else if (
               message.type === 'error' &&
@@ -229,18 +232,19 @@ export const pageConsole = ({
               message.message.includes('All fibers interrupted without errors') === false
             ) {
               if (errorGroupRef.current === undefined) {
-                emit.fail(new SiteError({ label, messages: [message] }))
+                Queue.failCauseUnsafe(queue, Cause.fail(new SiteError({ label, messages: [message] })))
               } else {
                 errorGroupRef.current.errorMessages.push(message)
               }
             } else {
-              emit.single(message)
+              Queue.offerUnsafe(queue, message)
             }
           }
         }
         page.on('console', onConsole)
 
-        const onPageError = (cause: Error) => emit.fail(new SiteError({ label, messages: [cause] }))
+        const onPageError = (cause: Error) =>
+          Queue.failCauseUnsafe(queue, Cause.fail(new SiteError({ label, messages: [cause] })))
         page.on('pageerror', onPageError)
 
         return { onConsole, onPageError }


### PR DESCRIPTION
## Problem

Part of #1340 under the Effect v4 migration stack (#1310). `@livestore/effect-playwright` still used Effect v3 stream/filter patterns in its Playwright console integration.

## Solution

- Migrates the Playwright console stream helper to the Effect v4 stream API shape.
- Updates filtering/mapping flow while keeping the package slice intentionally narrow.

## Trade-offs / follow-up

This PR only covers `@livestore/effect-playwright`. Broader tooling, docs, and test workspace cleanup remain in later stack slices.

## Validation

Not run in this PR creation pass. The branch diff is limited to `packages/@livestore/effect-playwright/src/index.ts`.

Closes #1340
Part of #1310