### PR TITLE
fix: make source types compatible with newer DOM libs

### DIFF
--- a/.changeset/source-compat-new-dom-types.md
+++ b/.changeset/source-compat-new-dom-types.md
@@ -1,0 +1,8 @@
+---
+"@livestore/common-cf": patch
+"@livestore/livestore": patch
+"@livestore/sync-cf": patch
+"@livestore/utils": patch
+---
+
+Improve source compatibility with newer TypeScript DOM and Cloudflare Worker global types.

--- a/packages/@livestore/common-cf/src/declare/cf-declare.ts
+++ b/packages/@livestore/common-cf/src/declare/cf-declare.ts
@@ -5,7 +5,7 @@
 import type * as CF from '@cloudflare/workers-types'
 
 // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- bridging standard Web API types to Cloudflare Worker types; inherent platform type mismatch
-const cfGlobalThis = globalThis as typeof globalThis & {
+const cfGlobalThis = globalThis as unknown as {
   ReadableStream: typeof CF.ReadableStream
   Request: typeof CF.Request
   Response: typeof CF.Response

--- a/packages/@livestore/livestore/src/utils/dev.ts
+++ b/packages/@livestore/livestore/src/utils/dev.ts
@@ -24,7 +24,7 @@ export const downloadURL = (data: string, fileName: string) => {
   const a = document.createElement('a')
   a.href = data
   a.download = fileName
-  document.body.append(a)
+  document.body.appendChild(a)
   a.style.display = 'none'
   a.click()
   a.remove()

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -29,12 +29,9 @@ import { createDoRpcHandler } from './transport/do-rpc-server.ts'
 import { createHttpRpcHandler } from './transport/http-rpc-server.ts'
 import { makeRpcServer } from './transport/ws-rpc-server.ts'
 
-// NOTE We need to redeclare runtime types here to avoid type conflicts with the lib.dom Response type.
-// TODO get rid of those once CF fixed their type mismatch in the worker types
-declare class Request extends CfDeclare.Request {}
-declare class Response extends CfDeclare.Response {}
-declare class WebSocketPair extends CfDeclare.WebSocketPair {}
-declare class WebSocketRequestResponsePair extends CfDeclare.WebSocketRequestResponsePair {}
+const Response = CfDeclare.Response
+const WebSocketPair = CfDeclare.WebSocketPair
+const WebSocketRequestResponsePair = CfDeclare.WebSocketRequestResponsePair
 
 const DurableObjectBase = DurableObject as any as new (
   state: CfTypes.DurableObjectState,
@@ -146,7 +143,7 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
       }
     }
 
-    override fetch = async (request: Request): Promise<Response> =>
+    override fetch = async (request: CfTypes.Request): Promise<CfTypes.Response> =>
       Effect.gen(this, function* () {
         const searchParams = matchSyncRequest(request)
         if (searchParams === undefined) {

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -2,10 +2,10 @@ import { env as importedEnv } from 'cloudflare:workers'
 
 import { UnknownError } from '@livestore/common'
 import type { HelperTypes } from '@livestore/common-cf'
+import { CfDeclare } from '@livestore/common-cf/declare'
 import { Effect, Schema } from '@livestore/utils/effect'
 
 import type { CfTypes, SearchParams } from '../common/mod.ts'
-import { CfDeclare } from './mod.ts'
 import { type Env, type ForwardedHeaders, matchSyncRequest } from './shared.ts'
 
 const Response = CfDeclare.Response

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -5,11 +5,10 @@ import type { HelperTypes } from '@livestore/common-cf'
 import { Effect, Schema } from '@livestore/utils/effect'
 
 import type { CfTypes, SearchParams } from '../common/mod.ts'
-import type { CfDeclare } from './mod.ts'
+import { CfDeclare } from './mod.ts'
 import { type Env, type ForwardedHeaders, matchSyncRequest } from './shared.ts'
 
-// NOTE We need to redeclare runtime types here to avoid type conflicts with the lib.dom Response type.
-declare class Response extends CfDeclare.Response {}
+const Response = CfDeclare.Response
 
 // HINT: If we ever extend user's custom worker RPC, type T can help here with expected return type safety. Currently unused.
 export type CFWorker<TEnv extends Env = Env, _T extends CfTypes.Rpc.DurableObjectBranded | undefined = undefined> = {

--- a/packages/@livestore/utils/src/browser/QuotaExceededError.ts
+++ b/packages/@livestore/utils/src/browser/QuotaExceededError.ts
@@ -26,17 +26,22 @@ declare global {
      */
     readonly message: string
     /**
-     * A number representing the quota limit in bytes, or undefined.
+     * A number representing the quota limit in bytes, or null.
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/QuotaExceededError/quota)
      */
-    readonly quota?: number
+    readonly quota: number | null
     /**
-     * A number representing the requested amount of storage in bytes, or undefined.
+     * A number representing the requested amount of storage in bytes, or null.
      *
      * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/QuotaExceededError/requested)
      */
-    readonly requested?: number
+    readonly requested: number | null
+  }
+
+  interface QuotaExceededErrorOptions {
+    quota?: number
+    requested?: number
   }
 
   /**
@@ -48,10 +53,8 @@ declare global {
    *
    * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/QuotaExceededError)
    */
-  var QuotaExceededError:
-    | {
-        prototype: QuotaExceededError
-        new (message?: string, options?: { quota: number; requested: number }): QuotaExceededError
-      }
-    | undefined
+  var QuotaExceededError: {
+    prototype: QuotaExceededError
+    new (message?: string, options?: QuotaExceededErrorOptions): QuotaExceededError
+  }
 }


### PR DESCRIPTION
## Summary

- avoid ambient Cloudflare `Request`/`Response` class redeclarations in `@livestore/sync-cf` source exports
- use the existing Cloudflare runtime bridge values at the boundary while keeping public signatures in `CfTypes`
- make the `QuotaExceededError` shim merge with newer DOM lib declarations
- use `appendChild` for single-node browser downloads to avoid mixed `Body.append` overload pollution

## Rationale

LiveStore publishes/source-exports TypeScript files. Consumers that type-check those sources with newer DOM libraries can see collisions between Cloudflare Worker globals, browser DOM globals, and LiveStore compatibility shims. This keeps the compatibility boundary explicit upstream instead of requiring downstream source consumers to add local shims or casts.

Tradeoff: the Cloudflare bridge still uses a deliberate assertion at the runtime boundary, but that assertion is now localized to the bridge instead of leaking ambient class declarations into source consumers.

## Verification

- `PUPPETEER_SKIP_DOWNLOAD=true pnpm install --frozen-lockfile`
- `pnpm --package=typescript@5.9.3 dlx tsc -b packages/@livestore/common packages/@livestore/utils packages/@livestore/common-cf packages/@livestore/livestore packages/@livestore/sync-cf --pretty false`
- `/home/schickling/.megarepo/github.com/schickling/dotfiles/refs/heads/schickling/2026-06-24-effect-lsp-refactor/node_modules/.bin/tsc -b packages/@livestore/common packages/@livestore/utils packages/@livestore/common-cf packages/@livestore/livestore packages/@livestore/sync-cf --pretty false`
- standalone declaration merge experiment: current `QuotaExceededError` shim conflicts with a newer DOM declaration, updated shape merges cleanly

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-06-26-ts6-source-compat |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->