### PR TITLE
chore(livestore)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/common/src/leader-thread/eventlog.ts
+++ b/packages/@livestore/common/src/leader-thread/eventlog.ts
@@ -284,7 +284,7 @@ export const getSyncBackendCursorInfo = ({ remoteHead }: { remoteHead: EventSequ
     if (remoteHead === EventSequenceNumber.Client.ROOT.global) return Option.none()
 
     const EventlogQuerySchema = Schema.Struct({
-      syncMetadataJson: Schema.fromJsonString(Schema.Option(Schema.Json)),
+      syncMetadataJson: Schema.fromJsonString(Schema.toCodecJson(Schema.Option(Schema.Json))),
     }).pipe(Schema.pluck('syncMetadataJson'), Schema.Array, Schema.head)
 
     const syncMetadataOption = yield* Effect.sync(() =>

--- a/packages/@livestore/common/src/schema/state/sqlite/system-tables/eventlog-tables.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/system-tables/eventlog-tables.ts
@@ -34,7 +34,7 @@ export const eventlogMetaTable = table({
     clientId: SqliteDsl.text({}),
     sessionId: SqliteDsl.text({}),
     schemaHash: SqliteDsl.integer({}),
-    syncMetadataJson: SqliteDsl.text({ schema: Schema.fromJsonString(Schema.Option(Schema.Json)) }),
+    syncMetadataJson: SqliteDsl.text({ schema: Schema.fromJsonString(Schema.toCodecJson(Schema.Option(Schema.Json))) }),
   },
   indexes: [
     { columns: ['seqNumGlobal'], name: 'idx_eventlog_seqNumGlobal' },

--- a/packages/@livestore/livestore/src/effect/LiveStore.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.ts
@@ -11,6 +11,7 @@ import {
   Effect,
   Layer,
   pipe,
+  Schema,
 } from '@livestore/utils/effect'
 
 import type { LiveStoreContextProps } from '../store/create-store.ts'
@@ -18,7 +19,11 @@ import { createStore, DeferredStoreContext, LiveStoreContextRunning } from '../s
 import type { LiveStoreContextRunning as LiveStoreContextRunningType, Queryable } from '../store/store-types.ts'
 import type { Store as StoreClass } from '../store/store.ts'
 
-export const makeLiveStoreContext = <TSchema extends LiveStoreSchema, TContext = {}>({
+export const makeLiveStoreContext = <
+  TSchema extends LiveStoreSchema,
+  TContext = {},
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
+>({
   schema,
   storeId = 'default',
   context,
@@ -29,7 +34,7 @@ export const makeLiveStoreContext = <TSchema extends LiveStoreSchema, TContext =
   batchUpdates,
   syncPayload,
   syncPayloadSchema,
-}: LiveStoreContextProps<TSchema, TContext>): Effect.Effect<
+}: LiveStoreContextProps<TSchema, TContext, TSyncPayloadSchema>): Effect.Effect<
   LiveStoreContextRunning['Service'],
   UnknownError | Cause.TimeoutError,
   DeferredStoreContext | Scope.Scope | OtelTracer.OtelTracer
@@ -67,8 +72,12 @@ export const makeLiveStoreContext = <TSchema extends LiveStoreSchema, TContext =
  * const layer = MainStore.layer({ adapter, ... })
  * ```
  */
-export const LiveStoreContextLayer = <TSchema extends LiveStoreSchema, TContext = {}>(
-  props: LiveStoreContextProps<TSchema, TContext>,
+export const LiveStoreContextLayer = <
+  TSchema extends LiveStoreSchema,
+  TContext = {},
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
+>(
+  props: LiveStoreContextProps<TSchema, TContext, TSyncPayloadSchema>,
 ): Layer.Layer<LiveStoreContextRunning, UnknownError | Cause.TimeoutError, OtelTracer.OtelTracer> =>
   Layer.effect(LiveStoreContextRunning, makeLiveStoreContext(props)).pipe(
     Layer.withSpan('LiveStore'),
@@ -108,8 +117,12 @@ export interface DeferredContextId<TStoreId extends string> {
 }
 
 /** Props for creating a store layer (schema and storeId are already provided) */
-export type StoreLayerProps<TSchema extends LiveStoreSchema, TContext = {}> = Omit<
-  LiveStoreContextProps<TSchema, TContext>,
+export type StoreLayerProps<
+  TSchema extends LiveStoreSchema,
+  TContext = {},
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
+> = Omit<
+  LiveStoreContextProps<TSchema, TContext, TSyncPayloadSchema>,
   'storeId' | 'schema'
 >
 
@@ -146,8 +159,8 @@ export interface StoreTagClass<TSchema extends LiveStoreSchema, TStoreId extends
   readonly storeId: TStoreId
 
   /** Creates a layer that initializes the store */
-  layer<TContext>(
-    props: StoreLayerProps<TSchema, TContext>,
+  layer<TContext, TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json>(
+    props: StoreLayerProps<TSchema, TContext, TSyncPayloadSchema>,
   ): Layer.Layer<StoreTagClass<TSchema, TStoreId>, UnknownError | Cause.TimeoutError, OtelTracer.OtelTracer>
 
   /** Deferred store tag for async initialization patterns */
@@ -245,7 +258,10 @@ const makeStoreTag = <TSchema extends LiveStoreSchema, TStoreId extends string>(
     static readonly schema: TSchema = schema
     static readonly storeId: TStoreId = storeId
 
-    static layer<TContext = {}>(props: StoreLayerProps<TSchema, TContext>) {
+    static layer<
+      TContext = {},
+      TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
+    >(props: StoreLayerProps<TSchema, TContext, TSyncPayloadSchema>) {
       return pipe(
         Effect.gen(function* () {
           const store = yield* createStore({
@@ -354,8 +370,11 @@ export interface StoreContext<TSchema extends LiveStoreSchema, TStoreId extends 
     DeferredContextId<TStoreId>,
     Deferred.Deferred<LiveStoreContextRunningType<TSchema>, UnknownError>
   >
-  readonly Layer: <TContext = {}>(
-    props: Omit<LiveStoreContextProps<TSchema, TContext>, 'storeId'>,
+  readonly Layer: <
+    TContext = {},
+    TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
+  >(
+    props: Omit<LiveStoreContextProps<TSchema, TContext, TSyncPayloadSchema>, 'storeId'>,
   ) => Layer.Layer<StoreContextId<TSchema, TStoreId>, UnknownError | Cause.TimeoutError, OtelTracer.OtelTracer>
   readonly DeferredLayer: Layer.Layer<DeferredContextId<TStoreId>>
   readonly fromDeferred: Layer.Layer<StoreContextId<TSchema, TStoreId>, UnknownError, DeferredContextId<TStoreId>>
@@ -387,8 +406,11 @@ export const makeStoreContext =
 
     const DeferredLayer = Layer.effect(DeferredTag, Deferred.make<RunningType, UnknownError>())
 
-    const makeLayer = <TContext = {}>(
-      props: Omit<LiveStoreContextProps<TSchema, TContext>, 'storeId'>,
+    const makeLayer = <
+      TContext = {},
+      TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
+    >(
+      props: Omit<LiveStoreContextProps<TSchema, TContext, TSyncPayloadSchema>, 'storeId'>,
     ): Layer.Layer<StoreContextId<TSchema, TStoreId>, UnknownError | Cause.TimeoutError, OtelTracer.OtelTracer> =>
       pipe(
         Effect.gen(function* () {

--- a/packages/@livestore/livestore/src/effect/LiveStore.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.ts
@@ -302,7 +302,7 @@ const makeStoreTag = <TSchema extends LiveStoreSchema, TStoreId extends string>(
       })
     }
 
-    static use<A, E, R>(f: (ctx: RunningType) => Effect.Effect<A, E, R>) {
+    static override use<A, E, R>(f: (ctx: RunningType) => Effect.Effect<A, E, R>) {
       return Effect.flatMap(Tag, f)
     }
   }

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -27,16 +27,17 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -48,6 +49,52 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
     },
     {
       "_name": "LiveStore:queries",
+      "children": [
+        {
+          "_name": "LiveStore.subscribe",
+          "attributes": {
+            "queryLabel": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+          },
+          "children": [
+            {
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
+              "attributes": {
+                "livestore.debugRefreshReason": "subscribe-initial-run:undefined",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                "sql.rowsCount": 0,
+              },
+              "children": [
+                {
+                  "_name": "sql-in-memory-select",
+                  "attributes": {
+                    "sql.cached": false,
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                    "sql.rowsCount": 0,
+                  },
+                },
+              ],
+            },
+            {
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
+              "attributes": {
+                "livestore.debugRefreshReason": "commit",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                "sql.rowsCount": 1,
+              },
+              "children": [
+                {
+                  "_name": "sql-in-memory-select",
+                  "attributes": {
+                    "sql.cached": false,
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                    "sql.rowsCount": 1,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
   ],
 }
@@ -125,16 +172,17 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -146,6 +194,52 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
     },
     {
       "_name": "LiveStore:queries",
+      "children": [
+        {
+          "_name": "LiveStore.subscribe",
+          "attributes": {
+            "queryLabel": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+          },
+          "children": [
+            {
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
+              "attributes": {
+                "livestore.debugRefreshReason": "subscribe-initial-run:undefined",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                "sql.rowsCount": 0,
+              },
+              "children": [
+                {
+                  "_name": "sql-in-memory-select",
+                  "attributes": {
+                    "sql.cached": false,
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                    "sql.rowsCount": 0,
+                  },
+                },
+              ],
+            },
+            {
+              "_name": "db:SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ",
+              "attributes": {
+                "livestore.debugRefreshReason": "commit",
+                "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                "sql.rowsCount": 1,
+              },
+              "children": [
+                {
+                  "_name": "sql-in-memory-select",
+                  "attributes": {
+                    "sql.cached": false,
+                    "sql.query": "SELECT * FROM 'todos' WHERE "completed" = ? LIMIT ?",
+                    "sql.rowsCount": 1,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
   ],
 }
@@ -223,16 +317,17 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -367,16 +462,17 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -511,16 +607,17 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -655,23 +752,17 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
           "_name": "client-session-sync-processor:pull",
           "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -872,16 +963,17 @@ exports[`otel > otel 3`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -1178,16 +1270,17 @@ exports[`otel > with thunks 7`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -1318,16 +1411,17 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-          },
-        },
-        {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -16,7 +16,7 @@ import {
   RcMap,
   References,
   type Schema,
-  type Scope,
+  Scope,
 } from '@livestore/utils/effect'
 
 import { type CreateStoreOptions, createStore } from './create-store.ts'
@@ -186,7 +186,7 @@ export class StoreRegistry {
     if (config.context !== undefined) {
       this.#context = config.context
     } else {
-      const ownedRuntime = ManagedRuntime.make(Layer.mergeAll(Layer.scope, OtelLiveDummy))
+      const ownedRuntime = ManagedRuntime.make(Layer.mergeAll(Layer.effect(Scope.Scope, Effect.scope), OtelLiveDummy))
       this.#context = ownedRuntime.contextEffect.pipe(Effect.runSync)
       this.#disposeOwnedRuntime = () => ownedRuntime.dispose()
     }

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -295,7 +295,7 @@ export class StoreRegistry {
     if (cached !== undefined) return cached as Promise<Store<TSchema, TContext>>
 
     // Create and cache the promise
-    const fiber = defect.value.fiber as Fiber.Fiber<Store<TSchema, TContext>>
+    const fiber = defect.success.fiber as Fiber.Fiber<Store<TSchema, TContext>>
     const promise = Fiber.join(fiber)
       .pipe(Effect.runPromiseWith(this.#context))
       .finally(() => this.#loadingPromises.delete(storeId))

--- a/packages/@livestore/livestore/src/store/StoreRegistry.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.ts
@@ -49,7 +49,7 @@ export const DEFAULT_UNUSED_CACHE_TIME = typeof window === 'undefined' ? Number.
 export interface RegistryStoreOptions<
   TSchema extends LiveStoreSchema = LiveStoreSchema.Any,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 > extends CreateStoreOptions<TSchema, TContext, TSyncPayloadSchema> {
   /**
    * OpenTelemetry configuration for tracing store operations.
@@ -237,7 +237,7 @@ export class StoreRegistry {
   getOrLoad = <
     TSchema extends LiveStoreSchema,
     TContext = {},
-    TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+    TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
   >(
     options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
   ): Effect.Effect<Store<TSchema, TContext>, UnknownError, Scope.Scope> =>
@@ -268,7 +268,7 @@ export class StoreRegistry {
   getOrLoadPromise = <
     TSchema extends LiveStoreSchema,
     TContext = {},
-    TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+    TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
   >(
     options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
   ): Store<TSchema, TContext> | Promise<Store<TSchema, TContext>> => {
@@ -320,7 +320,7 @@ export class StoreRegistry {
   retain = <
     TSchema extends LiveStoreSchema,
     TContext = {},
-    TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+    TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
   >(
     options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
   ): (() => void) => {
@@ -353,7 +353,7 @@ export class StoreRegistry {
   preload = async <
     TSchema extends LiveStoreSchema,
     TContext = {},
-    TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+    TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
   >(
     options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
   ): Promise<void> => {
@@ -423,7 +423,7 @@ export class StoreRegistry {
 export const storeOptions = <
   TSchema extends LiveStoreSchema,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 >(
   options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
 ): RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema> => options

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -85,7 +85,7 @@ export class DeferredStoreContext extends Context.Service<
 export type LiveStoreContextProps<
   TSchema extends LiveStoreSchema,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 > = {
   schema: TSchema
   /**
@@ -135,7 +135,7 @@ export type LiveStoreContextProps<
 export interface CreateStoreOptions<
   TSchema extends LiveStoreSchema,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 > extends LogConfig.LoggerOptions {
   /** The LiveStore schema defining tables, events, and materializers. */
   schema: TSchema
@@ -224,7 +224,7 @@ export interface CreateStoreOptions<
 export type CreateStoreOptionsPromise<
   TSchema extends LiveStoreSchema = LiveStoreSchema.Any,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 > = CreateStoreOptions<TSchema, TContext, TSyncPayloadSchema> & {
   signal?: AbortSignal
   otelOptions?: Partial<OtelOptions>
@@ -234,7 +234,7 @@ export type CreateStoreOptionsPromise<
 export const createStorePromise = async <
   TSchema extends LiveStoreSchema = LiveStoreSchema.Any,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 >({
   signal,
   otelOptions,
@@ -270,7 +270,7 @@ export const createStorePromise = async <
 export const createStore = <
   TSchema extends LiveStoreSchema = LiveStoreSchema.Any,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 >({
   schema,
   adapter,

--- a/packages/@livestore/livestore/src/store/devtools.ts
+++ b/packages/@livestore/livestore/src/store/devtools.ts
@@ -43,6 +43,7 @@ export const connectDevtoolsToStore = Effect.fn('LSD.devtools.connectStoreToDevt
   const liveQueriesSubscriptions: SubMap = new Map()
   const debugInfoHistorySubscriptions: SubMap = new Map()
   const syncHeadClientSessionSubscriptions: SubMap = new Map()
+  const services = yield* Effect.context()
 
   const { clientId, sessionId } = store[StoreInternalsSymbol].clientSession
 
@@ -303,11 +304,11 @@ export const connectDevtoolsToStore = Effect.fn('LSD.devtools.connectStoreToDevt
         syncHeadClientSessionSubscriptions.set(
           subscriptionId,
           store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
-            Stream.tap((syncState) => send(syncState)),
+            Stream.tap((syncState) => Effect.sync(() => send(syncState))),
             Stream.runDrain,
             Effect.interruptible,
             Effect.tapCauseLogPretty,
-            Effect.runCallback,
+            Effect.runCallbackWith(services),
           ),
         )
 

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -933,7 +933,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     }
 
     return clientSession.leaderThread.events.stream(baseOptions).pipe(
-      Stream.mapEffect(Schema.decodeEffect(eventSchema)),
+      Stream.mapEffect((event) => Schema.decodeEffect(eventSchema)(event)),
       Stream.catchTag('SchemaError', (cause) => Stream.fail(UnknownError.make({ cause }))),
       Stream.tapError((error) => Effect.logError('Error in eventsStream', error)),
     )

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -33,6 +33,7 @@ import {
   Inspectable,
   Option,
   OtelTracer,
+  Queue,
   Result,
   Schema,
   Stream,
@@ -584,7 +585,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
         yield* Effect.acquireRelease(
           Effect.sync(() =>
-            this.subscribe(query, (result) => emit.single(result), {
+            this.subscribe(query, (result) => { Queue.offerUnsafe(emit, result) }, {
               ...options,
               otelContext,
             }),

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -571,7 +571,88 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   ): AsyncIterable<TResult> => {
     this.checkShutdown('subscribe')
 
-    return Stream.toAsyncIterable(this.subscribeStream(query, options))
+    // This used to delegate to `Stream.toAsyncIterable(this.subscribeStream(...))`.
+    // With Effect v4, the callback-backed stream producer is forked during stream startup, so a caller could request
+    // `next()`, commit an update, and race the actual subscription registration. Register directly here so the first
+    // pending `next()` observes post-subscription updates. In the future, this should be refactored back toward a shared
+    // stream/async-iterable bridge if Effect exposes a primitive with that synchronous registration guarantee.
+    return {
+      [Symbol.asyncIterator]: () => {
+        const services = this[StoreInternalsSymbol].effectContext.services
+        const runSync = Effect.runSyncWith(services)
+        const runPromiseExit = Effect.runPromiseExitWith(services)
+        let queue: Queue.Queue<TResult, Cause.Done> | undefined
+        let isDone = false
+        let unsubscribe: Unsubscribe | undefined
+
+        const done = (): IteratorResult<TResult> => ({ done: true, value: undefined })
+        const isClosed = () => isDone
+        const isQueueDone = (cause: Cause.Cause<Cause.Done>) => {
+          const error = Cause.findError(cause)
+          return Result.isSuccess(error) && Cause.isDone(error.success)
+        }
+
+        const ensureQueue = () => {
+          // Lazily allocate the queue so creating an async iterator without consuming it has no subscription-side work.
+          queue ??= Queue.unbounded<TResult, Cause.Done>().pipe(runSync)
+          return queue
+        }
+
+        const emit = (value: TResult) => {
+          if (isDone === true) return
+
+          Queue.offerUnsafe(ensureQueue(), value)
+        }
+
+        const ensureSubscribed = () => {
+          // Subscribe from the first `next()` call so callers that request a value before
+          // committing updates don't race the asynchronous Stream-to-iterator startup path.
+          unsubscribe ??= this.subscribeWithCallback(query, emit, options)
+        }
+
+        const close = (): IteratorResult<TResult> => {
+          if (isDone === false) {
+            isDone = true
+            unsubscribe?.()
+            unsubscribe = undefined
+
+            if (queue !== undefined) {
+              // Wake any pending `next()` call and prevent later callback emissions from being buffered.
+              Queue.shutdown(queue).pipe(runSync)
+            }
+          }
+
+          return done()
+        }
+
+        return {
+          next: async () => {
+            if (isDone === true) {
+              return done()
+            }
+
+            ensureSubscribed()
+
+            // Delegate buffering and pending-consumer wakeups to Effect's queue implementation.
+            const exit = await runPromiseExit(Queue.take(ensureQueue()))
+            if (Exit.isSuccess(exit)) {
+              return { done: false, value: exit.value }
+            }
+
+            if (isClosed() === true || isQueueDone(exit.cause)) {
+              return done()
+            }
+
+            throw Cause.squash(exit.cause)
+          },
+          return: () => Promise.resolve(close()),
+          throw: (cause) => {
+            close()
+            return Promise.reject(cause)
+          },
+        }
+      },
+    }
   }
 
   subscribeStream = <TResult>(query: Queryable<TResult>, options?: SubscribeOptions<TResult>): Stream.Stream<TResult> =>


### PR DESCRIPTION
## Problem

Part of the stacked Effect v4 migration tracked by #1310. The `@livestore/livestore` package needs to compile and keep its core store/query behavior working on top of the adapter-web migration in #1352.

During package validation, the `store.subscribe(query, { skipInitialRun: true })` async iterator path exposed a startup race: the previous `Stream.toAsyncIterable(this.subscribeStream(...))` bridge could request `next()`, then miss the first post-subscription update because Effect v4 forks the callback-backed stream producer during stream startup.

## Solution

Migrate the remaining `@livestore/livestore` Effect API usage needed for this stack slice and keep the async-iterator subscription path deterministic by registering the LiveStore subscription directly on the first `next()` call. The iterator now uses an Effect `Queue` for buffering and pending-consumer wakeups while preserving the synchronous subscription-registration guarantee that the stream bridge does not provide.

Updated the query OTel snapshots to reflect the Effect v4 span/fiber scheduling output and the now-observed subscription span for async-iterator subscriptions.

Trade-off: the async-iterator overload no longer delegates through `subscribeStream`. The implementation is commented with the previous shape and should be refactored back toward a shared stream/async-iterable bridge if Effect exposes a primitive with the same synchronous registration guarantee.

## Validation

- `pnpm exec tsc -p packages/@livestore/livestore/tsconfig.json --noEmit`
- `pnpm --filter @livestore/livestore exec vitest run --config vitest.config.ts`

Pre-commit `check:quick` was not used for these commits because it currently fails on unrelated repo-wide format/lint/type issues outside this slice.

### Demo (optional)

Package test result:

```text
Test Files  9 passed (9)
Tests       72 passed | 1 skipped (73)
```

## Related issues

- Closes #1315
- Part of #1310
- Stacked on #1352
