### PR TITLE
fix(sync-cf): repair Effect v4 Durable Object RPC boundaries

### DIFF
--- a/.changeset/fix-do-rpc-effect-v4-boundaries.md
+++ b/.changeset/fix-do-rpc-effect-v4-boundaries.md
@@ -1,0 +1,6 @@
+---
+"@livestore/common-cf": patch
+"@livestore/sync-cf": patch
+---
+
+Fix Cloudflare Durable Object RPC sync providers failing to pull or receive live events after the Effect v4 migration.

--- a/packages/@livestore/common-cf/src/do-rpc/client.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.test.ts
@@ -1,9 +1,25 @@
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Effect, Fiber, Rpc, RpcClient, RpcGroup, Schema, Stream } from '@livestore/utils/effect'
+import {
+  Effect,
+  Exit,
+  Fiber,
+  Rpc,
+  RpcClient,
+  RpcGroup,
+  type RpcMessage,
+  RpcSerialization,
+  Schema,
+  Stream,
+} from '@livestore/utils/effect'
 
 import type * as CfTypes from '../cf-types.ts'
 import { layerProtocolDurableObject } from './client.ts'
 import { toDurableObjectHandler } from './server.ts'
+
+const EchoRpc = Rpc.make('Echo', {
+  payload: Schema.Struct({ text: Schema.String }),
+  success: Schema.Struct({ echo: Schema.String }),
+})
 
 class Rpcs extends RpcGroup.make(
   Rpc.make('BigStream', {
@@ -15,10 +31,7 @@ class Rpcs extends RpcGroup.make(
     }),
     stream: true,
   }),
-  Rpc.make('Echo', {
-    payload: Schema.Struct({ text: Schema.String }),
-    success: Schema.Struct({ echo: Schema.String }),
-  }),
+  EchoRpc,
 ) {}
 
 const READ_CHUNK_SIZE = 4096
@@ -35,6 +48,54 @@ const ServerLive = Rpcs.toLayer({
   BigStream: ({ n }) => Stream.fromIterable(expectedRows.slice(0, n)),
   Echo: ({ text }) => Effect.succeed({ echo: `Echo: ${text}` }),
 })
