### PR TITLE
chore(ci): make preview deploy checks optional

### DIFF
--- a/.changeset/optional-preview-checks.md
+++ b/.changeset/optional-preview-checks.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Keeps the docs and examples build/deploy jobs running on pull requests while removing them from the required status checks that block merging.

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -72,12 +72,6 @@
           },
           {
             "context": "wa-sqlite-test"
-          },
-          {
-            "context": "build-deploy-docs"
-          },
-          {
-            "context": "build-and-deploy-examples-src"
           }
         ]
       }

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -25,6 +25,4 @@ export const requiredCIJobs = [
   ...syncProviderMatrix.map((provider) => `test-integration-sync-provider (${provider})`),
   ...playwrightSuites.map((suite) => `test-integration-playwright (${suite})`),
   'wa-sqlite-test',
-  'build-deploy-docs',
-  'build-and-deploy-examples-src',
 ] as const


### PR DESCRIPTION
## Problem

The docs and examples build/deploy jobs run external preview deployment workflows and are among the longest PR checks. Requiring them for every merge makes preview infrastructure availability and deployment duration part of the merge gate, even when the core validation jobs have passed.

## Solution

Remove `build-deploy-docs` and `build-and-deploy-examples-src` from the Genie-managed required status check list. Both jobs remain in the CI workflow, continue to run for pull requests, and continue to report preview results; they simply no longer block merging.

Add an empty changeset because this is an internal repository-policy change with no package release impact.

## Expected merge-time impact

For passing PR-triggered jobs over the last two months:

- `build-deploy-docs` had an 18m 32s median duration.
- `build-and-deploy-examples-src` had a 13m 24s median duration.
- The longest remaining required job had an approximately 11m 15s median duration.

Because these jobs execute in parallel, removing the preview jobs from the merge gate is expected to reduce the median CI critical path from approximately 18m 32s to 11m 15s: a savings of about **7m 17s, or 39%**, for a healthy PR. This comparison measures job execution time and excludes runner queue time, review latency, and failures. It also removes preview deployment infrastructure as a source of merge blocking while preserving its CI signal.

## Validation

- Ran `dt lint:full:fix`.
- Ran `genie:check` against the generated repository settings.
- Confirmed the generated `.github/repo-settings.json` removes only the two intended required contexts.
- Confirmed both jobs remain defined in `ci.yml.genie.ts` and the generated CI workflow.

### Demo

```text
Required before: core checks + docs preview + examples preview
Required after:  core checks
Still running:    docs preview + examples preview
Median CI gate:   ~18m 32s -> ~11m 15s (-7m 17s / -39%)
```

## Related issues

No existing issue found for this merge-policy change.
