### PR TITLE
chore: finalize Effect v4 migration

### DIFF
--- a/.changeset/effect-v4-migration.md
+++ b/.changeset/effect-v4-migration.md
@@ -1,0 +1,22 @@
+---
+"@livestore/adapter-cloudflare": minor
+"@livestore/adapter-web": minor
+"@livestore/common": minor
+"@livestore/common-cf": minor
+"@livestore/framework-toolkit": minor
+"@livestore/livestore": minor
+"@livestore/peer-deps": minor
+"@livestore/react": minor
+"@livestore/sqlite-wasm": minor
+"@livestore/sync-cf": minor
+"@livestore/utils": minor
+"@livestore/utils-dev": minor
+"@livestore/wa-sqlite": minor
+"@livestore/webmesh": minor
+---
+
+Breaking: migrate the LiveStore package group to Effect v4.
+
+LiveStore now targets `effect@^4.0.0-beta.83` and the matching Effect v4 package family. Applications must install compatible Effect v4 peers and remove obsolete Effect v3 peer packages such as `@effect/ai`, `@effect/cli`, `@effect/cluster`, `@effect/experimental`, `@effect/platform`, `@effect/printer`, `@effect/printer-ansi`, `@effect/rpc`, `@effect/sql`, and `@effect/typeclass` when they were only present for LiveStore.
+
+The `@livestore/utils/effect` facade now follows Effect v4's consolidated package layout. Imports that depended on v3-era facade exports need to move to the corresponding Effect v4 modules. The facade no longer exports the LiveStore-local `BucketQueue` and `ServiceContext` helpers.

--- a/contributor-docs/effect-4.md
+++ b/contributor-docs/effect-4.md
@@ -1,6 +1,5 @@
 ## Things to do when upgrading to Effect 4
 
-- [ ] Refactor shutdown logic once `Mailbox.takeBetween` is available (@IMax153)
 - [ ] Re-visit re-design of LiveStore table definitions using a more Effect Schema-native approach
   - [ ] Using an abstraction such as `Model` vs. embedded schema annotations (if tracked at the type level in v4)
     - [ ] @IMax153 currently following up with Giulio about this

--- a/contributor-docs/effect-4.md
+++ b/contributor-docs/effect-4.md
@@ -1,8 +1,5 @@
 ## Things to do when upgrading to Effect 4
 
-- [ ] Improve logger replacement (e.g. in `make-leader-worker.ts`) in order to
-      conditionally provide the logger only if it's replacing the default
-      logger, not if there's a custom logger already provided.
 - [ ] Refactor shutdown logic once `Mailbox.takeBetween` is available (@IMax153)
 - [ ] Re-visit re-design of LiveStore table definitions using a more Effect Schema-native approach
   - [ ] Using an abstraction such as `Model` vs. embedded schema annotations (if tracked at the type level in v4)

--- a/contributor-docs/effect-4.md
+++ b/contributor-docs/effect-4.md
@@ -1,6 +1,0 @@
-## Things to do when upgrading to Effect 4
-
-- [ ] Re-visit re-design of LiveStore table definitions using a more Effect Schema-native approach
-  - [ ] Using an abstraction such as `Model` vs. embedded schema annotations (if tracked at the type level in v4)
-    - [ ] @IMax153 currently following up with Giulio about this
-  - [ ] Determine whether or not an opaque-first approach vs. verbose types are more appropriate

