### PR TITLE
chore(vitest): align configs with Vitest 4

### DIFF
--- a/.changeset/empty-vitest4-config-cleanup.md
+++ b/.changeset/empty-vitest4-config-cleanup.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Aligns Vitest 4 project configuration and test documentation without changing package runtime behavior.

--- a/packages/@livestore/livestore/vitest.config.ts
+++ b/packages/@livestore/livestore/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {

--- a/packages/@livestore/react/vitest.config.ts
+++ b/packages/@livestore/react/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {

--- a/packages/@livestore/sqlite-wasm/src/cf/test/README.md
+++ b/packages/@livestore/sqlite-wasm/src/cf/test/README.md
@@ -23,9 +23,9 @@ Tests for the CloudflareWorkerVFS implementation, which uses DurableObjectStorag
 
 ### Testing Framework
 
-- **Vitest** with **@cloudflare/vitest-pool-workers** for Workers runtime testing
-- **Isolated Storage** - Each test gets fresh storage instances
-- **Real Runtime** - Tests run in the actual Cloudflare Workers runtime environment
+- **Vitest** in the Node test environment
+- **Mocked Cloudflare storage interfaces** - Tests provide in-memory `DurableObjectStorage` and SQL storage doubles
+- **Per-test setup** - Each test creates fresh mock storage and VFS instances
 
 ## VFS Implementation Comparison
 
@@ -69,11 +69,6 @@ Tests for the CloudflareWorkerVFS implementation, which uses DurableObjectStorag
    pnpm install
    ```
 
-2. Ensure Wrangler configuration is correct:
-   ```bash
-   # Check wrangler.toml exists and has correct Durable Object bindings
-   ```
-
 ### Test Commands
 
 ```bash
@@ -100,8 +95,9 @@ pnpm test --coverage
 
 ### Test Environment
 
-- **Runtime**: Cloudflare Workers (via workerd)
-- **Storage**: Isolated per-test storage instances
+- **Runtime**: Node via Vitest
+- **Storage**: Mocked Durable Object storage and SQL storage instances created per test
+- **Scope**: Unit/integration coverage for VFS behavior against Cloudflare-shaped interfaces, not workerd runtime coverage
 
 ## Test Structure
 
@@ -185,7 +181,7 @@ describe('Async Storage VFS Test Suite', () => {
 
 ### Automatic Cleanup
 
-- **Isolated Storage**: Each test gets fresh storage instances
+- **Fresh mock storage**: Each test creates new in-memory storage instances
 - **Temporary Files**: Cleaned up automatically
 - **Cache Management**: Memory caches cleared between tests
 
@@ -225,6 +221,7 @@ console.log('File metadata:', metadata)
 2. **Migration Tests**: Converting between storage backends
 3. **Stress Tests**: High-load scenarios for both implementations
 4. **Real SQLite Integration**: Tests with actual SQLite WASM
+5. **Workers Runtime Coverage**: Add dedicated workerd-based tests if runtime bindings or Wrangler configuration need validation
 
 ### Implementation Improvements
 

--- a/packages/@livestore/sqlite-wasm/vitest.config.ts
+++ b/packages/@livestore/sqlite-wasm/vitest.config.ts
@@ -5,16 +5,6 @@ export default defineConfig({
     name: '@livestore/sqlite-wasm',
     root: import.meta.dirname,
     include: ['src/**/*.test.ts'],
-    // TODO(#1358): Migrate this removed Vitest 4 config shape.
-    poolOptions: {
-      workers: {
-        wrangler: {
-          configPath: './wrangler.toml',
-        },
-        isolatedStorage: false,
-        main: './src/test/setup.ts',
-      },
-    },
     server: { deps: { inline: ['@effect/vitest'] } },
   },
 })

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,9 +1,14 @@
+import path from 'node:path'
+
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
     include: ['src/**/*.test.ts'],
     environment: 'node',
+    env: {
+      WORKSPACE_ROOT: path.resolve(import.meta.dirname, '..'),
+    },
     server: { deps: { inline: ['@effect/vitest'] } },
   },
 })

--- a/tests/integration/src/tests/adapter-cloudflare/vitest.config.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/vitest.config.ts
@@ -1,5 +1,9 @@
-import { defineConfig } from 'vitest/config'
+import { defineProject } from 'vitest/config'
 
