### PR TITLE
fix: avoid ambient TypeScript conflicts

### DIFF
--- a/packages/@livestore/livestore/src/live-queries/client-document-get-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/client-document-get-query.ts
@@ -49,6 +49,6 @@ export const makeExecBeforeFirstRun =
 
     store.commit(
       { otelContext, skipRefresh: true, label: `${table.sqliteDef.name}.set:${idVal}` },
-      table.set(explicitDefaultValues, idVal as TODO),
+      table.set(explicitDefaultValues, idVal as any),
     )
   }

--- a/packages/@livestore/livestore/src/reactive.ts
+++ b/packages/@livestore/livestore/src/reactive.ts
@@ -31,7 +31,7 @@ import type { Types } from '@livestore/utils/effect'
 export const NOT_REFRESHED_YET = Symbol.for('NOT_REFRESHED_YET')
 export type NOT_REFRESHED_YET = typeof NOT_REFRESHED_YET
 
-export type GetAtom = <T>(atom: Atom<T, any, any>, otelContext?: otel.Context, debugRefreshReason?: TODO) => T
+export type GetAtom = <T>(atom: Atom<T, any, any>, otelContext?: otel.Context, debugRefreshReason?: any) => T
 
 export type Ref<T, TContext, TDebugRefreshReason extends DebugRefreshReason> = {
   _tag: 'ref'
@@ -76,7 +76,7 @@ export type Effect<TDebugRefreshReason extends DebugRefreshReason> = {
   id: string
   isDestroyed: boolean
   doEffect: (otelContext?: otel.Context, debugRefreshReason?: TDebugRefreshReason) => void
-  sub: Set<Atom<any, TODO, TODO>>
+  sub: Set<Atom<any, any, any>>
   label?: string | undefined
   invocations: number
 }

--- a/packages/@livestore/livestore/src/utils/dev.ts
+++ b/packages/@livestore/livestore/src/utils/dev.ts
@@ -24,7 +24,7 @@ export const downloadURL = (data: string, fileName: string) => {
   const a = document.createElement('a')
   a.href = data
   a.download = fileName
-  document.body.append(a)
+  document.body.appendChild(a)
   a.style.display = 'none'
   a.click()
   a.remove()

--- a/packages/@livestore/sqlite-wasm/src/cf/mod.ts
+++ b/packages/@livestore/sqlite-wasm/src/cf/mod.ts
@@ -134,5 +134,5 @@ const makeCloudflareFsDb = ({
     // NOTE SQLite will return a "disk I/O error" if the file path is too long.
     const dbPointer = sqlite3.open_v2Sync(fileName, undefined, vfsName)
 
-    return { dbPointer, vfs: {} as UNUSED<'only needed in web adapter currently and should longer-term be removed'> }
+    return { dbPointer, vfs: {} as any }
   }).pipe(UnknownError.mapToUnknownError)

--- a/packages/@livestore/sqlite-wasm/src/node/mod.ts
+++ b/packages/@livestore/sqlite-wasm/src/node/mod.ts
@@ -128,5 +128,5 @@ const makeNodeFsDb = ({
     // NOTE SQLite will return a "disk I/O error" if the file path is too long.
     const dbPointer = sqlite3.open_v2Sync(fileName, undefined, vfsName)
 
-    return { dbPointer, vfs: {} as UNUSED<'only needed in web adapter currently and should longer-term be removed'> }
+    return { dbPointer, vfs: {} as any }
   }).pipe(UnknownError.mapToUnknownError)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -29,12 +29,12 @@ import { createDoRpcHandler } from './transport/do-rpc-server.ts'
 import { createHttpRpcHandler } from './transport/http-rpc-server.ts'
 import { makeRpcServer } from './transport/ws-rpc-server.ts'
 
-// NOTE We need to redeclare runtime types here to avoid type conflicts with the lib.dom Response type.
-// TODO get rid of those once CF fixed their type mismatch in the worker types
-declare class Request extends CfDeclare.Request {}
-declare class Response extends CfDeclare.Response {}
-declare class WebSocketPair extends CfDeclare.WebSocketPair {}
-declare class WebSocketRequestResponsePair extends CfDeclare.WebSocketRequestResponsePair {}
+type Request = CfTypes.Request
+type Response = CfTypes.Response
+
+const Response = CfDeclare.Response
+const WebSocketPair = CfDeclare.WebSocketPair
+const WebSocketRequestResponsePair = CfDeclare.WebSocketRequestResponsePair
 
 const DurableObjectBase = DurableObject as any as new (
   state: CfTypes.DurableObjectState,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
@@ -22,7 +22,7 @@ export const createHttpRpcHandler = Effect.fn('createHttpRpcHandler')(function* 
   const webHandler = yield* httpApp.pipe(Effect.map(HttpApp.toWebHandler))
 
   const response = yield* Effect.promise(
-    () => webHandler(request as TODO as Request) as TODO as Promise<CfTypes.Response>,
+    () => webHandler(request as unknown as Request) as unknown as Promise<CfTypes.Response>,
   ).pipe(Effect.timeout(10000))
 
   if (responseHeaders !== undefined) {

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -5,11 +5,12 @@ import type { HelperTypes } from '@livestore/common-cf'
 import { Effect, Schema } from '@livestore/utils/effect'
 
 import type { CfTypes, SearchParams } from '../common/mod.ts'
-import type { CfDeclare } from './mod.ts'
+import { CfDeclare } from './mod.ts'
 import { type Env, type ForwardedHeaders, matchSyncRequest } from './shared.ts'
 
-// NOTE We need to redeclare runtime types here to avoid type conflicts with the lib.dom Response type.
-declare class Response extends CfDeclare.Response {}
+type Response = CfTypes.Response
+
+const Response = CfDeclare.Response
 
 // HINT: If we ever extend user's custom worker RPC, type T can help here with expected return type safety. Currently unused.
 export type CFWorker<TEnv extends Env = Env, _T extends CfTypes.Rpc.DurableObjectBranded | undefined = undefined> = {

--- a/packages/@livestore/utils/src/global.ts
+++ b/packages/@livestore/utils/src/global.ts
@@ -1,7 +1,4 @@
 declare global {
-  export type TODO<_Reason extends string = 'unknown'> = any
-  export type UNUSED<_Reason extends string = 'unknown'> = any
-
   interface ImportMeta {
     main: boolean
   }


### PR DESCRIPTION
## Summary

This PR reduces ambient TypeScript surface that currently breaks source-consuming workspaces using newer TypeScript / stricter project graphs.

- removes global `TODO` / `UNUSED` type aliases from `@livestore/utils/src/global.ts` and localizes the few real internal casts
- replaces Cloudflare worker ambient class redeclarations with local constructor aliases plus explicit `CfTypes` type aliases
- uses `document.body.appendChild(a)` for the browser download helper to avoid mixed DOM/worker `Body.append` ambiguity

## Rationale

Standalone TypeScript 6 experiments showed that global type aliases are the fragile part: aliases cannot declaration-merge, so two source copies of the side-effect global file produce duplicate identifier errors. Interfaces merge, but they would not preserve the old `any` bridge semantics. The least surprising fix is to stop exporting package-private TODO helpers into every consumer's global namespace and keep the casts local where they are needed.

For Cloudflare constructors, the previous `declare class Response extends CfDeclare.Response` pattern added ambient class declarations named like DOM globals. Local value aliases preserve runtime behavior while explicit `CfTypes.Response` / `CfTypes.Request` aliases keep the worker API type surface tied to Cloudflare's own types.

## Verification

- `PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile`
- `/home/schickling/.megarepo/github.com/schickling/dotfiles/refs/heads/schickling/2026-06-24-effect-lsp-refactor/node_modules/.bin/tsc --build packages/@livestore/utils/tsconfig.json packages/@livestore/common/tsconfig.json packages/@livestore/common-cf/tsconfig.json packages/@livestore/sqlite-wasm/tsconfig.json packages/@livestore/livestore/tsconfig.json packages/@livestore/sync-cf/tsconfig.json --pretty false`
- `CI=1 pnpm --filter @livestore/sync-cf test`
- `CI=1 pnpm --filter @livestore/utils test -- --run`
- `CI=1 pnpm --filter @livestore/livestore test -- --run`
- `CI=1 pnpm --filter @livestore/sqlite-wasm test -- --run`
- `oxlint --import-plugin --deny-warnings <touched files>`
- `git diff --check`

`oxfmt --check <touched files>` currently reports no target files because these paths are excluded by the repository formatter ignore configuration.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🟠 co1-amber |
| `agent_session_id` | 97b37895-a841-433b-8bc4-5f29481e229e |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.141.0 |
| `agent_runtime` | Codex CLI 0.141.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/xy5sp8sgw52wj95vq5v8pza7wnlsdnng-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/na6azhch1msd3dvks1k06yx5m0hqbwjw-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-06-26-ts6-ambient-types |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@9d3d02e |
</details>
<!-- agent-footer:end -->