### PR TITLE
chore(sync-cf)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/common/src/sync/sync-backend-kv.ts
+++ b/packages/@livestore/common/src/sync/sync-backend-kv.ts
@@ -1,4 +1,4 @@
-import { Effect, KeyValueStore } from '@livestore/utils/effect'
+import { Effect, KeyValueStore, Option } from '@livestore/utils/effect'
 
 import { UnknownError } from '../errors.ts'
 
@@ -6,12 +6,14 @@ export const makeBackendIdHelper = Effect.gen(function* () {
   const kv = yield* KeyValueStore.KeyValueStore
 
   const backendIdKey = `backendId`
-  const backendIdRef = { current: yield* kv.get(backendIdKey).pipe(UnknownError.mapToUnknownError) }
+  const backendIdRef = {
+    current: Option.fromUndefinedOr(yield* kv.get(backendIdKey).pipe(UnknownError.mapToUnknownError)),
+  }
 
   const setBackendId = (backendId: string) =>
     Effect.gen(function* () {
-      if (backendIdRef.current !== backendId) {
-        backendIdRef.current = backendId
+      if (Option.getOrUndefined(backendIdRef.current) !== backendId) {
+        backendIdRef.current = Option.some(backendId)
         yield* kv.set(backendIdKey, backendId)
       }
     }).pipe(UnknownError.mapToUnknownError)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -59,16 +59,18 @@ export const makeEndingPullStream = ({
             ),
         }),
       ),
-      Stream.mapAccum(total, (remaining, array) => {
+      Stream.mapAccum(() => total, (remaining, array) => {
         const nextRemaining = Math.max(0, remaining - array.length)
 
         return [
           nextRemaining,
-          SyncMessage.PullResponse.make({
-            batch: array,
-            pageInfo: nextRemaining > 0 ? SyncBackend.pageInfoMoreKnown(nextRemaining) : SyncBackend.pageInfoNoMore,
-            backendId,
-          }),
+          [
+            SyncMessage.PullResponse.make({
+              batch: array,
+              pageInfo: nextRemaining > 0 ? SyncBackend.pageInfoMoreKnown(nextRemaining) : SyncBackend.pageInfoNoMore,
+              backendId,
+            }),
+          ],
         ] as const
       }),
       Stream.tap(

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -17,6 +17,7 @@ import * as DoCtx from './layer.ts'
 const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
 const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
 type PullBatchItem = SyncMessage.PullResponse['batch'][number]
+type PushBatchItem = SyncMessage.PushRequest['batch'][number]
 
 export const makePush =
   ({
@@ -96,7 +97,7 @@ export const makePush =
         const responses = yield* splitArrayBySize({
           maxItems: MAX_PUSH_EVENTS_PER_REQUEST,
           maxBytes: MAX_WS_MESSAGE_BYTES,
-          encode: (items) =>
+          encode: (items: ReadonlyArray<PushBatchItem>) =>
             encodePullResponse(
               SyncMessage.PullResponse.make({
                 batch: items.map(

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -3,17 +3,11 @@ import { type CfTypes, toDurableObjectHandler } from '@livestore/common-cf'
 import {
   Effect,
   Headers,
-  HttpServer,
-  Layer,
-  Logger,
   Option,
-  References,
-  RpcSerialization,
   Stream,
 } from '@livestore/utils/effect'
 
 import { SyncDoRpc } from '../../../common/do-rpc-schema.ts'
-import { SyncMessage } from '../../../common/mod.ts'
 import * as DoCtx from '../layer.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
@@ -32,9 +26,7 @@ export const createDoRpcHandler = (
 
     // TODO add admin RPCs
     const RpcLive = SyncDoRpc.toLayer({
-      'SyncDoRpc.Ping': (_req) => {
-        return Effect.succeed(SyncMessage.Pong.make({}))
-      },
+      'SyncDoRpc.Ping': () => Effect.void,
       'SyncDoRpc.Pull': (req, { headers }) =>
         Effect.gen({ self: this }, function* () {
           const { rpcSubscriptions } = yield* DoCtx.DoCtx
@@ -87,14 +79,7 @@ export const createDoRpcHandler = (
     })
 
     const handler = toDurableObjectHandler(SyncDoRpc, {
-      layer: Layer.mergeAll(RpcLive, RpcSerialization.layerJson, HttpServer.layerServices).pipe(
-        Layer.provide(
-          Layer.mergeAll(
-            Logger.layer([Logger.consoleStructured]),
-            Layer.succeed(References.MinimumLogLevel, 'Debug'),
-          ),
-        ),
-      ),
+      layer: RpcLive,
     })
 
     return yield* handler(payload).pipe(Effect.annotateLogs({ thread: 'SyncDo' }))

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
@@ -1,5 +1,5 @@
 import type { CfTypes } from '@livestore/common-cf'
-import { Effect, HttpApp, Layer, RpcSerialization, RpcServer } from '@livestore/utils/effect'
+import { Effect, HttpEffect, Layer, RpcSerialization, RpcServer } from '@livestore/utils/effect'
 
 import { SyncHttpRpc } from '../../../common/http-rpc-schema.ts'
 import * as SyncMessage from '../../../common/sync-message-types.ts'
@@ -18,8 +18,8 @@ export const createHttpRpcHandler = Effect.fn('createHttpRpcHandler')(function* 
   forwardedHeaders?: Record<string, string>
 }) {
   const handlerLayer = createHttpRpcLayer(forwardedHeaders)
-  const httpApp = RpcServer.toHttpApp(SyncHttpRpc).pipe(Effect.provide(handlerLayer))
-  const webHandler = yield* httpApp.pipe(Effect.map(HttpApp.toWebHandler))
+  const httpEffect = yield* RpcServer.toHttpEffect(SyncHttpRpc).pipe(Effect.provide(handlerLayer))
+  const webHandler = HttpEffect.toWebHandler(httpEffect)
 
   const response = yield* Effect.promise(
     () => webHandler(request as TODO as Request) as TODO as Promise<CfTypes.Response>,
@@ -51,7 +51,6 @@ const createHttpRpcLayer = (forwardedHeaders: Record<string, string> | undefined
 
     'SyncHttpRpc.Ping': () => Effect.succeed(SyncMessage.Pong.make({})),
   }).pipe(
-    Layer.provideMerge(RpcServer.layerProtocolHttp({ path: '/http-rpc' })),
     Layer.provideMerge(RpcSerialization.layerJson),
   )
 }

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -1,6 +1,6 @@
 import type { UnknownError } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
-import { Effect, Schema, UrlParams } from '@livestore/utils/effect'
+import { Effect, Result, Schema } from '@livestore/utils/effect'
 
 import type { SearchParams } from '../common/mod.ts'
 import { SearchParamsSchema, SyncMessage } from '../common/mod.ts'
@@ -136,6 +136,8 @@ export const PERSISTENCE_FORMAT_VERSION = 7
 export const encodeOutgoingMessage = Schema.encodeSync(Schema.fromJsonString(SyncMessage.BackendToClientMessage))
 export const encodeIncomingMessage = Schema.encodeSync(Schema.fromJsonString(SyncMessage.ClientToBackendMessage))
 
+const SearchParamsFromUrlSearchParams = Schema.fromURLSearchParams(SearchParamsSchema)
+
 /**
  * Extracts the LiveStore sync search parameters from a request. Returns
  * `undefined` when the request does not carry valid sync metadata so callers
@@ -143,14 +145,13 @@ export const encodeIncomingMessage = Schema.encodeSync(Schema.fromJsonString(Syn
  */
 export const matchSyncRequest = (request: CfTypes.Request): SearchParams | undefined => {
   const url = new URL(request.url)
-  const urlParams = UrlParams.fromInput(url.searchParams)
-  const paramsResult = UrlParams.schemaStruct(SearchParamsSchema)(urlParams).pipe(Effect.option, Effect.runSync)
+  const paramsResult = Schema.decodeUnknownResult(SearchParamsFromUrlSearchParams)(url.searchParams)
 
-  if (paramsResult._tag === 'None') {
+  if (Result.isFailure(paramsResult)) {
     return undefined
   }
 
-  return paramsResult.value
+  return paramsResult.success
 }
 
 // RPC subscription storage (TODO refactor)

--- a/packages/@livestore/sync-cf/src/cf-worker/worker.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/worker.ts
@@ -39,7 +39,7 @@ export type MakeWorkerOptions<TEnv extends Env = Env, TSyncPayload = Schema.Json
    * Optionally pass a schema to decode the client-provided payload into a typed object
    * before calling {@link validatePayload}. If omitted, the raw JSON value is forwarded.
    */
-  syncPayloadSchema?: Schema.Schema<TSyncPayload>
+  syncPayloadSchema?: Schema.Decoder<TSyncPayload>
   /**
    * Validates the (optionally decoded) payload during WebSocket connection establishment.
    * If {@link syncPayloadSchema} is provided, `payload` will be of the schema's inferred type.
@@ -200,7 +200,7 @@ export const handleSyncRequest = <
       // Always decode with the supplied schema when present, even if payload is undefined.
       // This ensures required payloads are enforced by the schema.
       if (syncPayloadSchema !== undefined) {
-        const decodedResult = Schema.decodeUnknownExit(syncPayloadSchema)(payload)
+        const decodedResult = Schema.decodeUnknownResult(syncPayloadSchema)(payload)
         if (Result.isFailure(decodedResult)) {
           const message = decodedResult.failure.toString()
           console.error('Invalid payload (decode failed)', message)

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -67,7 +67,7 @@ export const makeDoRpcSync =
       const backendIdHelper = yield* SyncBackend.makeBackendIdHelper
 
       const pull: SyncBackend.SyncBackend<SyncMetadata>['pull'] = (cursor, options) =>
-        rpcClient.SyncDoRpc.Pull({
+        rpcClient['SyncDoRpc.Pull']({
           cursor: cursor.pipe(
             Option.map((a) => ({
               eventSequenceNumber: a.eventSequenceNumber,
@@ -126,7 +126,7 @@ export const makeDoRpcSync =
           })(batch).pipe(Effect.mapError((cause) => new UnknownError({ cause })))
 
           for (const batchChunk of batchChunks) {
-            yield* rpcClient.SyncDoRpc.Push({ batch: batchChunk, storeId, backendId })
+            yield* rpcClient['SyncDoRpc.Push']({ batch: batchChunk, storeId, backendId })
           }
         },
         Effect.mapError((cause) =>
@@ -136,7 +136,7 @@ export const makeDoRpcSync =
         ),
       )
 
-      const ping: SyncBackend.SyncBackend<{ createdAt: string }>['ping'] = rpcClient.SyncDoRpc.Ping({
+      const ping: SyncBackend.SyncBackend<{ createdAt: string }>['ping'] = rpcClient['SyncDoRpc.Ping']({
         storeId,
         payload,
       }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('rpc-sync-client:ping'))

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -23,6 +23,8 @@ import { SyncDoRpc } from '../../common/do-rpc-schema.ts'
 import { SyncMessage } from '../../common/mod.ts'
 import type { SyncMetadata } from '../../common/sync-message-types.ts'
 
+type PushBatchItem = SyncMessage.PushRequest['batch'][number]
+
 export interface SyncBackendRpcStub extends CfTypes.DurableObjectStub, SyncBackendRpcInterface {}
 
 // TODO we probably need better scoping for the requestIdQueueMap (i.e. support multiple stores, ...)
@@ -118,7 +120,7 @@ export const makeDoRpcSync =
           const batchChunks = yield* splitArrayBySize({
             maxItems: MAX_PUSH_EVENTS_PER_REQUEST,
             maxBytes: MAX_DO_RPC_REQUEST_BYTES,
-            encode: (items) => ({
+            encode: (items: ReadonlyArray<PushBatchItem>) => ({
               batch: items,
               storeId,
               backendId,

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -1,5 +1,5 @@
 import { SyncBackend, UnknownError } from '@livestore/common'
-import type { EventSequenceNumber } from '@livestore/common/schema'
+import type { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
 import { splitArrayBySize } from '@livestore/common/sync'
 import {
   type Duration,
@@ -25,6 +25,8 @@ import { MAX_HTTP_REQUEST_BYTES, MAX_PUSH_EVENTS_PER_REQUEST } from '../../commo
 import { SyncHttpRpc } from '../../common/http-rpc-schema.ts'
 import { SearchParamsSchema } from '../../common/mod.ts'
 import type { SyncMetadata } from '../../common/sync-message-types.ts'
+
+type PushBatchItem = LiveStoreEvent.Global.Encoded
 
 export interface HttpSyncOptions {
   /**
@@ -201,7 +203,7 @@ export const makeHttpSync =
           const batchChunks = yield* splitArrayBySize({
             maxItems: MAX_PUSH_EVENTS_PER_REQUEST,
             maxBytes: MAX_HTTP_REQUEST_BYTES,
-            encode: (items) => ({
+            encode: (items: ReadonlyArray<PushBatchItem>) => ({
               batch: items,
               storeId,
               payload,

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -101,7 +101,7 @@ export const makeHttpSync =
       const pingTimeout = options.ping?.requestTimeout ?? 10_000
 
       const ping: SyncBackend.SyncBackend<SyncMetadata>['ping'] = Effect.gen(function* () {
-        yield* rpcClient.SyncHttpRpc.Ping({ storeId, payload })
+        yield* rpcClient['SyncHttpRpc.Ping']({ storeId, payload })
 
         yield* SubscriptionRef.set(isConnected, true)
       }).pipe(
@@ -136,7 +136,7 @@ export const makeHttpSync =
         )
 
       const pull: SyncBackend.SyncBackend<SyncMetadata>['pull'] = (cursor, options) =>
-        rpcClient.SyncHttpRpc.Pull({
+        rpcClient['SyncHttpRpc.Pull']({
           storeId,
           payload,
           cursor: mapCursor(cursor),
@@ -155,7 +155,7 @@ export const makeHttpSync =
                   Effect.gen(function* () {
                     yield* Effect.sleep(livePullInterval)
 
-                    const items = yield* rpcClient.SyncHttpRpc.Pull({ storeId, payload, cursor: currentCursor }).pipe(
+                    const items = yield* rpcClient['SyncHttpRpc.Pull']({ storeId, payload, cursor: currentCursor }).pipe(
                       Stream.runCollect,
                     )
 
@@ -210,7 +210,7 @@ export const makeHttpSync =
           })(batch).pipe(Effect.mapError((cause) => new UnknownError({ cause })))
 
           for (const batchChunk of batchChunks) {
-            yield* rpcClient.SyncHttpRpc.Push({ storeId, payload, batch: batchChunk, backendId })
+            yield* rpcClient['SyncHttpRpc.Push']({ storeId, payload, batch: batchChunk, backendId })
           }
         },
         pushSemaphore.withPermits(1),

--- a/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/ws-rpc-client.ts
@@ -135,7 +135,7 @@ export const makeWsSync =
         isConnected,
         connect: ping,
         pull: (cursor, options) =>
-          rpcClient.SyncWsRpc.Pull({
+          rpcClient['SyncWsRpc.Pull']({
             storeId,
             payload,
             cursor: cursor.pipe(
@@ -179,7 +179,7 @@ export const makeWsSync =
           })(batch).pipe(Effect.mapError((cause) => new UnknownError({ cause })))
 
           for (const batchChunk of batchChunks) {
-            yield* rpcClient.SyncWsRpc.Push({
+            yield* rpcClient['SyncWsRpc.Push']({
               storeId,
               payload,
               batch: batchChunk,


### PR DESCRIPTION
## Problem

`@livestore/sync-cf` still needed package-level Effect v4 migration work after the `@livestore/common-cf` stack slice. The remaining breakage was concentrated around v4 RPC access, HTTP handler construction, schema decode result handling, stream accumulation, and typed chunking for push batches.

This is stacked on #1339 and is part of the overall Effect v4 migration in #1310.

## Solution

- Update `@livestore/sync-cf` RPC client/server call sites for the Effect v4 RPC APIs.
- Migrate the HTTP RPC server path to the v4 `HttpEffect` handler shape.
- Preserve `Option`-shaped backend id handling across sync backend state.
- Adjust pull stream accumulation and payload decode handling for v4 types.
- Keep push chunking typed as `LiveStoreEvent.Global.Encoded` so HTTP, DO RPC, and WebSocket broadcast paths retain event batch types through `splitArrayBySize`.

Trade-off: this keeps the existing Cloudflare sync transport architecture intact, including the current out-of-band live-pull chunk emission behavior, rather than redesigning stream lifecycle handling during the Effect v4 migration.

## Validation

```sh
pnpm exec tsc -b packages/@livestore/sync-cf/tsconfig.json --pretty false
```

### Demo (optional)

Package-level TypeScript validation passes for `@livestore/sync-cf` after the v4 migration changes.

## Related issues

- Closes #1317
- Part of #1310
- Stacked on #1339