### PR TITLE
chore: add root tooling tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
-    "typescript": "6.0.3"
+    "@types/node": "25.3.3",
+    "typescript": "6.0.3",
+    "vitest": "3.2.4"
   },
   "packageManager": "pnpm@11.3.0",
   "$genie": {

--- a/package.json.genie.ts
+++ b/package.json.genie.ts
@@ -1,7 +1,7 @@
 import docsPkg from './docs/package.json.genie.ts'
 import docsCodeSnippetsPkg from './docs/src/content/_assets/code/package.json.genie.ts'
 import { memberPathsForProjection, type LivestorePackageProjection } from './genie/repo-topology.ts'
-import { packageJson } from './genie/repo.ts'
+import { catalog, packageJson } from './genie/repo.ts'
 import adapterCloudflarePkg from './packages/@livestore/adapter-cloudflare/package.json.genie.ts'
 import adapterWebPkg from './packages/@livestore/adapter-web/package.json.genie.ts'
 import commonPkg from './packages/@livestore/common/package.json.genie.ts'
@@ -118,7 +118,7 @@ const rootWorkspaceExtraFields = {
   },
   devDependencies: {
     '@changesets/cli': '^2.31.0',
-    'typescript': '6.0.3',
+    ...catalog.pick('@types/node', 'typescript', 'vitest'),
   },
 } as const
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,15 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.3.3)
+      '@types/node':
+        specifier: 25.3.3
+        version: 25.3.3
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   docs:
     dependencies:

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -3,7 +3,8 @@ import process from 'node:process'
 import type { PlaywrightTestConfig } from '@playwright/test'
 import { devices } from '@playwright/test'
 
-import { envTruish } from '@livestore/utils'
+const envTruish = (env: string | undefined) =>
+  env !== undefined && env.toLowerCase() !== 'false' && env.toLowerCase() !== '0'
 
 /**
  * Ensure Playwright tests are run via the mono CLI (or VS Code extension) to guarantee proper environment setup.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,39 @@
+// Generated file - DO NOT EDIT
+// Source: tsconfig.json.genie.ts
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "ESNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "outDir": "dist",
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "plugins": [],
+    "moduleDetection": "force",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": [
+    "./vitest.config.ts",
+    "./packages/*/*/vitest.config.ts",
+    "./scripts/vitest.config.ts",
+    "./tests/*/playwright.config.ts",
+    "./tests/*/vitest.config.ts",
+    "./tests/integration/src/tests/devtools/fixtures/*/vite.config.ts"
+  ],
+  "exclude": ["node_modules", "**/dist", "**/node_modules/.pnpm"]
+}

--- a/tsconfig.json.genie.ts
+++ b/tsconfig.json.genie.ts
@@ -1,0 +1,34 @@
+import { baseTsconfigCompilerOptions, tsconfigJson } from './genie/repo.ts'
+
+/**
+ * Root TypeScript check config for repository-level tooling files.
+ *
+ * Package source is checked through `tsconfig.dev.json`. This config adds the
+ * tool configs that live outside package `src` roots without pulling docs into
+ * the TypeScript project graph; docs remain covered by Astro's checker.
+ */
+export default tsconfigJson({
+  compilerOptions: {
+    ...baseTsconfigCompilerOptions,
+    lib: ['ES2024'],
+    declaration: false,
+    declarationMap: false,
+    module: 'ESNext',
+    moduleDetection: 'force',
+    moduleResolution: 'Bundler',
+    noEmit: true,
+    plugins: [],
+    rootDir: '.',
+    sourceMap: false,
+    types: ['node'],
+  },
+  include: [
+    './vitest.config.ts',
+    './packages/*/*/vitest.config.ts',
+    './scripts/vitest.config.ts',
+    './tests/*/playwright.config.ts',
+    './tests/*/vitest.config.ts',
+    './tests/integration/src/tests/devtools/fixtures/*/vite.config.ts',
+  ],
+  exclude: ['node_modules', '**/dist', '**/node_modules/.pnpm'],
+})


### PR DESCRIPTION
## Problem

Several repository-level TypeScript config files were not covered by an explicit TypeScript project, so changes to Vite, Vitest, and Playwright configs could drift without type-check coverage.

## Solution

Add a generated root `tsconfig.json` for tooling config files and update the root workspace manifest so the root config can resolve Node and Vitest types. The root config is no-emit, excludes the Effect language-service plugin, and targets Node/tooling-style config files rather than package source.

This also makes the integration Playwright config self-contained by inlining its tiny `envTruish` helper, avoiding source/declaration mixing from `@livestore/utils` in the root tooling project.

## Trade-offs / Follow-up

`examples/web-todomvc-sync-cf/livestore-cli.config.ts` remains outside this root config because including it pulls workspace package source into the same program as installed LiveStore declaration files, which currently causes duplicate global declarations. A separate Node-oriented config can cover that file later.

## Validation

- `devenv tasks run pnpm:install`
- `devenv shell tsc -p tsconfig.json --pretty false`
- `devenv shell mono ts --clean`
- `devenv shell dt lint:full:fix`
- `git diff --check`