### PR TITLE
chore(sqlite-wasm)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/sqlite-wasm/src/node/mod.ts
+++ b/packages/@livestore/sqlite-wasm/src/node/mod.ts
@@ -54,7 +54,7 @@ export const sqliteDbFactory = ({
 }: {
   sqlite3: SQLiteAPI
 }): Effect.Effect<MakeNodeSqliteDb, never, FileSystem.FileSystem> =>
-  Effect.andThen(
+  Effect.map(
     FileSystem.FileSystem,
     (fs) => (input) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Problem

Part of #1341 under the Effect v4 migration stack (#1310). `@livestore/sqlite-wasm` is the bridge from the common package slice into the web adapter slice, and its node factory mapping needs the Effect v4 API shape before `@livestore/adapter-web` can stack on top cleanly.

## Solution

- Updates the SQLite WASM node factory mapping to the Effect v4 mapping API.
- Keeps the slice intentionally narrow so `@livestore/adapter-web` can own the downstream web adapter migration.

## Trade-offs / follow-up

This PR does not include `@livestore/adapter-web` or `@livestore/livestore`; those remain downstream stack slices.

## Validation

Not run in this PR creation pass. The branch diff is limited to `packages/@livestore/sqlite-wasm/src/node/mod.ts`.

Closes #1341
Part of #1310