### PR TITLE
refactor!: use Effect's built-in `Schema.DateFromMillis`

### DIFF
--- a/.changeset/use-effect-date-from-millis.md
+++ b/.changeset/use-effect-date-from-millis.md
@@ -1,0 +1,7 @@
+---
+'@livestore/utils': minor
+---
+
+Breaking: replace the LiveStore-specific `Schema.DateFromEpochMillis` export with Effect's built-in `Schema.DateFromMillis`.
+
+Applications should rename `Schema.DateFromEpochMillis` usages to `Schema.DateFromMillis`. The encoded value remains an epoch-millisecond number and the decoded value remains a JavaScript `Date`.

--- a/docs/src/content/_assets/code/data-modeling/todo-workspaces/workspace.schema.ts
+++ b/docs/src/content/_assets/code/data-modeling/todo-workspaces/workspace.schema.ts
@@ -54,7 +54,7 @@ const todosTable = State.SQLite.table({
     text: State.SQLite.text(),
     completed: State.SQLite.boolean({ default: false }),
     // Using soft delete by adding a deletedAt timestamp
-    deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+    deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
   },
 })
 

--- a/docs/src/content/_assets/code/getting-started/expo/livestore/schema.ts
+++ b/docs/src/content/_assets/code/getting-started/expo/livestore/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   uiState: State.SQLite.clientDocument({

--- a/docs/src/content/_assets/code/getting-started/react-web/livestore/schema.ts
+++ b/docs/src/content/_assets/code/getting-started/react-web/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/docs/src/content/_assets/code/getting-started/vue/livestore/schema.ts
+++ b/docs/src/content/_assets/code/getting-started/vue/livestore/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   uiState: State.SQLite.clientDocument({

--- a/docs/src/content/_assets/code/reference/custom-elements/livestore/schema.ts
+++ b/docs/src/content/_assets/code/reference/custom-elements/livestore/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   uiState: State.SQLite.clientDocument({

--- a/docs/src/content/_assets/code/reference/framework-integrations/solid/livestore/schema.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/solid/livestore/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   uiState: State.SQLite.clientDocument({

--- a/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/schema.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
 }

--- a/docs/src/content/_assets/code/reference/state/sqlite-schema/schema.ts
+++ b/docs/src/content/_assets/code/reference/state/sqlite-schema/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/docs/src/content/_assets/code/reference/syncing/cloudflare/schema.ts
+++ b/docs/src/content/_assets/code/reference/syncing/cloudflare/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
 }

--- a/docs/src/content/docs/patterns/storybook.mdx
+++ b/docs/src/content/docs/patterns/storybook.mdx
@@ -139,7 +139,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client document for UI state

--- a/examples/cloudflare-todomvc/src/livestore/schema.ts
+++ b/examples/cloudflare-todomvc/src/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
 }

--- a/examples/web-email-client/src/stores/mailbox/schema.ts
+++ b/examples/web-email-client/src/stores/mailbox/schema.ts
@@ -10,7 +10,7 @@ export const mailboxTables = {
       color: State.SQLite.text({ nullable: true }),
       threadCount: State.SQLite.integer({ default: 0 }),
       displayOrder: State.SQLite.integer({ default: 0 }), // Display order in UI
-      createdAt: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+      createdAt: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     },
   }),
 
@@ -22,8 +22,8 @@ export const mailboxTables = {
       id: State.SQLite.text({ primaryKey: true }), // threadId
       subject: State.SQLite.text(),
       participants: State.SQLite.text(), // JSON array of email addresses
-      lastActivity: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
-      createdAt: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+      lastActivity: State.SQLite.integer({ schema: Schema.DateFromMillis }),
+      createdAt: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     },
   }),
 
@@ -34,7 +34,7 @@ export const mailboxTables = {
     columns: {
       threadId: State.SQLite.text(),
       labelId: State.SQLite.text(),
-      appliedAt: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+      appliedAt: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     },
   }),
 

--- a/examples/web-email-client/src/stores/thread/schema.ts
+++ b/examples/web-email-client/src/stores/thread/schema.ts
@@ -7,8 +7,8 @@ export const threadTables = {
       id: State.SQLite.text({ primaryKey: true }),
       subject: State.SQLite.text(),
       participants: State.SQLite.text(), // JSON array of email addresses
-      lastActivity: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
-      createdAt: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+      lastActivity: State.SQLite.integer({ schema: Schema.DateFromMillis }),
+      createdAt: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     },
   }),
 