+
+const ResponseExitEncoded = Schema.Struct({
+  _tag: Schema.Literal('Exit'),
+  requestId: Schema.Union([Schema.String, Schema.Number]),
+  exit: Schema.Unknown,
+})
+
+Vitest.live('returns an encoded defect without invoking the handler for an invalid payload', () =>
+  Effect.gen(function* () {
+    let handlerCalled = false
+    const serverLive = Rpcs.toLayer({
+      BigStream: ({ n }) => Stream.fromIterable(expectedRows.slice(0, n)),
+      Echo: ({ text }) =>
+        Effect.sync(() => {
+          handlerCalled = true
+          return { echo: `Echo: ${text}` }
+        }),
+    })
+    const parser = RpcSerialization.msgPack.makeUnsafe()
+    const request: RpcMessage.RequestEncoded = {
+      _tag: 'Request',
+      id: 'invalid-echo',
+      tag: 'Echo',
+      payload: { text: 42 },
+      headers: [],
+    }
+    // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- msgPack parser.encode returns unknown; this request is the expected wire payload
+    const encodedRequest = parser.encode([request]) as Uint8Array<ArrayBuffer>
+    const encodedResponse = yield* toDurableObjectHandler(Rpcs, { layer: serverLive })(encodedRequest)
+
+    if (encodedResponse instanceof Uint8Array === false) {
+      return yield* Effect.die('Expected a unary RPC response')
+    }
+
+    const decodedResponse = parser.decode(encodedResponse)
+    const messages = Array.isArray(decodedResponse) === true ? decodedResponse.flat(1) : [decodedResponse]
+    const [response] = yield* Schema.decodeUnknownEffect(Schema.Array(ResponseExitEncoded))(messages)
+    if (response === undefined) {
+      return yield* Effect.die('Expected an RPC exit response')
+    }
+
+    const exitSchema = Rpc.exitSchema(EchoRpc)
+    const exit = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(exitSchema))(response.exit)
+
+    Vitest.expect(handlerCalled).toBe(false)
+    Vitest.expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)
 
 Vitest.live('keeps a straddling stream frame isolated from a concurrent unary response', () =>
   Effect.gen(function* () {

--- a/packages/@livestore/common-cf/src/do-rpc/rpc.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/rpc.test.ts
@@ -87,6 +87,22 @@ Vitest.describe('Durable Object RPC', { timeout: testTimeout }, () => {
     }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
   )
 
+  Vitest.live('should decode optional payload fields', (test) =>
+    Effect.gen(function* () {
+      const client = yield* RpcClient.make(TestRpcs)
+      const result = yield* client.OptionalPayload({})
+      expect(result).toEqual({ wasUndefined: true })
+    }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
+  )
+
+  Vitest.live('should decode optional payload fields for streams', (test) =>
+    Effect.gen(function* () {
+      const client = yield* RpcClient.make(TestRpcs)
+      const result = yield* client.StreamOptionalPayload({}).pipe(Stream.runFirstUnsafe)
+      expect(result).toEqual({ wasUndefined: true })
+    }).pipe(Effect.provide(ProtocolLive), withWranglerTest(test)),
+  )
+
   Vitest.live('should handle RPC fail method', (test) =>
     Effect.gen(function* () {
       const client = yield* RpcClient.make(TestRpcs)

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -5,6 +5,7 @@ import {
   type Layer,
   Option,
   type ReadonlyArray,
+  Result,
   Rpc,
   type RpcGroup,
   type RpcMessage,
@@ -70,11 +71,9 @@ export const toDurableObjectHandler =
 
         // Find the RPC handler
         // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- RpcGroup.requests map returns Rpc.Any; narrowing to AnyWithProps for property access
-        const rpc = group.requests.get(request.tag)! as unknown as Rpc.AnyWithProps
-        // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- context.mapUnsafe dynamic lookup; type safety ensured by RpcGroup registration
-        const entry = context.mapUnsafe.get(rpc.key) as Rpc.Handler<Rpcs['_tag']>
+        const rpc = group.requests.get(request.tag) as unknown as Rpc.AnyWithProps | undefined
 
-        if (rpc == null || entry == null) {
+        if (rpc === undefined) {
           responses.push({
             _tag: 'Exit',
             requestId: request.id,
@@ -83,17 +82,50 @@ export const toDurableObjectHandler =
           continue
         }
 
+        // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- context.mapUnsafe dynamic lookup; type safety ensured by RpcGroup registration
+        const entry = context.mapUnsafe.get(rpc.key) as Rpc.Handler<Rpcs['_tag']> | undefined
+
+        if (entry === undefined) {
+          responses.push({
+            _tag: 'Exit',
+            requestId: request.id,
+            exit: Exit.die(`No handler registered for request tag: ${request.tag}`),
+          })
+          continue
+        }
+
+        const payloadResult = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(rpc.payloadSchema))(
+          request.payload,
+        ).pipe(Effect.provideContext(entry.context), Effect.result)
+
+        if (Result.isFailure(payloadResult) === true) {
+          // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; rpc has already been narrowed above
+          const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
+          const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(
+            Exit.die(payloadResult.failure.issue.toString()),
+          ).pipe(Effect.provideContext(entry.context))
+
+          responses.push({
+            _tag: 'Exit',
+            requestId: request.id,
+            exit: encodedExit,
+          })
+          continue
+        }
+
+        const decodedRequest = { ...request, payload: payloadResult.success }
+
         // Check if this is a streaming RPC
         const isStream = RpcSchema.isStreamSchema(rpc.successSchema)
 
         // For streaming RPCs with only one request, return ReadableStream directly
         if (isStream === true && requests.length === 1) {
-          return yield* createStreamingResponse(rpc, entry, request, parser, options.layer)
+          return yield* createStreamingResponse(rpc, entry, decodedRequest, parser, options.layer)
         }
 
         // Execute the handler
         const result = yield* Effect.gen(function* () {
-          const handlerResult = entry.handler(request.payload, {
+          const handlerResult = entry.handler(decodedRequest.payload, {
             client: new Rpc.ServerClient(0), // TODO: add proper clientId if needed
             requestId: request.id,
             headers: Headers.fromInput({

--- a/packages/@livestore/common-cf/src/do-rpc/test-fixtures/rpc-schema.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/test-fixtures/rpc-schema.ts
@@ -13,6 +13,15 @@ export class TestRpcs extends RpcGroup.make(
     payload: Schema.Struct({ a: Schema.Number, b: Schema.Number }),
     success: Schema.Struct({ result: Schema.Number }),
   }),
+  Rpc.make('OptionalPayload', {
+    payload: Schema.Struct({ value: Schema.optional(Schema.String) }),
+    success: Schema.Struct({ wasUndefined: Schema.Boolean }),
+  }),
+  Rpc.make('StreamOptionalPayload', {
+    payload: Schema.Struct({ value: Schema.optional(Schema.String) }),
+    success: Schema.Struct({ wasUndefined: Schema.Boolean }),
+    stream: true,
+  }),
   Rpc.make('Defect', {
     payload: Schema.Struct({ message: Schema.String }),
     success: Schema.Struct({ never: Schema.String }),

--- a/packages/@livestore/common-cf/src/do-rpc/test-fixtures/worker.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/test-fixtures/worker.ts
@@ -29,6 +29,8 @@ export class TestRpcDurableObject extends DurableObject {
       Ping: ({ message }) => Effect.succeed({ response: `Pong: ${message}` }),
       Echo: ({ text }) => Effect.succeed({ echo: `Echo: ${text}` }),
       Add: ({ a, b }) => Effect.succeed({ result: a + b }),
+      OptionalPayload: ({ value }) => Effect.succeed({ wasUndefined: value === undefined }),
+      StreamOptionalPayload: ({ value }) => Stream.make({ wasUndefined: value === undefined }),
       Defect: ({ message }) => Effect.die(`some defect: ${message}`),
       Fail: ({ message }) => Effect.fail(`RPC failure: ${message}`),
       Stream: () =>
@@ -94,6 +96,8 @@ export default {
             Ping: (msg) => doRpcClient.Ping(msg).pipe(Effect.orDie),
             Echo: (msg) => doRpcClient.Echo(msg).pipe(Effect.orDie),
             Add: (msg) => doRpcClient.Add(msg).pipe(Effect.orDie),
+            OptionalPayload: () => doRpcClient.OptionalPayload({ value: undefined }).pipe(Effect.orDie),
+            StreamOptionalPayload: () => doRpcClient.StreamOptionalPayload({ value: undefined }).pipe(Stream.orDie),
             Defect: (msg) => doRpcClient.Defect(msg).pipe(Effect.orDie),
             Fail: (msg) => doRpcClient.Fail(msg).pipe(Effect.orDie),
             Stream: (msg) => doRpcClient.Stream(msg).pipe(Stream.orDie),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -14,7 +14,7 @@ import {
 } from '../shared.ts'
 import * as DoCtx from './layer.ts'
 
-const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
+const encodePullResponse = Schema.encodeSync(Schema.toCodecJson(SyncMessage.PullResponse))
 const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
 type PullBatchItem = SyncMessage.PullResponse['batch'][number]
 type PushBatchItem = SyncMessage.PushRequest['batch'][number]
@@ -126,7 +126,7 @@ export const makePush =
 
               return {
                 response,
-                encoded: Schema.encodeSync(SyncMessage.PullResponse)(response),
+                encoded: encodePullResponse(response),
               }
             }),
           ),

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -52,7 +52,7 @@ export const makeDoRpcSync =
   ({ syncBackendStub, durableObjectContext }: DoRpcSyncOptions): SyncBackend.SyncBackendConstructor<SyncMetadata> =>
   ({ storeId, payload }) =>
     Effect.gen(function* () {
-      const isConnected = yield* SubscriptionRef.make(true)
+      const isConnected = yield* SubscriptionRef.make(false)
 
       const ProtocolLive = layerProtocolDurableObject({
         callRpc: (payload) => syncBackendStub.rpc(payload),
@@ -63,8 +63,16 @@ export const makeDoRpcSync =
 
       const rpcClient = yield* RpcClient.make(SyncDoRpc).pipe(Effect.provide(context))
 
-      // Nothing to do here
-      const connect = Effect.void
+      const ping = rpcClient['SyncDoRpc.Ping']({
+        storeId,
+        payload,
+      }).pipe(
+        UnknownError.mapToUnknownError,
+        Effect.andThen(SubscriptionRef.set(isConnected, true)),
+        Effect.withSpan('rpc-sync-client:ping'),
+      )
+
+      const connect = ping
 
       const backendIdHelper = yield* SyncBackend.makeBackendIdHelper
 
@@ -137,11 +145,6 @@ export const makeDoRpcSync =
         ),
       )
 
-      const ping: SyncBackend.SyncBackend<{ createdAt: string }>['ping'] = rpcClient['SyncDoRpc.Ping']({
-        storeId,
-        payload,
-      }).pipe(UnknownError.mapToUnknownError, Effect.withSpan('rpc-sync-client:ping'))
-
       return SyncBackend.of({
         connect,
         isConnected,
@@ -179,7 +182,9 @@ export const makeDoRpcSync =
 export const handleSyncUpdateRpc = (payload: unknown) =>
   Effect.gen(function* () {
     const decodedPayload = yield* Schema.decodeUnknownEffect(ResponseChunkEncoded)(payload)
-    const decoded = yield* Schema.decodeUnknownEffect(SyncMessage.PullResponse)(decodedPayload.values[0])
+    const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(SyncMessage.PullResponse))(
+      decodedPayload.values[0],
+    )
 
     const pullStreamQueue = requestIdQueueMap.get(decodedPayload.requestId)
 

--- a/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
+++ b/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
@@ -118,9 +118,14 @@ const makeProxyDoRpcSync = ({
 
     const client: DoRpcProxyClient = yield* RpcClient.make(DoRpcProxyRpcs).pipe(Effect.provide(ctx))
 
-    const isConnected = yield* SubscriptionRef.fromStream(
-      client.IsConnected({ clientId, storeId, payload }).pipe(Stream.catchTag('RpcClientError', (e) => Stream.die(e))),
-      false,
+    const isConnected = yield* SubscriptionRef.make(false)
+
+    yield* client.IsConnected({ clientId, storeId, payload }).pipe(
+      Stream.catchTag('RpcClientError', (e) => Stream.die(e)),
+      Stream.tap((connected) => SubscriptionRef.set(isConnected, connected)),
+      Stream.runDrain,
+      // Register the long-lived connection stream before issuing other requests through the same RPC client.
+      Effect.forkScoped({ startImmediately: true }),
     )
 
     const metadata = yield* client.GetMetadata({ clientId, storeId, payload })

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -38,19 +38,23 @@ export interface Env {
   DB: CfTypes.D1Database
 }
 
-export class SyncBackendDO extends makeDurableObject({
-  // onPush: async (message) => {
-  //   console.log('onPush', message.batch)
-  // },
-  // onPull: async (message) => {
-  //   console.log('onPull', message)
-  // },
+const httpOptions = {
   http: {
     responseHeaders: {
       'X-Custom-Header': 'test-value',
       'X-LiveStore-Version': '1.0.0',
     },
   },
+}
+
+export class SyncBackendDO extends makeDurableObject({
+  ...httpOptions,
+  storage: { _tag: 'do-sqlite' },
+}) {}
+
+export class SyncBackendD1DO extends makeDurableObject({
+  ...httpOptions,
+  storage: { _tag: 'd1', binding: 'DB' },
 }) {}
 
 const DurableObjectBase = DurableObject as any as new (

--- a/tests/sync-provider/src/providers/cloudflare/wrangler-d1.toml
+++ b/tests/sync-provider/src/providers/cloudflare/wrangler-d1.toml
@@ -12,7 +12,7 @@ database_id = "hibernation-test-db"
 
 [[durable_objects.bindings]]
 name = "SYNC_BACKEND_DO"
-class_name = "SyncBackendDO"
+class_name = "SyncBackendD1DO"
 
 [[durable_objects.bindings]]
 name = "TEST_CLIENT_DO"
@@ -21,3 +21,7 @@ class_name = "TestClientDo"
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["SyncBackendDO", "TestClientDo"]
+
+[[migrations]]
+tag = "v2"
+renamed_classes = [{ from = "SyncBackendDO", to = "SyncBackendD1DO" }]


### PR DESCRIPTION
## Problem

After the Effect v4 migration, the two Cloudflare Durable Object RPC providers each passed only 3 of the 16 shared sync-provider cases, while Mock, HTTP RPC, and WebSocket providers still passed all 16. The 13 failures split across three transport/lifecycle boundaries:

| Cases | Root cause |
| ---: | --- |
| 9 | The custom native DO-RPC server decoded only the outer MessagePack envelope and sent JSON-codec payloads directly to handlers. An omitted optional `rpcContext` therefore arrived as `null` and was dereferenced. |
| 2 | Live `PullResponse` callbacks sent Effect v4 runtime `Option` objects through Cloudflare native RPC, which rejected them with `DataCloneError`. |
| 2 | The test proxy issued another request before its long-lived `IsConnected` RPC stream was registered, producing interrupted-fiber timeouts under the v4 dispatcher. |

Fixing the startup ordering also exposed a latent contract mismatch: the native client began permanently connected and implemented `connect` as a no-op. Separately, the provider labelled D1 was actually exercising DO SQLite because the test worker never selected D1 storage.

## Solution

- Decode each native DO-RPC request payload once with `Schema.toCodecJson(rpc.payloadSchema)` and the registered handler context before dispatching unary or streaming handlers. Malformed payloads now return a schema-encoded defect exit.
- Encode and decode out-of-band live `PullResponse` values with the same JSON codec, producing clone-safe native-RPC values.
- Model the native client lifecycle as `false -> successful Ping -> true`, with `connect` performing that real ping.
- Start only the proxy's `IsConnected` registration immediately, before `GetMetadata` uses the same client.
- Split the test worker into explicit D1 and DO SQLite Durable Object classes and preserve Wrangler's existing class migration history.
- Add unary, streaming, and malformed-payload regressions at the custom protocol boundary.

The eager fork is deliberately local. Bare `forkScoped` was scheduled/deferred in both Effect v3 and v4, so `startImmediately: true` is not presented as v3 compatibility. It is a stronger ordering requirement for this specific RPC registration. `uninterruptible: "inherit"` was tested independently and did not fix the failures, so the generic `SubscriptionRef.fromStream` behavior remains unchanged.

## Validation

- `devenv shell -- dt lint:full:fix`
- `devenv shell -- dt ts:check`
- `devenv shell -- mono test unit` (all configured unit projects passed; common-CF: 24 passed, 1 skipped)
- `pnpm vitest run src/do-rpc/client.test.ts` (2 passed)
- `pnpm vitest run src/do-rpc/rpc.test.ts` (11 passed, 1 skipped)
- `pnpm vitest run src/sync-provider.test.ts` (112 passed)
- Focused native DO-RPC matrix after the final fork localization (32 passed)
- Fork control experiment across D1 and DO: `startImmediately: true` passed 4/4 affected invocations; bare `forkScoped` and `uninterruptible: "inherit"` each passed 0/4.

`dt test:run`, referenced by the contributor guide, is not defined in the current task graph; `mono test unit` was used for the repository-wide unit gate instead.

### Demo

| Provider | Before | After |
| --- | ---: | ---: |
| Mock | 16/16 | 16/16 |
| Cloudflare HTTP RPC (D1 / DO) | 16/16 | 16/16 |
| Cloudflare WebSocket (D1 / DO) | 16/16 | 16/16 |
| Cloudflare Durable Object RPC (D1) | 3/16 | 16/16 |
| Cloudflare Durable Object RPC (DO) | 3/16 | 16/16 |

## Related issues

- Follow-up to #1369
- Related to #1356
- Related to #1321
