### PR TITLE
chore: remove obsolete Expo hoisting rules

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -8,8 +8,3 @@ strict-peer-dependencies=false
 
 # We're manually installing peers as needed to avoid dependency conflicts
 auto-install-peers=false
-
-# TODO get rid of Expo-related hoisting rules once Expo properly works with PNPM https://github.com/expo/expo/issues/22413
-public-hoist-pattern[]=*expo*
-public-hoist-pattern[]=*hermes*
-public-hoist-pattern[]=*react-native*


### PR DESCRIPTION
## Problem

The workspace still carried temporary PNPM `public-hoist-pattern` entries for Expo, Hermes, and React Native. The adjacent TODO said these should be removed once Expo properly works with PNPM, and keeping the rules in place means installs continue to hoist those package families globally even when the workaround is no longer needed.

## Solution

Removed the Expo-related TODO and the three `public-hoist-pattern` entries from `.npmrc`. No changelog entry was added because this is an internal package-manager configuration cleanup and does not change a public package API or runtime behavior.

## Validation

- `pnpm config get public-hoist-pattern --location project` returned `undefined`
- `git diff --check`
- Commit hook `check-quick` passed

### Demo (optional)

Before this change, `.npmrc` configured project-level public hoisting for `*expo*`, `*hermes*`, and `*react-native*`. After this change, PNPM reports no project-level `public-hoist-pattern` value.

## Related issues

- https://github.com/expo/expo/issues/22413