@@ -20,7 +20,7 @@ export const threadTables = {
       content: State.SQLite.text(),
       sender: State.SQLite.text(), // Email address
       senderName: State.SQLite.text({ nullable: true }), // Display name
-      timestamp: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+      timestamp: State.SQLite.integer({ schema: Schema.DateFromMillis }),
       messageType: State.SQLite.text({
         schema: Schema.Literals(['received', 'sent', 'draft']),
       }),
@@ -32,7 +32,7 @@ export const threadTables = {
     columns: {
       threadId: State.SQLite.text(),
       labelId: State.SQLite.text(),
-      appliedAt: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+      appliedAt: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     },
   }),
 }

--- a/examples/web-linearlite/src/livestore/events.ts
+++ b/examples/web-linearlite/src/livestore/events.ts
@@ -10,8 +10,8 @@ export const createIssueWithDescription = Events.synced({
     title: Schema.String,
     priority: Priority,
     status: Status,
-    created: Schema.DateFromEpochMillis,
-    modified: Schema.DateFromEpochMillis,
+    created: Schema.DateFromMillis,
+    modified: Schema.DateFromMillis,
     kanbanorder: Schema.String,
     description: Schema.String,
     creator: Schema.String,
@@ -24,29 +24,29 @@ export const createComment = Events.synced({
     id: Schema.String,
     body: Schema.String,
     issueId: Schema.Number,
-    created: Schema.DateFromEpochMillis,
+    created: Schema.DateFromMillis,
     creator: Schema.String,
   }),
 })
 
 export const deleteIssue = Events.synced({
   name: 'v1.DeleteIssue',
-  schema: Schema.Struct({ id: Schema.Number, deleted: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ id: Schema.Number, deleted: Schema.DateFromMillis }),
 })
 
 export const deleteDescription = Events.synced({
   name: 'v1.DeleteDescription',
-  schema: Schema.Struct({ id: Schema.Number, deleted: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ id: Schema.Number, deleted: Schema.DateFromMillis }),
 })
 
 export const deleteComment = Events.synced({
   name: 'v1.DeleteComment',
-  schema: Schema.Struct({ id: Schema.String, deleted: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ id: Schema.String, deleted: Schema.DateFromMillis }),
 })
 
 export const deleteCommentsByIssueId = Events.synced({
   name: 'v1.DeleteCommentsByIssueId',
-  schema: Schema.Struct({ issueId: Schema.Number, deleted: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ issueId: Schema.Number, deleted: Schema.DateFromMillis }),
 })
 
 export const updateIssue = Events.synced({
@@ -56,13 +56,13 @@ export const updateIssue = Events.synced({
     title: Schema.String,
     priority: Priority,
     status: Status,
-    modified: Schema.DateFromEpochMillis,
+    modified: Schema.DateFromMillis,
   }),
 })
 
 export const updateIssueStatus = Events.synced({
   name: 'v1.UpdateIssueStatus',
-  schema: Schema.Struct({ id: Schema.Number, status: Status, modified: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ id: Schema.Number, status: Status, modified: Schema.DateFromMillis }),
 })
 
 export const updateIssueKanbanOrder = Events.synced({
@@ -71,13 +71,13 @@ export const updateIssueKanbanOrder = Events.synced({
     id: Schema.Number,
     status: Status,
     kanbanorder: Schema.String,
-    modified: Schema.DateFromEpochMillis,
+    modified: Schema.DateFromMillis,
   }),
 })
 
 export const updateIssueTitle = Events.synced({
   name: 'v1.UpdateIssueTitle',
-  schema: Schema.Struct({ id: Schema.Number, title: Schema.String, modified: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ id: Schema.Number, title: Schema.String, modified: Schema.DateFromMillis }),
 })
 
 export const moveIssue = Events.synced({
@@ -86,13 +86,13 @@ export const moveIssue = Events.synced({
     id: Schema.Number,
     kanbanorder: Schema.String,
     status: Status,
-    modified: Schema.DateFromEpochMillis,
+    modified: Schema.DateFromMillis,
   }),
 })
 
 export const updateIssuePriority = Events.synced({
   name: 'v1.UpdateIssuePriority',
-  schema: Schema.Struct({ id: Schema.Number, priority: Priority, modified: Schema.DateFromEpochMillis }),
+  schema: Schema.Struct({ id: Schema.Number, priority: Priority, modified: Schema.DateFromMillis }),
 })
 
 export const updateDescription = Events.synced({

--- a/examples/web-linearlite/src/livestore/schema/comment.ts
+++ b/examples/web-linearlite/src/livestore/schema/comment.ts
@@ -7,8 +7,8 @@ export const comment = State.SQLite.table({
     body: State.SQLite.text({ default: '' }),
     creator: State.SQLite.text({ default: '' }),
     issueId: State.SQLite.integer(),
-    created: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
-    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+    created: State.SQLite.integer({ schema: Schema.DateFromMillis }),
+    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
   },
   indexes: [{ name: 'issue_id', columns: ['issueId'] }],
 })

--- a/examples/web-linearlite/src/livestore/schema/description.ts
+++ b/examples/web-linearlite/src/livestore/schema/description.ts
@@ -6,7 +6,7 @@ export const description = State.SQLite.table({
     // TODO: id is also a foreign key to issue
     id: State.SQLite.integer({ primaryKey: true }),
     body: State.SQLite.text({ default: '' }),
-    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
   },
 })
 

