### PR TITLE
fix(docs): render external example screenshots without build-time fetch

### DIFF
--- a/docs/src/content/docs/examples/cloudflare-adapter.mdx
+++ b/docs/src/content/docs/examples/cloudflare-adapter.mdx
@@ -4,7 +4,6 @@ description: LiveStore examples built with the Cloudflare adapter for edge compu
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
-import { Image } from 'astro:assets';
 import { contribExamplesUrl, cloudflareExamples, getExampleDemoLinks } from '../../../data/examples.ts';
 
 # Cloudflare Durable Objects Examples
@@ -18,7 +17,7 @@ Examples using `@livestore/adapter-cloudflare` for Cloudflare Workers and Durabl
   return (
     <Card title={example.title} key={example.title}>
     {example.image ? (
-      <Image src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} />
+      <img src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} loading="lazy" decoding="async" />
     ) : (
       <div style="background: linear-gradient(135deg, #1f2937 0%, #374151 100%); height: 200px; display: flex; align-items: center; justify-content: center; color: #9ca3af; font-size: 14px; border-radius: 8px;">
         Screenshot coming soon

--- a/docs/src/content/docs/examples/expo-adapter.mdx
+++ b/docs/src/content/docs/examples/expo-adapter.mdx
@@ -4,7 +4,6 @@ description: LiveStore examples built with the Expo adapter for React Native mob
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
-import { Image } from 'astro:assets';
 import { contribExamplesUrl, expoExamples, getExampleDemoLinks } from '../../../data/examples.ts';
 
 # Expo Adapter Examples
@@ -18,7 +17,7 @@ Examples using `@livestore/adapter-expo` for React Native mobile applications.
   return (
     <Card title={example.title} key={example.title}>
     {example.image ? (
-      <Image src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} />
+      <img src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} loading="lazy" decoding="async" />
     ) : (
       <div style="background: linear-gradient(135deg, #1f2937 0%, #374151 100%); height: 200px; display: flex; align-items: center; justify-content: center; color: #9ca3af; font-size: 14px; border-radius: 8px;">
         Screenshot coming soon

--- a/docs/src/content/docs/examples/node-adapter.mdx
+++ b/docs/src/content/docs/examples/node-adapter.mdx
@@ -4,7 +4,6 @@ description: LiveStore examples built with the Node adapter for server-side envi
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
-import { Image } from 'astro:assets';
 import { contribExamplesUrl, nodeExamples, getExampleDemoLinks } from '../../../data/examples.ts';
 
 # Node Adapter Examples
@@ -18,7 +17,7 @@ Examples using `@livestore/adapter-node` for Node.js server-side applications.
   return (
     <Card title={example.title} key={example.title}>
     {example.image ? (
-      <Image src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} />
+      <img src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} loading="lazy" decoding="async" />
     ) : (
       <div style="background: linear-gradient(135deg, #1f2937 0%, #374151 100%); height: 200px; display: flex; align-items: center; justify-content: center; color: #9ca3af; font-size: 14px; border-radius: 8px;">
         Screenshot coming soon

--- a/docs/src/content/docs/examples/web-adapter.mdx
+++ b/docs/src/content/docs/examples/web-adapter.mdx
@@ -4,7 +4,6 @@ description: LiveStore examples built with the Web adapter for browser environme
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
-import { Image } from 'astro:assets';
 import { contribExamplesUrl, webExamples, getExampleDemoLinks } from '../../../data/examples.ts';
 
 # Web Adapter Examples
@@ -18,7 +17,7 @@ Examples using `@livestore/adapter-web` for browser environments.
   return (
     <Card title={example.title} key={example.title}>
     {example.image ? (
-      <Image src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} />
+      <img src={example.image.url} width={example.image.width} height={example.image.height} alt={`${example.title} application interface`} loading="lazy" decoding="async" />
     ) : (
       <div style="background: linear-gradient(135deg, #1f2937 0%, #374151 100%); height: 200px; display: flex; align-items: center; justify-content: center; color: #9ca3af; font-size: 14px; border-radius: 8px;">
         Screenshot coming soon


### PR DESCRIPTION
## Problem

The production docs deploy (`deploy-prod.yml -f target=docs`) fails during the Astro build with:

```
Error generating image for https://gitbucket.schickling.dev/api/get/…png: TypeError: fetch failed
  at astro/dist/core/build/generate.js:195:21
```

This is **why `docs.livestore.dev/misc/sponsoring` is still 502 in production** even though #1329 (the Astro 6 / SSR fix) is merged: the merge never deployed (the `publish-release` job only runs on stable releases), and the manual `deploy-prod.yml` build can't complete.

## Root cause

The examples gallery renders 6 external screenshots (hosted on `gitbucket.schickling.dev`) via Astro's `<Image>` from `astro:assets`. With `imageCDN: false` (set in #1329 to fix the `/_image` 500), Astro 6 optimizes **remote images at build time** — fetching each one — and **hard-fails the entire build if any single remote fetch fails**. On the GitHub-hosted prod runner, one screenshot's fetch fails repeatably, aborting the whole deploy. (The earlier draft-deploy proof succeeded only because it ran locally, where the host reliably reaches gitbucket.)

## Fix

Render these external gallery screenshots with a plain `<img>` instead of `<Image>`, across the 4 example adapter pages. The browser loads them at view time, so the **build no longer depends on reaching an external host**. `width`/`height` are kept (no layout shift) and `loading="lazy" decoding="async"` preserve the prior lazy behavior. Local image optimization is unaffected.

## Verification

- Production-mode `astro build` succeeds; built HTML emits the **raw** `<img src="https://gitbucket.schickling.dev/…png">` (no `/_astro` rewrite, no `/_image`) — proving the build no longer fetches external images.
- `devenv tasks run check:all` passed.

After this merges, a `deploy-prod.yml -f target=docs` run will ship the #1329 fix to production and resolve the `/misc/sponsoring` 502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🫑 cl1-sorrel |
| `agent_session_id` | c5481079-88d4-4406-b2bf-d31ff5588e67 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.165 |
| `agent_runtime` | Claude Code 2.1.165 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/ffppqrb9xkq0jamayzc05dwlm86yi5yk-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/f4bp1wnsfzypdxckkp0vyqcgw5xq4yp1-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-06-27-docs-example-img-no-build-fetch |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b39be89 |
</details>
<!-- agent-footer:end -->