### PR TITLE
fix(tests): stabilize perf-eventlog reset flow

### DIFF
--- a/.changeset/little-kiwis-ring.md
+++ b/.changeset/little-kiwis-ring.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Stabilizes the perf-eventlog reset path used by the streaming performance test.

--- a/tests/perf-eventlog/test-app/src/livestore/store.ts
+++ b/tests/perf-eventlog/test-app/src/livestore/store.ts
@@ -8,10 +8,19 @@ import LiveStoreWorker from '../livestore.worker.ts?worker'
 import { makeTracer } from '../otel.ts'
 import { schema } from './schema.ts'
 
+const resetPersistence = import.meta.env.DEV && new URLSearchParams(window.location.search).get('reset') !== null
+
+if (resetPersistence === true) {
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.delete('reset')
+  window.history.replaceState(null, '', `${window.location.pathname}?${searchParams.toString()}`)
+}
+
 export const adapter = makePersistedAdapter({
   worker: LiveStoreWorker,
   sharedWorker: LiveStoreSharedWorker,
   storage: { type: 'opfs' },
+  resetPersistence,
 })
 
 export const otelTracer = makeTracer('livestore-perf-streaming-loopback')

--- a/tests/perf-eventlog/tests/suites/event-streaming.test.ts
+++ b/tests/perf-eventlog/tests/suites/event-streaming.test.ts
@@ -7,10 +7,10 @@ import { test } from '../fixtures.ts'
 test.describe('Streaming latency', () => {
   test('stream 1.000 events', async ({ page }, _testInfo) => {
     await test.step('prepare', async () => {
-      await page.goto('/')
-      await page.getByTestId('reset-harness').click()
-      await expect(page.getByTestId('app')).toBeVisible()
+      await resetHarness(page)
       await page.getByTestId('seed-1k').click()
+      await expect(page.getByText('Todo count: 1,000')).toBeVisible({ timeout: 60_000 })
+      await expect(page.getByText('Upstream head: 1000')).toBeVisible({ timeout: 60_000 })
       await expect(page.getByTestId('syncstate')).toHaveText('Synced', { timeout: 60000 })
       await page.requestGC()
     })
@@ -119,10 +119,15 @@ const loadSnapshots = async (page: Page, count: number) => {
   })
 }
 
-const prepareSnapshots = async (page: Page, eventCount: number) => {
-  await page.goto('/')
-  await page.getByTestId('reset-harness').click()
+const resetHarness = async (page: Page) => {
+  await page.goto('/?reset')
   await expect(page.getByTestId('app')).toBeVisible()
+  await expect(page.getByText('Todo count: 0')).toBeVisible()
+  await expect(page.getByText('Upstream head: 0')).toBeVisible()
+}
+
+const prepareSnapshots = async (page: Page, eventCount: number) => {
+  await resetHarness(page)
 
   await loadSnapshots(page, eventCount)
   await page.reload()


### PR DESCRIPTION
## Problem

The active `perf-eventlog` Playwright test reset the harness by clicking the in-app reset button and then immediately continued seeding events. That button sends an asynchronous hard-reset request and can leave the test interacting with a store that is shutting down. The test also treated `Synced` as proof that the 1,000-event seed completed, even though the empty reset state is also synced.

## Solution

This changes the perf-eventlog harness to support a development-only `?reset` boot path backed by the web adapter's `resetPersistence` option. The Playwright setup now opens `/?reset`, waits for an empty persisted state, seeds 1,000 events, and verifies both the todo count and upstream head before measuring the event stream.

The trade-off is that the reset path is explicit in the app bootstrap instead of reusing the visible reset button, but it exercises the adapter startup reset path and avoids racing against a store shutdown. The PR also includes an empty changeset with a one-line no-release-impact body.

## Validation

- `bun scripts/src/commands/changesets.ts check-bodies`
- `devenv shell -- dt lint:full:fix`
- `pnpm --filter @local/tests-perf-streaming-loopback test`
- pre-commit `check-quick`

### Demo (optional)

```text
1 passed
3 skipped
[COLD]: Streamed 1K events in 418ms
[WARM]: Streamed 1K events in 747ms
```

## Related issues

- None found.