### PR TITLE
chore(react)!: migrate to Effect v4

### DIFF
--- a/packages/@livestore/livestore/src/reactive.ts
+++ b/packages/@livestore/livestore/src/reactive.ts
@@ -25,7 +25,7 @@ import type * as otel from '@opentelemetry/api'
 
 import { BoundArray } from '@livestore/common'
 import { deepEqual, omitUndefineds, shouldNeverHappen } from '@livestore/utils'
-import type { Types } from '@livestore/utils/effect'
+import { Schema, type Types } from '@livestore/utils/effect'
 // import { getDurationMsFromSpan } from './otel.ts'
 
 export const NOT_REFRESHED_YET = Symbol.for('NOT_REFRESHED_YET')
@@ -635,7 +635,24 @@ const serializeAtom = (atom: Atom<any, unknown, any>, includeResult: boolean): S
       ? encodedOptionSome(
           atom.previousResult === NOT_REFRESHED_YET
             ? '"SYMBOL_NOT_REFRESHED_YET"'
-            : JSON.stringify(atom.previousResult),
+            : JSON.stringify(atom.previousResult, (key, nestedValue) => {
+                if (Schema.isSchema(nestedValue) === false) return nestedValue
+
+                // Query inputs carry schemas for result decoding, but graph snapshots use previousResult
+                // to explain reactive data flow. Omitting that field preserves the stable query shape
+                // without embedding Effect full schema object graph.
+                if (key === 'schema') return undefined
+
+                const annotations = Schema.resolveAnnotations(nestedValue)
+
+                return omitUndefineds({
+                  _tag: 'Schema',
+                  ast: nestedValue.ast._tag,
+                  identifier: annotations?.identifier,
+                  title: annotations?.title,
+                  hash: Schema.hash(nestedValue),
+                })
+              }),
         )
       : encodedOptionNone()
 

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -27,23 +27,17 @@ exports[`useClientDocument > otel > should update the data based on component ke
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
           "_name": "client-session-sync-processor:pull",
           "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },
@@ -307,23 +301,17 @@ exports[`useClientDocument > otel > should update the data based on component ke
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
           "_name": "client-session-sync-processor:pull",
           "attributes": {
-            "code.stacktrace": "<STACKTRACE>",
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
           },

--- a/packages/@livestore/react/src/useStore.ts
+++ b/packages/@livestore/react/src/useStore.ts
@@ -57,7 +57,7 @@ import { useSyncStatus } from './useSyncStatus.ts'
 export const useStore = <
   TSchema extends LiveStoreSchema,
   TContext = {},
-  TSyncPayloadSchema extends Schema.Top = typeof Schema.Json,
+  TSyncPayloadSchema extends Schema.Codec<Schema.Json, Schema.Json> = typeof Schema.Json,
 >(
   options: RegistryStoreOptions<TSchema, TContext, TSyncPayloadSchema>,
 ): Store<TSchema, TContext> & ReactApi => {


### PR DESCRIPTION
## Problem

Part of the stacked Effect v4 migration tracked by #1310. The `@livestore/react` package needs to compile and keep its React integration behavior working on top of the `@livestore/livestore` migration in #1353.

This slice also exposed a reactive graph snapshot issue after the Effect v4 schema migration: query inputs can carry full schema objects, and serializing those directly makes graph snapshots noisy and unstable.

## Solution

Migrate the React-facing sync payload schema generic for Effect v4 and update the affected client document OTel snapshots for the new Effect v4 scheduling/span shape.

Graph snapshot result serialization now recognizes Effect schemas and replaces them with a compact schema summary, while omitting the nested `schema` field from query-input previous results so the snapshot continues to describe the reactive data flow without embedding the full Effect schema object graph.

## Validation

- `devenv shell -- vitest run packages/@livestore/react/src/useClientDocument.test.tsx --testNamePattern "should update the data based on component key"`
- `devenv shell -- vitest run packages/@livestore/react/src/useQuery.test.tsx`
- `git diff --cached --check`

The focused React tests passed. The `devenv shell` preflight still reports broader Effect v4 TypeScript failures outside this slice while the migration stack is in progress.

## Related issues

- Closes #1318
- Part of #1310
- Stacked on #1353
