### PR TITLE
fix(sync-cf): restore Effect v4 Durable Object RPC sync

### DIFF
--- a/.changeset/fix-do-rpc-effect4.md
+++ b/.changeset/fix-do-rpc-effect4.md
@@ -1,0 +1,6 @@
+---
+'@livestore/common-cf': patch
+'@livestore/sync-cf': patch
+---
+
+Restore Cloudflare Durable Object RPC sync after the Effect 4 migration by keeping cached sync clients in their owning scope, decoding request payloads through JSON codecs, and serializing live-update callbacks as clone-safe bytes.

--- a/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/client-do.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/client-do.ts
@@ -78,7 +78,7 @@ export class LiveStoreClientDO extends DurableObject<Env> implements ClientDoWit
     return this.subscribeToStore()
   }
 
-  async syncUpdateRpc(payload: unknown) {
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     await handleSyncUpdateRpc(payload)
   }
 }

--- a/examples/cloudflare-todomvc/src/live-store-client-do.ts
+++ b/examples/cloudflare-todomvc/src/live-store-client-do.ts
@@ -71,7 +71,7 @@ export class LiveStoreClientDO extends DurableObject<Env> implements ClientDoWit
     this.subscribeToStore()
   }
 
-  async syncUpdateRpc(payload: unknown) {
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     await handleSyncUpdateRpc(payload)
   }
 }

--- a/examples/web-email-client/src/cf-worker/MailboxClientDO.ts
+++ b/examples/web-email-client/src/cf-worker/MailboxClientDO.ts
@@ -119,7 +119,7 @@ export class MailboxClientDO extends DurableObject<Env> implements ClientDoWithR
     }
   }
 
-  async syncUpdateRpc(payload: unknown) {
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     // Make sure to wake up the store before processing the sync update
     await handleSyncUpdateRpc(payload)
   }

--- a/examples/web-email-client/src/cf-worker/ThreadClientDO.ts
+++ b/examples/web-email-client/src/cf-worker/ThreadClientDO.ts
@@ -146,7 +146,7 @@ export class ThreadClientDO extends DurableObject<Env> implements ClientDoWithRp
     return this.subscribeToStore()
   }
 
