### PR TITLE
chore(adapter-web)!: migrate worker RPCs to Effect v4

### DIFF
--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -25,12 +25,11 @@ import {
   type Scope,
   Effect,
   FetchHttpClient,
-  Fiber,
   Layer,
   Queue,
+  RpcClient,
   type Schema,
   SubscriptionRef,
-  Worker,
 } from '@livestore/utils/effect'
 import { BrowserWorker } from '@livestore/utils/effect/browser'
 import { nanoid } from '@livestore/utils/nanoid'
@@ -39,8 +38,14 @@ import * as WebmeshWorker from '@livestore/webmesh/worker'
 
 import { connectWebmeshNodeClientSession } from '../web-worker/client-session/client-session-devtools.ts'
 import { loadSqlite3 } from '../web-worker/client-session/sqlite-loader.ts'
+import {
+  dieOnRpcClientError,
+  makeWebmeshWorkerProxy,
+  type WebmeshWorkerProxy,
+} from '../web-worker/common/rpc-worker.ts'
 import { makeShutdownChannel } from '../web-worker/common/shutdown-channel.ts'
 import { makeSharedWorkerNodeName } from '../web-worker/common/webmesh-node-names.ts'
+import * as WorkerSchema from '../web-worker/common/worker-schema.ts'
 
 export interface InMemoryAdapterOptions {
   importSnapshot?: Uint8Array<ArrayBuffer>
@@ -129,17 +134,13 @@ export const makeInMemoryAdapter =
             })
           : undefined
 
-      const sharedWorkerFiber =
+      const sharedWorkerClient =
         sharedWebWorker !== undefined
-          ? yield* Worker.makePoolSerialized<typeof WebmeshWorker.Schema.Request.Type>({
-              size: 1,
-              concurrency: 100,
-            }).pipe(
+          ? yield* RpcClient.make(WorkerSchema.SharedWorkerRpcs).pipe(
+              Effect.provide(RpcClient.layerProtocolWorker({ size: 1, concurrency: 100 })),
               Effect.provide(BrowserWorker.layer(() => sharedWebWorker)),
               Effect.tapCauseLogPretty,
               UnknownError.mapToUnknownError,
-              // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-              Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
             )
           : undefined
 
@@ -153,7 +154,7 @@ export const makeInMemoryAdapter =
         syncPayloadSchema,
         importSnapshot: options.importSnapshot,
         devtoolsEnabled,
-        sharedWorkerFiber,
+        sharedWorker: sharedWorkerClient === undefined ? undefined : makeWebmeshWorkerProxy(sharedWorkerClient),
       })
 
       sqliteDb.import(initialSnapshot)
