### PR TITLE
fix(ci): ignore inactive GitHub ruleset defaults

### DIFF
--- a/.changeset/empty-ruleset-default-drift.md
+++ b/.changeset/empty-ruleset-default-drift.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Ignore inactive defaults expanded by GitHub when checking repository ruleset drift.

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -154,8 +154,14 @@ const formatValue = (value: TJsonValue) => JSON.stringify(value)
 const isBypassActorsDiff = (diff: string) => diff.startsWith('$.bypass_actors')
 
 const isGitHubExpandedDefaultDiff = (diff: string) =>
-  diff === '$.rules.0.parameters.allowed_merge_methods: desired null, live ["merge","squash","rebase"]' ||
-  diff === '$.rules.0.parameters.required_reviewers: desired null, live []'
+  githubExpandedDefaultDiffSuffixes.some((suffix) => diff.endsWith(suffix))
+
+/** GitHub may add inactive defaults to ruleset responses that were omitted from the request. */
+const githubExpandedDefaultDiffSuffixes = [
+  '.parameters.allowed_merge_methods: desired null, live ["merge","squash","rebase"]',
+  '.parameters.required_reviewers: desired null, live []',
+  '.parameters.dismissal_restriction: desired null, live {"allowed_actors":[],"enabled":false}',
+]
 
 const collectDiffs = (
   desired: TJsonValue,


### PR DESCRIPTION
## Problem

The [ruleset-drift-check job](https://github.com/livestorejs/livestore/actions/runs/29251360225/job/86820462105) failed after GitHub began expanding an inactive `dismissal_restriction` default in the live pull-request ruleset:

```json
{
  "allowed_actors": [],
  "enabled": false
}
```

The generated repository settings omit this inactive option, so the drift checker treated the API-expanded response as configuration drift. Synchronizing the ruleset would not be durable because GitHub can expand the default again when returning it.

Why now: the live ruleset was last updated on June 12, while the drift check [passed on July 6](https://github.com/livestorejs/livestore/actions/runs/28795569866) and [first failed on July 7](https://github.com/livestorejs/livestore/actions/runs/28882559545). Neither the managed ruleset nor the checker changed between those runs, indicating a server-side GitHub response-serialization change rather than actual repository drift.

## Solution

Treat GitHub's exact inactive dismissal-restriction object as an expanded default, alongside the existing `allowed_merge_methods` and `required_reviewers` defaults. Default matching now uses path suffixes so it remains independent of the pull-request rule's array position.

Active restrictions and nonempty actor lists still produce drift. This PR also includes an empty changeset because the fix only affects internal repository tooling and has no published-package release impact.

## Validation

- `devenv shell -- mono github rulesets check` (passes against the live ruleset)
- `devenv shell -- dt lint:full:fix`
- `devenv shell -- dt ts:check`
- `pnpm exec changeset status --since=origin/main`
- `devenv shell -- mono test unit` reported an unrelated WebMesh property-test failure where `DirectChannelPing` arrived before the expected application message
- Targeted rerun passed: `devenv shell -- vitest run packages/@livestore/webmesh/src/node.test.ts --testNamePattern "a / b connect at different times with different channel types"`

### Demo

Before:

```text
Ruleset 'main-branch-rules' drift detected
- $.rules.0.parameters.dismissal_restriction: desired null, live {"allowed_actors":[],"enabled":false}
```

After:

```text
Ruleset 'main-branch-rules' is in sync with .github/repo-settings.json.
```

## Related issues

- Failed run: https://github.com/livestorejs/livestore/actions/runs/29251360225/job/86820462105
- No matching open issue was found for this ruleset API drift.