--- a/packages/@livestore/common-cf/src/do-rpc/client.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.test.ts
@@ -75,7 +75,7 @@ Vitest.live('keeps a straddling stream frame isolated from a concurrent unary re
       const client = yield* RpcClient.make(Rpcs)
       const streamFiber = yield* client.BigStream({ n: expectedRows.length }).pipe(
         Stream.runCollect,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/common-cf/src/do-rpc/client.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.ts
@@ -104,7 +104,7 @@ const makeProtocolDurableObject = ({
               (response) => writeResponse(clientId, response),
             ).pipe(
               // Effect.tapCauseLogPretty,
-              // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+              // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
               Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
             )
 

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -178,7 +178,7 @@ export const setupDurableObjectWebSocketRpc = ({
 
       yield* Layer.launch(ServerLive).pipe(
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -329,7 +329,7 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServer
         }),
         Stream.runDrain,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/common/src/devtools/devtools-sessioninfo.ts
+++ b/packages/@livestore/common/src/devtools/devtools-sessioninfo.ts
@@ -67,7 +67,7 @@ export const requestSessionInfoSubscription = ({
       Effect.repeat(Schedule.spaced(pollInterval)),
       Effect.interruptible,
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 
@@ -95,7 +95,7 @@ export const requestSessionInfoSubscription = ({
       ),
       Stream.runDrain,
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -718,7 +718,7 @@ export const make = Effect.fnUntraced(function* ({
 
       yield* backgroundApplyLocalPushes.pipe(
         Effect.catchCause(maybeShutdownOnError),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -755,7 +755,7 @@ export const make = Effect.fnUntraced(function* ({
         // Needed to avoid `Fiber terminated with an unhandled error` logs which seem to happen because of the `Effect.retry` above.
         // This might be a bug in Effect. Only seems to happen in the browser.
         Effect.provideService(References.UnhandledLogLevel, undefined),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
+++ b/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
@@ -41,7 +41,7 @@ export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:
     sendMessage: () => Effect.void,
   }).pipe(
     Effect.tapCauseLogPretty,
-    // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+    // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
     Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
   )
 
@@ -93,7 +93,7 @@ export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:
         yield* syncProcessor.pull({ cursor: syncState.localHead }).pipe(
           Stream.tap(({ payload }) => sendMessage(Devtools.Leader.SyncPull.make({ payload, liveStoreVersion }))),
           Stream.runDrain,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -104,7 +104,7 @@ export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:
         })
       }).pipe(
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       ),
     ),

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.test.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.test.ts
@@ -29,7 +29,7 @@ Vitest.describe('makeNetworkStatusSubscribable', () => {
         networkStatus.changes.pipe(Stream.filter(predicate), Stream.runFirstUnsafe)
 
       const onlineFiber = yield* waitFor((status) => status.isConnected).pipe(
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
       yield* mockBackend.connect
@@ -38,7 +38,7 @@ Vitest.describe('makeNetworkStatusSubscribable', () => {
       Vitest.expect(online.timestampMs).toBeGreaterThanOrEqual(initial.timestampMs)
 
       const latchedFiber = yield* waitFor((status) => status.devtools.latchClosed).pipe(
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
       yield* SubscriptionRef.set(latchStateRef, { latchClosed: true })

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -151,7 +151,7 @@ export const makeLeaderThreadLayer = ({
       // We're already connecting to the sync backend concurrently
       yield* syncBackend.connect.pipe(
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
     }
@@ -330,7 +330,7 @@ const makeInitialBlockingSyncContext = ({
     if (blockingDeferred !== undefined && initialSyncOptions._tag === 'Blocking') {
       yield* Deferred.succeed(blockingDeferred, void 0).pipe(
         Effect.delay(initialSyncOptions.timeout),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
     }
@@ -398,7 +398,7 @@ const bootLeaderThread = ({
 
     yield* bootDevtools(devtoolsOptions).pipe(
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 
@@ -441,7 +441,7 @@ export const makeNetworkStatusSubscribable = ({
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
     }
@@ -452,7 +452,7 @@ export const makeNetworkStatusSubscribable = ({
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
     }

--- a/packages/@livestore/common/src/leader-thread/stream-events.ts
+++ b/packages/@livestore/common/src/leader-thread/stream-events.ts
@@ -95,7 +95,7 @@ export const streamEventsWithSyncState = ({
           return false
         }),
         Stream.runForEach((head) => Queue.offer(headQueue, head)),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/common/src/make-client-session.ts
+++ b/packages/@livestore/common/src/make-client-session.ts
@@ -84,7 +84,7 @@ export const makeClientSession = <R>({
           sessionInfo,
         }).pipe(
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -120,7 +120,7 @@ export const makeClientSession = <R>({
                 yield* connectDevtoolsToStore(clientSessionDevtoolsChannel)
               },
               Effect.tapCauseLogPretty,
-              // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+              // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
               Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
             ),
           ),
@@ -129,7 +129,7 @@ export const makeClientSession = <R>({
       }).pipe(
         Effect.withSpan('@livestore/common:make-client-session:devtools'),
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
     }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -261,7 +261,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.interruptible,
       Effect.withSpan('client-session-sync-processor:pull'),
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
   })()

--- a/packages/@livestore/livestore/src/store/StoreRegistry.test.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.test.ts
@@ -396,7 +396,7 @@ describe('StoreRegistry', () => {
         yield* TestClock.adjust(unusedCacheTime)
 
         // Start a fresh load — since the first was aborted, this should be a new entry
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         const freshLoadFiber = yield* Effect.forkChild(registry.getOrLoad(options).pipe(Effect.scoped), {
           startImmediately: true,
           uninterruptible: 'inherit',

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -316,7 +316,7 @@ export const createStore = <
         ),
         Effect.forever,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/livestore/src/store/store-eventstream.test.ts
+++ b/packages/@livestore/livestore/src/store/store-eventstream.test.ts
@@ -57,7 +57,7 @@ Vitest.describe('Store events API', () => {
       yield* store.eventsStream().pipe(
         Stream.tap((event) => Queue.offer(eventsQueue, event)),
         Stream.runDrain,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -941,7 +941,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         ],
       }),
       Effect.tapCause(Effect.logError),
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.catchCause((cause) =>
         Effect.forkChild(this.shutdown(cause), { startImmediately: true, uninterruptible: 'inherit' }),
       ),
@@ -1268,7 +1268,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
   private runEffectFork = <A, E>(effect: Effect.Effect<A, E, Scope.Scope>) =>
     effect.pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkIn(this[StoreInternalsSymbol].effectContext.lifetimeScope, {
         startImmediately: true,
         uninterruptible: 'inherit',

--- a/packages/@livestore/sqlite-wasm/vitest.config.ts
+++ b/packages/@livestore/sqlite-wasm/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     name: '@livestore/sqlite-wasm',
     root: import.meta.dirname,
     include: ['src/**/*.test.ts'],
+    // TODO(#1358): Migrate this removed Vitest 4 config shape.
     poolOptions: {
       workers: {
         wrangler: {

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -182,7 +182,7 @@ export const makePush =
         Effect.tapCauseLogPretty,
         Effect.withSpan('push-rpc-broadcast'),
         Effect.uninterruptible, // We need to make sure Effect RPC doesn't interrupt this fiber
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -120,7 +120,7 @@ export const makeHttpSync =
         yield* ping.pipe(
           Effect.repeat(Schedule.spaced(pingInterval)),
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
       }

--- a/packages/@livestore/utils/src/effect/Effect.ts
+++ b/packages/@livestore/utils/src/effect/Effect.ts
@@ -303,7 +303,7 @@ export const toForkedDeferred = <R, E, A>(
         Effect.exit(eff),
         Effect.flatMap((ex) => Deferred.done(deferred, ex)),
         tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       ),
     ),

--- a/packages/@livestore/utils/src/effect/RpcClient.ts
+++ b/packages/@livestore/utils/src/effect/RpcClient.ts
@@ -159,7 +159,7 @@ export const makeProtocolSocketWithIsConnected = (options: {
         Effect.interruptible,
         Effect.ignore, // Errors are already handled
         Effect.provideService(References.UnhandledLogLevel, undefined),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -218,7 +218,7 @@ const makePinger = Effect.fnUntraced(function* <A, E, R>(
     Effect.ignore,
     Effect.forever,
     Effect.interruptible,
-    // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+    // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
     Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
   )
 

--- a/packages/@livestore/utils/src/effect/Scheduler.ts
+++ b/packages/@livestore/utils/src/effect/Scheduler.ts
@@ -8,8 +8,8 @@ import { Scheduler } from 'effect'
  * primitive from the default worker fallback (`setTimeout(0)`) to
  * `MessageChannel`.
  *
- * TODO: Reconsider whether this custom scheduler is still needed now that v4's
- * default scheduler handles batching directly.
+ * TODO(#1357): Reconsider whether this custom scheduler is still needed now
+ * that v4's default scheduler handles batching directly.
  */
 export const messageChannel = (): Scheduler.Scheduler =>
   new Scheduler.MixedScheduler('async', scheduleTaskWithMessageChannel)

--- a/packages/@livestore/utils/src/effect/SubscriptionRef.ts
+++ b/packages/@livestore/utils/src/effect/SubscriptionRef.ts
@@ -23,7 +23,7 @@ export const fromStream = <A>(stream: Stream.Stream<A>, initialValue: A) =>
     yield* stream.pipe(
       Stream.tap((a) => SubscriptionRef.set(sref, a)),
       Stream.runDrain,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
@@ -23,7 +23,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 
@@ -44,7 +44,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 
@@ -73,7 +73,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 
@@ -94,7 +94,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
@@ -365,7 +365,7 @@ export const toOpenChannel = <MsgListen, MsgSend>(
         : identity,
       Stream.tapArray((array) => Queue.offerAll(queue, array)),
       Stream.runDrain,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 
@@ -385,7 +385,7 @@ export const toOpenChannel = <MsgListen, MsgSend>(
         }
       }).pipe(
         Effect.withSpan(`WebChannel:heartbeat`),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
     }

--- a/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
@@ -267,7 +267,7 @@ export const makeDirectChannelInternal = ({
               Stream.filter(Schema.is(MeshSchema.DirectChannelPong)),
               Stream.take(1),
               Stream.runDrain,
-              // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+              // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
               Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
             )
 
@@ -346,7 +346,7 @@ export const makeDirectChannelInternal = ({
     }).pipe(
       Effect.interruptible,
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/packages/@livestore/webmesh/src/channel/direct-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel.ts
@@ -101,7 +101,7 @@ export const makeDirectChannel = ({
             Stream.take(1),
             Stream.runDrain,
             Effect.as('new-edge' as const),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 
@@ -119,7 +119,7 @@ export const makeDirectChannel = ({
             scope: makeDirectChannelScope,
           }).pipe(
             Scope.provide(makeDirectChannelScope),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
             // Given we only await the exit later when observing the fiber,
             // we don't want Effect to produce a "unhandled error" log message
@@ -169,7 +169,7 @@ export const makeDirectChannel = ({
           Stream.tapArray((array) => Queue.offerAll(listenQueue, array)),
           Stream.runDrain,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -184,7 +184,7 @@ export const makeDirectChannel = ({
             yield* TxQueue.take(sendQueue) // Remove the message from the queue
           }
         }).pipe(
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -200,7 +200,7 @@ export const makeDirectChannel = ({
         Effect.scoped, // Additionally scoping here to clean up finalizers after each loop run
         Effect.forever,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
       //#endregion reconnect-loop

--- a/packages/@livestore/webmesh/src/channel/proxy-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/proxy-channel.ts
@@ -328,7 +328,7 @@ export const makeProxyChannel = ({
 
               yield* ackSendEffect.pipe(
                 Effect.tapCauseLogPretty,
-                // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+                // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
                 Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
               )
 
@@ -396,7 +396,7 @@ export const makeProxyChannel = ({
         const retryOnNewEdgeFiber = yield* Stream.fromPubSub(newEdgeAvailablePubSub).pipe(
           Stream.tap(() => edgeRequest),
           Stream.runDrain,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -406,7 +406,7 @@ export const makeProxyChannel = ({
           Stream.tap(processProxyPacket),
           Stream.runDrain,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -465,7 +465,7 @@ export const makeProxyChannel = ({
             Stream.filter((_) => _ === false),
             Stream.tap(() => FiberHandle.run(sendFiberHandle, trySend)),
             Stream.runDrain,
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 

--- a/packages/@livestore/webmesh/src/node.test.ts
+++ b/packages/@livestore/webmesh/src/node.test.ts
@@ -484,7 +484,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
             )
           }).pipe(
             Effect.scoped,
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 
@@ -1292,14 +1292,14 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
           Stream.mapEffect(Effect.fromResult),
           Stream.runHead,
           Effect.flatMap(Effect.fromOption),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
         )
         const listenOnCFiber = yield* channelOnC.listen.pipe(
           Stream.mapEffect(Effect.fromResult),
           Stream.runHead,
           Effect.flatMap(Effect.fromOption),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 

--- a/packages/@livestore/webmesh/src/node.ts
+++ b/packages/@livestore/webmesh/src/node.ts
@@ -441,7 +441,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
           Effect.interruptible,
           Effect.orDie,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -525,7 +525,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
             Effect.forever,
             Effect.interruptible,
             Effect.tapCauseLogPretty,
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 

--- a/packages/@livestore/webmesh/src/websocket-edge.ts
+++ b/packages/@livestore/webmesh/src/websocket-edge.ts
@@ -151,7 +151,7 @@ export const makeWebSocketEdge = ({
         Effect.interruptible,
         Effect.withSpan('makeWebSocketEdge:listen'),
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/packages/@livestore/webmesh/src/worker/mod.ts
+++ b/packages/@livestore/webmesh/src/worker/mod.ts
@@ -71,7 +71,7 @@ export const connectViaWorker = ({
       Stream.tap(() => Deferred.succeed(isConnected, true)),
       Stream.runDrain,
       Effect.tapCauseLogPretty,
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/packages/@livestore/webmesh/tsconfig.json
+++ b/packages/@livestore/webmesh/tsconfig.json
@@ -3,7 +3,7 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "lib": ["ES2024", "DOM"],
     "module": "NodeNext",
     "allowImportingTsExtensions": true,
     "rewriteRelativeImportExtensions": true,

--- a/packages/@local/astro-tldraw/src/cli.watch.test.ts
+++ b/packages/@local/astro-tldraw/src/cli.watch.test.ts
@@ -78,7 +78,7 @@ Vitest.describe('watchDiagrams', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
 
       yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
 
@@ -108,7 +108,7 @@ Vitest.describe('watchDiagrams', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
 
       yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
 
@@ -147,7 +147,7 @@ Vitest.describe('watchDiagrams', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
 
       yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
 

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
@@ -68,7 +68,7 @@ describe('watchSnippets', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
 
       yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
 

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -41,7 +41,7 @@ const viteDevServer = ({
       },
     }).pipe(
       Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -48,7 +48,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
         },
       }).pipe(
         Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -124,7 +124,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
         },
       }).pipe(
         Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 
@@ -191,7 +191,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
         },
       }).pipe(
         Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)),
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
@@ -87,7 +87,7 @@ const makeTabPair = (
       name: `${tabName}-page`,
       shouldEvaluateArgs: false,
     }).pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 
@@ -106,7 +106,7 @@ const makeTabPair = (
       name: `${tabName}-devtools`,
       shouldEvaluateArgs: false,
     }).pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/tests/integration/src/tests/playwright/devtools/web.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/web.play.ts
@@ -82,7 +82,7 @@ const makeTabPair = (
       name: `${tabName}-page`,
       shouldEvaluateArgs: false,
     }).pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 
@@ -120,7 +120,7 @@ const makeTabPair = (
       name: `${tabName}-devtools`,
       shouldEvaluateArgs: false,
     }).pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/tests/integration/src/tests/playwright/shared-test.ts
+++ b/tests/integration/src/tests/playwright/shared-test.ts
@@ -58,7 +58,7 @@ export const runAndGetExit = <S extends Schema.Decoder<{ readonly exit: unknown 
     )
 
     const pageConsoleFiber = yield* Playwright.handlePageConsole({ page, name: `tab-1` }).pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
       Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
     )
 

--- a/tests/integration/src/tests/playwright/todomvc.play.ts
+++ b/tests/integration/src/tests/playwright/todomvc.play.ts
@@ -13,7 +13,7 @@ test(
       const page = yield* Effect.promise(() => browserContext.newPage())
 
       const pageConsoleFiber = yield* Playwright.handlePageConsole({ page, name: `tab-1` }).pipe(
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
       )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -142,7 +142,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         yield* mockSyncBackend
           .advance(eventFactory.todoCreated.next({ id: `backend_${i}`, text: '', completed: false }))
           .pipe(
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
       }

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -418,7 +418,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         yield* testContext.mockSyncBackend
           .advance(backendFactory.todoCreated.next({ id: `backend_${i}`, text: '', completed: false }))
           .pipe(
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
           )
       }
@@ -907,7 +907,7 @@ const LeaderThreadCtxLive = ({
           Effect.flip,
           Effect.exit,
           Effect.flatMap((exit) => Deferred.done(shutdownDeferred, exit)),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
       }

--- a/tests/package-common/src/leader-thread/stream-events.test.ts
+++ b/tests/package-common/src/leader-thread/stream-events.test.ts
@@ -162,7 +162,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectFiber = yield* stream.pipe(
           Stream.take(4),
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -226,7 +226,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectedFiber = yield* stream.pipe(
           Stream.take(2),
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -269,7 +269,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         // Stream.take(n) here is omitted to verify that the stream finalizes when reaching until cursor
         const collectFiber = yield* stream.pipe(
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -304,7 +304,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectedFiber = yield* stream.pipe(
           Stream.take(1),
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -347,7 +347,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectedFiber = yield* stream.pipe(
           Stream.take(1),
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -394,7 +394,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectedFiber = yield* stream.pipe(
           Stream.take(1),
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -450,7 +450,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectFiber = yield* stream.pipe(
           Stream.take(backendApproved.length),
           Stream.runCollect,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -560,7 +560,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
           const collectFiber = yield* stream.pipe(
             Stream.take(eventCount),
             Stream.runCollect,
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
             Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
           )
 

--- a/tests/package-common/src/test-adapter.ts
+++ b/tests/package-common/src/test-adapter.ts
@@ -80,7 +80,7 @@ export const makeTestAdapter = ({
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
         Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
       )
       const syncInMemoryDb = yield* makeSqliteDb({ _tag: 'in-memory' }).pipe(Effect.orDie)

--- a/tests/perf-eventlog/test-app/src/components/EventsList.tsx
+++ b/tests/perf-eventlog/test-app/src/components/EventsList.tsx
@@ -49,7 +49,7 @@ const stringify = (value: unknown) => {
 }
 
 const getSeqNum = (value: unknown): EventSeqNum | undefined => {
-  if (typeof value !== 'object' || value === null || ('seqNum' in value) === false) {
+  if (typeof value !== 'object' || value === null || 'seqNum' in value === false) {
     return undefined
   }
 

--- a/tests/perf-eventlog/test-app/src/components/EventsList.tsx
+++ b/tests/perf-eventlog/test-app/src/components/EventsList.tsx
@@ -49,7 +49,7 @@ const stringify = (value: unknown) => {
 }
 
 const getSeqNum = (value: unknown): EventSeqNum | undefined => {
-  if (typeof value !== 'object' || value === null || 'seqNum' in value === false) {
+  if (typeof value !== 'object' || value === null || ('seqNum' in value) === false) {
     return undefined
   }
 

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -164,7 +164,7 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
         // Start live pull and wait for the first non-empty batch in a fiber
         const fiber = yield* syncBackend.pull(Option.none(), { live: true }).pipe(
           runFirstNonEmpty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 
@@ -421,7 +421,7 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
 
         const fiber = yield* syncBackend.pull(Option.none(), { live: true }).pipe(
           runFirstNonEmpty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
+          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
           Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
         )
 


### PR DESCRIPTION
## Problem

The Effect v4 migration stack needs a final release-control slice on top of the docs, examples, and test workspace migration PR (#1355). Issue #1321 calls for a breaking Changeset, final validation evidence, and explicit tracking for any migration cleanup intentionally left out of the minimal stack.

## Solution

- Added a breaking Changeset for the fixed LiveStore package group documenting the Effect v4 migration.
- Documented that LiveStore now targets `effect@^4.0.0-beta.83` and the matching Effect v4 package family.
- Called out public peer dependency changes and the `@livestore/utils/effect` facade changes, including the removed `BucketQueue` and `ServiceContext` exports.
- Linked migration-debt TODOs in code to follow-up issues so the final stack records what was intentionally postponed.

## Breaking Changes

LiveStore now targets Effect v4. Consumers need compatible Effect v4 peers and should remove obsolete Effect v3 peer packages when those packages were only installed for LiveStore.

The `@livestore/utils/effect` facade now follows Effect v4 module boundaries. Consumers importing v3-era facade symbols should move to the corresponding Effect v4 APIs. The LiveStore-local `BucketQueue` and `ServiceContext` helpers are no longer exported.

## Follow-ups

- #1356 audits the temporary fork options used to preserve Effect v3 behavior during the migration.
- #1357 reassesses whether the custom `MessageChannel` scheduler is still needed under Effect v4.
- #1358 migrates the remaining Vitest 4 `poolOptions` config shape.

## Validation

- `devenv shell dt ts:check`
- `devenv shell dt lint:full`
- `devenv shell vitest run packages/@livestore/utils/src/effect/spanEvent.test.ts packages/@livestore/utils/src/effect/Stream.test.ts packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts packages/@livestore/utils/src/effect/WebSocket.test.ts packages/@livestore/utils/src/effect/Schema/debug-diff.test.ts packages/@livestore/livestore/src/effect/LiveStore.test.ts packages/@livestore/livestore/src/store/StoreRegistry.test.ts packages/@livestore/livestore/src/store/store-eventstream.test.ts packages/@livestore/common/src/schema/LiveStoreEvent/client.test.ts packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts packages/@livestore/common/src/sync/syncstate.test.ts packages/@livestore/common-cf/src/do-rpc/rpc.test.ts packages/@livestore/common-cf/src/ws-rpc/ws-rpc.test.ts`

Closes #1321.