-  async syncUpdateRpc(payload: unknown) {
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     // Make sure to wake up the store before processing the sync update
     await this.subscribeToStore()
     await handleSyncUpdateRpc(payload)

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -20,7 +20,7 @@ import type * as CfTypes from '../cf-types.ts'
 
 export interface ClientDoWithRpcCallback {
   __DURABLE_OBJECT_BRAND: never
-  syncUpdateRpc: (payload: RpcMessage.ResponseChunkEncoded) => Promise<void>
+  syncUpdateRpc: (payload: Uint8Array<ArrayBuffer>) => Promise<void>
 }
 
 /**
@@ -215,8 +215,13 @@ export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(functio
   const clientDo = clientDoNamespace.get(clientDoNamespace.idFromString(callerContext.durableObjectId))
 
   const res: RpcMessage.ResponseChunkEncoded = { _tag: 'Chunk', requestId, values }
+  const parser = RpcSerialization.msgPack.makeUnsafe()
+  // Native Cloudflare RPC rejects schema values with custom prototypes. Keep the callback
+  // boundary clone-safe by sending the already-encoded Effect RPC message as bytes.
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- msgPack parser.encode returns unknown; the encoded result is a byte payload
+  const serializedRes = parser.encode(res) as Uint8Array<ArrayBuffer>
 
-  yield* Effect.tryPromise(() => clientDo.syncUpdateRpc(res))
+  yield* Effect.tryPromise(() => clientDo.syncUpdateRpc(serializedRes))
 })
 
 /**

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -7,9 +7,10 @@ import {
   type ReadonlyArray,
   Rpc,
   type RpcGroup,
-  type RpcMessage,
+  RpcMessage,
   RpcSchema,
   RpcSerialization,
+  Result,
   Schema,
   type Scope,
   Stream,
@@ -46,7 +47,7 @@ export const toDurableObjectHandler =
       const decoded = parser.decode(serializedPayload)
 
       // Handle potential nested array from client serialization
-      let requests: RpcMessage.FromClient<Rpcs>[]
+      let requests: RpcMessage.FromClientEncoded[]
       if (Array.isArray(decoded) === true && decoded.length === 1 && Array.isArray(decoded[0]) === true) {
         // Double-wrapped array [[{...}]] -> [{...}]
         requests = decoded[0]
@@ -67,6 +68,7 @@ export const toDurableObjectHandler =
         if (request._tag !== 'Request') {
           continue
         }
+        const requestId = RpcMessage.RequestId(request.id)
 
         // Find the RPC handler
         // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- RpcGroup.requests map returns Rpc.Any; narrowing to AnyWithProps for property access
@@ -77,27 +79,50 @@ export const toDurableObjectHandler =
         if (rpc == null || entry == null) {
           responses.push({
             _tag: 'Exit',
-            requestId: request.id,
+            requestId,
             exit: Exit.die(`Unknown request tag: ${request.tag}`),
           })
           continue
         }
+
+        const payloadResult = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(rpc.payloadSchema))(
+          request.payload,
+        ).pipe(Effect.provideContext(entry.context), Effect.result)
+
+        if (Result.isFailure(payloadResult) === true) {
+          // Request payloads are encoded with the JSON codec by Effect's RPC client. Decode them
+          // before dispatch so JSON-only representations such as `null` become their schema values.
+          // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
+          const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
+          const rawExit = Exit.die(payloadResult.failure.issue.toString())
+          const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit).pipe(
+            Effect.provideContext(entry.context),
+          )
+          responses.push({
+            _tag: 'Exit',
+            requestId,
+            exit: encodedExit,
+          })
+          continue
+        }
+
+        const payload = payloadResult.success
 
         // Check if this is a streaming RPC
         const isStream = RpcSchema.isStreamSchema(rpc.successSchema)
 
         // For streaming RPCs with only one request, return ReadableStream directly
         if (isStream === true && requests.length === 1) {
-          return yield* createStreamingResponse(rpc, entry, request, parser, options.layer)
+          return yield* createStreamingResponse(rpc, entry, requestId, payload, parser, options.layer)
         }
 
         // Execute the handler
         const result = yield* Effect.gen(function* () {
-          const handlerResult = entry.handler(request.payload, {
+          const handlerResult = entry.handler(payload, {
             client: new Rpc.ServerClient(0), // TODO: add proper clientId if needed
-            requestId: request.id,
+            requestId,
             headers: Headers.fromInput({
-              'x-rpc-request-id': request.id.toString(),
+              'x-rpc-request-id': requestId.toString(),
             }),
             rpc,
           })
@@ -127,7 +152,7 @@ export const toDurableObjectHandler =
 
           return {
             _tag: 'Exit' as const,
-            requestId: request.id,
+            requestId,
             exit: encodedExit,
           }
         }).pipe(
@@ -149,7 +174,7 @@ export const toDurableObjectHandler =
 
               return {
                 _tag: 'Exit' as const,
-                requestId: request.id,
+                requestId,
                 exit: encodedExit,
               }
             })
@@ -201,17 +226,18 @@ export const emitStreamResponse = Effect.fn('do-rpc/emitStreamResponse')(functio
 const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
   rpc: Rpc.AnyWithProps,
   entry: Rpc.Handler<Rpcs['_tag']>,
-  request: any,
+  requestId: RpcMessage.RequestId,
+  payload: unknown,
   parser: ReturnType<typeof RpcSerialization.msgPack.makeUnsafe>,
   layer: Layer.Layer<Rpc.ToHandler<Rpcs> | Rpc.Middleware<Rpcs>, LE>,
 ): Effect.Effect<CfTypes.ReadableStream, never, Scope.Scope> =>
   Effect.gen(function* () {
     // Execute the handler to get the stream
-    const handlerResult = entry.handler(request.payload, {
+    const handlerResult = entry.handler(payload, {
       client: new Rpc.ServerClient(0), // TODO: add proper clientId if needed
-      requestId: request.id,
+      requestId,
       headers: Headers.fromInput({
-        'x-rpc-request-id': request.id.toString(),
+        'x-rpc-request-id': requestId.toString(),
       }),
       rpc,
     })
@@ -250,7 +276,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
 
               const chunkMessage = {
                 _tag: 'Chunk' as const,
-                requestId: request.id,
+                requestId,
                 values: encodedValues,
               }
 
@@ -268,7 +294,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
 
           const exitMessage = {
             _tag: 'Exit' as const,
-            requestId: request.id,
+            requestId,
             exit: encodedExit,
           }
 
@@ -287,7 +313,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
 
               const exitMessage = {
                 _tag: 'Exit' as const,
-                requestId: request.id,
+                requestId,
                 exit: encodedExit,
               }
 

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -14,7 +14,8 @@ import {
 } from '../shared.ts'
 import * as DoCtx from './layer.ts'
 
-const encodePullResponse = Schema.encodeSync(SyncMessage.PullResponse)
+const pullResponseJsonSchema = Schema.toCodecJson(SyncMessage.PullResponse)
+const encodePullResponse = Schema.encodeSync(pullResponseJsonSchema)
 const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
 type PullBatchItem = SyncMessage.PullResponse['batch'][number]
 type PushBatchItem = SyncMessage.PushRequest['batch'][number]
@@ -126,7 +127,7 @@ export const makePush =
 
               return {
                 response,
-                encoded: Schema.encodeSync(SyncMessage.PullResponse)(response),
+                encoded: encodePullResponse(response),
               }
             }),
           ),

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -170,16 +170,21 @@ export const makeDoRpcSync =
  * export class MyDurableObject extends DurableObject implements ClientDoWithRpcCallback {
  *   // ...
  *
- *   async syncUpdateRpc(payload: RpcMessage.ResponseChunkEncoded) {
+ *   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
  *     return handleSyncUpdateRpc(payload)
  *   }
  * }
  * ```
  */
-export const handleSyncUpdateRpc = (payload: unknown) =>
+export const handleSyncUpdateRpc = (payload: Uint8Array<ArrayBuffer>) =>
   Effect.gen(function* () {
-    const decodedPayload = yield* Schema.decodeUnknownEffect(ResponseChunkEncoded)(payload)
-    const decoded = yield* Schema.decodeUnknownEffect(SyncMessage.PullResponse)(decodedPayload.values[0])
+    const parser = RpcSerialization.msgPack.makeUnsafe()
+    const decodedMessage = parser.decode(payload)
+    const [response] = Array.isArray(decodedMessage) === true ? decodedMessage.flat(1) : [decodedMessage]
+    const decodedPayload = yield* Schema.decodeUnknownEffect(ResponseChunkEncoded)(response)
+    const decoded = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(SyncMessage.PullResponse))(
+      decodedPayload.values[0],
+    )
 
     const pullStreamQueue = requestIdQueueMap.get(decodedPayload.requestId)
 

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -203,7 +203,7 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
     return makeCfResponse('Not found', { status: 404 })
   }
 
-  async syncUpdateRpc(payload: unknown) {
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     await handleSyncUpdateRpc(payload)
   }
 

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -2,7 +2,6 @@
 
 import { DurableObject } from 'cloudflare:workers'
 
-import type { SyncBackend } from '@livestore/common'
 import { type ClientDoWithRpcCallback, setupDurableObjectWebSocketRpc } from '@livestore/common-cf'
 import type { CfDeclare } from '@livestore/common-cf/declare'
 import {
@@ -13,14 +12,15 @@ import {
   type SyncBackendRpcInterface,
 } from '@livestore/sync-cf/cf-worker'
 import { handleSyncUpdateRpc, makeDoRpcSync } from '@livestore/sync-cf/client'
-import type { SyncMessage } from '@livestore/sync-cf/common'
 import {
+  Cache,
   Effect,
   FetchHttpClient,
   KeyValueStore,
   Layer,
   type RpcMessage,
   RpcServer,
+  Scope,
   Stream,
   SubscriptionRef,
 } from '@livestore/utils/effect'
@@ -68,61 +68,64 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
     this.ctx = state
     this.env = env
 
-    const syncBackendMap = new Map<string, SyncBackend.SyncBackend<SyncMessage.SyncMetadata>>()
-
-    const getSyncBackend = ({ clientId, storeId, payload }: { clientId: string; storeId: string; payload: any }) =>
+    /**
+     * RPC handlers run in request scopes, but cached clients must live for the longer-lived WebSocket server scope.
+     */
+    const handlersLayer = Layer.unwrap(
       Effect.gen({ self: this }, function* () {
-        const key = JSON.stringify({ clientId, storeId, payload })
-        if (syncBackendMap.has(key) === true) {
-          return syncBackendMap.get(key)!
-        }
+        const syncBackendScope = yield* Effect.scope
+        const syncBackendCache = yield* Cache.make({
+          capacity: Number.POSITIVE_INFINITY,
+          lookup: (key: string) =>
+            Effect.gen({ self: this }, function* () {
+              const { clientId, storeId, payload } = JSON.parse(key) as SyncBackendArgs
 
-        const syncBackend = yield* makeDoRpcSync({
-          syncBackendStub: this.env.SYNC_BACKEND_DO.get(this.env.SYNC_BACKEND_DO.idFromName(storeId)),
-          durableObjectContext: { bindingName: 'TEST_CLIENT_DO', durableObjectId: this.ctx.id.toString() },
-        })({ storeId, clientId, payload })
+              return yield* makeDoRpcSync({
+                syncBackendStub: this.env.SYNC_BACKEND_DO.get(this.env.SYNC_BACKEND_DO.idFromName(storeId)),
+                durableObjectContext: { bindingName: 'TEST_CLIENT_DO', durableObjectId: this.ctx.id.toString() },
+              })({ storeId, clientId, payload }).pipe(Scope.provide(syncBackendScope), Effect.orDie)
+            }),
+        })
 
-        syncBackendMap.set(key, syncBackend)
+        const getSyncBackend = (args: SyncBackendArgs) => Cache.get(syncBackendCache, JSON.stringify(args))
 
-        return syncBackend
-      }).pipe(Effect.orDie)
-
-    /** Proxies WS messages to the DO RPC sync backend */
-    const handlersLayer = DoRpcProxyRpcs.toLayer({
-      Connect: (args) =>
-        Effect.gen(function* () {
-          const syncBackend = yield* getSyncBackend(args)
-          yield* syncBackend.connect
-        }),
-      Pull: (args) =>
-        Effect.gen(function* () {
-          const syncBackend = yield* getSyncBackend(args)
-          return syncBackend.pull(args.cursor as any, { live: args.live })
-        }).pipe(
-          Stream.unwrap,
-          Stream.map((msg) => ({ ...msg, backendId: 'TODO' })),
-        ),
-      Push: ({ batch, ...args }) =>
-        Effect.gen(function* () {
-          const syncBackend = yield* getSyncBackend(args)
-          yield* syncBackend.push(batch)
-        }),
-      Ping: (args) =>
-        Effect.gen(function* () {
-          const syncBackend = yield* getSyncBackend(args)
-          yield* syncBackend.ping
-        }).pipe(Effect.orDie),
-      IsConnected: (args) =>
-        Effect.gen(function* () {
-          const syncBackend = yield* getSyncBackend(args)
-          return SubscriptionRef.changes(syncBackend.isConnected)
-        }).pipe(Stream.unwrap),
-      GetMetadata: (args) =>
-        Effect.gen(function* () {
-          const syncBackend = yield* getSyncBackend(args)
-          return syncBackend.metadata
-        }),
-    })
+        return DoRpcProxyRpcs.toLayer({
+          Connect: (args) =>
+            Effect.gen(function* () {
+              const syncBackend = yield* getSyncBackend(args)
+              yield* syncBackend.connect
+            }),
+          Pull: (args) =>
+            Effect.gen(function* () {
+              const syncBackend = yield* getSyncBackend(args)
+              return syncBackend.pull(args.cursor as any, { live: args.live })
+            }).pipe(
+              Stream.unwrap,
+              Stream.map((msg) => ({ ...msg, backendId: 'TODO' })),
+            ),
+          Push: ({ batch, ...args }) =>
+            Effect.gen(function* () {
+              const syncBackend = yield* getSyncBackend(args)
+              yield* syncBackend.push(batch)
+            }),
+          Ping: (args) =>
+            Effect.gen(function* () {
+              const syncBackend = yield* getSyncBackend(args)
+              yield* syncBackend.ping
+            }).pipe(Effect.orDie),
+          IsConnected: (args) =>
+            Effect.gen(function* () {
+              const syncBackend = yield* getSyncBackend(args)
+              return SubscriptionRef.changes(syncBackend.isConnected)
+            }).pipe(Stream.unwrap),
+          GetMetadata: (args) =>
+            Effect.gen(function* () {
+              const syncBackend = yield* getSyncBackend(args)
+              return syncBackend.metadata
+            }),
+        })
+      }),
+    )
 
     const ServerLive = RpcServer.layer(DoRpcProxyRpcs).pipe(
       Layer.provide(handlersLayer),
@@ -194,4 +197,10 @@ export default {
 
     return new Response('Invalid path', { status: 400 })
   },
+}
+
+type SyncBackendArgs = {
+  clientId: string
+  storeId: string
+  payload: any
 }

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -18,7 +18,6 @@ import {
   FetchHttpClient,
   KeyValueStore,
   Layer,
-  type RpcMessage,
   RpcServer,
   Scope,
   Stream,
@@ -167,7 +166,7 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
     })
   }
 
