### PR TITLE
fix(tests): await startup rebase materialization

### DIFF
--- a/.changeset/empty-startup-sync-wait.md
+++ b/.changeset/empty-startup-sync-wait.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Stabilizes the client-session startup rebase test by waiting for the post-materialization sync state update.

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -339,15 +339,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       // Wait for the sync backend to receive the pushed event
       yield* mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain)
 
-      // Wait for the client session to have reached e2
-      // The sync processor can catch up during createStore, before this test subscribes to future changes.
-      const currentSyncState = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
-      if (currentSyncState.localHead.global !== 2) {
-        yield* store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
-          Stream.takeUntil((_) => _.localHead.global === 2),
-          Stream.runDrain,
-        )
-      }
+      // `syncState.get` advances before rollback and materialization, while `changes` is emitted afterward.
+      // Always consume the queued e2 update so the query below observes the fully rebased state.
+      yield* store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
+        Stream.takeUntil((_) => _.localHead.global === 2),
+        Stream.runDrain,
+      )
 
       const res = store.query(tables.todos.orderBy('text', 'asc'))
 


### PR DESCRIPTION
## Problem

`client should push pending persisted events on start` became flaky after the Effect v4 fork scheduling cleanup in #1369. The test used `syncState.get.localHead === e2` as a readiness check, but the sync processor advances that operational head before rollback and SQLite materialization. When the test observed the intermediate state, it skipped the post-materialization wait and queried a client-session database that still contained only the persisted local event.

## Solution

Restore the unconditional wait for the queued `syncState.changes` update at `e2`. That update is deliberately emitted only after rollback, event materialization, and table refresh, so the subsequent query observes both the pulled backend event and the rebased pending event.

The queue retains updates emitted before the test begins consuming it, so no current-value fast path is needed. A comment documents why `syncState.get` is not a safe materialization barrier.

An empty changeset records that this test-only correction has no release impact. No changelog entry is required.

## Validation

- Ran the formerly flaky test in 100 fresh Vitest processes: 100 passed, 0 failed.
- Ran `dt lint:full:fix`.
- Ran `dt ts:check`.
- Ran `devenv tasks run test:unit`.
- Ran `devenv tasks run release:changeset:check-bodies`.
- The repository pre-commit `check:quick` hook passed.

### Demo (optional)

```text
syncState.get = e2
        |
        v
rollback -> materialize backend_0 + rebased client_0 -> syncState.changes = e2
                                                          |
                                                          v
                                                       query state
```

Previously, the fast path could query at the first marker. The restored wait queries only after the applied-state notification.

## Related issues

- #1356
- #1369