--- a/examples/web-linearlite/src/livestore/schema/issue.ts
+++ b/examples/web-linearlite/src/livestore/schema/issue.ts
@@ -11,9 +11,9 @@ export const issue = State.SQLite.table({
     creator: State.SQLite.text({ default: '' }),
     priority: State.SQLite.integer({ schema: Priority, default: 0 }),
     status: State.SQLite.integer({ schema: Status, default: 0 }),
-    created: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
-    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
-    modified: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+    created: State.SQLite.integer({ schema: Schema.DateFromMillis }),
+    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
+    modified: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     kanbanorder: State.SQLite.text({ nullable: false, default: '' }),
   },
   indexes: [

--- a/examples/web-todomvc-react-router/src/livestore/schema.ts
+++ b/examples/web-todomvc-react-router/src/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/examples/web-todomvc-redwood/src/app/todomvc/livestore/schema.ts
+++ b/examples/web-todomvc-redwood/src/app/todomvc/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/examples/web-todomvc-script/src/livestore/schema.ts
+++ b/examples/web-todomvc-script/src/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/examples/web-todomvc-sync-cf/src/livestore/schema.ts
+++ b/examples/web-todomvc-sync-cf/src/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/examples/web-todomvc/src/livestore/schema.ts
+++ b/examples/web-todomvc/src/livestore/schema.ts
@@ -8,7 +8,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   // Client documents can be used for local-only state (e.g. form inputs)

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
@@ -279,7 +279,7 @@ describe('client document table', () => {
   describe('optimistic schema', () => {
     /** Models persisted JSON using epoch numbers + base64 while app code expects Date + Uint8Array. */
     const valueSchema = Schema.Struct({
-      createdAt: Schema.DateFromEpochMillis,
+      createdAt: Schema.DateFromMillis,
       avatar: Schema.Uint8ArrayFromBase64,
     })
     const defaultValue = {

--- a/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
@@ -31,8 +31,8 @@ describe('getColumnDefForSchema', () => {
       ).toEqual({ _tag: 'Date' })
     })
 
-    it('should map Schema.DateFromEpochMillis to integer column', () => {
-      const columnDef = State.SQLite.getColumnDefForSchema(Schema.DateFromEpochMillis)
+    it('should map Schema.DateFromMillis to integer column', () => {
+      const columnDef = State.SQLite.getColumnDefForSchema(Schema.DateFromMillis)
       expect(columnDef.columnType).toBe('integer')
       expect(Schema.toEncoded(columnDef.schema).ast._tag).toBe('Number')
       expect(

--- a/packages/@livestore/common/src/schema/state/sqlite/column-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-def.ts
@@ -173,7 +173,7 @@ const getColumnForSchema = (schema: Schema.Top, nullable = false): SqliteDsl.Col
   }
 
   if (SchemaAST.isNumber(encodedAst) === true) {
-    if (hasCheck(coreAst.checks, 'isInt') === true || SchemaAST.resolveIdentifier(coreAst) === 'DateFromEpochMillis') {
+    if (hasCheck(coreAst.checks, 'isInt') === true || hasDateTypeConstructor(coreAst) === true) {
       return SqliteDsl.integer({ schema: coreSchema, nullable })
     }
     return SqliteDsl.real({ schema: coreSchema, nullable })
@@ -227,10 +227,7 @@ const getLiteralColumnDefinition = (
     case 'string':
       return SqliteDsl.text({ schema, nullable })
     case 'number': {
-      if (
-        hasCheck(sourceAst.checks, 'isInt') === true ||
-        SchemaAST.resolveIdentifier(sourceAst) === 'DateFromEpochMillis'
-      ) {
+      if (hasCheck(sourceAst.checks, 'isInt') === true || hasDateTypeConstructor(sourceAst) === true) {
         return SqliteDsl.integer({ schema, nullable })
       }
 
@@ -247,6 +244,10 @@ const getLiteralColumnDefinition = (
       return null
   }
 }
+
+/** Effect's built-in date codecs expose their semantic type through the Date type-constructor annotation. */
+const hasDateTypeConstructor = (ast: SchemaAST.AST): boolean =>
+  SchemaAST.resolveAt<{ readonly _tag: string }>('typeConstructor')(ast)?._tag === 'Date'
 
 const extractLiteralValues = (ast: SchemaAST.AST): ReadonlyArray<SchemaAST.LiteralValue> | null => {
   if (SchemaAST.isLiteral(ast) === true) return [ast.literal]

--- a/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
@@ -231,7 +231,7 @@ export const datetime: SpecializedColDefFn<'text', false, Date> = makeSpecialize
 
 export const datetimeInteger: SpecializedColDefFn<'integer', false, Date> = makeSpecializedColDef('integer', {
   _tag: 'baseSchema',
-  baseSchema: Schema.DateFromEpochMillis,
+  baseSchema: Schema.DateFromMillis,
 })
 
 export const boolean: SpecializedColDefFn<'integer', false, boolean> = makeSpecializedColDef('integer', {

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
@@ -62,9 +62,9 @@ const issue = State.SQLite.table({
     title: State.SQLite.text({ default: '' }),
     creator: State.SQLite.text({ default: '' }),
     priority: State.SQLite.integer({ schema: Schema.Literals([0, 1, 2, 3, 4]), default: 0 }),
-    created: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
-    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
-    modified: State.SQLite.integer({ schema: Schema.DateFromEpochMillis }),
+    created: State.SQLite.integer({ schema: Schema.DateFromMillis }),
+    deleted: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
+    modified: State.SQLite.integer({ schema: Schema.DateFromMillis }),
     kanbanorder: State.SQLite.text({ nullable: false, default: '' }),
   },
   indexes: [

--- a/packages/@livestore/utils/src/effect/Schema/index.ts
+++ b/packages/@livestore/utils/src/effect/Schema/index.ts
@@ -86,16 +86,6 @@ export const headOrElse: {
     ),
 )
 
-export const DateFromEpochMillis = Schema.Date.pipe(
-  Schema.encodeTo(
-    Schema.Number,
-    SchemaTransformation.transform({
-      decode: (epochMillis) => new Date(epochMillis),
-      encode: (date) => date.getTime(),
-    }),
-  ),
-).annotate({ identifier: 'DateFromEpochMillis' })
-
 // NOTE this is a temporary workaround until Effect schema has a better way to hash schemas
 // https://github.com/Effect-TS/effect/issues/2719
 // TODO remove this once the issue is resolved

--- a/tests/integration/src/tests/playwright/fixtures/devtools/todomvc/livestore/schema.ts
+++ b/tests/integration/src/tests/playwright/fixtures/devtools/todomvc/livestore/schema.ts
@@ -22,7 +22,7 @@ const todos = State.SQLite.table({
     id: State.SQLite.text({ primaryKey: true }),
     text: State.SQLite.text({ default: '' }),
     completed: State.SQLite.boolean({ default: false }),
-    deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+    deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
   },
 })
 

--- a/tests/perf-eventlog/test-app/src/livestore/schema.ts
+++ b/tests/perf-eventlog/test-app/src/livestore/schema.ts
@@ -7,7 +7,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       text: State.SQLite.text({ default: '' }),
       completed: State.SQLite.boolean({ default: false }),
-      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromEpochMillis }),
+      deletedAt: State.SQLite.integer({ nullable: true, schema: Schema.DateFromMillis }),
     },
   }),
   uiState: State.SQLite.clientDocument({


### PR DESCRIPTION
## Problem

LiveStore maintains a custom `Schema.DateFromEpochMillis` codec even though Effect beta.97 now provides the equivalent `Schema.DateFromMillis` codec. Keeping both names duplicates behavior and leaves application schemas on a LiveStore-specific API.

This PR is stacked on #1384 and must merge after it.

## Solution

- Remove the custom `Schema.DateFromEpochMillis` export from `@livestore/utils/effect`.
- Migrate LiveStore packages, tests, examples, performance fixtures, and documentation to `Schema.DateFromMillis`.
- Teach SQLite column inference to recognize Effect's built-in Date type-constructor annotation. The built-in codec intentionally has no `DateFromMillis` identifier annotation, so identifier matching would incorrectly infer a `REAL` column.
- Widen the changeset at `@livestore/utils` minor because consumers must rename the public schema symbol.

The wire and storage representation does not change: values still encode as epoch-millisecond numbers and decode as JavaScript `Date` instances.

## Validation

- Targeted `column-def.test.ts` and `client-document-def.test.ts` Date tests
- `devenv tasks run lint:full:fix --mode before --no-tui --refresh-task-cache`
- `devenv tasks run ts:check --mode before --no-tui --refresh-task-cache`
- `mono test unit`
- Verified there are no remaining `DateFromEpochMillis` references
- `git diff --check`

## Trade-offs and migration

This intentionally removes the compatibility alias rather than deprecating it. Applications should replace `Schema.DateFromEpochMillis` with `Schema.DateFromMillis`; no database migration or event payload rewrite is required.
