### PR TITLE
refactor: remove Effect v3 fork compatibility options

### DIFF
--- a/.changeset/empty-effect-v4-fork-options.md
+++ b/.changeset/empty-effect-v4-fork-options.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Removes temporary Effect v3 fork compatibility options after auditing the affected runtime and test call sites against Effect v4 defaults.

--- a/examples/web-linearlite/src/components/layout/toolbar/sync-toggle.tsx
+++ b/examples/web-linearlite/src/components/layout/toolbar/sync-toggle.tsx
@@ -101,8 +101,7 @@ const usePendingSyncEvents = () => {
           Stream.runDrain,
           Effect.interruptible,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         yield* leaderSyncState.changes.pipe(
@@ -112,8 +111,7 @@ const usePendingSyncEvents = () => {
           Stream.runDrain,
           Effect.interruptible,
           Effect.tapCauseLogPretty,
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         return yield* Effect.never

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -155,7 +155,7 @@ export const makeAdapter =
             //     node: webmeshNode,
             //     url: `ws://${devtoolsOptions.host}:${devtoolsOptions.port}`,
             //     openTimeout: 500,
-            //   }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }))
+            //   }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
           }
         }),
         leaderThread,

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -346,7 +346,7 @@ const makeDevtoolsOptions = ({
           node,
           worker: sharedWorker,
           target: makeSharedWorkerNodeName({ storeId }),
-        }).pipe(Effect.tapCauseLogPretty, dieOnRpcClientError, Effect.forkScoped({ startImmediately: true }))
+        }).pipe(Effect.tapCauseLogPretty, dieOnRpcClientError, Effect.forkScoped)
 
         return { node, persistenceInfo, mode: 'direct' }
       }),

--- a/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
+++ b/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
@@ -203,7 +203,7 @@ export const makeSingleTabAdapter =
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       // In single-tab mode, we always have the lock (we're always the leader)
@@ -296,14 +296,14 @@ export const makeSingleTabAdapter =
         ),
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       yield* Queue.await(bootStatusQueue).pipe(
         Effect.andThen(Fiber.interrupt(bootStatusFiber)),
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       // Get initial snapshot (either from fast-path or from worker)

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/client-session-devtools.ts
@@ -74,7 +74,7 @@ export const connectWebmeshNodeClientSession = Effect.fn(function* ({
     yield* Devtools.SessionInfo.provideSessionInfo({
       webChannel: yield* DevtoolsWeb.makeSessionInfoBroadcastChannel,
       sessionInfo,
-    }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }))
+    }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
 
     yield* Effect.gen(function* () {
       const clientSessionStaticChannel = yield* DevtoolsWeb.makeStaticClientSessionChannel.clientSession
@@ -102,7 +102,7 @@ export const connectWebmeshNodeClientSession = Effect.fn(function* ({
     }).pipe(
       Effect.withSpan('@livestore/adapter-web:client-session:devtools:browser-extension'),
       Effect.tapCauseLogPretty,
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+      Effect.forkScoped,
     )
 
     yield* WebmeshWorker.connectViaWorker({

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -377,14 +377,10 @@ export const makePersistedAdapter =
           }),
           Effect.interruptible,
           Effect.tapCauseLogPretty,
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
       } else {
-        yield* runLocked.pipe(
-          Effect.interruptible,
-          Effect.tapCauseLogPretty,
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        yield* runLocked.pipe(Effect.interruptible, Effect.tapCauseLogPretty, Effect.forkScoped)
       }
 
       const runInWorker = <A, E, R>(
@@ -425,14 +421,14 @@ export const makePersistedAdapter =
         ),
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       yield* Queue.await(bootStatusQueue).pipe(
         Effect.andThen(Fiber.interrupt(bootStatusFiber)),
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       // TODO maybe bring back transfering the initially created in-memory db snapshot instead of

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -182,7 +182,7 @@ const makeWorkerRunner = Effect.gen(function* () {
             Stream.tap(() => reset),
             Stream.runDrain,
             Effect.tapCauseLogPretty,
-            Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkScoped,
           )
 
           const clientContext = yield* Layer.build(
@@ -209,13 +209,13 @@ const makeWorkerRunner = Effect.gen(function* () {
             node,
             worker: makeWebmeshWorkerProxy(client),
             target: Devtools.makeNodeName.client.leader({ storeId, clientId }),
-          }).pipe(Effect.tapCauseLogPretty, dieOnRpcClientError, Effect.forkScoped({ startImmediately: true }))
+          }).pipe(Effect.tapCauseLogPretty, dieOnRpcClientError, Effect.forkScoped)
 
           yield* SubscriptionRef.set(leaderWorkerContextSubRef, {
             client: client as RpcClient.FromGroup<typeof WorkerSchema.LeaderWorkerInnerRpcs>,
             scope,
           })
-        }).pipe(Effect.tapCauseLogPretty, Scope.provide(scope), Effect.forkIn(scope, { startImmediately: true }))
+        }).pipe(Effect.tapCauseLogPretty, Scope.provide(scope), Effect.forkIn(scope))
       }).pipe(Effect.withSpan('@livestore/adapter-web:shared-worker:updateMessagePort'), Effect.tapCauseLogPretty),
 
     // Proxied requests

