### PR TITLE
fix(docs): restore `docs` type checking

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "astro": "astro",
-    "build": "astro check && astro build",
+    "check": "astro sync && astro-check",
+    "build": "pnpm check && astro build",
     "dev": "astro dev",
     "dev:docs:sync": "mxbai store sync \"livestore-docs-dev\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\"  --yes --strategy fast",
     "prod:docs:sync": "mxbai store sync \"livestore-docs\" \"./src/content/**/*.mdx\" \"./src/content/**/*.md\" --yes --strategy fast",

--- a/docs/package.json.genie.ts
+++ b/docs/package.json.genie.ts
@@ -86,7 +86,10 @@ export default packageJson(
     },
     scripts: {
       astro: 'astro',
-      build: 'astro check && astro build',
+      // Temporary workaround for https://github.com/livestorejs/livestore/issues/1377.
+      // Astro 6 resolves @astrojs/check from Astro's virtual-store location instead of the docs project.
+      check: 'astro sync && astro-check',
+      build: 'pnpm check && astro build',
       dev: 'astro dev',
       'dev:docs:sync':
         'mxbai store sync "livestore-docs-dev" "./src/content/**/*.mdx" "./src/content/**/*.md"  --yes --strategy fast',

--- a/docs/src/pages/api/docs-slugs.json.ts
+++ b/docs/src/pages/api/docs-slugs.json.ts
@@ -27,7 +27,9 @@ export const GET = async () => {
   }
 
   const docs = await getCollection('docs')
-  const slugs = docs.map((doc) => toSlug(doc.id, doc.slug)).filter((slug) => slug !== '')
+  const slugs = docs
+    .map((doc) => toSlug(doc.id, 'slug' in doc && typeof doc.slug === 'string' ? doc.slug : undefined))
+    .filter((slug) => slug !== '')
 
   return new Response(JSON.stringify({ slugs }), {
     headers: {

--- a/docs/src/pages/api/search.ts
+++ b/docs/src/pages/api/search.ts
@@ -96,8 +96,10 @@ export const GET: APIRoute = async ({ url }) => {
 
     response.data.forEach((item, index) => {
       const metadata = {
-        ...item.metadata,
-        ...item.generated_metadata,
+        ...(typeof item.metadata === 'object' && item.metadata !== null ? item.metadata : {}),
+        ...(typeof item.generated_metadata === 'object' && item.generated_metadata !== null
+          ? item.generated_metadata
+          : {}),
       } as SearchMetadata
 
       const url = filePathToHref(metadata?.file_path || '')

--- a/docs/src/pages/llms-full.txt.ts
+++ b/docs/src/pages/llms-full.txt.ts
@@ -16,7 +16,7 @@ export const GET: APIRoute = async ({ site }) => {
       const content = await transformMultiCodeDocument({
         id: doc.id,
         collection: doc.collection,
-        body: doc.body,
+        body: doc.body ?? '',
       })
       return { doc, body: stripLeadingImports(content).trim() }
     }),

--- a/docs/src/plugins/starlight/markdown/markdown.ts
+++ b/docs/src/plugins/starlight/markdown/markdown.ts
@@ -30,7 +30,7 @@ const normalizeDocPath = (value: unknown): string => {
 }
 
 const staticPathFromDoc = (doc: TDoc): string => {
-  const slug = typeof doc.slug === 'string' ? doc.slug.replace(/^\//u, '') : undefined
+  const slug = 'slug' in doc && typeof doc.slug === 'string' ? doc.slug.replace(/^\//u, '') : undefined
   return slug && slug !== '' ? slug : normalizeDocPath(doc.id)
 }
 
@@ -38,7 +38,7 @@ const transformBody = async (doc: TDoc): Promise<string> =>
   transformMultiCodeDocument({
     id: doc.id,
     collection: doc.collection,
-    body: doc.body,
+    body: doc.body ?? '',
     debug: process.env.LS_DEBUG_MARKDOWN === '1',
   })
 
@@ -58,7 +58,8 @@ export async function GET({ params }: APIContext): Promise<Response> {
     for (const doc of docs) {
       const idNorm = normalizeDocPath(doc.id)
       const slugNorm = staticPathFromDoc(doc)
-      if (idNorm === key || doc.slug === key) return doc
+      const docSlug = 'slug' in doc && typeof doc.slug === 'string' ? doc.slug : undefined
+      if (idNorm === key || docSlug === key) return doc
       if (idNorm === `${key}/index`) return doc
       if (`${idNorm}/index` === key) return doc
       if (slugNorm === key) return doc
@@ -91,7 +92,7 @@ export async function GET({ params }: APIContext): Promise<Response> {
     })
   }
 
-  const title = doc.data?.title ?? doc.slug ?? key
+  const title = doc.data?.title ?? ('slug' in doc && typeof doc.slug === 'string' ? doc.slug : key)
   const transformedBody = await transformBody(doc)
   /**
    * Substitute the MDX-only `<LlmsShort />` marker so markdown fetches mirror

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -34,6 +34,7 @@
       }
     ],
     "rootDir": "./src",
+    "moduleResolution": "Bundler",
     "jsx": "preserve",
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },

--- a/docs/tsconfig.json.genie.ts
+++ b/docs/tsconfig.json.genie.ts
@@ -14,6 +14,7 @@ export default tsconfigJson({
     declaration: false,
     declarationMap: false,
     module: 'ESNext',
+    moduleResolution: 'Bundler',
     target: 'ESNext',
     jsx: 'preserve',
     tsBuildInfoFile: './dist/.tsbuildinfo',

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -279,20 +279,27 @@ const docsBuildCommand = Cli.Command.make(
       yield* cleanupChromiumChildren()
     }
 
+    const astroEnv = {
+      STARLIGHT_INCLUDE_API_DOCS: apiDocs === true ? '1' : undefined,
+      // Building the docs sometimes runs out of memory, so we give it more
+      NODE_OPTIONS: '--max_old_space_size=4096',
+      // Snippets/diagrams already built above (or skipped), tell Astro integrations not to auto-build.
+      // Without these flags, the integrations would rebuild during astro:build:start, duplicating work.
+      LS_SKIP_SNIPPET_AUTO_BUILD_AND_WATCH: '1',
+      LS_TLDRAW_SKIP_AUTO_BUILD: '1',
+      LS_SKIP_OG_IMAGES: process.env.LS_SKIP_OG_IMAGES ?? '1',
+      DT_PASSTHROUGH: '1',
+    }
+
+    // Temporary workaround for https://github.com/livestorejs/livestore/issues/1377.
+    // Astro 6 imports @astrojs/check from Astro's virtual-store package context, so run sync + astro-check
+    // directly until the Astro/Vite package stack is upgraded.
+    yield* cmd('pnpm astro sync', { env: astroEnv }).pipe(Effect.provide(LivestoreWorkspace.toCwd('docs')))
+    yield* cmd('pnpm exec astro-check', { env: astroEnv }).pipe(Effect.provide(LivestoreWorkspace.toCwd('docs')))
+
     // Local/CI prebuild uses Astro directly. The deploy step performs the
     // Netlify build (single build overall), which handles Edge bundling.
-    yield* cmd('pnpm astro build', {
-      env: {
-        STARLIGHT_INCLUDE_API_DOCS: apiDocs === true ? '1' : undefined,
-        // Building the docs sometimes runs out of memory, so we give it more
-        NODE_OPTIONS: '--max_old_space_size=4096',
-        // Snippets/diagrams already built above (or skipped), tell Astro integrations not to auto-build.
-        // Without these flags, the integrations would rebuild during astro:build:start, duplicating work.
-        LS_SKIP_SNIPPET_AUTO_BUILD_AND_WATCH: '1',
-        LS_TLDRAW_SKIP_AUTO_BUILD: '1',
-        LS_SKIP_OG_IMAGES: process.env.LS_SKIP_OG_IMAGES ?? '1',
-      },
-    }).pipe(Effect.provide(LivestoreWorkspace.toCwd('docs')))
+    yield* cmd('pnpm astro build', { env: astroEnv }).pipe(Effect.provide(LivestoreWorkspace.toCwd('docs')))
     yield* cleanupChromiumChildren()
   }),
 )


### PR DESCRIPTION
## Problem

The docs package had a type-check gate in `build`, but docs type checking was not working end to end. Running the checker exposed two separate blockers:

- The docs TypeScript config did not use bundler module resolution, so TypeScript 6 could not resolve workspace package exports like `@livestore/common`, `@livestore/utils`, and `@local/shared` from the Astro docs project.
- The current Astro 6 CLI path for `astro check` misloads `@astrojs/check` under this repo's pnpm/devenv virtual-store layout, so the package-level check command needed a project-local workaround until #1377 is actually fixed.

After getting the checker to run, it also surfaced a small set of docs/content typing errors around optional content entry fields and untyped search metadata.

## Solution

This PR restores docs type checking as a usable validation path:

- Adds `moduleResolution: "Bundler"` to the generated docs tsconfig so TypeScript 6 resolves the docs app's workspace package imports the same way Astro/Vite expects.
- Changes the docs check script to run `astro sync && astro-check`, preserving Astro type generation while invoking the project-local checker binary directly.
- Updates `mono docs build` to run the same sync/check sequence before `astro build`.
- Fixes the remaining docs/content diagnostics with narrow inline guards for optional `doc.slug`, optional `doc.body`, and non-object Mixedbread metadata.

Trade-off: the `astro-check` invocation is a workaround for #1377, not a fix for it. The long-term fix remains upgrading to an Astro version where `astro check` resolves `@astrojs/check` correctly under the virtual-store layout.

## Validation

Ran:

```sh
devenv shell -- bash -lc 'cd docs && DT_PASSTHROUGH=1 pnpm check'
```

Result:

```text
Result (30 files):
- 0 errors
- 0 warnings
- 0 hints
```

Also confirmed `devenv shell` setup tasks completed successfully, including `ts:build`, before the docs check command ran.

### Demo (optional)

Before this branch, docs type checking failed on unresolved workspace imports, missing `doc.slug`, possibly undefined `doc.body`, and unsafe metadata spreads. After this branch, the docs checker reports zero diagnostics.

## Related issues

- Workaround for #1377
