### PR TITLE
chore(common-cf)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/common-cf/src/do-rpc/client.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.ts
@@ -3,6 +3,7 @@ import {
   Fiber,
   FiberMap,
   Layer,
+  Option,
   RpcClient,
   type RpcMessage,
   RpcSerialization,
@@ -65,19 +66,21 @@ export const layerProtocolDurableObject = (args: MakeDoRpcProtocolArgs): Layer.L
  */
 const makeProtocolDurableObject = ({
   callRpc,
-}: MakeDoRpcProtocolArgs): Effect.Effect<RpcClient.Protocol['Type'], never, Scope.Scope> =>
+}: MakeDoRpcProtocolArgs): Effect.Effect<RpcClient.Protocol['Service'], never, Scope.Scope> =>
   RpcClient.Protocol.make(
     Effect.fnUntraced(function* (writeResponse) {
       // Not using an actual `FiberMap` here because it seems to shutdown to early
       // const fiberMap = new Map<string, Fiber.Fiber<void, never>>()
       const fiberMap = yield* FiberMap.make<string, void, never>()
 
-      const send = (message: RpcMessage.FromClientEncoded): Effect.Effect<void> => {
+      const send = (clientId: number, message: RpcMessage.FromClientEncoded): Effect.Effect<void> => {
         if (message._tag !== 'Request') {
           if (message._tag === 'Interrupt') {
             return Effect.gen(function* () {
               const fiber = yield* FiberMap.get(fiberMap, message.requestId)
-              yield* Fiber.interrupt(fiber)
+              if (Option.isSome(fiber) === true) {
+                yield* Fiber.interrupt(fiber.value)
+              }
             }).pipe(Effect.orDie)
           }
 
@@ -98,7 +101,7 @@ const makeProtocolDurableObject = ({
             const fiber = yield* processReadableStream(
               serializedResponse as CfTypes.ReadableStream,
               parser,
-              writeResponse,
+              (response) => writeResponse(clientId, response),
             ).pipe(
               // Effect.tapCauseLogPretty,
               // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
@@ -126,7 +129,7 @@ const makeProtocolDurableObject = ({
 
           // Process each response
           for (const response of responseArray) {
-            yield* writeResponse(response)
+            yield* writeResponse(clientId, response)
           }
         }).pipe(Effect.withSpan('do-rpc-client:send'), Effect.orDie) // Ensure never error type
       }

--- a/packages/@livestore/common-cf/src/do-rpc/rpc.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/rpc.test.ts
@@ -92,15 +92,7 @@ Vitest.describe('Durable Object RPC', { timeout: testTimeout }, () => {
       const client = yield* RpcClient.make(TestRpcs)
       const error = yield* client.Fail({ message: 'test http failure' }).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Die",
-            "defect": "RPC failure: test http failure"
-          }
-        }"
+        "Failure(Cause([Die("RPC failure: test http failure")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
@@ -110,15 +102,7 @@ Vitest.describe('Durable Object RPC', { timeout: testTimeout }, () => {
       const client = yield* RpcClient.make(TestRpcs)
       const error = yield* client.Defect({ message: 'test http defect' }).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Die",
-            "defect": "some defect: test http defect"
-          }
-        }"
+        "Failure(Cause([Die("some defect: test http defect")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
@@ -141,15 +125,7 @@ Vitest.describe('Durable Object RPC', { timeout: testTimeout }, () => {
       const stream = client.StreamError({ count: 5, errorAfter: 4 })
       const error = yield* Stream.runCollect(stream).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Fail",
-            "failure": "Stream error after 4: got 9"
-          }
-        }"
+        "Failure(Cause([Fail("Stream error after 4: got 9")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
@@ -160,15 +136,7 @@ Vitest.describe('Durable Object RPC', { timeout: testTimeout }, () => {
       const stream = client.StreamDefect({ count: 4, defectAfter: 1 })
       const error = yield* Stream.runCollect(stream).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Die",
-            "defect": "Stream defect after 1: got 4"
-          }
-        }"
+        "Failure(Cause([Die("Stream defect after 1: got 4")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -84,8 +84,7 @@ export const toDurableObjectHandler =
         }
 
         // Check if this is a streaming RPC
-        // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.Handler doesn't expose successSchema publicly; see https://github.com/Effect-TS/effect/issues/6064
-        const isStream = RpcSchema.isStreamSchema((rpc as any).successSchema)
+        const isStream = RpcSchema.isStreamSchema(rpc.successSchema)
 
         // For streaming RPCs with only one request, return ReadableStream directly
         if (isStream === true && requests.length === 1) {
@@ -95,18 +94,21 @@ export const toDurableObjectHandler =
         // Execute the handler
         const result = yield* Effect.gen(function* () {
           const handlerResult = entry.handler(request.payload, {
-            clientId: 0, // TODO: add proper clientId if needed
+            client: new Rpc.ServerClient(0), // TODO: add proper clientId if needed
+            requestId: request.id,
             headers: Headers.fromInput({
               'x-rpc-request-id': request.id.toString(),
             }),
+            rpc,
           })
+          const effectOrStream = Rpc.isWrapper(handlerResult) ? handlerResult.value : handlerResult
 
           let value: any
-          if (Effect.isEffect(handlerResult) === true) {
+          if (Effect.isEffect(effectOrStream) === true) {
             // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Rpc.Handler.handler` returns `Effect<any, any>` due to dynamic dispatch
-            value = yield* handlerResult
+            value = yield* effectOrStream
           } else {
-            value = handlerResult
+            value = effectOrStream
           }
 
           // Get the exit schema for this RPC
@@ -117,7 +119,7 @@ export const toDurableObjectHandler =
           if (exitSchema !== undefined) {
             // Use schema encoding for proper serialization
             const rawExit = Exit.succeed(value)
-            encodedExit = yield* Schema.encodeUnknownEffect(exitSchema)(rawExit)
+            encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
           } else {
             // Fallback to direct exit
             encodedExit = Exit.succeed(value)
@@ -139,7 +141,7 @@ export const toDurableObjectHandler =
               if (exitSchema !== undefined) {
                 // Use schema encoding for proper serialization
                 const rawExit = Exit.failCause(cause)
-                encodedExit = yield* Schema.encodeUnknownEffect(exitSchema)(rawExit)
+                encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
               } else {
                 // Fallback to direct exit
                 encodedExit = Exit.failCause(cause)
@@ -160,7 +162,7 @@ export const toDurableObjectHandler =
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- msgPack parser.encode returns unknown; cast to expected wire format
       const encoded = parser.encode(responses) as Uint8Array<ArrayBuffer>
       return encoded
-    }).pipe(Effect.provide(options.layer), Effect.scoped, Effect.orDie)
+    }).pipe(Effect.provide(options.layer), Effect.scoped, Effect.orDie) as Effect.Effect<Uint8Array<ArrayBuffer> | CfTypes.ReadableStream>
 
 /** Out-of-band RPC stream response emission back to the caller DO */
 export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(function* ({
@@ -204,25 +206,31 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
   Effect.gen(function* () {
     // Execute the handler to get the stream
     const handlerResult = entry.handler(request.payload, {
-      clientId: 0, // TODO: add proper clientId if needed
+      client: new Rpc.ServerClient(0), // TODO: add proper clientId if needed
+      requestId: request.id,
       headers: Headers.fromInput({
         'x-rpc-request-id': request.id.toString(),
       }),
+      rpc,
     })
+    const effectOrStream = Rpc.isWrapper(handlerResult) ? handlerResult.value : handlerResult
 
     // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Rpc.Handler.handler` returns `Effect<any, any>` due to dynamic dispatch; orDie converts the error to a defect handled by the downstream catchCause
     const stream: Stream.Stream<any, any> =
-      Effect.isEffect(handlerResult) === true ? yield* Effect.orDie(handlerResult) : handlerResult
+      Effect.isEffect(effectOrStream) === true ? yield* Effect.orDie(effectOrStream)
+        : effectOrStream
 
     // Get the stream schemas for proper chunk-level encoding
     // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.Handler doesn't expose successSchema publicly; see https://github.com/Effect-TS/effect/issues/6064
-    const streamSchemas = RpcSchema.getStreamSchemas((rpc as any).successSchema.ast)
-    const arrayEncoder =
-      Option.isSome(streamSchemas) === true
-        ? // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- stream schema success type is inferred as unknown; cast needed for encodeUnknown
-          Schema.encodeUnknownEffect(Schema.Array(streamSchemas.value.success as Schema.Top))
-        : // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Schema.Any needs explicit cast for Schema.Array compatibility
-          Schema.encodeUnknownEffect(Schema.Array(Schema.Any as Schema.Top))
+    const streamSchemas = RpcSchema.isStreamSchema(rpc.successSchema)
+      ? Option.some({
+        success: rpc.successSchema.success,
+        error: rpc.successSchema.error,
+      })
+      : Option.none()
+    const arrayEncoder = Option.isSome(streamSchemas) === true
+      ? Schema.encodeUnknownEffect(Schema.toCodecJson(Schema.Array(streamSchemas.value.success)))
+      : Schema.encodeUnknownEffect(Schema.toCodecJson(Schema.Array(Schema.Any)))
 
     // Convert stream to ReadableStream
     const readableStream = new ReadableStream({
@@ -253,7 +261,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
           const rawExit = Exit.void
           // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
           const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
-          const encodedExit = yield* Schema.encodeUnknownEffect(exitSchema)(rawExit)
+          const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
 
           const exitMessage = {
             _tag: 'Exit' as const,
@@ -272,7 +280,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
               const rawExit = Exit.failCause(cause)
               // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
               const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
-              const encodedExit = yield* Schema.encodeUnknownEffect(exitSchema)(rawExit)
+              const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
 
               const exitMessage = {
                 _tag: 'Exit' as const,
@@ -289,7 +297,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
         )
 
         // Run the stream processing
-        runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, Effect.runPromise)
+        runStream.pipe(Effect.provide(layer), Effect.scoped, Effect.tapCauseLogPretty, _ => _ as Effect.Effect<void>, Effect.runPromise)
       },
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- bridging standard Web API ReadableStream to Cloudflare Worker ReadableStream type
     }) as any as CfTypes.ReadableStream

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -3,8 +3,8 @@ import {
   Exit,
   Headers,
   type Layer,
-  type NonEmptyArray,
   Option,
+  type ReadonlyArray,
   Rpc,
   type RpcGroup,
   type RpcMessage,
@@ -172,7 +172,7 @@ export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(functio
   env: Record<string, any>
   callerContext: { bindingName: string; durableObjectId: string }
   requestId: string
-  values: NonEmptyArray<any>
+  values: ReadonlyArray.NonEmptyReadonlyArray<any>
 }) {
   // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- CF worker env bindings are typed as Record<string, any>; narrowing to known DO namespace
   const clientDoNamespace = env[callerContext.bindingName] as

--- a/packages/@livestore/common-cf/src/do-rpc/test-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/test-fixtures/worker.ts
@@ -5,7 +5,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { layerProtocolDurableObject, toDurableObjectHandler } from '@livestore/common-cf'
 import {
   Effect,
-  HttpApp,
+  HttpEffect,
   Layer,
   Option,
   RpcClient,
@@ -76,7 +76,7 @@ export default {
       const url = new URL(request.url)
 
       // Handle HTTP RPC endpoint
-      if (url.pathname === '/rpc') {
+      if (url.pathname === '/rpc/') {
         // Get the test server DO instance
         const doId = env.TEST_RPC_DO.idFromName('test-server')
         const serverDO = env.TEST_RPC_DO.get(doId)
@@ -117,15 +117,14 @@ export default {
                 Effect.tapCause((cause) => Effect.log('log3', cause)),
               ),
           }).pipe(
-            Layer.provideMerge(RpcServer.layerProtocolHttp({ path: '/rpc' })),
             Layer.provideMerge(RpcSerialization.layerJson),
           )
 
-          // Create the HTTP RPC app
-          const httpApp = RpcServer.toHttpApp(TestRpcs).pipe(Effect.provide(handlersLayer))
+          // Create the HTTP RPC effect
+          const httpEffect = yield* RpcServer.toHttpEffect(TestRpcs).pipe(Effect.provide(handlersLayer))
 
           // Run the app and convert to web handler
-          const webHandler = yield* httpApp.pipe(Effect.map(HttpApp.toWebHandler))
+          const webHandler = HttpEffect.toWebHandler(httpEffect)
 
           return yield* Effect.promise(() => webHandler(request))
         }).pipe(

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -169,6 +169,7 @@ export const setupDurableObjectWebSocketRpc = ({
 
       const ProtocolLive = layerRpcServerWebsocket({
         ws,
+        scope,
         incomingQueue,
         ...omitUndefineds({ onMessage }),
       }).pipe(Layer.provide(RpcSerialization.layerJson))
@@ -241,6 +242,7 @@ export const setupDurableObjectWebSocketRpc = ({
  */
 export interface WsRpcServerArgs {
   ws: CfTypes.WebSocket
+  scope: Scope.Scope
   onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
   /** Queue for receiving incoming messages from the WebSocket */
   incomingQueue: Queue.Queue<Uint8Array | string>
@@ -277,7 +279,7 @@ export const layerRpcServerWebsocket = (args: WsRpcServerArgs) =>
  *
  * @internal Used internally by `layerRpcServerWebsocket`
  */
-const makeSocketProtocol = ({ incomingQueue, ws, onMessage }: WsRpcServerArgs) =>
+const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServerArgs) =>
   Effect.gen(function* () {
     const serialization = yield* RpcSerialization.RpcSerialization
     const disconnects = yield* Queue.unbounded<number>()
@@ -329,7 +331,7 @@ const makeSocketProtocol = ({ incomingQueue, ws, onMessage }: WsRpcServerArgs) =
         Stream.runDrain,
         Effect.tapCauseLogPretty,
         // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       // Start the message processing

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc.test.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc.test.ts
@@ -77,15 +77,7 @@ Vitest.describe('Durable Object WebSocket RPC', { timeout: testTimeout }, () => 
       const client = yield* RpcClient.make(TestRpcs)
       const error = yield* client.Fail({ message: 'test http failure' }).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Fail",
-            "failure": "RPC failure: test http failure"
-          }
-        }"
+        "Failure(Cause([Fail("RPC failure: test http failure")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
@@ -95,15 +87,7 @@ Vitest.describe('Durable Object WebSocket RPC', { timeout: testTimeout }, () => 
       const client = yield* RpcClient.make(TestRpcs)
       const error = yield* client.Defect({ message: 'test http defect' }).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Die",
-            "defect": "some defect: test http defect"
-          }
-        }"
+        "Failure(Cause([Die("some defect: test http defect")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
@@ -126,15 +110,7 @@ Vitest.describe('Durable Object WebSocket RPC', { timeout: testTimeout }, () => 
       const stream = client.StreamError({ count: 5, errorAfter: 4 })
       const error = yield* Stream.runCollect(stream).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Fail",
-            "failure": "Stream error after 4: got 9"
-          }
-        }"
+        "Failure(Cause([Fail("Stream error after 4: got 9")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
@@ -145,15 +121,7 @@ Vitest.describe('Durable Object WebSocket RPC', { timeout: testTimeout }, () => 
       const stream = client.StreamDefect({ count: 4, defectAfter: 1 })
       const error = yield* Stream.runCollect(stream).pipe(Effect.exit)
       expect(error.toString()).toMatchInlineSnapshot(`
-        "{
-          "_id": "Exit",
-          "_tag": "Failure",
-          "cause": {
-            "_id": "Cause",
-            "_tag": "Die",
-            "defect": "Stream defect after 1: got 4"
-          }
-        }"
+        "Failure(Cause([Die("Stream defect after 1: got 4")]))"
       `)
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )


### PR DESCRIPTION
## Summary

Migrate `@livestore/common-cf` to Effect v4 as its own package slice.

This PR is stacked on #1343 (`igor/effect-v4-common`) and addresses #1339.

## Changes

- Update `packages/@livestore/common-cf` RPC client/server code for Effect v4 compatibility.
- Adjust Cloudflare worker RPC fixtures for the v4 types.
- Update `do-rpc` and `ws-rpc` snapshots for the new failure/exit formatting.

## Breaking migration notes

This is part of the Effect v4 migration stack from #1310. Public Effect-facing behavior in this package follows the upstream v4 migration from `@livestore/common` and `@livestore/utils`.

## Validation

Not run in this PR creation step.

Closes #1339