@@ -174,13 +175,17 @@ export const makeInMemoryAdapter =
         origin: globalThis.location?.origin,
         connectWebmeshNode: ({ sessionInfo, webmeshNode }) =>
           Effect.gen(function* () {
-            if (sharedWorkerFiber === undefined || devtoolsEnabled === false) {
+            if (sharedWorkerClient === undefined || devtoolsEnabled === false) {
               return
             }
 
-            const sharedWorker = yield* sharedWorkerFiber.pipe(Fiber.join)
-
-            yield* connectWebmeshNodeClientSession({ webmeshNode, sessionInfo, sharedWorker, devtoolsEnabled, schema })
+            yield* connectWebmeshNodeClientSession({
+              webmeshNode,
+              sessionInfo,
+              sharedWorker: makeWebmeshWorkerProxy(sharedWorkerClient),
+              devtoolsEnabled,
+              schema,
+            })
           }),
         registerBeforeUnload: (onBeforeUnload) => {
           if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
@@ -205,7 +210,7 @@ export interface MakeLeaderThreadArgs {
   syncPayloadSchema: Schema.Top | undefined
   importSnapshot: Uint8Array<ArrayBuffer> | undefined
   devtoolsEnabled: boolean
-  sharedWorkerFiber: SharedWorkerFiber | undefined
+  sharedWorker: WebmeshWorkerProxy | undefined
 }
 
 const makeLeaderThread = ({
@@ -218,7 +223,7 @@ const makeLeaderThread = ({
   syncPayloadSchema,
   importSnapshot,
   devtoolsEnabled,
-  sharedWorkerFiber,
+  sharedWorker,
 }: MakeLeaderThreadArgs) =>
   Effect.gen(function* () {
     const services = yield* Effect.context()
@@ -226,8 +231,7 @@ const makeLeaderThread = ({
     const makeDb = (_kind: 'state' | 'eventlog') => {
       return makeSqliteDb({
         _tag: 'in-memory',
-        configureDb: (db) =>
-          configureConnection(db, { foreignKeys: true }).pipe(Effect.runSyncWith(services)),
+        configureDb: (db) => configureConnection(db, { foreignKeys: true }).pipe(Effect.runSyncWith(services)),
       })
     }
 
@@ -244,7 +248,7 @@ const makeLeaderThread = ({
 
     const devtoolsOptions = yield* makeDevtoolsOptions({
       devtoolsEnabled,
-      sharedWorkerFiber,
+      sharedWorker,
       dbState,
       dbEventlog,
       storeId,
@@ -263,7 +267,7 @@ const makeLeaderThread = ({
         devtoolsOptions,
         shutdownChannel,
         syncPayloadEncoded,
-        syncPayloadSchema,
+        syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
       }),
     )
 
@@ -302,28 +306,23 @@ const makeLeaderThread = ({
     }).pipe(Effect.provide(layer))
   })
 
-type SharedWorkerFiber = Fiber.Fiber<
-  Worker.SerializedWorkerPool<typeof WebmeshWorker.Schema.Request.Type>,
-  UnknownError
->
-
 const makeDevtoolsOptions = ({
   devtoolsEnabled,
-  sharedWorkerFiber,
+  sharedWorker,
   dbState,
   dbEventlog,
   storeId,
   clientId,
 }: {
   devtoolsEnabled: boolean
-  sharedWorkerFiber: SharedWorkerFiber | undefined
+  sharedWorker: WebmeshWorkerProxy | undefined
   dbState: LeaderSqliteDb
   dbEventlog: LeaderSqliteDb
   storeId: string
   clientId: string
 }): Effect.Effect<DevtoolsOptions, UnknownError, Scope.Scope> =>
   Effect.gen(function* () {
-    if (devtoolsEnabled === false || sharedWorkerFiber === undefined) {
+    if (devtoolsEnabled === false || sharedWorker === undefined) {
       return { enabled: false }
     }
 
@@ -339,8 +338,6 @@ const makeDevtoolsOptions = ({
         // @ts-expect-error TODO type this
         globalThis.__debugWebmeshNodeLeader = node
 
-        const sharedWorker = yield* sharedWorkerFiber.pipe(Fiber.join)
-
         // TODO also make this work with the browser extension
         // basic idea: instead of also connecting to the shared worker,
         // connect to the client session node above which will already connect to the shared worker + browser extension
@@ -349,11 +346,7 @@ const makeDevtoolsOptions = ({
           node,
           worker: sharedWorker,
           target: makeSharedWorkerNodeName({ storeId }),
-        }).pipe(
-          Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        }).pipe(Effect.tapCauseLogPretty, dieOnRpcClientError, Effect.forkScoped({ startImmediately: true }))
 
         return { node, persistenceInfo, mode: 'direct' }
       }),

--- a/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
+++ b/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
@@ -16,7 +16,6 @@
 import type { Adapter, BootWarningReason, ClientSession, LockStatus } from '@livestore/common'
 import {
   IntentionalShutdownCause,
-  isWorkerTransportError,
   makeClientSession,
   StoreInterrupted,
   sessionChangesetMetaTable,
@@ -32,11 +31,12 @@ import {
   Fiber,
   Layer,
   Queue,
+  RpcClient,
+  RpcWorker,
   Schema,
   Stream,
   Subscribable,
   SubscriptionRef,
-  Worker,
 } from '@livestore/utils/effect'
 import { BrowserWorker, Opfs, WebError } from '@livestore/utils/effect/browser'
 import { nanoid } from '@livestore/utils/nanoid'
@@ -46,6 +46,11 @@ import {
   readPersistedStateDbFromClientSession,
   resetPersistedDataFromClientSession,
 } from '../web-worker/common/persisted-sqlite.ts'
+import {
+  type WithoutRpcClientError,
+  dieOnRpcClientError,
+  dieOnRpcClientErrorStream,
+} from '../web-worker/common/rpc-worker.ts'
 import { makeShutdownChannel } from '../web-worker/common/shutdown-channel.ts'
 import * as WorkerSchema from '../web-worker/common/worker-schema.ts'
 
@@ -198,7 +203,6 @@ export const makeSingleTabAdapter =
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -212,75 +216,79 @@ export const makeSingleTabAdapter =
       const worker = tryAsFunctionAndNew(options.worker, { name: `livestore-worker-${storeId}-${sessionId}` })
 
       // Set up communication with the dedicated worker via the outer protocol
-      const _dedicatedWorkerFiber = yield* Worker.makeSerialized<typeof WorkerSchema.LeaderWorkerOuterRequest.Type>({
-        initialMessage: () => new WorkerSchema.LeaderWorkerOuterInitialMessage({ port: mc.port1, storeId, clientId }),
-      }).pipe(
-        Effect.provide(BrowserWorker.layer(() => worker)),
+      const outerWorkerContext = yield* Layer.build(
+        RpcClient.layerProtocolWorker({ size: 1 }).pipe(
+          Layer.provide(BrowserWorker.layer(() => worker)),
+          Layer.provide(
+            RpcWorker.layerInitialMessage(
+              WorkerSchema.LeaderWorkerOuterInitialMessage.payloadSchema,
+              Effect.succeed({ port: mc.port1, storeId, clientId }),
+            ),
+          ),
+        ),
+      )
+      yield* RpcClient.make(WorkerSchema.LeaderWorkerOuterRpcs).pipe(
+        Effect.provide(outerWorkerContext),
         UnknownError.mapToUnknownError,
         Effect.tapCause((cause) => shutdown(Exit.failCause(cause))),
         Effect.withSpan('@livestore/adapter-web:single-tab:setupDedicatedWorker'),
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       // Set up the inner worker communication via port2 (like SharedWorker would do)
       // BrowserWorker.layer accepts a MessagePort as well as a Worker
-      const innerWorkerContext = yield* Layer.build(BrowserWorker.layer(() => mc.port2 as unknown as globalThis.Worker))
-      const innerWorkerFiber = yield* Worker.makePoolSerialized<WorkerSchema.LeaderWorkerInnerRequest>({
-        size: 1,
-        concurrency: 100,
-        initialMessage: () =>
-          new WorkerSchema.LeaderWorkerInnerInitialMessage({
-            storageOptions,
-            storeId,
-            clientId,
-            // Devtools disabled in single-tab mode (requires SharedWorker)
-            devtoolsEnabled: false,
-            debugInstanceId: adapterArgs.debugInstanceId,
-            syncPayloadEncoded,
-          }),
-      }).pipe(
+      const innerWorkerContext = yield* Layer.build(
+        RpcClient.layerProtocolWorker({ size: 1, concurrency: 100 }).pipe(
+          Layer.provide(BrowserWorker.layer(() => mc.port2)),
+          Layer.provide(
+            RpcWorker.layerInitialMessage(
+              WorkerSchema.LeaderWorkerInnerInitialMessage.payloadSchema,
+              Effect.succeed({
+                storageOptions,
+                storeId,
+                clientId,
+                // Devtools disabled in single-tab mode (requires SharedWorker)
+                devtoolsEnabled: false,
+                debugInstanceId: adapterArgs.debugInstanceId,
+                syncPayloadEncoded,
+              }),
+            ),
+          ),
+        ),
+      )
+      const innerWorker = yield* RpcClient.make(WorkerSchema.LeaderWorkerInnerRpcs).pipe(
         Effect.provide(innerWorkerContext),
         Effect.tapCauseLogPretty,
-        Effect.orDie,
+        UnknownError.mapToUnknownError,
         Effect.tapCause((cause) => shutdown(Exit.failCause(cause))),
         Effect.withSpan('@livestore/adapter-web:single-tab:setupInnerWorker'),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       // Helper to run requests against the worker
-      const runInWorker = <A, I, E, EI, R>(
-        req: WorkerSchema.LeaderWorkerInnerRequest & Schema.WithResult<A, I, E, EI, R>,
-      ): Effect.Effect<A, E, R> =>
-        Fiber.join(innerWorkerFiber).pipe(
-          Effect.flatMap((worker) => worker.executeEffect(req)),
-          Effect.catchIf(isWorkerTransportError, (e) => Effect.die(e)),
+      const runInWorker = <A, E, R>(
+        tag: string,
+        effect: Effect.Effect<A, E, R>,
+      ): Effect.Effect<A, WithoutRpcClientError<E>, R> =>
+        effect.pipe(
+          dieOnRpcClientError,
           Effect.logWarnIfTakesLongerThan({
-            label: `@livestore/adapter-web:single-tab:runInWorker:${req._tag}`,
+            label: `@livestore/adapter-web:single-tab:runInWorker:${tag}`,
             duration: 2000,
           }),
-          Effect.withSpan(`@livestore/adapter-web:single-tab:runInWorker:${req._tag}`),
+          Effect.withSpan(`@livestore/adapter-web:single-tab:runInWorker:${tag}`),
         )
 
-      const runInWorkerStream = <A, I, E, EI, R>(
-        req: WorkerSchema.LeaderWorkerInnerRequest & Schema.WithResult<A, I, E, EI, R>,
-      ): Stream.Stream<A, E, R> =>
-        Effect.gen(function* () {
-          const innerWorker = yield* Fiber.join(innerWorkerFiber)
-          return innerWorker.execute(req).pipe(
-            Stream.catchIf(
-              isWorkerTransportError,
-              (e) => Stream.die(e),
-              (e) => Stream.fail(e),
-            ),
-            Stream.withSpan(`@livestore/adapter-web:single-tab:runInWorkerStream:${req._tag}`),
-          )
-        }).pipe(Stream.unwrap)
+      const runInWorkerStream = <A, E, R>(
+        tag: string,
+        stream: Stream.Stream<A, E, R>,
+      ): Stream.Stream<A, WithoutRpcClientError<E>, R> =>
+        stream.pipe(
+          dieOnRpcClientErrorStream,
+          Stream.withSpan(`@livestore/adapter-web:single-tab:runInWorkerStream:${tag}`),
+        )
 
       // Forward boot status from worker
-      const bootStatusFiber = yield* runInWorkerStream(new WorkerSchema.LeaderWorkerInnerBootStatusStream()).pipe(
+      const bootStatusFiber = yield* runInWorkerStream('BootStatusStream', innerWorker.BootStatusStream({})).pipe(
         Stream.tap((_) => Queue.offer(bootStatusQueue, _)),
         Stream.runDrain,
         Effect.tapCause((cause) =>
@@ -288,21 +296,20 @@ export const makeSingleTabAdapter =
         ),
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       yield* Queue.await(bootStatusQueue).pipe(
         Effect.andThen(Fiber.interrupt(bootStatusFiber)),
+        Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       // Get initial snapshot (either from fast-path or from worker)
       const initialResult =
         dataFromFile === undefined
-          ? yield* runInWorker(new WorkerSchema.LeaderWorkerInnerGetRecreateSnapshot()).pipe(
+          ? yield* runInWorker('GetRecreateSnapshot', innerWorker.GetRecreateSnapshot({})).pipe(
               Effect.map(({ snapshot, migrationsReport }) => ({
                 _tag: 'from-leader-worker' as const,
                 snapshot,
@@ -348,38 +355,40 @@ export const makeSingleTabAdapter =
             })
           : EventSequenceNumber.Client.ROOT
 
-      yield* Effect.addFinalizer((ex) =>
+      yield* Effect.addFinalizer((ex: Exit.Exit<unknown, unknown>) =>
         Effect.gen(function* () {
-          if (
-            Exit.isFailure(ex) === true &&
-            Exit.hasInterrupts(ex) === false &&
-            Schema.is(IntentionalShutdownCause)(Cause.squash(ex.cause)) === false &&
-            Schema.is(StoreInterrupted)(Cause.squash(ex.cause)) === false
-          ) {
-            yield* Effect.logError('[@livestore/adapter-web:single-tab] client-session shutdown', ex.cause)
-          } else {
-            yield* Effect.logDebug('[@livestore/adapter-web:single-tab] client-session shutdown', ex)
+          if (Exit.isFailure(ex) === true) {
+            const cause = ex.cause
+            if (
+              Exit.hasInterrupts(ex) === false &&
+              Schema.is(IntentionalShutdownCause)(Cause.squash(cause)) === false &&
+              Schema.is(StoreInterrupted)(Cause.squash(cause)) === false
+            ) {
+              yield* Effect.logError('[@livestore/adapter-web:single-tab] client-session shutdown', cause)
+              return
+            }
           }
+
+          yield* Effect.logDebug('[@livestore/adapter-web:single-tab] client-session shutdown', ex)
         }).pipe(Effect.tapCauseLogPretty, Effect.orDie),
       )
 
       const leaderThread: ClientSession['leaderThread'] = {
-        export: runInWorker(new WorkerSchema.LeaderWorkerInnerExport()).pipe(
+        export: runInWorker('Export', innerWorker.Export({})).pipe(
           Effect.timeoutOrDie(10_000),
           Effect.withSpan('@livestore/adapter-web:single-tab:export'),
         ),
 
         events: {
-          pull: ({ cursor }) =>
-            runInWorkerStream(new WorkerSchema.LeaderWorkerInnerPullStream({ cursor })).pipe(Stream.orDie),
+          pull: ({ cursor }) => runInWorkerStream('PullStream', innerWorker.PullStream({ cursor })).pipe(Stream.orDie),
           push: (batch) =>
-            runInWorker(new WorkerSchema.LeaderWorkerInnerPushToLeader({ batch })).pipe(
+            runInWorker('PushToLeader', innerWorker.PushToLeader({ batch })).pipe(
               Effect.withSpan('@livestore/adapter-web:single-tab:pushToLeader', {
                 attributes: { batchSize: batch.length },
               }),
             ),
           stream: (options) =>
-            runInWorkerStream(new WorkerSchema.LeaderWorkerInnerStreamEvents(options)).pipe(
+            runInWorkerStream('StreamEvents', innerWorker.StreamEvents(options)).pipe(
               Stream.withSpan('@livestore/adapter-web:single-tab:streamEvents'),
               Stream.orDie,
             ),
@@ -391,16 +400,16 @@ export const makeSingleTabAdapter =
           storageMode: opfsWarning === undefined ? 'persisted' : 'in-memory',
         },
 
-        getEventlogData: runInWorker(new WorkerSchema.LeaderWorkerInnerExportEventlog()).pipe(
+        getEventlogData: runInWorker('ExportEventlog', innerWorker.ExportEventlog({})).pipe(
           Effect.timeoutOrDie(10_000),
           Effect.withSpan('@livestore/adapter-web:single-tab:getEventlogData'),
         ),
 
         syncState: Subscribable.make({
-          get: runInWorker(new WorkerSchema.LeaderWorkerInnerGetLeaderSyncState()).pipe(
+          get: runInWorker('GetLeaderSyncState', innerWorker.GetLeaderSyncState({})).pipe(
             Effect.withSpan('@livestore/adapter-web:single-tab:getLeaderSyncState'),
           ),
-          changes: runInWorkerStream(new WorkerSchema.LeaderWorkerInnerSyncStateStream()).pipe(Stream.orDie),
+          changes: runInWorkerStream('SyncStateStream', innerWorker.SyncStateStream({})).pipe(Stream.orDie),
         }),
 
         sendDevtoolsMessage: (_message) =>
@@ -408,8 +417,8 @@ export const makeSingleTabAdapter =
           Effect.void,
 
         networkStatus: Subscribable.make({
-          get: runInWorker(new WorkerSchema.LeaderWorkerInnerGetNetworkStatus()).pipe(Effect.orDie),
-          changes: runInWorkerStream(new WorkerSchema.LeaderWorkerInnerNetworkStatusStream()).pipe(Stream.orDie),
+          get: runInWorker('GetNetworkStatus', innerWorker.GetNetworkStatus({})).pipe(Effect.orDie),
+          changes: runInWorkerStream('NetworkStatusStream', innerWorker.NetworkStatusStream({})).pipe(Stream.orDie),
         }),
       }
 

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
@@ -1,11 +1,12 @@
 import { Devtools, liveStoreVersion } from '@livestore/common'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { isDevEnv } from '@livestore/utils'
-import { type Worker, Effect, Stream } from '@livestore/utils/effect'
+import { Effect, Stream } from '@livestore/utils/effect'
 import { WebChannelBrowser } from '@livestore/utils/effect/browser'
 import * as Webmesh from '@livestore/webmesh'
 import * as WebmeshWorker from '@livestore/webmesh/worker'
 
+import type { WebmeshWorkerProxy } from '../common/rpc-worker.ts'
 import { makeSharedWorkerNodeName } from '../common/webmesh-node-names.ts'
 import * as DevtoolsWeb from './devtools-web-channel.ts'
 
@@ -60,7 +61,7 @@ export const connectWebmeshNodeClientSession = Effect.fn(function* ({
 }: {
   webmeshNode: Webmesh.MeshNode
   sessionInfo: Devtools.SessionInfo.SessionInfo
-  sharedWorker: Worker.SerializedWorkerPool<typeof WebmeshWorker.Schema.Request.Type>
+  sharedWorker: WebmeshWorkerProxy
   devtoolsEnabled: boolean
   schema: LiveStoreSchema
 }) {
@@ -73,11 +74,7 @@ export const connectWebmeshNodeClientSession = Effect.fn(function* ({
     yield* Devtools.SessionInfo.provideSessionInfo({
       webChannel: yield* DevtoolsWeb.makeSessionInfoBroadcastChannel,
       sessionInfo,
-    }).pipe(
-      Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }))
 
     yield* Effect.gen(function* () {
       const clientSessionStaticChannel = yield* DevtoolsWeb.makeStaticClientSessionChannel.clientSession
@@ -105,7 +102,6 @@ export const connectWebmeshNodeClientSession = Effect.fn(function* ({
     }).pipe(
       Effect.withSpan('@livestore/adapter-web:client-session:devtools:browser-extension'),
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -1,7 +1,6 @@
 import type { Adapter, BootWarningReason, ClientSession, LockStatus } from '@livestore/common'
 import {
   IntentionalShutdownCause,
-  isWorkerTransportError,
   liveStoreVersion,
   makeClientSession,
   StoreInterrupted,
@@ -22,11 +21,12 @@ import {
   Fiber,
   Layer,
   Queue,
+  RpcClient,
+  RpcWorker,
   Schema,
   Stream,
   Subscribable,
   SubscriptionRef,
-  Worker,
 } from '@livestore/utils/effect'
 import { BrowserWorker, Opfs, WebError, WebLock } from '@livestore/utils/effect/browser'
 import { nanoid } from '@livestore/utils/nanoid'
@@ -36,6 +36,12 @@ import {
   readPersistedStateDbFromClientSession,
   resetPersistedDataFromClientSession,
 } from '../common/persisted-sqlite.ts'
+import {
+  type WithoutRpcClientError,
+  dieOnRpcClientError,
+  dieOnRpcClientErrorStream,
+  makeWebmeshWorkerProxy,
+} from '../common/rpc-worker.ts'
 import { makeShutdownChannel } from '../common/shutdown-channel.ts'
 import { DedicatedWorkerDisconnectBroadcast, makeWorkerDisconnectChannel } from '../common/worker-disconnect-channel.ts'
 import * as WorkerSchema from '../common/worker-schema.ts'
@@ -257,8 +263,7 @@ export const makePersistedAdapter =
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       const sharedWebWorker = tryAsFunctionAndNew(options.sharedWorker, { name: `livestore-shared-worker-${storeId}` })
@@ -269,18 +274,17 @@ export const makePersistedAdapter =
         yield* Effect.addFinalizer(() => WebLock.waitForLock(LIVESTORE_SHARED_WORKER_TERMINATION_LOCK))
       }
 
-      const sharedWorkerContext = yield* Layer.build(BrowserWorker.layer(() => sharedWebWorker))
-      const sharedWorkerFiber = yield* Worker.makePoolSerialized<typeof WorkerSchema.SharedWorkerRequest.Type>({
-        size: 1,
-        concurrency: 100,
-      }).pipe(
+      const sharedWorkerContext = yield* Layer.build(
+        RpcClient.layerProtocolWorker({ size: 1, concurrency: 100 }).pipe(
+          Layer.provide(BrowserWorker.layer(() => sharedWebWorker)),
+        ),
+      )
+      const sharedWorker = yield* RpcClient.make(WorkerSchema.SharedWorkerRpcs).pipe(
         Effect.provide(sharedWorkerContext),
         Effect.tapCauseLogPretty,
-        Effect.orDie,
+        UnknownError.mapToUnknownError,
         Effect.tapCause((cause) => shutdown(Exit.failCause(cause))),
         Effect.withSpan('@livestore/adapter-web:client-session:setupSharedWorker'),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       const lockDeferred = yield* Deferred.make<void>()
@@ -315,36 +319,40 @@ export const makePersistedAdapter =
         // and adding the `sessionId` to make it easier to debug which session a worker belongs to in logs
         const worker = tryAsFunctionAndNew(options.worker, { name: `livestore-worker-${storeId}-${sessionId}` })
 
-        yield* Worker.makeSerialized<typeof WorkerSchema.LeaderWorkerOuterRequest.Type>({
-          initialMessage: () => new WorkerSchema.LeaderWorkerOuterInitialMessage({ port: mc.port1, storeId, clientId }),
-        }).pipe(
-          Effect.provide(BrowserWorker.layer(() => worker)),
+        const outerWorkerContext = yield* Layer.build(
+          RpcClient.layerProtocolWorker({ size: 1 }).pipe(
+            Layer.provide(BrowserWorker.layer(() => worker)),
+            Layer.provide(
+              RpcWorker.layerInitialMessage(
+                WorkerSchema.LeaderWorkerOuterInitialMessage.payloadSchema,
+                Effect.succeed({ port: mc.port1, storeId, clientId }),
+              ),
+            ),
+          ),
+        )
+        yield* RpcClient.make(WorkerSchema.LeaderWorkerOuterRpcs).pipe(
+          Effect.provide(outerWorkerContext),
           UnknownError.mapToUnknownError,
           Effect.tapCause((cause) => shutdown(Exit.failCause(cause))),
           Effect.withSpan('@livestore/adapter-web:client-session:setupDedicatedWorker'),
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
         yield* workerDisconnectChannel.send(DedicatedWorkerDisconnectBroadcast.make({}))
 
-        const sharedWorker = yield* Fiber.join(sharedWorkerFiber)
         yield* sharedWorker
-          .executeEffect(
-            new WorkerSchema.SharedWorkerUpdateMessagePort({
-              port: mc.port2,
-              liveStoreVersion,
-              initial: new WorkerSchema.LeaderWorkerInnerInitialMessage({
-                storageOptions,
-                storeId,
-                clientId,
-                devtoolsEnabled,
-                debugInstanceId,
-                syncPayloadEncoded,
-              }),
-            }),
-          )
+          .UpdateMessagePort({
+            port: mc.port2,
+            liveStoreVersion,
+            initial: {
+              storageOptions,
+              storeId,
+              clientId,
+              devtoolsEnabled,
+              debugInstanceId,
+              syncPayloadEncoded,
+            },
+          })
           .pipe(
             UnknownError.mapToUnknownError,
             Effect.tapCause((cause) => shutdown(Exit.failCause(cause))),
@@ -369,52 +377,47 @@ export const makePersistedAdapter =
           }),
           Effect.interruptible,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
       } else {
         yield* runLocked.pipe(
           Effect.interruptible,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
       }
 
-      const runInWorker = <A, I, E, EI, R>(
-        req: WorkerSchema.SharedWorkerRequest & Schema.WithResult<A, I, E, EI, R>,
-      ): Effect.Effect<A, E, R> =>
-        Fiber.join(sharedWorkerFiber).pipe(
+      const runInWorker = <A, E, R>(
+        tag: string,
+        effect: Effect.Effect<A, E, R>,
+      ): Effect.Effect<A, WithoutRpcClientError<E>, R> =>
+        Deferred.await(waitForSharedWorkerInitialized).pipe(
           // NOTE we need to wait for the shared worker to be initialized before we can send requests to it
-          Effect.tap(() => waitForSharedWorkerInitialized),
-          Effect.flatMap((worker) => worker.executeEffect(req)),
-          Effect.catchIf(isWorkerTransportError, (e) => Effect.die(e)),
+          Effect.andThen(effect),
+          dieOnRpcClientError,
           // NOTE we want to treat worker requests as atomic and therefore not allow them to be interrupted
           // Interruption usually only happens during leader re-election or store shutdown
           // Effect.uninterruptible,
           Effect.logWarnIfTakesLongerThan({
-            label: `@livestore/adapter-web:client-session:runInWorker:${req._tag}`,
+            label: `@livestore/adapter-web:client-session:runInWorker:${tag}`,
             duration: 2000,
           }),
-          Effect.withSpan(`@livestore/adapter-web:client-session:runInWorker:${req._tag}`),
+          Effect.withSpan(`@livestore/adapter-web:client-session:runInWorker:${tag}`),
         )
 
-      const runInWorkerStream = <A, I, E, EI, R>(
-        req: WorkerSchema.SharedWorkerRequest & Schema.WithResult<A, I, E, EI, R>,
-      ): Stream.Stream<A, E, R> =>
+      const runInWorkerStream = <A, E, R>(
+        tag: string,
+        stream: Stream.Stream<A, E, R>,
+      ): Stream.Stream<A, WithoutRpcClientError<E>, R> =>
         Effect.gen(function* () {
-          const sharedWorker = yield* Fiber.join(sharedWorkerFiber)
-          return sharedWorker.execute(req).pipe(
-            Stream.catchIf(
-              isWorkerTransportError,
-              (e) => Stream.die(e),
-              (e) => Stream.fail(e),
-            ),
-            Stream.withSpan(`@livestore/adapter-web:client-session:runInWorkerStream:${req._tag}`),
+          yield* Deferred.await(waitForSharedWorkerInitialized)
+          return stream.pipe(
+            dieOnRpcClientErrorStream,
+            Stream.withSpan(`@livestore/adapter-web:client-session:runInWorkerStream:${tag}`),
           )
         }).pipe(Stream.unwrap)
 
-      const bootStatusFiber = yield* runInWorkerStream(new WorkerSchema.LeaderWorkerInnerBootStatusStream()).pipe(
+      const bootStatusFiber = yield* runInWorkerStream('BootStatusStream', sharedWorker.BootStatusStream({})).pipe(
         Stream.tap((_) => Queue.offer(bootStatusQueue, _)),
         Stream.runDrain,
         Effect.tapCause((cause) =>
@@ -422,14 +425,13 @@ export const makePersistedAdapter =
         ),
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
       yield* Queue.await(bootStatusQueue).pipe(
         Effect.andThen(Fiber.interrupt(bootStatusFiber)),
+        Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -437,7 +439,7 @@ export const makePersistedAdapter =
       // re-exporting the db
       const initialResult =
         dataFromFile === undefined
-          ? yield* runInWorker(new WorkerSchema.LeaderWorkerInnerGetRecreateSnapshot()).pipe(
+          ? yield* runInWorker('GetRecreateSnapshot', sharedWorker.GetRecreateSnapshot({})).pipe(
               Effect.map(({ snapshot, migrationsReport }) => ({
                 _tag: 'from-leader-worker' as const,
                 snapshot,
@@ -486,15 +488,20 @@ export const makePersistedAdapter =
 
       // console.debug('[@livestore/adapter-web:client-session] initialLeaderHead', initialLeaderHead)
 
-      yield* Effect.addFinalizer((ex) =>
+      yield* Effect.addFinalizer((ex: Exit.Exit<unknown, unknown>) =>
         Effect.gen(function* () {
-          if (
-            Exit.isFailure(ex) === true &&
-            Exit.hasInterrupts(ex) === false &&
-            Schema.is(IntentionalShutdownCause)(Cause.squash(ex.cause)) === false &&
-            Schema.is(StoreInterrupted)(Cause.squash(ex.cause)) === false
-          ) {
-            yield* Effect.logError('[@livestore/adapter-web:client-session] client-session shutdown', ex.cause)
+          if (Exit.isFailure(ex) === true) {
+            const cause = ex.cause
+            const shouldLogAsError =
+              Exit.hasInterrupts(ex) === false &&
+              Schema.is(IntentionalShutdownCause)(Cause.squash(cause)) === false &&
+              Schema.is(StoreInterrupted)(Cause.squash(cause)) === false
+
+            if (shouldLogAsError === true) {
+              yield* Effect.logError('[@livestore/adapter-web:client-session] client-session shutdown', cause)
+            } else {
+              yield* Effect.logDebug('[@livestore/adapter-web:client-session] client-session shutdown', gotLocky, ex)
+            }
           } else {
             yield* Effect.logDebug('[@livestore/adapter-web:client-session] client-session shutdown', gotLocky, ex)
           }
@@ -506,22 +513,21 @@ export const makePersistedAdapter =
       )
 
       const leaderThread: ClientSession['leaderThread'] = {
-        export: runInWorker(new WorkerSchema.LeaderWorkerInnerExport()).pipe(
+        export: runInWorker('Export', sharedWorker.Export({})).pipe(
           Effect.timeoutOrDie(10_000),
           Effect.withSpan('@livestore/adapter-web:client-session:export'),
         ),
 
         events: {
-          pull: ({ cursor }) =>
-            runInWorkerStream(new WorkerSchema.LeaderWorkerInnerPullStream({ cursor })).pipe(Stream.orDie),
+          pull: ({ cursor }) => runInWorkerStream('PullStream', sharedWorker.PullStream({ cursor })).pipe(Stream.orDie),
           push: (batch) =>
-            runInWorker(new WorkerSchema.LeaderWorkerInnerPushToLeader({ batch })).pipe(
+            runInWorker('PushToLeader', sharedWorker.PushToLeader({ batch })).pipe(
               Effect.withSpan('@livestore/adapter-web:client-session:pushToLeader', {
                 attributes: { batchSize: batch.length },
               }),
             ),
           stream: (options) =>
-            runInWorkerStream(new WorkerSchema.LeaderWorkerInnerStreamEvents(options)).pipe(
+            runInWorkerStream('StreamEvents', sharedWorker.StreamEvents(options)).pipe(
               Stream.withSpan('@livestore/adapter-web:client-session:streamEvents'),
               Stream.orDie,
             ),
@@ -533,29 +539,27 @@ export const makePersistedAdapter =
           storageMode: opfsWarning === undefined ? 'persisted' : 'in-memory',
         },
 
-        getEventlogData: runInWorker(new WorkerSchema.LeaderWorkerInnerExportEventlog()).pipe(
+        getEventlogData: runInWorker('ExportEventlog', sharedWorker.ExportEventlog({})).pipe(
           Effect.timeoutOrDie(10_000),
           Effect.withSpan('@livestore/adapter-web:client-session:getEventlogData'),
         ),
 
         syncState: Subscribable.make({
-          get: runInWorker(new WorkerSchema.LeaderWorkerInnerGetLeaderSyncState()).pipe(
+          get: runInWorker('GetLeaderSyncState', sharedWorker.GetLeaderSyncState({})).pipe(
             Effect.withSpan('@livestore/adapter-web:client-session:getLeaderSyncState'),
           ),
-          changes: runInWorkerStream(new WorkerSchema.LeaderWorkerInnerSyncStateStream()).pipe(Stream.orDie),
+          changes: runInWorkerStream('SyncStateStream', sharedWorker.SyncStateStream({})).pipe(Stream.orDie),
         }),
 
         sendDevtoolsMessage: (message) =>
-          runInWorker(new WorkerSchema.LeaderWorkerInnerExtraDevtoolsMessage({ message })).pipe(
+          runInWorker('ExtraDevtoolsMessage', sharedWorker.ExtraDevtoolsMessage({ message })).pipe(
             Effect.withSpan('@livestore/adapter-web:client-session:devtoolsMessageForLeader'),
           ),
         networkStatus: Subscribable.make({
-          get: runInWorker(new WorkerSchema.LeaderWorkerInnerGetNetworkStatus()),
-          changes: runInWorkerStream(new WorkerSchema.LeaderWorkerInnerNetworkStatusStream()),
+          get: runInWorker('GetNetworkStatus', sharedWorker.GetNetworkStatus({})),
+          changes: runInWorkerStream('NetworkStatusStream', sharedWorker.NetworkStatusStream({})),
         }),
       }
-
-      const sharedWorker = yield* Fiber.join(sharedWorkerFiber)
 
       const clientSession = yield* makeClientSession({
         ...adapterArgs,
@@ -569,7 +573,13 @@ export const makePersistedAdapter =
         // Can be undefined in Node.js
         origin: globalThis.location?.origin,
         connectWebmeshNode: ({ sessionInfo, webmeshNode }) =>
-          connectWebmeshNodeClientSession({ webmeshNode, sessionInfo, sharedWorker, devtoolsEnabled, schema }),
+          connectWebmeshNodeClientSession({
+            webmeshNode,
+            sessionInfo,
+            sharedWorker: makeWebmeshWorkerProxy(sharedWorker),
+            devtoolsEnabled,
+            schema,
+          }),
         registerBeforeUnload: (onBeforeUnload) => {
           if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
             window.addEventListener('beforeunload', onBeforeUnload)

--- a/packages/@livestore/adapter-web/src/web-worker/common/rpc-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/rpc-worker.ts
@@ -1,0 +1,39 @@
+import { Effect, RpcClientError, Schema, Stream } from '@livestore/utils/effect'
+import type * as WebmeshWorker from '@livestore/webmesh/worker'
+
+export type WebmeshWorkerProxy = Parameters<typeof WebmeshWorker.connectViaWorker>[0]['worker']
+export type WithoutRpcClientError<E> = E extends { readonly _tag: infer Tag }
+  ? 'RpcClientError' extends Tag
+    ? never
+    : E
+  : E
+export type WebmeshWorkerRpcClient = {
+  readonly ['WebmeshWorker.CreateConnection']: (
+    request: typeof WebmeshWorker.Schema.CreateConnection.Type,
+  ) => Stream.Stream<{}, RpcClientError.RpcClientError>
+}
+
+export const isRpcClientError = (error: unknown): error is RpcClientError.RpcClientError =>
+  Schema.is(RpcClientError.RpcClientError)(error)
+
+export const dieOnRpcClientError = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, WithoutRpcClientError<E>, R> =>
+  (effect as Effect.Effect<A, RpcClientError.RpcClientError | WithoutRpcClientError<E>, R>).pipe(
+    Effect.catchIf(isRpcClientError, (error) => Effect.die(error)),
+  ) as Effect.Effect<A, WithoutRpcClientError<E>, R>
+
+export const dieOnRpcClientErrorStream = <A, E, R>(
+  stream: Stream.Stream<A, E, R>,
+): Stream.Stream<A, WithoutRpcClientError<E>, R> =>
+  (stream as Stream.Stream<A, RpcClientError.RpcClientError | WithoutRpcClientError<E>, R>).pipe(
+    Stream.catchIf(
+      isRpcClientError,
+      (error) => Stream.die(error),
+      (error) => Stream.fail(error),
+    ),
+  ) as Stream.Stream<A, WithoutRpcClientError<E>, R>
+
+export const makeWebmeshWorkerProxy = (client: WebmeshWorkerRpcClient): WebmeshWorkerProxy => ({
+  execute: (request) => dieOnRpcClientErrorStream(client['WebmeshWorker.CreateConnection'](request)),
+})

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -51,7 +51,7 @@ export class LeaderWorkerOuterInitialMessage extends Rpc.make('InitialMessage', 
   error: Schema.Never,
 }) {}
 
-export class LeaderWorkerOuterRequest extends RpcGroup.make(LeaderWorkerOuterInitialMessage) {}
+export class LeaderWorkerOuterRpcs extends RpcGroup.make(LeaderWorkerOuterInitialMessage) {}
 
 // TODO unify this code with schema from node adapter
 export class LeaderWorkerInnerInitialMessage extends Rpc.make('InitialMessage', {
@@ -174,7 +174,7 @@ export class WebmeshWorkerCreateConnection extends Rpc.make('WebmeshWorker.Creat
   stream: true,
 }) {}
 
-export class LeaderWorkerInnerRequest extends RpcGroup.make(
+export class LeaderWorkerInnerRpcs extends RpcGroup.make(
   LeaderWorkerInnerInitialMessage,
   LeaderWorkerInnerBootStatusStream,
   LeaderWorkerInnerPushToLeader,
@@ -210,7 +210,7 @@ export class SharedWorkerUpdateMessagePort extends Rpc.make('UpdateMessagePort',
   error: UnknownError,
 }) {}
 
-export class SharedWorkerRequest extends RpcGroup.make(
+export class SharedWorkerRpcs extends RpcGroup.make(
   SharedWorkerUpdateMessagePort,
 
   // Proxied requests

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -175,7 +175,6 @@ export class WebmeshWorkerCreateConnection extends Rpc.make('WebmeshWorker.Creat
 }) {}
 
 export class LeaderWorkerInnerRpcs extends RpcGroup.make(
-  LeaderWorkerInnerInitialMessage,
   LeaderWorkerInnerBootStatusStream,
   LeaderWorkerInnerPushToLeader,
   LeaderWorkerInnerPullStream,

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -10,7 +10,7 @@ import {
 } from '@livestore/common'
 import { StreamEventsOptionsFields } from '@livestore/common/leader-thread'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
-import { Schema, Transferable } from '@livestore/utils/effect'
+import { Rpc, RpcGroup, Schema, Transferable } from '@livestore/utils/effect'
 import * as WebmeshWorker from '@livestore/webmesh/worker'
 
 export const StorageTypeOpfs = Schema.Struct({
@@ -45,163 +45,136 @@ export type StorageTypeEncoded = typeof StorageType.Encoded
 export const SyncBackendOptions = Schema.Record(Schema.String, Schema.Json)
 export type SyncBackendOptions = Record<string, Schema.Json>
 
-export class LeaderWorkerOuterInitialMessage extends Schema.TaggedRequest<LeaderWorkerOuterInitialMessage>()(
-  'InitialMessage',
-  {
-    payload: { port: Transferable.MessagePort, storeId: Schema.String, clientId: Schema.String },
-    success: Schema.Void,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerOuterInitialMessage extends Rpc.make('InitialMessage', {
+  payload: { port: Transferable.MessagePort, storeId: Schema.String, clientId: Schema.String },
+  success: Schema.Void,
+  error: Schema.Never,
+}) {}
 
-export const LeaderWorkerOuterRequest = Schema.Union([LeaderWorkerOuterInitialMessage])
+export class LeaderWorkerOuterRequest extends RpcGroup.make(LeaderWorkerOuterInitialMessage) {}
 
 // TODO unify this code with schema from node adapter
-export class LeaderWorkerInnerInitialMessage extends Schema.TaggedRequest<LeaderWorkerInnerInitialMessage>()(
-  'InitialMessage',
-  {
-    payload: {
-      storageOptions: StorageType,
-      devtoolsEnabled: Schema.Boolean,
-      storeId: Schema.String,
-      clientId: Schema.String,
-      debugInstanceId: Schema.String,
-      syncPayloadEncoded: Schema.UndefinedOr(Schema.Json),
-    },
-    success: Schema.Void,
-    failure: UnknownError,
+export class LeaderWorkerInnerInitialMessage extends Rpc.make('InitialMessage', {
+  payload: {
+    storageOptions: StorageType,
+    devtoolsEnabled: Schema.Boolean,
+    storeId: Schema.String,
+    clientId: Schema.String,
+    debugInstanceId: Schema.String,
+    syncPayloadEncoded: Schema.UndefinedOr(Schema.Json),
   },
-) {}
+  success: Schema.Void,
+  error: UnknownError,
+}) {}
 
-export class LeaderWorkerInnerBootStatusStream extends Schema.TaggedRequest<LeaderWorkerInnerBootStatusStream>()(
-  'BootStatusStream',
-  {
-    payload: {},
-    success: BootStatus,
-    failure: Schema.Never,
+export class LeaderWorkerInnerBootStatusStream extends Rpc.make('BootStatusStream', {
+  payload: {},
+  success: BootStatus,
+  error: Schema.Never,
+  stream: true,
+}) {}
+
+export class LeaderWorkerInnerPushToLeader extends Rpc.make('PushToLeader', {
+  payload: {
+    batch: Schema.Array(Schema.toType(LiveStoreEvent.Client.Encoded)),
   },
-) {}
+  success: Schema.Void,
+  error: RejectedPushError,
+}) {}
 
-export class LeaderWorkerInnerPushToLeader extends Schema.TaggedRequest<LeaderWorkerInnerPushToLeader>()(
-  'PushToLeader',
-  {
-    payload: {
-      batch: Schema.Array(Schema.toType(LiveStoreEvent.Client.Encoded)),
-    },
-    success: Schema.Void,
-    failure: RejectedPushError,
-  },
-) {}
-
-export class LeaderWorkerInnerPullStream extends Schema.TaggedRequest<LeaderWorkerInnerPullStream>()('PullStream', {
+export class LeaderWorkerInnerPullStream extends Rpc.make('PullStream', {
   payload: {
     cursor: Schema.toType(EventSequenceNumber.Client.Composite),
   },
   success: Schema.Struct({
     payload: SyncState.PayloadUpstream,
   }),
-  failure: Schema.Never,
+  error: Schema.Never,
+  stream: true,
 }) {}
 
-export class LeaderWorkerInnerStreamEvents extends Schema.TaggedRequest<LeaderWorkerInnerStreamEvents>()(
-  'StreamEvents',
-  {
-    payload: StreamEventsOptionsFields,
-    success: LiveStoreEvent.Client.Encoded,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerStreamEvents extends Rpc.make('StreamEvents', {
+  payload: StreamEventsOptionsFields,
+  success: LiveStoreEvent.Client.Encoded,
+  error: Schema.Never,
+  stream: true,
+}) {}
 
-export class LeaderWorkerInnerExport extends Schema.TaggedRequest<LeaderWorkerInnerExport>()('Export', {
+export class LeaderWorkerInnerExport extends Rpc.make('Export', {
   payload: {},
   success: Transferable.Uint8Array as Schema.Codec<Uint8Array<ArrayBuffer>>,
-  failure: Schema.Never,
+  error: Schema.Never,
 }) {}
 
-export class LeaderWorkerInnerExportEventlog extends Schema.TaggedRequest<LeaderWorkerInnerExportEventlog>()(
-  'ExportEventlog',
-  {
-    payload: {},
-    success: Transferable.Uint8Array as Schema.Codec<Uint8Array<ArrayBuffer>>,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerExportEventlog extends Rpc.make('ExportEventlog', {
+  payload: {},
+  success: Transferable.Uint8Array as Schema.Codec<Uint8Array<ArrayBuffer>>,
+  error: Schema.Never,
+}) {}
 
-export class LeaderWorkerInnerGetRecreateSnapshot extends Schema.TaggedRequest<LeaderWorkerInnerGetRecreateSnapshot>()(
-  'GetRecreateSnapshot',
-  {
-    payload: {},
-    success: Schema.Struct({
-      snapshot: Transferable.Uint8Array as Schema.Codec<Uint8Array<ArrayBuffer>>,
-      migrationsReport: MigrationsReport,
-    }),
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerGetRecreateSnapshot extends Rpc.make('GetRecreateSnapshot', {
+  payload: {},
+  success: Schema.Struct({
+    snapshot: Transferable.Uint8Array as Schema.Codec<Uint8Array<ArrayBuffer>>,
+    migrationsReport: MigrationsReport,
+  }),
+  error: Schema.Never,
+}) {}
 
-export class LeaderWorkerInnerGetLeaderHead extends Schema.TaggedRequest<LeaderWorkerInnerGetLeaderHead>()(
-  'GetLeaderHead',
-  {
-    payload: {},
-    success: Schema.toType(EventSequenceNumber.Client.Composite),
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerGetLeaderHead extends Rpc.make('GetLeaderHead', {
+  payload: {},
+  success: Schema.toType(EventSequenceNumber.Client.Composite),
+  error: Schema.Never,
+}) {}
 
-export class LeaderWorkerInnerGetLeaderSyncState extends Schema.TaggedRequest<LeaderWorkerInnerGetLeaderSyncState>()(
-  'GetLeaderSyncState',
-  {
-    payload: {},
-    success: SyncState.SyncState,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerGetLeaderSyncState extends Rpc.make('GetLeaderSyncState', {
+  payload: {},
+  success: SyncState.SyncState,
+  error: Schema.Never,
+}) {}
 
-export class LeaderWorkerInnerSyncStateStream extends Schema.TaggedRequest<LeaderWorkerInnerSyncStateStream>()(
-  'SyncStateStream',
-  {
-    payload: {},
-    success: SyncState.SyncState,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerSyncStateStream extends Rpc.make('SyncStateStream', {
+  payload: {},
+  success: SyncState.SyncState,
+  error: Schema.Never,
+  stream: true,
+}) {}
 
-export class LeaderWorkerInnerGetNetworkStatus extends Schema.TaggedRequest<LeaderWorkerInnerGetNetworkStatus>()(
-  'GetNetworkStatus',
-  {
-    payload: {},
-    success: SyncBackend.NetworkStatus,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerGetNetworkStatus extends Rpc.make('GetNetworkStatus', {
+  payload: {},
+  success: SyncBackend.NetworkStatus,
+  error: Schema.Never,
+}) {}
 
-export class LeaderWorkerInnerNetworkStatusStream extends Schema.TaggedRequest<LeaderWorkerInnerNetworkStatusStream>()(
-  'NetworkStatusStream',
-  {
-    payload: {},
-    success: SyncBackend.NetworkStatus,
-    failure: Schema.Never,
-  },
-) {}
+export class LeaderWorkerInnerNetworkStatusStream extends Rpc.make('NetworkStatusStream', {
+  payload: {},
+  success: SyncBackend.NetworkStatus,
+  error: Schema.Never,
+  stream: true,
+}) {}
 
-export class LeaderWorkerInnerShutdown extends Schema.TaggedRequest<LeaderWorkerInnerShutdown>()('Shutdown', {
+export class LeaderWorkerInnerShutdown extends Rpc.make('Shutdown', {
   payload: {},
   success: Schema.Void,
-  failure: Schema.Never,
+  error: Schema.Never,
 }) {}
 
-export class LeaderWorkerInnerExtraDevtoolsMessage extends Schema.TaggedRequest<LeaderWorkerInnerExtraDevtoolsMessage>()(
-  'ExtraDevtoolsMessage',
-  {
-    payload: {
-      message: Devtools.Leader.MessageToApp,
-    },
-    success: Schema.Void,
-    failure: Schema.Never,
+export class LeaderWorkerInnerExtraDevtoolsMessage extends Rpc.make('ExtraDevtoolsMessage', {
+  payload: {
+    message: Devtools.Leader.MessageToApp,
   },
-) {}
+  success: Schema.Void,
+  error: Schema.Never,
+}) {}
 
-export const LeaderWorkerInnerRequest = Schema.Union([
+export class WebmeshWorkerCreateConnection extends Rpc.make('WebmeshWorker.CreateConnection', {
+  payload: WebmeshWorker.Schema.CreateConnection,
+  success: Schema.Struct({}),
+  error: Schema.Never,
+  stream: true,
+}) {}
+
+export class LeaderWorkerInnerRequest extends RpcGroup.make(
   LeaderWorkerInnerInitialMessage,
   LeaderWorkerInnerBootStatusStream,
   LeaderWorkerInnerPushToLeader,
@@ -217,31 +190,27 @@ export const LeaderWorkerInnerRequest = Schema.Union([
   LeaderWorkerInnerNetworkStatusStream,
   LeaderWorkerInnerShutdown,
   LeaderWorkerInnerExtraDevtoolsMessage,
-  WebmeshWorker.Schema.CreateConnection,
-])
-export type LeaderWorkerInnerRequest = typeof LeaderWorkerInnerRequest.Type
-
-export class SharedWorkerUpdateMessagePort extends Schema.TaggedRequest<SharedWorkerUpdateMessagePort>()(
-  'UpdateMessagePort',
-  {
-    payload: {
-      port: Transferable.MessagePort,
-      // Version gate to prevent mixed LiveStore builds talking to the same SharedWorker
-      liveStoreVersion: Schema.Literal(liveStoreVersion),
-      /**
-       * Initial configuration for the leader worker. This replaces the previous
-       * two-phase SharedWorker handshake and is sent under the tab lock by the
-       * elected leader. Subsequent calls can omit changes and will simply rebind
-       * the port (join) without reinitializing the store.
-       */
-      initial: LeaderWorkerInnerInitialMessage,
-    },
-    success: Schema.Void,
-    failure: UnknownError,
-  },
+  WebmeshWorkerCreateConnection,
 ) {}
 
-export const SharedWorkerRequest = Schema.Union([
+export class SharedWorkerUpdateMessagePort extends Rpc.make('UpdateMessagePort', {
+  payload: {
+    port: Transferable.MessagePort,
+    // Version gate to prevent mixed LiveStore builds talking to the same SharedWorker
+    liveStoreVersion: Schema.Literal(liveStoreVersion),
+    /**
+     * Initial configuration for the leader worker. This replaces the previous
+     * two-phase SharedWorker handshake and is sent under the tab lock by the
+     * elected leader. Subsequent calls can omit changes and will simply rebind
+     * the port (join) without reinitializing the store.
+     */
+    initial: LeaderWorkerInnerInitialMessage.payloadSchema,
+  },
+  success: Schema.Void,
+  error: UnknownError,
+}) {}
+
+export class SharedWorkerRequest extends RpcGroup.make(
   SharedWorkerUpdateMessagePort,
 
   // Proxied requests
@@ -260,6 +229,5 @@ export const SharedWorkerRequest = Schema.Union([
   LeaderWorkerInnerShutdown,
   LeaderWorkerInnerExtraDevtoolsMessage,
 
-  WebmeshWorker.Schema.CreateConnection,
-])
-export type SharedWorkerRequest = typeof SharedWorkerRequest.Type
+  WebmeshWorkerCreateConnection,
+) {}

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -268,15 +268,20 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
         Stream.withSpan('@livestore/adapter-web:worker:StreamEvents'),
       ),
     Export: () =>
-      Effect.andThen(LeaderThreadCtx, (_) => _.dbState.export()).pipe(
+      LeaderThreadCtx.pipe(
+        Effect.flatMap((_) => Effect.sync(() => _.dbState.export())),
         Effect.withSpan('@livestore/adapter-web:worker:Export'),
       ),
     ExportEventlog: () =>
-      Effect.andThen(LeaderThreadCtx, (_) => _.dbEventlog.export()).pipe(
+      LeaderThreadCtx.pipe(
+        Effect.flatMap((_) => Effect.sync(() => _.dbEventlog.export())),
         Effect.withSpan('@livestore/adapter-web:worker:ExportEventlog'),
       ),
     BootStatusStream: () =>
-      Effect.andThen(LeaderThreadCtx, (_) => Stream.fromQueue(_.bootStatusQueue)).pipe(Stream.unwrap),
+      LeaderThreadCtx.pipe(
+        Effect.map((_) => Stream.fromQueue(_.bootStatusQueue)),
+        Stream.unwrap,
+      ),
     GetLeaderHead: Effect.fn('@livestore/adapter-web:worker:GetLeaderHead')(function* () {
       const workerCtx = yield* LeaderThreadCtx
       return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -16,10 +16,8 @@ import { sqliteDbFactory } from '@livestore/sqlite-wasm/browser'
 import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
 import { isDevEnv, LS_DEV } from '@livestore/utils'
 import {
-  type HttpClient,
-  type Scope,
-  type WorkerError,
   Cause,
+  Deferred,
   Effect,
   FetchHttpClient,
   identity,
@@ -27,11 +25,12 @@ import {
   OtelTracer,
   Queue,
   References,
-  Scheduler,
+  RpcServer,
+  RpcWorker,
   Schema,
+  Scope,
   Stream,
   TaskTracing,
-  WorkerRunner,
 } from '@livestore/utils/effect'
 import { BrowserWorkerRunner, Opfs, WebError } from '@livestore/utils/effect/browser'
 import * as WebmeshWorker from '@livestore/webmesh/worker'
@@ -60,7 +59,7 @@ if (isDevEnv() === true) {
 }
 
 export const makeWorker = (options: WorkerOptions) => {
-  makeWorkerEffect(options).pipe(Effect.runFork)
+  Effect.runFork(makeWorkerEffect(options))
 }
 
 export const makeWorkerEffect = (options: WorkerOptions) => {
@@ -71,23 +70,20 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
         )
       : Layer.empty
 
-  const runtimeLayer = Layer.mergeAll(FetchHttpClient.layer, TracingLive)
+  const runtimeLayer = Layer.mergeAll(
+    FetchHttpClient.layer,
+    TracingLive,
+    Layer.succeed(References.MaxOpsBeforeYield, 4096),
+  )
 
   return makeWorkerRunnerOuter(options).pipe(
-    Layer.provide(BrowserWorkerRunner.layer),
-    WorkerRunner.launch,
+    Effect.provide(RpcServer.layerProtocolWorkerRunner),
+    Effect.provide(BrowserWorkerRunner.layer),
     Effect.scoped,
     Effect.tapCauseLogPretty,
     Effect.annotateLogs({ thread: self.name }),
     Effect.provide(runtimeLayer),
     LS_DEV === true ? TaskTracing.withAsyncTaggingTracing((name) => (console as any).createTask(name)) : identity,
-    // This v3-era custom scheduler now only swaps Effect v4's default worker fallback
-    // (`setTimeout(0)`) for `MessageChannel`; v4's `MixedScheduler` still owns batching.
-    // TODO: Reconsider whether this is still needed for the leader worker.
-    // Despite the "message channel" name, it has nothing to do with the `incomingRequestsPort` above.
-    Effect.withScheduler(Scheduler.messageChannel()),
-    // We're increasing the Effect ops limit here to allow for larger chunks of operations at a time
-    Effect.withMaxOpsBeforeYield(4096),
     Effect.provide(
       Layer.mergeAll(
         options.logger ?? Layer.empty,
@@ -97,226 +93,325 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
   )
 }
 
-const makeWorkerRunnerOuter = (
-  workerOptions: WorkerOptions,
-): Layer.Layer<never, WorkerError.WorkerError, WorkerRunner.PlatformRunner | HttpClient.HttpClient> =>
-  WorkerRunner.layerSerialized(WorkerSchema.LeaderWorkerOuterInitialMessage, {
-    // Port coming from client session and forwarded via the shared worker
-    InitialMessage: ({ port: incomingRequestsPort, storeId, clientId }) =>
-      Effect.gen(function* () {
-        yield* makeWorkerRunnerInner(workerOptions).pipe(
-          Layer.provide(BrowserWorkerRunner.layerMessagePort(incomingRequestsPort)),
-          WorkerRunner.launch,
-          Effect.scoped,
-          Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage:innerFiber'),
-          Effect.tapCauseLogPretty,
-          Effect.provide(
-            Layer.mergeAll(
-              Opfs.layer,
-              WebmeshWorker.CacheService.layer({
-                nodeName: Devtools.makeNodeName.client.leader({ storeId, clientId }),
-              }),
-            ),
-          ),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+const makeWorkerRunnerOuter = (workerOptions: WorkerOptions) =>
+  Effect.gen(function* () {
+    // Port coming from client session and forwarded via the shared worker.
+    const {
+      port: incomingRequestsPort,
+      storeId,
+      clientId,
+    } = yield* RpcWorker.initialMessage(WorkerSchema.LeaderWorkerOuterInitialMessage.payloadSchema)
 
-        return Layer.empty
-      }).pipe(Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage'), Layer.unwrap),
-  })
+    return yield* RpcServer.make(WorkerSchema.LeaderWorkerInnerRpcs).pipe(
+      Effect.provide(makeWorkerRunnerInner(workerOptions)),
+      Effect.provide(makeMessagePortRpcServerProtocol(incomingRequestsPort)),
+      Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage:innerFiber'),
+      Effect.tapCauseLogPretty,
+      Effect.provide(
+        Layer.mergeAll(
+          Opfs.layer,
+          WebmeshWorker.CacheService.layer({
+            nodeName: Devtools.makeNodeName.client.leader({ storeId, clientId }),
+          }),
+        ),
+      ),
+    )
+  }).pipe(Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage'))
+
+const makeMessagePortRpcServerProtocol = (port: MessagePort): Layer.Layer<RpcServer.Protocol> =>
+  Layer.effect(
+    RpcServer.Protocol,
+    Effect.gen(function* () {
+      const disconnects = yield* Queue.unbounded<number>()
+      const initialMessage = yield* Deferred.make<unknown>()
+      const closed = yield* Deferred.make<void>()
+      const clientIds = new Set<number>()
+
+      return RpcServer.Protocol.of({
+        disconnects,
+        send: (_clientId, response, transferables) =>
+          Effect.sync(() => port.postMessage([1, response], { transfer: (transferables ?? []) as Transferable[] })),
+        end: () => Effect.void,
+        clientIds: Effect.sync(() => clientIds),
+        initialMessage: Effect.asSome(Deferred.await(initialMessage)),
+        supportsAck: true,
+        supportsTransferables: true,
+        supportsSpanPropagation: true,
+        run: (writeRequest) =>
+          Effect.gen(function* () {
+            const context = yield* Effect.context<never>()
+            const runFork = Effect.runForkWith(context)
+            const onMessage = (event: MessageEvent) => {
+              const message = event.data as readonly [0 | 1, unknown?]
+              if (message[0] === 1) {
+                runFork(
+                  Effect.gen(function* () {
+                    yield* Queue.offer(disconnects, 0)
+                    yield* Deferred.succeed(closed, undefined)
+                  }),
+                )
+                return
+              }
+
+              const request = message[1] as { readonly _tag?: string; readonly value?: unknown }
+              clientIds.add(0)
+              if (request._tag === 'InitialMessage') {
+                runFork(Deferred.succeed(initialMessage, request.value))
+              } else {
+                runFork(writeRequest(0, request as never))
+              }
+            }
+
+            port.addEventListener('message', onMessage)
+            port.start()
+            port.postMessage([0])
+
+            return yield* Deferred.await(closed).pipe(
+              Effect.andThen(Effect.interrupt),
+              Effect.ensuring(
+                Effect.sync(() => {
+                  port.removeEventListener('message', onMessage)
+                  port.close()
+                }),
+              ),
+            )
+          }),
+      })
+    }),
+  )
 
 const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }: WorkerOptions) =>
-  WorkerRunner.layerSerialized(WorkerSchema.LeaderWorkerInnerRequest, {
-    InitialMessage: ({ storageOptions, storeId, clientId, devtoolsEnabled, debugInstanceId, syncPayloadEncoded }) =>
-      Effect.gen(function* () {
-        const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
-        const makeSqliteDb = sqliteDbFactory({ sqlite3 })
-        const services = yield* Effect.context()
+  WorkerSchema.LeaderWorkerInnerRpcs.toLayer(
+    Effect.gen(function* () {
+      const leaderThreadScope = yield* Scope.make()
+      yield* Effect.addFinalizer((exit) => Scope.close(leaderThreadScope, exit))
 
-        // Check OPFS availability and determine storage mode
-        const opfsCheck = yield* checkOpfsAvailability
-        const useOpfs = opfsCheck === undefined
+      const leaderThreadContextOnce = yield* Effect.cached(
+        Effect.gen(function* () {
+          const { storageOptions, storeId, clientId, devtoolsEnabled, debugInstanceId, syncPayloadEncoded } =
+            yield* RpcWorker.initialMessage(WorkerSchema.LeaderWorkerInnerInitialMessage.payloadSchema)
 
-        // Track boot warning to emit later
-        let bootWarning: BootStatus | undefined
-        if (useOpfs === false) {
-          yield* Effect.logWarning(
-            '[@livestore/adapter-web:worker] OPFS unavailable, using in-memory storage',
-            opfsCheck,
-          )
-          bootWarning = { stage: 'warning', ...opfsCheck }
-        }
+          const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+          const makeSqliteDb = sqliteDbFactory({ sqlite3 })
+          const services = yield* Effect.context()
 
-        const opfsDirectory = useOpfs === true ? yield* sanitizeOpfsDir(storageOptions.directory, storeId) : undefined
+          // Check OPFS availability and determine storage mode
+          const opfsCheck = yield* checkOpfsAvailability
+          const useOpfs = opfsCheck === undefined
 
-        const makeOpfsDb = (kind: 'state' | 'eventlog') =>
-          Effect.acquireRelease(
-            makeSqliteDb({
-              _tag: 'opfs',
-              opfsDirectory: opfsDirectory!,
-              fileName: kind === 'state' ? getStateDbFileName(schema) : 'eventlog.db',
-              configureDb: (db) =>
-                configureConnection(db, {
-                  //  The persisted databases use the AccessHandlePoolVFS which always uses a single database connection.
-                  //  Multiple connections are not supported. This means that we can use the exclusive locking mode to
-                  //  avoid unnecessary system calls and enable the use of the WAL journal mode without the use of shared memory.
-                  // TODO bring back exclusive locking mode when `WAL` is working properly
-                  // lockingMode: 'EXCLUSIVE',
-                  foreignKeys: true,
-                }).pipe(Effect.runSyncWith(services)),
+          // Track boot warning to emit later
+          let bootWarning: BootStatus | undefined
+          if (useOpfs === false) {
+            yield* Effect.logWarning(
+              '[@livestore/adapter-web:worker] OPFS unavailable, using in-memory storage',
+              opfsCheck,
+            )
+            bootWarning = { stage: 'warning', ...opfsCheck }
+          }
+
+          const opfsDirectory = useOpfs === true ? yield* sanitizeOpfsDir(storageOptions.directory, storeId) : undefined
+
+          const makeOpfsDb = (kind: 'state' | 'eventlog') =>
+            Effect.acquireRelease(
+              makeSqliteDb({
+                _tag: 'opfs',
+                opfsDirectory: opfsDirectory!,
+                fileName: kind === 'state' ? getStateDbFileName(schema) : 'eventlog.db',
+                configureDb: (db) =>
+                  configureConnection(db, {
+                    //  The persisted databases use the AccessHandlePoolVFS which always uses a single database connection.
+                    //  Multiple connections are not supported. This means that we can use the exclusive locking mode to
+                    //  avoid unnecessary system calls and enable the use of the WAL journal mode without the use of shared memory.
+                    // TODO bring back exclusive locking mode when `WAL` is working properly
+                    // lockingMode: 'EXCLUSIVE',
+                    foreignKeys: true,
+                  }).pipe(Effect.runSyncWith(services)),
+              }),
+              (db) =>
+                Effect.try({
+                  try: () => db.close(),
+                  catch: (cause) => new Cause.UnknownError(cause),
+                }).pipe(Effect.ignore),
+            )
+
+          const makeInMemoryDb = () =>
+            Effect.acquireRelease(
+              makeSqliteDb({
+                _tag: 'in-memory',
+                configureDb: (db) => configureConnection(db, { foreignKeys: true }).pipe(Effect.runSyncWith(services)),
+              }),
+              (db) =>
+                Effect.try({
+                  try: () => db.close(),
+                  catch: (cause) => new Cause.UnknownError(cause),
+                }).pipe(Effect.ignore),
+            )
+
+          // Use OPFS if available, otherwise fall back to in-memory
+          const [dbState, dbEventlog] =
+            useOpfs === true
+              ? yield* Effect.all([makeOpfsDb('state'), makeOpfsDb('eventlog')], { concurrency: 2 })
+              : yield* Effect.all([makeInMemoryDb(), makeInMemoryDb()], { concurrency: 2 })
+
+          // Clean up old state database files after successful database creation
+          // This prevents OPFS file pool capacity exhaustion from accumulated state db files after schema changes/migrations
+          if (dbState.metadata._tag === 'opfs') {
+            yield* cleanupOldStateDbFiles({
+              vfs: dbState.metadata.vfs,
+              currentSchema: schema,
+              opfsDirectory: dbState.metadata.persistenceInfo.opfsDirectory,
+            })
+          }
+
+          const devtoolsOptions = yield* makeDevtoolsOptions({ devtoolsEnabled, dbState, dbEventlog })
+          const shutdownChannel = yield* makeShutdownChannel(storeId)
+
+          return yield* Layer.buildWithScope(
+            makeLeaderThreadLayer({
+              schema,
+              storeId,
+              clientId,
+              makeSqliteDb,
+              syncOptions,
+              dbState,
+              dbEventlog,
+              devtoolsOptions,
+              shutdownChannel,
+              syncPayloadEncoded,
+              syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
+              ...(bootWarning !== undefined ? { bootWarning } : {}),
             }),
-            (db) =>
-              Effect.try({
-                try: () => db.close(),
-                catch: (cause) => new Cause.UnknownError(cause),
-              }).pipe(Effect.ignore),
+            leaderThreadScope,
           )
+        }).pipe(
+          Scope.provide(leaderThreadScope),
+          Effect.tapCauseLogPretty,
+          UnknownError.mapToUnknownError,
+          Effect.withPerformanceMeasure('@livestore/adapter-web:worker:InitialMessage'),
+          Effect.withSpan('@livestore/adapter-web:worker:InitialMessage'),
+          Effect.orDie,
+        ),
+      )
 
-        const makeInMemoryDb = () =>
-          Effect.acquireRelease(
-            makeSqliteDb({
-              _tag: 'in-memory',
-              configureDb: (db) =>
-                configureConnection(db, { foreignKeys: true }).pipe(Effect.runSyncWith(services)),
-            }),
-            (db) =>
-              Effect.try({
-                try: () => db.close(),
-                catch: (cause) => new Cause.UnknownError(cause),
-              }).pipe(Effect.ignore),
-          )
-
-        // Use OPFS if available, otherwise fall back to in-memory
-        const [dbState, dbEventlog] =
-          useOpfs === true
-            ? yield* Effect.all([makeOpfsDb('state'), makeOpfsDb('eventlog')], { concurrency: 2 })
-            : yield* Effect.all([makeInMemoryDb(), makeInMemoryDb()], { concurrency: 2 })
-
-        // Clean up old state database files after successful database creation
-        // This prevents OPFS file pool capacity exhaustion from accumulated state db files after schema changes/migrations
-        if (dbState.metadata._tag === 'opfs') {
-          yield* cleanupOldStateDbFiles({
-            vfs: dbState.metadata.vfs,
-            currentSchema: schema,
-            opfsDirectory: dbState.metadata.persistenceInfo.opfsDirectory,
-          })
-        }
-
-        const devtoolsOptions = yield* makeDevtoolsOptions({ devtoolsEnabled, dbState, dbEventlog })
-        const shutdownChannel = yield* makeShutdownChannel(storeId)
-
-        return makeLeaderThreadLayer({
-          schema,
-          storeId,
-          clientId,
-          makeSqliteDb,
-          syncOptions,
-          dbState,
-          dbEventlog,
-          devtoolsOptions,
-          shutdownChannel,
-          syncPayloadEncoded,
-          syncPayloadSchema,
-          ...(bootWarning !== undefined ? { bootWarning } : {}),
+      const provideLeaderThread = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+        Effect.gen(function* () {
+          const leaderThreadContext = yield* leaderThreadContextOnce
+          return yield* effect.pipe(Effect.provide(leaderThreadContext))
         })
-      }).pipe(
-        Effect.tapCauseLogPretty,
-        UnknownError.mapToUnknownError,
-        Effect.withPerformanceMeasure('@livestore/adapter-web:worker:InitialMessage'),
-        Effect.withSpan('@livestore/adapter-web:worker:InitialMessage'),
-        Effect.annotateSpans({ debugInstanceId }),
-        Layer.unwrap,
-      ),
-    GetRecreateSnapshot: Effect.fn('@livestore/adapter-web:worker:GetRecreateSnapshot')(function* () {
-      const workerCtx = yield* LeaderThreadCtx
+      const provideLeaderThreadStream = <A, E, R>(stream: Stream.Stream<A, E, R>) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const leaderThreadContext = yield* leaderThreadContextOnce
+            return stream.pipe(Stream.provide(leaderThreadContext))
+          }),
+        )
 
-      // NOTE we can only return the cached snapshot once as it's transferred (i.e. disposed), so we need to set it to undefined
-      // const cachedSnapshot =
-      //   result._tag === 'Recreate' ? yield* Ref.getAndSet(result.snapshotRef, undefined) : undefined
+      return WorkerSchema.LeaderWorkerInnerRpcs.of({
+        GetRecreateSnapshot: () =>
+          Effect.gen(function* () {
+            const workerCtx = yield* LeaderThreadCtx
 
-      // return cachedSnapshot ?? workerCtx.db.export()
+            // NOTE we can only return the cached snapshot once as it's transferred (i.e. disposed), so we need to set it to undefined
+            // const cachedSnapshot =
+            //   result._tag === 'Recreate' ? yield* Ref.getAndSet(result.snapshotRef, undefined) : undefined
 
-      const snapshot = workerCtx.dbState.export()
-      return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
-    }),
-    PullStream: ({ cursor }) =>
-      Effect.gen(function* () {
-        const { syncProcessor } = yield* LeaderThreadCtx // <- syncState comes from here
-        return syncProcessor.pull({ cursor })
-      }).pipe(
-        Stream.unwrap,
-        // For debugging purposes
-        // Stream.tapLogWithLabel('@livestore/adapter-web:worker:PullStream'),
-      ),
-    PushToLeader: ({ batch }) =>
-      Effect.andThen(LeaderThreadCtx, ({ syncProcessor }) =>
-        syncProcessor.push(batch.map((event) => new LiveStoreEvent.Client.EncodedWithMeta(event))),
-      ).pipe(Effect.uninterruptible, Effect.withSpan('@livestore/adapter-web:worker:PushToLeader')),
-    StreamEvents: (options) =>
-      LeaderThreadCtx.pipe(
-        Effect.map(({ dbEventlog, syncProcessor }) => {
-          const { _tag: _ignored, ...payload } = options as any
-          const streamOptions = payload as StreamEventsOptions
-          return streamEventsWithSyncState({
-            dbEventlog,
-            syncState: syncProcessor.syncState,
-            options: streamOptions,
-          })
+            // return cachedSnapshot ?? workerCtx.db.export()
+
+            const snapshot = workerCtx.dbState.export()
+            return { snapshot, migrationsReport: workerCtx.initialState.migrationsReport }
+          }).pipe(provideLeaderThread),
+        PullStream: ({ cursor }) =>
+          Effect.gen(function* () {
+            const { syncProcessor } = yield* LeaderThreadCtx // <- syncState comes from here
+            return syncProcessor.pull({ cursor })
+          }).pipe(
+            provideLeaderThread,
+            Stream.unwrap,
+            // For debugging purposes
+            // Stream.tapLogWithLabel('@livestore/adapter-web:worker:PullStream'),
+          ),
+        PushToLeader: ({ batch }) =>
+          Effect.andThen(LeaderThreadCtx, ({ syncProcessor }) =>
+            syncProcessor.push(batch.map((event) => new LiveStoreEvent.Client.EncodedWithMeta(event))),
+          ).pipe(
+            provideLeaderThread,
+            Effect.uninterruptible,
+            Effect.withSpan('@livestore/adapter-web:worker:PushToLeader'),
+          ),
+        StreamEvents: (options) =>
+          LeaderThreadCtx.pipe(
+            Effect.map(({ dbEventlog, syncProcessor }) =>
+              streamEventsWithSyncState({
+                dbEventlog,
+                syncState: syncProcessor.syncState,
+                options: options as StreamEventsOptions,
+              }),
+            ),
+            provideLeaderThread,
+            Stream.unwrap,
+            Stream.withSpan('@livestore/adapter-web:worker:StreamEvents'),
+          ),
+        Export: () =>
+          LeaderThreadCtx.pipe(
+            Effect.flatMap((_) => Effect.sync(() => _.dbState.export())),
+            provideLeaderThread,
+            Effect.withSpan('@livestore/adapter-web:worker:Export'),
+          ),
+        ExportEventlog: () =>
+          LeaderThreadCtx.pipe(
+            Effect.flatMap((_) => Effect.sync(() => _.dbEventlog.export())),
+            provideLeaderThread,
+            Effect.withSpan('@livestore/adapter-web:worker:ExportEventlog'),
+          ),
+        BootStatusStream: () =>
+          LeaderThreadCtx.pipe(
+            Effect.map((_) => Stream.fromQueue(_.bootStatusQueue)),
+            provideLeaderThread,
+            Stream.unwrap,
+          ),
+        GetLeaderHead: () =>
+          Effect.gen(function* () {
+            const workerCtx = yield* LeaderThreadCtx
+            return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
+          }).pipe(provideLeaderThread),
+        GetLeaderSyncState: () =>
+          Effect.gen(function* () {
+            const workerCtx = yield* LeaderThreadCtx
+            return yield* workerCtx.syncProcessor.syncState
+          }).pipe(provideLeaderThread),
+        SyncStateStream: () =>
+          Effect.gen(function* () {
+            const workerCtx = yield* LeaderThreadCtx
+            return workerCtx.syncProcessor.syncState.changes
+          }).pipe(provideLeaderThread, Stream.unwrap),
+        GetNetworkStatus: () =>
+          Effect.gen(function* () {
+            const workerCtx = yield* LeaderThreadCtx
+            return yield* workerCtx.networkStatus
+          }).pipe(provideLeaderThread),
+        NetworkStatusStream: () =>
+          Effect.gen(function* () {
+            const workerCtx = yield* LeaderThreadCtx
+            return workerCtx.networkStatus.changes
+          }).pipe(provideLeaderThread, Stream.unwrap),
+        Shutdown: Effect.fn('@livestore/adapter-web:worker:Shutdown')(function* () {
+          yield* Effect.logDebug('[@livestore/adapter-web:worker] Shutdown')
+
+          // Buy some time for Otel to flush
+          // TODO find a cleaner way to do this
+          yield* Effect.sleep(300)
         }),
-        Stream.unwrap,
-        Stream.withSpan('@livestore/adapter-web:worker:StreamEvents'),
-      ),
-    Export: () =>
-      LeaderThreadCtx.pipe(
-        Effect.flatMap((_) => Effect.sync(() => _.dbState.export())),
-        Effect.withSpan('@livestore/adapter-web:worker:Export'),
-      ),
-    ExportEventlog: () =>
-      LeaderThreadCtx.pipe(
-        Effect.flatMap((_) => Effect.sync(() => _.dbEventlog.export())),
-        Effect.withSpan('@livestore/adapter-web:worker:ExportEventlog'),
-      ),
-    BootStatusStream: () =>
-      LeaderThreadCtx.pipe(
-        Effect.map((_) => Stream.fromQueue(_.bootStatusQueue)),
-        Stream.unwrap,
-      ),
-    GetLeaderHead: Effect.fn('@livestore/adapter-web:worker:GetLeaderHead')(function* () {
-      const workerCtx = yield* LeaderThreadCtx
-      return Eventlog.getClientHeadFromDb(workerCtx.dbEventlog)
+        ExtraDevtoolsMessage: ({ message }) =>
+          Effect.andThen(LeaderThreadCtx, (_) => Queue.offer(_.extraIncomingMessagesQueue, message)).pipe(
+            provideLeaderThread,
+            Effect.asVoid,
+            Effect.withSpan('@livestore/adapter-web:worker:ExtraDevtoolsMessage'),
+          ),
+        'WebmeshWorker.CreateConnection': (payload) =>
+          WebmeshWorker.CreateConnection(payload).pipe(provideLeaderThreadStream),
+      })
     }),
-    GetLeaderSyncState: Effect.fn('@livestore/adapter-web:worker:GetLeaderSyncState')(function* () {
-      const workerCtx = yield* LeaderThreadCtx
-      return yield* workerCtx.syncProcessor.syncState
-    }),
-    SyncStateStream: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return workerCtx.syncProcessor.syncState.changes
-      }).pipe(Stream.unwrap),
-    GetNetworkStatus: Effect.fn('@livestore/adapter-web:worker:GetNetworkStatus')(function* () {
-      const workerCtx = yield* LeaderThreadCtx
-      return yield* workerCtx.networkStatus
-    }),
-    NetworkStatusStream: () =>
-      Effect.gen(function* () {
-        const workerCtx = yield* LeaderThreadCtx
-        return workerCtx.networkStatus.changes
-      }).pipe(Stream.unwrap),
-    Shutdown: Effect.fn('@livestore/adapter-web:worker:Shutdown')(function* () {
-      yield* Effect.logDebug('[@livestore/adapter-web:worker] Shutdown')
-
-      // Buy some time for Otel to flush
-      // TODO find a cleaner way to do this
-      yield* Effect.sleep(300)
-    }),
-    ExtraDevtoolsMessage: ({ message }) =>
-      Effect.andThen(LeaderThreadCtx, (_) => Queue.offer(_.extraIncomingMessagesQueue, message)).pipe(
-        Effect.withSpan('@livestore/adapter-web:worker:ExtraDevtoolsMessage'),
-      ),
-    'WebmeshWorker.CreateConnection': WebmeshWorker.CreateConnection,
-  })
+  )
 
 const makeDevtoolsOptions = ({
   devtoolsEnabled,

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -1,5 +1,5 @@
 import type { LogConfig } from '@livestore/common'
-import { Devtools, isWorkerTransportError, liveStoreVersion, UnknownError } from '@livestore/common'
+import { Devtools, liveStoreVersion, UnknownError } from '@livestore/common'
 import { isDevEnv, LS_DEV } from '@livestore/utils'
 import {
   Deferred,
@@ -8,20 +8,21 @@ import {
   FetchHttpClient,
   identity,
   Layer,
-  Predicate,
   Ref,
   References,
+  RpcClient,
+  RpcServer,
+  RpcWorker,
   Schema,
   Scope,
   Stream,
   SubscriptionRef,
   TaskTracing,
-  Worker,
-  WorkerRunner,
 } from '@livestore/utils/effect'
 import { BrowserWorker, BrowserWorkerRunner } from '@livestore/utils/effect/browser'
 import * as WebmeshWorker from '@livestore/webmesh/worker'
 
+import { dieOnRpcClientError, dieOnRpcClientErrorStream, makeWebmeshWorkerProxy } from '../common/rpc-worker.ts'
 import { makeShutdownChannel } from '../common/shutdown-channel.ts'
 import { makeSharedWorkerNodeName } from '../common/webmesh-node-names.ts'
 import * as WorkerSchema from '../common/worker-schema.ts'
@@ -49,51 +50,43 @@ if (isDevEnv() === true) {
   }
 }
 
-// @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `SerializedRunner.Handlers` uses `any` in the R channel, propagating as `unknown` in `HandlersContext`
 const makeWorkerRunner = Effect.gen(function* () {
-  const leaderWorkerContextSubRef = yield* SubscriptionRef.make<
-    | {
-        worker: Worker.SerializedWorkerPool<WorkerSchema.LeaderWorkerInnerRequest>
-        scope: Scope.Closeable
-      }
-    | undefined
-  >(undefined)
+  type LeaderWorkerContext = {
+    client: RpcClient.FromGroup<typeof WorkerSchema.LeaderWorkerInnerRpcs>
+    scope: Scope.Closeable
+  }
 
-  const waitForWorker = SubscriptionRef.waitUntil(leaderWorkerContextSubRef, (c) => Predicate.isNotUndefined(c)).pipe(
-    Effect.map((_) => _.worker),
-  )
+  const leaderWorkerContextSubRef = yield* SubscriptionRef.make<LeaderWorkerContext | undefined>(undefined)
 
-  const forwardRequest = <A, I, E, EI, R>(
-    req: WorkerSchema.LeaderWorkerInnerRequest & Schema.WithResult<A, I, E, EI, R>,
+  const isLeaderWorkerContext = (context: LeaderWorkerContext | undefined): context is LeaderWorkerContext =>
+    context !== undefined
+
+  const waitForWorker = SubscriptionRef.waitUntil(leaderWorkerContextSubRef, isLeaderWorkerContext)
+
+  const forwardRequest = <A, E, R>(
+    tag: string,
+    f: (client: RpcClient.FromGroup<typeof WorkerSchema.LeaderWorkerInnerRpcs>) => Effect.Effect<A, E, R>,
   ): Effect.Effect<A, E, R> =>
     // Forward the request to the active worker and convert transport errors to defects.
     waitForWorker.pipe(
-      // Effect.logBefore(`forwardRequest: ${req._tag}`),
-      Effect.andThen((worker) => worker.executeEffect(req)),
-      Effect.catchIf(isWorkerTransportError, (e) => Effect.die(e)),
-      // Effect.tap((_) => Effect.log(`forwardRequest: ${req._tag}`, _)),
-      // Effect.tapError((cause) => Effect.logError(`forwardRequest err: ${req._tag}`, cause)),
+      Effect.flatMap(({ client }) => f(client)),
+      dieOnRpcClientError,
       Effect.interruptible,
       Effect.logWarnIfTakesLongerThan({
-        label: `@livestore/adapter-web:shared-worker:forwardRequest:${req._tag}`,
+        label: `@livestore/adapter-web:shared-worker:forwardRequest:${tag}`,
         duration: 500,
       }),
       Effect.tapCauseLogPretty,
     )
 
-  const forwardRequestStream = <A, I, E, EI, R>(
-    req: WorkerSchema.LeaderWorkerInnerRequest & Schema.WithResult<A, I, E, EI, R>,
+  const forwardRequestStream = <A, E, R>(
+    tag: string,
+    f: (client: RpcClient.FromGroup<typeof WorkerSchema.LeaderWorkerInnerRpcs>) => Stream.Stream<A, E, R>,
   ): Stream.Stream<A, E, R> =>
     Effect.gen(function* () {
-      yield* Effect.logDebug(`forwardRequestStream: ${req._tag}`)
-      const { worker, scope } = yield* SubscriptionRef.waitUntil(leaderWorkerContextSubRef, isLeaderWorkerContext)
-      const stream = worker.execute(req).pipe(
-        Stream.catchIf(
-          isWorkerTransportError,
-          (e) => Stream.die(e),
-          (e) => Stream.fail(e),
-        ),
-      )
+      yield* Effect.logDebug(`forwardRequestStream: ${tag}`)
+      const { client, scope } = yield* SubscriptionRef.waitUntil(leaderWorkerContextSubRef, isLeaderWorkerContext)
+      const stream = f(client).pipe(dieOnRpcClientErrorStream)
       // It seems the request stream is not automatically interrupted when the scope shuts down
       // so we need to manually interrupt it when the scope shuts down
       const shutdownDeferred = yield* Deferred.make<void>()
@@ -110,7 +103,7 @@ const makeWorkerRunner = Effect.gen(function* () {
       Effect.interruptible,
       Effect.tapCauseLogPretty,
       Stream.unwrap,
-      Stream.ensuring(Effect.logDebug(`shutting down stream for ${req._tag}`)),
+      Stream.ensuring(Effect.logDebug(`shutting down stream for ${tag}`)),
     )
 
   const resetCurrentWorkerCtx = Effect.gen(function* () {
@@ -150,8 +143,7 @@ const makeWorkerRunner = Effect.gen(function* () {
   const invariantsRef = yield* Ref.make<Invariants | undefined>(undefined)
   const sameInvariants = Schema.toEquivalence(InvariantsSchema)
 
-  // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `SerializedRunner.Handlers` uses `any` in the R channel
-  return WorkerRunner.layerSerialized(WorkerSchema.SharedWorkerRequest, {
+  return WorkerSchema.SharedWorkerRpcs.of({
     // Whenever the client session leader changes (and thus creates a new leader thread), the new client session leader
     // sends a new MessagePort to the shared worker which proxies messages to the new leader thread.
     UpdateMessagePort: ({ port, initial, liveStoreVersion: clientLiveStoreVersion }) =>
@@ -190,18 +182,22 @@ const makeWorkerRunner = Effect.gen(function* () {
             Stream.tap(() => reset),
             Stream.runDrain,
             Effect.tapCauseLogPretty,
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 
-          const workerLayer = yield* Layer.build(BrowserWorker.layer(() => port))
-
-          const worker = yield* Worker.makePoolSerialized<WorkerSchema.LeaderWorkerInnerRequest>({
-            size: 1,
-            concurrency: 100,
-            initialMessage: () => initial,
-          }).pipe(
-            Effect.provide(workerLayer),
+          const clientContext = yield* Layer.build(
+            RpcClient.layerProtocolWorker({ size: 1, concurrency: 100 }).pipe(
+              Layer.provide(BrowserWorker.layer(() => port)),
+              Layer.provide(
+                RpcWorker.layerInitialMessage(
+                  WorkerSchema.LeaderWorkerInnerInitialMessage.payloadSchema,
+                  Effect.succeed(initial),
+                ),
+              ),
+            ),
+          )
+          const client = yield* RpcClient.make(WorkerSchema.LeaderWorkerInnerRpcs).pipe(
+            Effect.provide(clientContext),
             Effect.withSpan('@livestore/adapter-web:shared-worker:makeWorkerProxyFromPort'),
           )
 
@@ -211,44 +207,42 @@ const makeWorkerRunner = Effect.gen(function* () {
 
           yield* WebmeshWorker.connectViaWorker({
             node,
-            worker,
+            worker: makeWebmeshWorkerProxy(client),
             target: Devtools.makeNodeName.client.leader({ storeId, clientId }),
-          }).pipe(
-            Effect.tapCauseLogPretty,
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-          )
+          }).pipe(Effect.tapCauseLogPretty, dieOnRpcClientError, Effect.forkScoped({ startImmediately: true }))
 
-          yield* SubscriptionRef.set(leaderWorkerContextSubRef, { worker, scope })
-        }).pipe(
-          Effect.tapCauseLogPretty,
-          Scope.provide(scope),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' }),
-        )
+          yield* SubscriptionRef.set(leaderWorkerContextSubRef, {
+            client: client as RpcClient.FromGroup<typeof WorkerSchema.LeaderWorkerInnerRpcs>,
+            scope,
+          })
+        }).pipe(Effect.tapCauseLogPretty, Scope.provide(scope), Effect.forkIn(scope, { startImmediately: true }))
       }).pipe(Effect.withSpan('@livestore/adapter-web:shared-worker:updateMessagePort'), Effect.tapCauseLogPretty),
 
     // Proxied requests
-    BootStatusStream: forwardRequestStream,
-    PushToLeader: forwardRequest,
-    PullStream: forwardRequestStream,
-    StreamEvents: forwardRequestStream,
-    Export: forwardRequest,
-    GetRecreateSnapshot: forwardRequest,
-    ExportEventlog: forwardRequest,
-    Setup: forwardRequest,
-    GetLeaderSyncState: forwardRequest,
-    SyncStateStream: forwardRequestStream,
-    GetLeaderHead: forwardRequest,
-    GetNetworkStatus: forwardRequest,
-    NetworkStatusStream: forwardRequestStream,
-    Shutdown: forwardRequest,
-    ExtraDevtoolsMessage: forwardRequest,
+    BootStatusStream: (payload) =>
+      forwardRequestStream('BootStatusStream', (client) => client.BootStatusStream(payload)),
+    PushToLeader: (payload) => forwardRequest('PushToLeader', (client) => client.PushToLeader(payload)),
+    PullStream: (payload) => forwardRequestStream('PullStream', (client) => client.PullStream(payload)),
+    StreamEvents: (payload) => forwardRequestStream('StreamEvents', (client) => client.StreamEvents(payload)),
+    Export: (payload) => forwardRequest('Export', (client) => client.Export(payload)),
+    GetRecreateSnapshot: (payload) =>
+      forwardRequest('GetRecreateSnapshot', (client) => client.GetRecreateSnapshot(payload)),
+    ExportEventlog: (payload) => forwardRequest('ExportEventlog', (client) => client.ExportEventlog(payload)),
+    GetLeaderSyncState: (payload) =>
+      forwardRequest('GetLeaderSyncState', (client) => client.GetLeaderSyncState(payload)),
+    SyncStateStream: (payload) => forwardRequestStream('SyncStateStream', (client) => client.SyncStateStream(payload)),
+    GetLeaderHead: (payload) => forwardRequest('GetLeaderHead', (client) => client.GetLeaderHead(payload)),
+    GetNetworkStatus: (payload) => forwardRequest('GetNetworkStatus', (client) => client.GetNetworkStatus(payload)),
+    NetworkStatusStream: (payload) =>
+      forwardRequestStream('NetworkStatusStream', (client) => client.NetworkStatusStream(payload)),
+    Shutdown: (payload) => forwardRequest('Shutdown', (client) => client.Shutdown(payload)),
+    ExtraDevtoolsMessage: (payload) =>
+      forwardRequest('ExtraDevtoolsMessage', (client) => client.ExtraDevtoolsMessage(payload)),
 
     // Accept devtools connections (from leader and client sessions)
     'WebmeshWorker.CreateConnection': WebmeshWorker.CreateConnection,
   })
-}).pipe(Layer.unwrap)
+})
 
 export const makeWorker = (options?: LogConfig.LoggerOptions): void => {
   const runtimeLayer = Layer.mergeAll(
@@ -256,19 +250,16 @@ export const makeWorker = (options?: LogConfig.LoggerOptions): void => {
     WebmeshWorker.CacheService.layer({ nodeName: makeSharedWorkerNodeName({ storeId }) }),
   )
 
-  // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- propagated from `makeWorkerRunner`
-  makeWorkerRunner.pipe(
+  RpcServer.layer(WorkerSchema.SharedWorkerRpcs).pipe(
+    Layer.provide(WorkerSchema.SharedWorkerRpcs.toLayer(makeWorkerRunner)),
+    Layer.provide(RpcServer.layerProtocolWorkerRunner),
     Layer.provide(BrowserWorkerRunner.layer),
-    // WorkerRunner.launch,
     Layer.launch,
     Effect.scoped,
     Effect.tapCauseLogPretty,
     Effect.annotateLogs({ thread: self.name }),
     Effect.provide(runtimeLayer),
     LS_DEV === true ? TaskTracing.withAsyncTaggingTracing((name) => (console as any).createTask(name)) : identity,
-    // TODO remove type-cast (currently needed to silence a tsc bug)
-    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- TSC bug workaround; the cast uses `any` as an intermediate
-    (_) => _ as any as Effect.Effect<void>,
     Effect.provide(
       Layer.mergeAll(
         options?.logger ?? Layer.empty,


### PR DESCRIPTION
## Problem

`@livestore/adapter-web` still used the legacy worker RPC shape from the Effect v3 migration stack. This blocked the adapter-web slice of the Effect v4 migration tracked by #1316 and the broader migration tracked by #1310.

## Solution

- Migrates adapter-web worker schemas and worker clients to the Effect v4 RPC APIs.
- Removes the legacy `InitialMessage` RPCs and uses the worker initial-message bootstrap protocol directly.
- Makes the worker RPC client shape explicit once, then threads the RPC functions directly through webmesh worker connection setup.
- Uses v4-native layer composition consistently across the worker boot paths.
- Removes the leftover `StreamEvents` cast path and composes the shared-worker RPC group from the inner worker RPC group.

## Trade-offs / follow-up

This PR focuses on the adapter-web Effect v4 migration slice and intentionally leaves broader stack cleanup outside this package for follow-up work.

## Validation

- `pnpm exec tsc -p packages/@livestore/adapter-web/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/@livestore/common/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/@livestore/webmesh/tsconfig.json --noEmit`

Closes #1316
Part of #1310