-  async syncUpdateRpc(payload: RpcMessage.ResponseChunkEncoded) {
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     await handleSyncUpdateRpc(payload)
   }
 }


### PR DESCRIPTION
## Problem

After the Effect v4 migration, both Cloudflare Durable Object RPC sync providers passed only 3 of the 16 shared sync-provider cases. Mock, HTTP RPC, and WebSocket providers continued to pass all cases.

The failures came from three boundaries that the custom native DO-RPC transport handled differently from Effect's standard transports:

1. Cached sync clients were created in individual RPC request scopes and then reused after those scopes closed.
2. The native server decoded the outer MessagePack envelope but dispatched JSON-codec request payloads directly to handlers without reconstructing their schema values.
3. Live pull callbacks passed Effect v4 runtime values, including prototype-backed `Option` objects, through Cloudflare native RPC. Cloudflare rejected those values with `DataCloneError`.

## Solution

- Allocate the sync-backend cache in the longer-lived WebSocket server scope and explicitly provide that owning scope when constructing cached clients.
- Decode each request payload through `Schema.toCodecJson(rpc.payloadSchema)` with its registered handler context before unary or streaming dispatch. Invalid payloads now return a schema-encoded defect exit.
- Encode live `PullResponse` values through their JSON codec, serialize the complete Effect RPC callback envelope to MessagePack bytes, and decode those bytes on the client Durable Object.
- Keep MessagePack parsers isolated per callback invocation, preserving the concurrency invariant established by #1266.
- Update callback signatures in test fixtures, documentation, and Cloudflare examples to reflect the byte transport contract.
- Add one patch changeset covering `@livestore/common-cf` and `@livestore/sync-cf`.

The callback path now performs one additional MessagePack encode/decode and byte allocation per live update. This makes the native Cloudflare RPC boundary explicitly clone-safe instead of relying on every value in the logical Effect RPC envelope remaining structured-cloneable.

## Validation

- `devenv shell -- dt lint:full:fix`
- Repository-wide TypeScript build through the devenv setup gate
- `pnpm exec changeset status`
- Cloudflare Durable Object RPC provider matrix: 32 passed (D1 16/16, DO 16/16)
- Cloudflare WebSocket regression matrix: 32 passed (D1 16/16, DO 16/16)
- Common Cloudflare DO-RPC tests: 10 passed, 1 skipped
- #1266 parser-concurrency regression: passed
- Pre-commit `check-quick`: passed for all four commits

### Demo

| Provider | Before | After |
| --- | ---: | ---: |
| Cloudflare Durable Object RPC (D1) | 3/16 | 16/16 |
| Cloudflare Durable Object RPC (DO) | 3/16 | 16/16 |

## Related issues

- Supersedes #1387, which used an earlier startup-ordering approach for part of the failure set.
- Preserves the per-request MessagePack parser isolation introduced by #1266.
- Follow-up to the Effect v4 fork migration in #1369.