-export default defineConfig({
-  test: { server: { deps: { inline: ['@effect/vitest'] } } },
+export default defineProject({
+  test: {
+    root: import.meta.dirname,
+    include: ['*.test.ts'],
+    server: { deps: { inline: ['@effect/vitest'] } },
+  },
 })

--- a/tests/integration/src/tests/adapter-web/vitest.config.ts
+++ b/tests/integration/src/tests/adapter-web/vitest.config.ts
@@ -1,5 +1,9 @@
-import { defineConfig } from 'vitest/config'
+import { defineProject } from 'vitest/config'
 
-export default defineConfig({
-  test: { server: { deps: { inline: ['@effect/vitest'] } } },
+export default defineProject({
+  test: {
+    root: import.meta.dirname,
+    include: ['*.test.ts'],
+    server: { deps: { inline: ['@effect/vitest'] } },
+  },
 })

--- a/tests/integration/src/tests/devtools/vitest.config.ts
+++ b/tests/integration/src/tests/devtools/vitest.config.ts
@@ -1,5 +1,9 @@
-import { defineConfig } from 'vitest/config'
+import { defineProject } from 'vitest/config'
 
-export default defineConfig({
-  test: { server: { deps: { inline: ['@effect/vitest'] } } },
+export default defineProject({
+  test: {
+    root: import.meta.dirname,
+    include: ['*.test.ts'],
+    server: { deps: { inline: ['@effect/vitest'] } },
+  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ NOTE we're mapping to absolute paths here to avoid issues where tests seem to be
 */
 
 const rootDir = import.meta.dirname
-const resolveProjectPath = (packageDir: string): string => {
+const resolveProjectPath = (packageDir: string): string | undefined => {
   const rootConfig = path.join(packageDir, 'vitest.config.ts')
   if (fs.existsSync(rootConfig)) {
     return rootConfig
@@ -19,13 +19,14 @@ const resolveProjectPath = (packageDir: string): string => {
     return testsConfig
   }
 
-  return packageDir
+  return undefined
 }
 
 const rootPackages = fs
   .readdirSync(path.join(rootDir, './packages/@livestore'))
   .filter((dir) => fs.statSync(path.join(rootDir, './packages/@livestore', dir)).isDirectory())
   .map((dir) => resolveProjectPath(path.join(rootDir, './packages/@livestore', dir)))
+  .filter((projectPath): projectPath is string => projectPath !== undefined)
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Problem

Several Vitest configs were still carrying pre-Vitest-4 assumptions after the Effect v4 migration branch. The root workspace config could not be loaded from the repository root because Vitest was not a root dev dependency, nested integration configs collected the broader integration tree, standalone package configs typed their `test` block through Vite instead of Vitest, and `@livestore/sqlite-wasm` still documented a Workers-pool setup that was not actually wired.

## Solution

- Add Vitest to the root workspace metadata and lockfile so `vitest.config.ts` can resolve `vitest/config`.
- Limit root project discovery to packages with explicit Vitest configs.
- Scope the nested integration project configs to their local test directories.
- Import standalone package `defineConfig` from `vitest/config` so their `test` blocks are type-safe.
- Remove the stale sqlite-wasm `poolOptions.workers` block and update the README to describe the current Node/Vitest mock-storage setup.
- Provide `WORKSPACE_ROOT` in the scripts Vitest config so root project listing can collect scripts tests outside a direnv shell.

Trade-off: sqlite-wasm no longer pretends to exercise workerd/Wrangler bindings. Dedicated Workers runtime coverage remains future work if those bindings need validation.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `pnpm exec vitest list --config vitest.config.ts`
- `pnpm --dir packages/@livestore/sqlite-wasm exec vitest list --config vitest.config.ts`
- `pnpm --dir packages/@livestore/react exec tsc --noEmit --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 vitest.config.ts`
- `pnpm --dir packages/@livestore/livestore exec tsc --noEmit --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 vitest.config.ts`
- `pnpm --dir packages/@livestore/react exec vitest list --config vitest.config.ts`
- `pnpm --dir packages/@livestore/livestore exec vitest list --config vitest.config.ts`

### Demo (optional)

`pnpm exec vitest list --config vitest.config.ts` now lists 816 tests from the root workspace project config instead of failing during config loading or collection.

## Related issues

- Fixes #1358