### PR TITLE
fix(ci): normalize GitHub defaults in ruleset task

### DIFF
--- a/.changeset/empty-ruleset-ci-default.md
+++ b/.changeset/empty-ruleset-ci-default.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Normalize inactive GitHub defaults in the CI ruleset drift task.

--- a/nix/devenv-modules/tasks/local/github-rulesets.nix
+++ b/nix/devenv-modules/tasks/local/github-rulesets.nix
@@ -31,7 +31,15 @@
           rules: [
             .rules[]
             | if .type == "pull_request" then
-                .parameters |= (del(.allowed_merge_methods) | del(.required_reviewers))
+                .parameters |= (
+                  del(.allowed_merge_methods)
+                  | del(.required_reviewers)
+                  | if .dismissal_restriction == { allowed_actors: [], enabled: false } then
+                      del(.dismissal_restriction)
+                    else
+                      .
+                    end
+                )
               else
                 .
               end


### PR DESCRIPTION
## Problem

After [#1390](https://github.com/livestorejs/livestore/pull/1390) merged, the [main-branch ruleset-drift-check](https://github.com/livestorejs/livestore/actions/runs/29256094344/job/86836710787) still rejected GitHub's inactive `dismissal_restriction` default.

The earlier fix updated `mono github rulesets check`, but main CI runs a separate `github:rulesets:check` devenv task implemented in Nix/JQ. That task had its own normalization rules and continued comparing the API-expanded default literally.

## Solution

Update the CI task's JQ normalization to remove `dismissal_restriction` only when it exactly equals:

```json
{
  "allowed_actors": [],
  "enabled": false
}
```

Active restrictions and nonempty actor lists remain visible as drift. This keeps the repair focused on the CI execution path; #1393 tracks consolidating the duplicated TypeScript and Nix comparators.

An empty changeset records the internal CI-only change without bumping a published package.

## Validation

- `devenv tasks run github:rulesets:check --mode before`
- `devenv shell -- dt lint:full:fix`
- `devenv shell -- dt ts:check`
- `pnpm exec changeset status --since=origin/main`
- Pre-commit `check-quick`

### Demo

The exact task invoked by main CI now succeeds against the live ruleset:

```text
Running github:rulesets:check
Succeeded github:rulesets:check
1 Succeeded
```

## Related issues

- Follow-up to #1390
- Consolidation follow-up: #1393
- Failed main run: https://github.com/livestorejs/livestore/actions/runs/29256094344/job/86836710787