--- a/packages/@livestore/common-cf/src/do-rpc/client.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.test.ts
@@ -73,11 +73,7 @@ Vitest.live('keeps a straddling stream frame isolated from a concurrent unary re
 
     const result = yield* Effect.gen(function* () {
       const client = yield* RpcClient.make(Rpcs)
-      const streamFiber = yield* client.BigStream({ n: expectedRows.length }).pipe(
-        Stream.runCollect,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      const streamFiber = yield* client.BigStream({ n: expectedRows.length }).pipe(Stream.runCollect, Effect.forkChild)
 
       yield* Effect.promise(() => firstStreamReadDone)
       const echo = yield* client.Echo({ text: 'hi' }).pipe(Effect.timeout('500 millis'))

--- a/packages/@livestore/common-cf/src/do-rpc/client.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.ts
@@ -104,8 +104,7 @@ const makeProtocolDurableObject = ({
               (response) => writeResponse(clientId, response),
             ).pipe(
               // Effect.tapCauseLogPretty,
-              // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-              Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+              Effect.forkChild,
             )
 
             // fiberMap.set(message.id, fiber)

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -176,11 +176,7 @@ export const setupDurableObjectWebSocketRpc = ({
 
       const ServerLive = rpcLayer.pipe(Layer.provide(ProtocolLive))
 
-      yield* Layer.launch(ServerLive).pipe(
-        Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      yield* Layer.launch(ServerLive).pipe(Effect.tapCauseLogPretty, Effect.forkIn(scope))
 
       const services = yield* Effect.context()
 
@@ -329,8 +325,7 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServer
         }),
         Stream.runDrain,
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkIn(scope),
       )
 
       // Start the message processing

--- a/packages/@livestore/common/src/devtools/devtools-sessioninfo.ts
+++ b/packages/@livestore/common/src/devtools/devtools-sessioninfo.ts
@@ -63,13 +63,14 @@ export const requestSessionInfoSubscription = ({
   staleTimeout?: Duration.Input
 }): Effect.Effect<Subscribable.Subscribable<HashSet.HashSet<SessionInfo>>, Schema.SchemaError, Scope.Scope> =>
   Effect.gen(function* () {
-    yield* webChannel.send(RequestSessions.make({})).pipe(
-      Effect.repeat(Schedule.spaced(pollInterval)),
-      Effect.interruptible,
-      Effect.tapCauseLogPretty,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    yield* webChannel
+      .send(RequestSessions.make({}))
+      .pipe(
+        Effect.repeat(Schedule.spaced(pollInterval)),
+        Effect.interruptible,
+        Effect.tapCauseLogPretty,
+        Effect.forkScoped,
+      )
 
     const timeoutFiberMap = yield* FiberMap.make<SessionInfo>()
 
@@ -95,8 +96,7 @@ export const requestSessionInfoSubscription = ({
       ),
       Stream.runDrain,
       Effect.tapCauseLogPretty,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+      Effect.forkScoped,
     )
 
     return Subscribable.make({

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -716,11 +716,7 @@ export const make = Effect.fnUntraced(function* ({
           return yield* Effect.failCause(cause).pipe(Effect.orDie)
         })
 
-      yield* backgroundApplyLocalPushes.pipe(
-        Effect.catchCause(maybeShutdownOnError),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      yield* backgroundApplyLocalPushes.pipe(Effect.catchCause(maybeShutdownOnError), Effect.forkScoped)
 
       const backendPushingFiberHandle = yield* FiberHandle.make<void, never>()
       const backendPushingEffect = backgroundBackendPushing.pipe(
@@ -755,8 +751,7 @@ export const make = Effect.fnUntraced(function* ({
         // Needed to avoid `Fiber terminated with an unhandled error` logs which seem to happen because of the `Effect.retry` above.
         // This might be a bug in Effect. Only seems to happen in the browser.
         Effect.provideService(References.UnhandledLogLevel, undefined),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       return { initialLeaderHead: initialSyncState.localHead }

--- a/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
+++ b/packages/@livestore/common/src/leader-thread/leader-worker-devtools.ts
@@ -39,11 +39,7 @@ export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:
   yield* listenToDevtools({
     incomingMessages: Stream.fromQueue(extraIncomingMessagesQueue),
     sendMessage: () => Effect.void,
-  }).pipe(
-    Effect.tapCauseLogPretty,
-    // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-    Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-  )
+  }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
 
   const bootResult = yield* options.boot.pipe(
     Effect.map(Option.some),
@@ -93,8 +89,7 @@ export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:
         yield* syncProcessor.pull({ cursor: syncState.localHead }).pipe(
           Stream.tap(({ payload }) => sendMessage(Devtools.Leader.SyncPull.make({ payload, liveStoreVersion }))),
           Stream.runDrain,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         yield* listenToDevtools({
@@ -102,11 +97,7 @@ export const bootDevtools = Effect.fn('@livestore/common:leader-thread:devtools:
           sendMessage,
           persistenceInfo,
         })
-      }).pipe(
-        Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      ),
+      }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped),
     ),
     Stream.runDrain,
   )

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.test.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.test.ts
@@ -28,19 +28,13 @@ Vitest.describe('makeNetworkStatusSubscribable', () => {
       const waitFor = (predicate: (status: SyncBackend.NetworkStatus) => boolean) =>
         networkStatus.changes.pipe(Stream.filter(predicate), Stream.runFirstUnsafe)
 
-      const onlineFiber = yield* waitFor((status) => status.isConnected).pipe(
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      const onlineFiber = yield* waitFor((status) => status.isConnected).pipe(Effect.forkScoped)
       yield* mockBackend.connect
       const online = yield* Fiber.join(onlineFiber)
       Vitest.expect(online.isConnected).toBe(true)
       Vitest.expect(online.timestampMs).toBeGreaterThanOrEqual(initial.timestampMs)
 
-      const latchedFiber = yield* waitFor((status) => status.devtools.latchClosed).pipe(
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      const latchedFiber = yield* waitFor((status) => status.devtools.latchClosed).pipe(Effect.forkScoped)
       yield* SubscriptionRef.set(latchStateRef, { latchClosed: true })
       const latched = yield* Fiber.join(latchedFiber)
       Vitest.expect(latched.devtools.latchClosed).toBe(true)

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -149,11 +149,7 @@ export const makeLeaderThreadLayer = ({
 
     if (syncBackend !== undefined) {
       // We're already connecting to the sync backend concurrently
-      yield* syncBackend.connect.pipe(
-        Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      yield* syncBackend.connect.pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
     }
 
     const initialBlockingSyncContext = yield* makeInitialBlockingSyncContext({
@@ -330,8 +326,7 @@ const makeInitialBlockingSyncContext = ({
     if (blockingDeferred !== undefined && initialSyncOptions._tag === 'Blocking') {
       yield* Deferred.succeed(blockingDeferred, void 0).pipe(
         Effect.delay(initialSyncOptions.timeout),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
     }
 
@@ -396,11 +391,7 @@ const bootLeaderThread = ({
 
     yield* Queue.offer(bootStatusQueue, { stage: 'done' })
 
-    yield* bootDevtools(devtoolsOptions).pipe(
-      Effect.tapCauseLogPretty,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    yield* bootDevtools(devtoolsOptions).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
 
     return { migrationsReport, leaderHead: initialLeaderHead }
   })
@@ -441,8 +432,7 @@ export const makeNetworkStatusSubscribable = ({
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
     }
 
@@ -452,8 +442,7 @@ export const makeNetworkStatusSubscribable = ({
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
     }
 

--- a/packages/@livestore/common/src/leader-thread/stream-events.ts
+++ b/packages/@livestore/common/src/leader-thread/stream-events.ts
@@ -95,8 +95,7 @@ export const streamEventsWithSyncState = ({
           return false
         }),
         Stream.runForEach((head) => Queue.offer(headQueue, head)),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       return Stream.paginate({ cursor: initialCursor, head: EventSequenceNumber.Client.ROOT }, ({ cursor, head }) =>

--- a/packages/@livestore/common/src/make-client-session.ts
+++ b/packages/@livestore/common/src/make-client-session.ts
@@ -82,11 +82,7 @@ export const makeClientSession = <R>({
         yield* Devtools.SessionInfo.provideSessionInfo({
           webChannel: sessionInfoBroadcastChannel,
           sessionInfo,
-        }).pipe(
-          Effect.tapCauseLogPretty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        }).pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
 
         yield* webmeshNode.listenForChannel.pipe(
           Stream.filter(
@@ -120,8 +116,7 @@ export const makeClientSession = <R>({
                 yield* connectDevtoolsToStore(clientSessionDevtoolsChannel)
               },
               Effect.tapCauseLogPretty,
-              // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-              Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+              Effect.forkScoped(),
             ),
           ),
           Stream.runDrain,
@@ -129,8 +124,7 @@ export const makeClientSession = <R>({
       }).pipe(
         Effect.withSpan('@livestore/common:make-client-session:devtools'),
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
     }
 

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -261,8 +261,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.interruptible,
       Effect.withSpan('client-session-sync-processor:pull'),
       Effect.tapCauseLogPretty,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+      Effect.forkScoped,
     )
   })()
 

--- a/packages/@livestore/effect-playwright/src/index.ts
+++ b/packages/@livestore/effect-playwright/src/index.ts
@@ -74,7 +74,7 @@ export const browserContext = ({
 
       // TODO bring back once Playwright supports console messages for workers/service workers
       // const backgroundPage = browserContext.serviceWorkers()[0] ?? (yield* Effect.promise(() => browserContext.waitForEvent('serviceworker')))
-      // backgroundPageConsoleFiber = yield* handlePageConsole(backgroundPage, 'background').pipe(Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }))
+      // backgroundPageConsoleFiber = yield* handlePageConsole(backgroundPage, 'background').pipe(Effect.forkChild)
     }
 
     yield* Effect.addFinalizer(() => Effect.promise(() => browserContext.close()))

--- a/packages/@livestore/livestore/src/store/StoreRegistry.test.ts
+++ b/packages/@livestore/livestore/src/store/StoreRegistry.test.ts
@@ -396,11 +396,7 @@ describe('StoreRegistry', () => {
         yield* TestClock.adjust(unusedCacheTime)
 
         // Start a fresh load — since the first was aborted, this should be a new entry
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        const freshLoadFiber = yield* Effect.forkChild(registry.getOrLoad(options).pipe(Effect.scoped), {
-          startImmediately: true,
-          uninterruptible: 'inherit',
-        })
+        const freshLoadFiber = yield* Effect.forkChild(registry.getOrLoad(options).pipe(Effect.scoped))
         yield* Effect.yieldNow
 
         // Advance enough for the fresh load to complete

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -316,8 +316,7 @@ export const createStore = <
         ),
         Effect.forever,
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       const storeDeferred = yield* Deferred.make<Store>()

--- a/packages/@livestore/livestore/src/store/store-eventstream.test.ts
+++ b/packages/@livestore/livestore/src/store/store-eventstream.test.ts
@@ -57,8 +57,7 @@ Vitest.describe('Store events API', () => {
       yield* store.eventsStream().pipe(
         Stream.tap((event) => Queue.offer(eventsQueue, event)),
         Stream.runDrain,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       store.commit(eventFactory.todoCreated.next({ id: '1', text: 't1', completed: false }))

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -941,10 +941,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         ],
       }),
       Effect.tapCause(Effect.logError),
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.catchCause((cause) =>
-        Effect.forkChild(this.shutdown(cause), { startImmediately: true, uninterruptible: 'inherit' }),
-      ),
+      Effect.catchCause((cause) => Effect.forkChild(this.shutdown(cause))),
       Effect.runSyncWith(this[StoreInternalsSymbol].effectContext.services),
     )
   }
@@ -1268,11 +1265,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
 
   private runEffectFork = <A, E>(effect: Effect.Effect<A, E, Scope.Scope>) =>
     effect.pipe(
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkIn(this[StoreInternalsSymbol].effectContext.lifetimeScope, {
-        startImmediately: true,
-        uninterruptible: 'inherit',
-      }),
+      Effect.forkIn(this[StoreInternalsSymbol].effectContext.lifetimeScope),
       Effect.tapCauseLogPretty,
       Effect.runForkWith(this[StoreInternalsSymbol].effectContext.services),
     )

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -182,8 +182,7 @@ export const makePush =
         Effect.tapCauseLogPretty,
         Effect.withSpan('push-rpc-broadcast'),
         Effect.uninterruptible, // We need to make sure Effect RPC doesn't interrupt this fiber
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkChild,
       )
 
       // We need to yield here to make sure the fork above is kicked off before we let Effect RPC finish the request

--- a/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/http-rpc-client.ts
@@ -117,12 +117,7 @@ export const makeHttpSync =
 
       if (options.ping?.enabled !== false) {
         // Automatically ping the server to keep the connection alive
-        yield* ping.pipe(
-          Effect.repeat(Schedule.spaced(pingInterval)),
-          Effect.tapCauseLogPretty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        yield* ping.pipe(Effect.repeat(Schedule.spaced(pingInterval)), Effect.tapCauseLogPretty, Effect.forkScoped)
       }
 
       // Helps already establish a TCP connection to the server

--- a/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
@@ -95,7 +95,7 @@ export const make = (args: Options) =>
           (acc, chunk) => acc + chunk,
         ),
         // Drain subprocess output immediately so the child cannot block while we wait for its exit code.
-        Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkChild,
       )
 
       const stderrFiber = yield* process.stderr.pipe(
@@ -105,7 +105,7 @@ export const make = (args: Options) =>
           (acc, chunk) => acc + chunk,
         ),
         // Drain subprocess output immediately so the child cannot block while we wait for its exit code.
-        Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkChild,
       )
 
       const exitCode = yield* process.exitCode

--- a/packages/@livestore/utils-dev/src/node/cmd.ts
+++ b/packages/@livestore/utils-dev/src/node/cmd.ts
@@ -263,15 +263,13 @@ const runWithLogging = ({
       const stdoutFiber = yield* runningProcess.stdout.pipe(
         Stream.decodeText({ encoding: 'utf8' }),
         Stream.runForEach((chunk) => stdoutHandler.onChunk(chunk)),
-        // Start immediately so output draining is installed before waiting on the process.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       const stderrFiber = yield* runningProcess.stderr.pipe(
         Stream.decodeText({ encoding: 'utf8' }),
         Stream.runForEach((chunk) => stderrHandler.onChunk(chunk)),
-        // Start immediately so output draining is installed before waiting on the process.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       // Dump any buffered data and finish both stream fibers before we return.

--- a/packages/@livestore/utils/src/effect/Effect.ts
+++ b/packages/@livestore/utils/src/effect/Effect.ts
@@ -303,8 +303,7 @@ export const toForkedDeferred = <R, E, A>(
         Effect.exit(eff),
         Effect.flatMap((ex) => Deferred.done(deferred, ex)),
         tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       ),
     ),
   )

--- a/packages/@livestore/utils/src/effect/RpcClient.ts
+++ b/packages/@livestore/utils/src/effect/RpcClient.ts
@@ -159,8 +159,7 @@ export const makeProtocolSocketWithIsConnected = (options: {
         Effect.interruptible,
         Effect.ignore, // Errors are already handled
         Effect.provideService(References.UnhandledLogLevel, undefined),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       return {
@@ -218,8 +217,7 @@ const makePinger = Effect.fnUntraced(function* <A, E, R>(
     Effect.ignore,
     Effect.forever,
     Effect.interruptible,
-    // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-    Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+    Effect.forkScoped,
   )
 
   // CHANGED: add manual ping

--- a/packages/@livestore/utils/src/effect/SubscriptionRef.ts
+++ b/packages/@livestore/utils/src/effect/SubscriptionRef.ts
@@ -23,8 +23,7 @@ export const fromStream = <A>(stream: Stream.Stream<A>, initialValue: A) =>
     yield* stream.pipe(
       Stream.tap((a) => SubscriptionRef.set(sref, a)),
       Stream.runDrain,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+      Effect.forkScoped,
     )
 
     return sref

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
@@ -23,8 +23,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkChild,
           )
 
           yield* channelToB.send(1)
@@ -44,8 +43,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkChild,
           )
 
           yield* channelToA.send(2)
@@ -73,8 +71,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkChild,
           )
 
           yield* channelToB.send(1)
@@ -94,8 +91,7 @@ Vitest.describe('WebChannel', () => {
             Stream.runHead,
             Effect.flatMap(Effect.fromOption),
             Effect.flatMap(Effect.fromResult),
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkChild,
           )
 
           yield* channelToA.send(2)

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.ts
@@ -365,8 +365,7 @@ export const toOpenChannel = <MsgListen, MsgSend>(
         : identity,
       Stream.tapArray((array) => Queue.offerAll(queue, array)),
       Stream.runDrain,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+      Effect.forkScoped,
     )
 
     if (options?.heartbeat !== undefined) {
@@ -383,11 +382,7 @@ export const toOpenChannel = <MsgListen, MsgSend>(
             Effect.catchTag('TimeoutError', () => channel.shutdown),
           )
         }
-      }).pipe(
-        Effect.withSpan(`WebChannel:heartbeat`),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      }).pipe(Effect.withSpan(`WebChannel:heartbeat`), Effect.forkScoped)
     }
 
     // We're currently limiting the chunk size to 1 to not drop messages in scearnios where

--- a/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel-internal.ts
@@ -267,8 +267,7 @@ export const makeDirectChannelInternal = ({
               Stream.filter(Schema.is(MeshSchema.DirectChannelPong)),
               Stream.take(1),
               Stream.runDrain,
-              // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-              Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+              Effect.forkChild,
             )
 
             // There seems to be some scenario where the initial ping message is lost.
@@ -343,12 +342,7 @@ export const makeDirectChannelInternal = ({
           return
         }
       }
-    }).pipe(
-      Effect.interruptible,
-      Effect.tapCauseLogPretty,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.interruptible, Effect.tapCauseLogPretty, Effect.forkScoped)
 
     const channel = yield* Deferred.await(deferred)
 

--- a/packages/@livestore/webmesh/src/channel/direct-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/direct-channel.ts
@@ -101,8 +101,7 @@ export const makeDirectChannel = ({
             Stream.take(1),
             Stream.runDrain,
             Effect.as('new-edge' as const),
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkChild,
           )
 
           const makeChannel = makeDirectChannelInternal({
@@ -119,8 +118,7 @@ export const makeDirectChannel = ({
             scope: makeDirectChannelScope,
           }).pipe(
             Scope.provide(makeDirectChannelScope),
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkIn(makeDirectChannelScope),
             // Given we only await the exit later when observing the fiber,
             // we don't want Effect to produce a "unhandled error" log message
             Effect.provideService(References.UnhandledLogLevel, undefined),
@@ -169,8 +167,7 @@ export const makeDirectChannel = ({
           Stream.tapArray((array) => Queue.offerAll(listenQueue, array)),
           Stream.runDrain,
           Effect.tapCauseLogPretty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkIn(makeDirectChannelScope),
         )
 
         yield* Effect.gen(function* () {
@@ -183,10 +180,7 @@ export const makeDirectChannel = ({
             yield* Deferred.succeed(deferred, void 0)
             yield* TxQueue.take(sendQueue) // Remove the message from the queue
           }
-        }).pipe(
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkIn(makeDirectChannelScope, { startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        }).pipe(Effect.forkIn(makeDirectChannelScope))
 
         // Wait until the channel is closed and then try to reconnect
         yield* Deferred.await(channel.closedDeferred)
@@ -200,8 +194,7 @@ export const makeDirectChannel = ({
         Effect.scoped, // Additionally scoping here to clean up finalizers after each loop run
         Effect.forever,
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
       //#endregion reconnect-loop
 

--- a/packages/@livestore/webmesh/src/channel/proxy-channel.ts
+++ b/packages/@livestore/webmesh/src/channel/proxy-channel.ts
@@ -326,11 +326,7 @@ export const makeProxyChannel = ({
                 )
               })
 
-              yield* ackSendEffect.pipe(
-                Effect.tapCauseLogPretty,
-                // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-                Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-              )
+              yield* ackSendEffect.pipe(Effect.tapCauseLogPretty, Effect.forkScoped)
 
               // Simulation point: delay after forking ACK (before processing message)
               yield* simSleep('onPayload', 'afterAckFork')
@@ -396,8 +392,7 @@ export const makeProxyChannel = ({
         const retryOnNewEdgeFiber = yield* Stream.fromPubSub(newEdgeAvailablePubSub).pipe(
           Stream.tap(() => edgeRequest),
           Stream.runDrain,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         // Drain queued proxy packets only after the local side entered `Pending` and sent its
@@ -406,8 +401,7 @@ export const makeProxyChannel = ({
           Stream.tap(processProxyPacket),
           Stream.runDrain,
           Effect.tapCauseLogPretty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         const { combinedChannelId: channelId } = yield* waitForEstablished
@@ -465,8 +459,7 @@ export const makeProxyChannel = ({
             Stream.filter((_) => _ === false),
             Stream.tap(() => FiberHandle.run(sendFiberHandle, trySend)),
             Stream.runDrain,
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkChild,
           )
 
           yield* FiberHandle.run(sendFiberHandle, trySend)

--- a/packages/@livestore/webmesh/src/node.test.ts
+++ b/packages/@livestore/webmesh/src/node.test.ts
@@ -482,11 +482,7 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
               Stream.take(messageCount),
               Stream.runDrain,
             )
-          }).pipe(
-            Effect.scoped,
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-          )
+          }).pipe(Effect.scoped, Effect.forkChild)
 
           // yield* createChannel(nodeA, 'B').pipe(Effect.andThen(WebChannel.shutdown))
           // // yield* createChannel(nodeA, 'B').pipe(Effect.andThen(WebChannel.shutdown))
@@ -1292,15 +1288,13 @@ Vitest.describe('webmesh node', { timeout: testTimeout }, () => {
           Stream.mapEffect(Effect.fromResult),
           Stream.runHead,
           Effect.flatMap(Effect.fromOption),
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkChild,
         )
         const listenOnCFiber = yield* channelOnC.listen.pipe(
           Stream.mapEffect(Effect.fromResult),
           Stream.runHead,
           Effect.flatMap(Effect.fromOption),
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkChild,
         )
 
         yield* channelOnA.send('A1')

--- a/packages/@livestore/webmesh/src/node.ts
+++ b/packages/@livestore/webmesh/src/node.ts
@@ -441,8 +441,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
           Effect.interruptible,
           Effect.orDie,
           Effect.tapCauseLogPretty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         edgeChannels.set(targetNodeName, { channel: edgeChannel, listenFiber })
@@ -525,8 +524,7 @@ export const makeMeshNode = <TName extends MeshNodeName>(
             Effect.forever,
             Effect.interruptible,
             Effect.tapCauseLogPretty,
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkScoped,
           )
 
           // NOTE already retries internally when transferables are required

--- a/packages/@livestore/webmesh/src/websocket-edge.ts
+++ b/packages/@livestore/webmesh/src/websocket-edge.ts
@@ -151,8 +151,7 @@ export const makeWebSocketEdge = ({
         Effect.interruptible,
         Effect.withSpan('makeWebSocketEdge:listen'),
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
 
       const initHandshake = (from: string) =>

--- a/packages/@livestore/webmesh/src/worker/mod.ts
+++ b/packages/@livestore/webmesh/src/worker/mod.ts
@@ -71,8 +71,7 @@ export const connectViaWorker = ({
       Stream.tap(() => Deferred.succeed(isConnected, true)),
       Stream.runDrain,
       Effect.tapCauseLogPretty,
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+      Effect.forkScoped,
     )
 
     yield* Deferred.await(isConnected)

--- a/packages/@local/astro-tldraw/src/cli.watch.test.ts
+++ b/packages/@local/astro-tldraw/src/cli.watch.test.ts
@@ -78,9 +78,7 @@ Vitest.describe('watchDiagrams', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-
-      yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
+      yield* Effect.forkScoped(watchEffect)
 
       const initial = yield* Queue.take(rebuildEvents).pipe(Effect.timeout('5 seconds'), Effect.orDie)
       Vitest.expect(initial.reason).toBe('initial')
@@ -108,9 +106,7 @@ Vitest.describe('watchDiagrams', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-
-      yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
+      yield* Effect.forkScoped(watchEffect)
 
       /* Wait for initial build */
       const initial = yield* Queue.take(rebuildEvents).pipe(Effect.timeout('5 seconds'), Effect.orDie)
@@ -147,9 +143,7 @@ Vitest.describe('watchDiagrams', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-
-      yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
+      yield* Effect.forkScoped(watchEffect)
 
       /* Wait for initial build */
       const initial = yield* Queue.take(rebuildEvents).pipe(Effect.timeout('5 seconds'), Effect.orDie)

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
@@ -68,9 +68,7 @@ describe('watchSnippets', () => {
         onRebuild: (info) => Queue.offer(rebuildEvents, info),
       })
 
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-
-      yield* Effect.forkScoped(watchEffect, { startImmediately: true, uninterruptible: 'inherit' })
+      yield* Effect.forkScoped(watchEffect)
 
       const initial = yield* Queue.take(rebuildEvents)
       expect(initial.reason).toBe('initial')

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -242,10 +242,7 @@ const startHeartbeat = ({ phase, intervalMs = 30_000 }: { phase: string; interva
         console.log(`::notice title=docs-deploy-heartbeat::phase=${phase} elapsed=${elapsedSec}s`)
       }),
       Schedule.spaced(Duration.millis(intervalMs)),
-    ).pipe(
-      // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    ).pipe(Effect.forkScoped)
   })
 
 type DocsBuildOptions = {
@@ -468,8 +465,7 @@ export const docsCommand = Cli.Command.make('docs').pipe(
         if (skipDeps === false) {
           yield* runDocsDiagramsWatchNoInitialBuild.pipe(
             Effect.catchCause((cause) => Effect.logWarning('Diagrams watch stopped', cause)),
-            // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+            Effect.forkScoped,
           )
         }
 

--- a/scripts/src/shared/netlify.ts
+++ b/scripts/src/shared/netlify.ts
@@ -193,8 +193,7 @@ export const deployToNetlify = Effect.fn('netlify.deploy')(
             () => '',
             (acc, chunk) => acc + chunk,
           ),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         const stderrFiber = yield* proc.stderr.pipe(
@@ -203,8 +202,7 @@ export const deployToNetlify = Effect.fn('netlify.deploy')(
             () => '',
             (acc, chunk) => acc + chunk,
           ),
-          // TODO: These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         yield* proc.exitCode

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -39,11 +39,7 @@ const viteDevServer = ({
         ).pipe(Effect.orDie),
         LSD_DEVTOOLS_LOCAL_PREVIEW: useDevtoolsLocalPreview === true ? '1' : undefined,
       },
-    }).pipe(
-      Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)), Effect.forkScoped)
 
     return { devPort }
   })

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -46,11 +46,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
           TEST_LIVESTORE_SCHEMA_PATH_JSON: undefined, // ensure devtools plugin is disabled
           LSD_DEVTOOLS_LOCAL_PREVIEW: undefined,
         },
-      }).pipe(
-        Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)), Effect.forkScoped)
 
       const appUrl = (pathname: string) => `http://localhost:${port}${pathname}`
 
@@ -122,11 +118,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
           TEST_LIVESTORE_SCHEMA_PATH_JSON: undefined,
           LSD_DEVTOOLS_LOCAL_PREVIEW: undefined,
         },
-      }).pipe(
-        Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)), Effect.forkScoped)
 
       const appUrl = (pathname: string) => `http://localhost:${port}${pathname}`
 
@@ -189,11 +181,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
           TEST_LIVESTORE_SCHEMA_PATH_JSON: undefined,
           LSD_DEVTOOLS_LOCAL_PREVIEW: undefined,
         },
-      }).pipe(
-        Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)),
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)), Effect.forkScoped)
 
       const appUrl = (pathname: string) => `http://localhost:${port}${pathname}`
 

--- a/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
@@ -52,7 +52,7 @@ const makeTabPair = (
     const newPage = Effect.gen(function* () {
       // const pageEventFiber = yield* Effect.callback((cb) => {
       //   browserContext.on('page', () => cb(Effect.void))
-      // }).pipe(Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }))
+      // }).pipe(Effect.forkChild)
 
       const page = yield* Effect.tryPromise(() => browserContext.newPage())
       // yield* Fiber.await(pageEventFiber)
@@ -86,10 +86,7 @@ const makeTabPair = (
       page,
       name: `${tabName}-page`,
       shouldEvaluateArgs: false,
-    }).pipe(
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.forkChild)
 
     usedPages.add(page)
 
@@ -105,10 +102,7 @@ const makeTabPair = (
       page: devtools,
       name: `${tabName}-devtools`,
       shouldEvaluateArgs: false,
-    }).pipe(
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.forkChild)
 
     usedPages.add(devtools)
 

--- a/tests/integration/src/tests/playwright/devtools/web.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/web.play.ts
@@ -81,10 +81,7 @@ const makeTabPair = (
       page,
       name: `${tabName}-page`,
       shouldEvaluateArgs: false,
-    }).pipe(
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.forkScoped)
 
     usedPages.add(page)
     yield* Effect.addFinalizer(() => Effect.sync(() => usedPages.delete(page)))
@@ -119,10 +116,7 @@ const makeTabPair = (
       page: devtools,
       name: `${tabName}-devtools`,
       shouldEvaluateArgs: false,
-    }).pipe(
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    }).pipe(Effect.forkScoped)
 
     const devtoolsRoute =
       options?.devtoolsRoute === 'direct-session'

--- a/tests/integration/src/tests/playwright/shared-test.ts
+++ b/tests/integration/src/tests/playwright/shared-test.ts
@@ -57,10 +57,7 @@ export const runAndGetExit = <S extends Schema.Decoder<{ readonly exit: unknown 
       ),
     )
 
-    const pageConsoleFiber = yield* Playwright.handlePageConsole({ page, name: `tab-1` }).pipe(
-      // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-      Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-    )
+    const pageConsoleFiber = yield* Playwright.handlePageConsole({ page, name: `tab-1` }).pipe(Effect.forkChild)
 
     return yield* Effect.gen(function* () {
       type Result = Schema.Schema.Type<S>

--- a/tests/integration/src/tests/playwright/todomvc.play.ts
+++ b/tests/integration/src/tests/playwright/todomvc.play.ts
@@ -12,10 +12,7 @@ test(
       const { browserContext } = yield* Playwright.BrowserContext
       const page = yield* Effect.promise(() => browserContext.newPage())
 
-      const pageConsoleFiber = yield* Playwright.handlePageConsole({ page, name: `tab-1` }).pipe(
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-      )
+      const pageConsoleFiber = yield* Playwright.handlePageConsole({ page, name: `tab-1` }).pipe(Effect.forkChild)
 
       yield* Effect.promise(async () => {
         await page.goto(`http://localhost:${process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT}/devtools/todomvc`)

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -141,10 +141,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       for (let i = 0; i < 5; i++) {
         yield* mockSyncBackend
           .advance(eventFactory.todoCreated.next({ id: `backend_${i}`, text: '', completed: false }))
-          .pipe(
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-          )
+          .pipe(Effect.forkChild)
       }
 
       for (let i = 0; i < 5; i++) {

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -417,10 +417,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       for (let i = 0; i < 5; i++) {
         yield* testContext.mockSyncBackend
           .advance(backendFactory.todoCreated.next({ id: `backend_${i}`, text: '', completed: false }))
-          .pipe(
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-          )
+          .pipe(Effect.forkChild)
       }
 
       for (let i = 0; i < 5; i++) {
@@ -907,8 +904,7 @@ const LeaderThreadCtxLive = ({
           Effect.flip,
           Effect.exit,
           Effect.flatMap((exit) => Deferred.done(shutdownDeferred, exit)),
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
       }
 

--- a/tests/package-common/src/leader-thread/stream-events.test.ts
+++ b/tests/package-common/src/leader-thread/stream-events.test.ts
@@ -159,12 +159,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
           },
         })
 
-        const collectFiber = yield* stream.pipe(
-          Stream.take(4),
-          Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const collectFiber = yield* stream.pipe(Stream.take(4), Stream.runCollect, Effect.forkScoped)
 
         yield* advanceHead(initialEvents[1]!.seqNum)
 
@@ -223,12 +218,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
           },
         })
 
-        const collectedFiber = yield* stream.pipe(
-          Stream.take(2),
-          Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const collectedFiber = yield* stream.pipe(Stream.take(2), Stream.runCollect, Effect.forkScoped)
 
         yield* advanceHead(encodedEvents.at(-1)!.seqNum)
 
@@ -267,11 +257,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         yield* advanceHead(encodedEvents[1]!.seqNum)
 
         // Stream.take(n) here is omitted to verify that the stream finalizes when reaching until cursor
-        const collectFiber = yield* stream.pipe(
-          Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const collectFiber = yield* stream.pipe(Stream.runCollect, Effect.forkScoped)
 
         const emitted = yield* collectFiber.pipe(Fiber.join)
         yield* closeHeads
@@ -301,12 +287,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
           },
         })
 
-        const collectedFiber = yield* stream.pipe(
-          Stream.take(1),
-          Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const collectedFiber = yield* stream.pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
 
         yield* advanceHead(second.seqNum)
 
@@ -344,12 +325,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
           },
         })
 
-        const collectedFiber = yield* stream.pipe(
-          Stream.take(1),
-          Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const collectedFiber = yield* stream.pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
 
         yield* advanceHead(eventB.seqNum)
 
@@ -391,12 +367,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
           },
         })
 
-        const collectedFiber = yield* stream.pipe(
-          Stream.take(1),
-          Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const collectedFiber = yield* stream.pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
 
         yield* advanceHead(eventSessionTwo.seqNum)
 
@@ -450,8 +421,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
         const collectFiber = yield* stream.pipe(
           Stream.take(backendApproved.length),
           Stream.runCollect,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+          Effect.forkScoped,
         )
 
         yield* advanceHead(backendApproved[backendApproved.length - 1]!.seqNum)
@@ -557,12 +527,7 @@ Vitest.describe.concurrent('streamEventsWithSyncState', () => {
             },
           })
 
-          const collectFiber = yield* stream.pipe(
-            Stream.take(eventCount),
-            Stream.runCollect,
-            // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-            Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
-          )
+          const collectFiber = yield* stream.pipe(Stream.take(eventCount), Stream.runCollect, Effect.forkScoped)
 
           const tickSize = batchSize * batchesPerTick
           for (let index = tickSize; index < generatedEvents.length; index += tickSize) {

--- a/tests/package-common/src/test-adapter.ts
+++ b/tests/package-common/src/test-adapter.ts
@@ -80,8 +80,7 @@ export const makeTestAdapter = ({
         Stream.runDrain,
         Effect.interruptible,
         Effect.tapCauseLogPretty,
-        // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-        Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' }),
+        Effect.forkScoped,
       )
       const syncInMemoryDb = yield* makeSqliteDb({ _tag: 'in-memory' }).pipe(Effect.orDie)
       const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -162,11 +162,7 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
         const eventFactory = makeFactory({ client: defaultClient, startSeq: 1, initialParent: 'root' })
 
         // Start live pull and wait for the first non-empty batch in a fiber
-        const fiber = yield* syncBackend.pull(Option.none(), { live: true }).pipe(
-          runFirstNonEmpty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const fiber = yield* syncBackend.pull(Option.none(), { live: true }).pipe(runFirstNonEmpty, Effect.forkChild)
 
         // Let the live pull idle for a bit (covers long-poll/SSE)
         yield* Effect.sleep(800)
@@ -419,11 +415,7 @@ Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, 
       Effect.gen(function* () {
         const syncBackend = yield* makeProvider(test.task.name)
 
-        const fiber = yield* syncBackend.pull(Option.none(), { live: true }).pipe(
-          runFirstNonEmpty,
-          // TODO(#1356): These options were set to preserve Effect v3 fork behavior while migrating to Effect v4. Verify if they're the most appropriate configuration for this specific fork.
-          Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' }),
-        )
+        const fiber = yield* syncBackend.pull(Option.none(), { live: true }).pipe(runFirstNonEmpty, Effect.forkChild)
 
         const syncProvider = yield* SyncProviderImpl
 


### PR DESCRIPTION
## Problem

The Effect v4 migration kept many fork call sites on explicit v3-compatibility options while the runtime/test behavior was audited. That left repeated migration TODOs around `Effect.forkScoped`, `Effect.forkChild`, and `Effect.forkIn` in sync, store, WebChannel, webmesh, docs tooling, and integration test code. Those comments made the intended fork semantics unclear and kept #1356 open.

## Solution

Remove the temporary `{ startImmediately: true, uninterruptible: 'inherit' }` compatibility options from the audited call sites and let the Effect v4 fork helpers use their defaults directly. This also removes the repeated TODO comments rather than adding a shared helper, because the audit did not identify a distinct non-default policy that should be named and reused.

The changed surface is intentionally mechanical across runtime and tests:

- adapter/store sync background fibers
- common-cf and sync-cf RPC fibers
- WebChannel/webmesh listeners
- Playwright/devtools/test helper fibers
- docs/example watcher and deploy helper fibers

Trade-off: this PR depends on the Effect v4 default fork semantics matching the audited call sites instead of preserving the earlier migration shim defensively.

## Validation

- `rg "TODO\\(#1356\\)|LS-406|forkScoped\\(\\{ startImmediately|forkChild\\(\\{ startImmediately|forkIn\\([^\\n]*startImmediately" -n` returns no matches.
- GitHub Actions on commit `5a79db10e` passed: `lint`, `type-check`, `test-unit`, `wa-sqlite-test`, `perf-test`, Playwright integration suites, sync-provider integration suites, `changeset-check`, `source-policy`, and `build-and-deploy-examples-src`.
- At the time of this PR description update, `build-deploy-docs` was still pending and the release/manifest automation jobs `validate-release-plan` and `update-manifest-pr` were failing; those appear separate from the fork-option audit.

### Demo (optional)

The audit replaces the temporary compatibility form:

```ts
Effect.forkScoped({ startImmediately: true, uninterruptible: 'inherit' })
Effect.forkChild({ startImmediately: true, uninterruptible: 'inherit' })
Effect.forkIn(scope, { startImmediately: true, uninterruptible: 'inherit' })
```

with direct Effect v4 helper usage such as `Effect.forkScoped`, `Effect.forkChild`, and `Effect.forkIn(scope)`.

## Related issues

- Closes #1356
