### PR TITLE
chore: remove stale Vercel config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ repos/
 /certs
 
 .wrangler
-.vercel
 .netlify
 
 # Created by the Netlify CLI when it bundles Deno edge functions during deploy

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
     // "**/node_modules/**/dist": false,
     // "**/{examples,packages}/**/dist": true,
     "**/.git": true,
-    "**/.vercel": true,
     "**/.netlify": true,
     "**/playwright-report": true,
     "**/.direnv": true,
@@ -18,7 +17,6 @@
   "search.exclude": {
     "**/.expo": true,
     "**/build": true,
-    "**/.vercel": true,
     "**/.direnv": true,
     "**/.wrangler": true,
     "**/dist": true,

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -12,7 +12,6 @@ tmp
 *.tsbuildinfo
 
 .wrangler
-.vercel
 .netlify
 
 *.config.timestamp_*.js

--- a/scripts/src/shared/cloudflare.ts
+++ b/scripts/src/shared/cloudflare.ts
@@ -1,10 +1,10 @@
 import { createHash } from 'node:crypto'
 import process from 'node:process'
 
-import { cmd, cmdText, LivestoreWorkspace } from '@livestore/utils-dev/node'
+import { cmd, LivestoreWorkspace } from '@livestore/utils-dev/node'
 import { Config, Effect, Schema } from '@livestore/utils/effect'
 
-import { type CloudflareDomain, type CloudflareExample, cloudflareExamplesBySlug } from './cloudflare-manifest.ts'
+import { type CloudflareExample, cloudflareExamplesBySlug } from './cloudflare-manifest.ts'
 
 /**
  * Tagged error used across Cloudflare deployment utilities so callers can
@@ -248,90 +248,3 @@ export const deployCloudflareWorker = ({
     }),
   )
 }
-
-type VercelDnsRecord = {
-  readonly id: string
-  readonly name: string
-  readonly type: string
-  readonly value: string
-}
-
-const parseVercelDnsRecords = (output: string): readonly VercelDnsRecord[] =>
-  output
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith('rec_'))
-    .flatMap((line) => {
-      const [id, name, type, ...rest] = line.split(/\s+/)
-      if (id === undefined || name === undefined || type === undefined || rest.length === 0) {
-        return []
-      }
-
-      return [
-        {
-          id,
-          name,
-          type,
-          value: rest.join(' '),
-        } satisfies VercelDnsRecord,
-      ]
-    })
-
-const normalizeDnsValue = (value: string) => value.replace(/\.$/, '')
-
-export const ensureVercelCnameRecord = ({ domain, name, target }: CloudflareDomain & { target: string }) =>
-  Effect.gen(function* () {
-    const dnsList = yield* cmdText(['bunx', 'vercel', 'dns', 'ls', domain]).pipe(
-      Effect.provide(LivestoreWorkspace.toCwd()),
-      Effect.mapError(
-        (cause) =>
-          new CloudflareError({
-            reason: 'dns',
-            message: `Failed to list DNS records for ${domain}`,
-            cause,
-          }),
-      ),
-    )
-
-    const records = parseVercelDnsRecords(dnsList)
-    const targetValue = normalizeDnsValue(target)
-
-    const matchingRecords = records.filter((record) => record.name === name && record.type.toUpperCase() === 'CNAME')
-
-    const staleRecords = matchingRecords.filter((record) => normalizeDnsValue(record.value) !== targetValue)
-
-    for (const staleRecord of staleRecords) {
-      yield* cmd(`printf 'y\\n' | bunx vercel dns rm ${staleRecord.id}`, {
-        shell: true,
-      }).pipe(
-        Effect.provide(LivestoreWorkspace.toCwd()),
-        Effect.mapError(
-          (cause) =>
-            new CloudflareError({
-              reason: 'dns',
-              message: `Failed to remove stale DNS record ${staleRecord.id} (${staleRecord.name}).`,
-              cause,
-            }),
-        ),
-      )
-    }
-
-    const existingTargetRecords = matchingRecords.filter(
-      (record) =>
-        normalizeDnsValue(record.value) === targetValue && !staleRecords.some((stale) => stale.id === record.id),
-    )
-
-    if (existingTargetRecords.length === 0) {
-      yield* cmd(['bunx', 'vercel', 'dns', 'add', domain, name, 'CNAME', target], {}).pipe(
-        Effect.provide(LivestoreWorkspace.toCwd()),
-        Effect.mapError(
-          (cause) =>
-            new CloudflareError({
-              reason: 'dns',
-              message: `Failed to add DNS record for ${name}.${domain}.`,
-              cause,
-            }),
-        ),
-      )
-    }
-  })

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "github": {
-    "silent": true
-  }
-}


### PR DESCRIPTION
## Problem

The repo still carried first-party Vercel references even though the active deployment paths are Netlify for docs and Cloudflare Workers for examples. This made the deployment tooling confusing: stale DNS helpers and local workflow config could suggest that `livestore.dev` DNS or local repo state still expected Vercel.

## Solution

Removed the root `vercel.json`, deleted the unused Vercel DNS helper from the Cloudflare deployment utilities, and removed `.vercel` ignore/exclude entries from tracked repo-local config.

Third-party and inherited shared-tooling artifacts are intentionally untouched. `pnpm-lock.yaml` still contains `@vercel/*` package metadata from dependency internals, `packages/@livestore/wa-sqlite/.yarn/releases/yarn-4.0.2.cjs` remains a vendored Yarn release, and generated oxlint configs still inherit `.vercel` ignore defaults from shared tooling.

Trade-off: this does not replace DNS automation with Netlify or Cloudflare DNS management. That broader IaC work is tracked separately.

## Validation

- `devenv shell dt ts:check`
- `git diff --check`
- `git grep -n -i -e vercel -e vercle -- . ':(exclude)pnpm-lock.yaml' ':(exclude)packages/@livestore/wa-sqlite/.yarn/releases/yarn-4.0.2.cjs'` only reports inherited/generated oxlint ignore defaults.

### Demo (optional)

The remaining Vercel references are limited to intentionally out-of-scope artifacts:

- generated `.oxlintrc.json` files inheriting shared ignore defaults
- `pnpm-lock.yaml`
- `packages/@livestore/wa-sqlite/.yarn/releases/yarn-4.0.2.cjs`

## Related issues

- Related to #1244
