### PR TITLE
fix(common): gracefully drain leader pushes on shutdown

### DIFF
--- a/.changeset/fix-leader-push-shutdown-event-loss.md
+++ b/.changeset/fix-leader-push-shutdown-event-loss.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Fixed event loss on `store.shutdown()` when the leader runs in-process (for example the single-threaded node adapter). Shutting down could interrupt an in-flight leader push and drop events still queued for the leader. LiveStore now completes the in-flight push and flushes the remaining queued events before the client session sync processor tears down.

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -122,6 +122,28 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       )
     }
 
+    // Register this before the pushing fiber's finalizer so scope teardown first interrupts and awaits the
+    // fiber (including an uninterruptible in-flight push), then flushes queued events without concurrent pushes.
+    // The leader belongs to the surrounding client-session scope and remains available throughout this teardown.
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        const remaining = yield* TxQueue.clear(leaderPushQueue)
+
+        for (let offset = 0; offset < remaining.length; offset += params.leaderPushBatchSize) {
+          const batch = remaining.slice(offset, offset + params.leaderPushBatchSize)
+          const wasAccepted = yield* clientSession.leaderThread.events.push(batch).pipe(
+            Effect.as(true),
+            Effect.catchIf(isRejectedPushError, () => {
+              debugInfo.rejectCount++
+              return Effect.succeed(false)
+            }),
+          )
+
+          if (wasAccepted === false) break
+        }
+      }).pipe(Effect.uninterruptible),
+    )
+
     const leaderPushingFiberHandle = yield* FiberHandle.make()
 
     const backgroundLeaderPushing = Effect.gen(function* () {
@@ -144,19 +166,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
-
-    // On store shutdown the background pushing fiber is interrupted, which can leave events queued in
-    // `leaderPushQueue` that were never handed to the leader. Flush them here so they are still durably
-    // persisted. This finalizer is registered after the pushing fiber, so it runs before it during scope
-    // teardown, while the leader is still alive to accept and persist the batch.
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        const remaining = yield* TxQueue.clear(leaderPushQueue)
-        if (remaining.length > 0) {
-          yield* clientSession.leaderThread.events.push(remaining).pipe(Effect.catchCause(() => Effect.void))
-        }
-      }).pipe(Effect.uninterruptible),
-    )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -126,11 +126,15 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     const backgroundLeaderPushing = Effect.gen(function* () {
       const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
+      // The push must run uninterruptibly so a batch that has already been taken off the queue is fully
+      // persisted by the leader before this fiber is interrupted on store shutdown. Otherwise, with a
+      // co-located leader (e.g. the single-threaded node adapter), the in-flight batch is silently lost.
       yield* clientSession.leaderThread.events.push(batch).pipe(
         Effect.catchIf(isRejectedPushError, () => {
           debugInfo.rejectCount++
           return TxQueue.clear(leaderPushQueue)
         }),
+        Effect.uninterruptible,
       )
     }).pipe(
       Effect.forever,
@@ -140,6 +144,19 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+
+    // On store shutdown the background pushing fiber is interrupted, which can leave events queued in
+    // `leaderPushQueue` that were never handed to the leader. Flush them here so they are still durably
+    // persisted. This finalizer is registered after the pushing fiber, so it runs before it during scope
+    // teardown, while the leader is still alive to accept and persist the batch.
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        const remaining = yield* TxQueue.clear(leaderPushQueue)
+        if (remaining.length > 0) {
+          yield* clientSession.leaderThread.events.push(remaining).pipe(Effect.catchCause(() => Effect.void))
+        }
+      }).pipe(Effect.uninterruptible),
+    )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -12,6 +12,7 @@ import {
   Stream,
   Subscribable,
   TxQueue,
+  TxRef,
 } from '@livestore/utils/effect'
 
 import type { ClientSession } from '../adapter-types.ts'
@@ -102,6 +103,26 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
+  const leaderPushLifecycleState = yield* TxRef.make<LeaderPushLifecycleState>({
+    _tag: 'accepting',
+    activePushCount: 0,
+  })
+
+  const takeNextLeaderPushWorkerAction: Effect.Effect<LeaderPushWorkerAction> = Effect.tx(
+    Effect.gen(function* () {
+      if ((yield* TxQueue.isEmpty(leaderPushQueue)) === false) {
+        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
+        return { _tag: 'push' as const, batch }
+      }
+
+      const lifecycleState = yield* TxRef.get(leaderPushLifecycleState)
+      if (lifecycleState._tag === 'stopping' && lifecycleState.activePushCount === 0) {
+        return { _tag: 'stop' as const }
+      }
+
+      return yield* Effect.txRetry
+    }),
+  )
 
   const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
@@ -122,50 +143,53 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       )
     }
 
-    // Register this before the pushing fiber's finalizer so scope teardown first interrupts and awaits the
-    // fiber (including an uninterruptible in-flight push), then flushes queued events without concurrent pushes.
-    // The leader belongs to the surrounding client-session scope and remains available throughout this teardown.
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        const remaining = yield* TxQueue.clear(leaderPushQueue)
+    const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
 
-        for (let offset = 0; offset < remaining.length; offset += params.leaderPushBatchSize) {
-          const batch = remaining.slice(offset, offset + params.leaderPushBatchSize)
-          const wasAccepted = yield* clientSession.leaderThread.events.push(batch).pipe(
-            Effect.as(true),
-            Effect.catchIf(isRejectedPushError, () => {
-              debugInfo.rejectCount++
-              return Effect.succeed(false)
-            }),
-          )
+    const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
+      while (true) {
+        const action = yield* takeNextLeaderPushWorkerAction
+        if (action._tag === 'stop') return
 
-          if (wasAccepted === false) break
-        }
-      }).pipe(Effect.uninterruptible),
-    )
-
-    const leaderPushingFiberHandle = yield* FiberHandle.make()
-
-    const backgroundLeaderPushing = Effect.gen(function* () {
-      const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
-      // The push must run uninterruptibly so a batch that has already been taken off the queue is fully
-      // persisted by the leader before this fiber is interrupted on store shutdown. Otherwise, with a
-      // co-located leader (e.g. the single-threaded node adapter), the in-flight batch is silently lost.
-      yield* clientSession.leaderThread.events.push(batch).pipe(
-        Effect.catchIf(isRejectedPushError, () => {
-          debugInfo.rejectCount++
-          return TxQueue.clear(leaderPushQueue)
-        }),
-        Effect.uninterruptible,
-      )
+        yield* clientSession.leaderThread.events.push(action.batch).pipe(
+          Effect.catchIf(isRejectedPushError, () => {
+            debugInfo.rejectCount++
+            return TxQueue.clear(leaderPushQueue)
+          }),
+        )
+      }
     }).pipe(
-      Effect.forever,
       Effect.interruptible,
       Effect.tapCauseLogPretty,
-      Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
+      // The worker must exit before shutdown can await it, otherwise a fatal push creates a self-deadlock.
+      Effect.catchCause((cause) =>
+        clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid),
+      ),
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+
+    // Close admission and let the sole push worker drain every admitted event before it exits. This finalizer is
+    // registered after the FiberHandle so it runs first; once the worker exits, the handle finalizer has nothing
+    // left to interrupt. The pull fiber is registered later and therefore stops before this shutdown begins.
+    yield* Effect.addFinalizer((exit) =>
+      Effect.gen(function* () {
+        yield* Effect.tx(
+          TxRef.update(
+            leaderPushLifecycleState,
+            (state): LeaderPushLifecycleState => ({
+              _tag: 'stopping',
+              activePushCount: state.activePushCount,
+            }),
+          ),
+        )
+
+        // A healthy shutdown drains durably. On failure, the leader may already be unavailable or blocked in
+        // the failing push, so waiting would deadlock teardown and cannot provide a durability guarantee.
+        yield* Exit.isSuccess(exit) === true
+          ? FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+          : FiberHandle.clear(leaderPushingFiberHandle)
+      }).pipe(Effect.uninterruptible),
+    )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>
@@ -343,30 +367,56 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
     function* (encodedEvents) {
-      const mergeResult = yield* SyncState.merge({
-        syncState: syncStateRef.current,
-        payload: { _tag: 'local-push', newEvents: encodedEvents },
-        isClientOnlyEvent,
-        isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-      }).pipe(
-        Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
-          Effect.die(new Error('Expected advance from local-push merge')),
+      const wasAdmitted = yield* Effect.tx(
+        TxRef.modify(leaderPushLifecycleState, (state): [boolean, LeaderPushLifecycleState] =>
+          state._tag === 'accepting'
+            ? [true, { _tag: 'accepting', activePushCount: state.activePushCount + 1 }]
+            : [false, state],
         ),
       )
 
-      yield* Effect.annotateCurrentSpan({
-        batchSize: encodedEvents.length,
-        mergeResultTag: mergeResult._tag,
-        eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
-          acc[event.name] = (acc[event.name] ?? 0) + 1
-          return acc
-        }, {}),
-        ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-      })
+      if (wasAdmitted === false) {
+        return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
+      }
 
-      syncStateRef.current = mergeResult.newSyncState
-      yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-      yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      yield* Effect.gen(function* () {
+        const mergeResult = yield* SyncState.merge({
+          syncState: syncStateRef.current,
+          payload: { _tag: 'local-push', newEvents: encodedEvents },
+          isClientOnlyEvent,
+          isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+        }).pipe(
+          Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
+            Effect.die(new Error('Expected advance from local-push merge')),
+          ),
+        )
+
+        yield* Effect.annotateCurrentSpan({
+          batchSize: encodedEvents.length,
+          mergeResultTag: mergeResult._tag,
+          eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
+            acc[event.name] = (acc[event.name] ?? 0) + 1
+            return acc
+          }, {}),
+          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+        })
+
+        syncStateRef.current = mergeResult.newSyncState
+        yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+        yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      }).pipe(
+        Effect.ensuring(
+          Effect.tx(
+            TxRef.update(
+              leaderPushLifecycleState,
+              (state): LeaderPushLifecycleState => ({
+                ...state,
+                activePushCount: state.activePushCount - 1,
+              }),
+            ),
+          ),
+        ),
+      )
     },
   )
 
@@ -447,3 +497,11 @@ export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
   }),
 })
 type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type
+
+type LeaderPushLifecycleState =
+  | { readonly _tag: 'accepting'; readonly activePushCount: number }
+  | { readonly _tag: 'stopping'; readonly activePushCount: number }
+
+type LeaderPushWorkerAction =
+  | { readonly _tag: 'push'; readonly batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta> }
+  | { readonly _tag: 'stop' }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -17,7 +17,7 @@ import {
 
 import type { ClientSession } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
-import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
+import { isRejectedPushError, type RejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
@@ -124,6 +124,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     }
 
     const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
+    let drainRejection: RejectedPushError | undefined
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
@@ -133,9 +134,22 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         if (batch === undefined) return
 
         yield* clientSession.leaderThread.events.push(batch).pipe(
-          Effect.catchIf(isRejectedPushError, () => {
+          Effect.catchIf(isRejectedPushError, (error) => {
             debugInfo.rejectCount++
-            return TxQueue.clear(leaderPushQueue)
+            return Effect.gen(function* () {
+              const wasOpen = yield* Effect.tx(
+                Effect.gen(function* () {
+                  const wasOpen = yield* TxQueue.isOpen(leaderPushQueue)
+                  yield* TxQueue.clear(leaderPushQueue)
+                  return wasOpen
+                }),
+              )
+
+              // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
+              // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
+              // successful durable drain after discarding pending events.
+              if (wasOpen === false) drainRejection = error
+            })
           }),
         )
       }
@@ -158,6 +172,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         ? Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)
             yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+            if (drainRejection !== undefined) return yield* Effect.die(drainRejection)
           })
         : Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -2,6 +2,7 @@
 import { LS_DEV, TRACE_VERBOSE } from '@livestore/utils'
 import {
   Cause,
+  Deferred,
   Effect,
   Exit,
   Filter,
@@ -98,6 +99,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** Only used for debugging / observability / testing, it's not relied upon for correctness of the sync processor. */
   const syncStateUpdateQueue = yield* Queue.unbounded<SyncState.SyncState>()
+  const rejectionObserved = yield* Deferred.make<void>()
   const isClientOnlyEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
@@ -126,7 +128,13 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
     let drainFailure: Cause.Cause<never> | undefined
     let rejectionRevision = 0
-    let rejectionAwaitingPull: { readonly error: Error; readonly revision: number } | undefined
+    let rejectionAwaitingPull:
+      | {
+          readonly error: Error
+          readonly rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
+          readonly revision: number
+        }
+      | undefined
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
@@ -150,8 +158,10 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
               // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
               // successful durable drain after discarding pending events.
-              if (wasOpen === true) rejectionAwaitingPull = { error, revision: ++rejectionRevision }
-              else drainFailure = Cause.die(error)
+              if (wasOpen === true) {
+                rejectionAwaitingPull = { error, rejectedEvents: batch, revision: ++rejectionRevision }
+              } else drainFailure = Cause.die(error)
+              yield* Deferred.succeed(rejectionObserved, undefined)
             })
           }),
         )
@@ -283,9 +293,14 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (mergeResult.newEvents.length === 0) {
             // If there are no new events, we need to update the sync state as well
             yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-            // An advance only resolves a cleared transport queue when it confirms every canonical pending event.
-            // Otherwise keep the marker so shutdown cannot claim a durable drain for still-stranded pending events.
-            if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+            // Clear only when this pull confirms the rejected prefix. Newer pending events may already have been
+            // admitted successfully and must not keep an obsolete rejection marker alive.
+            if (
+              rejectionAtPullStart !== undefined &&
+              isRejectedBatchRecovered(rejectionAtPullStart.rejectedEvents, mergeResult.newSyncState.pending) ===
+                true &&
+              rejectionAwaitingPull === rejectionAtPullStart
+            ) {
               rejectionAwaitingPull = undefined
             }
             return
@@ -313,7 +328,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-          if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+          if (
+            rejectionAtPullStart !== undefined &&
+            isRejectedBatchRecovered(rejectionAtPullStart.rejectedEvents, mergeResult.newSyncState.pending) === true &&
+            rejectionAwaitingPull === rejectionAtPullStart
+          ) {
             rejectionAwaitingPull = undefined
           }
         }).pipe(
@@ -432,6 +451,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       changes: Stream.fromQueue(syncStateUpdateQueue),
     }),
     debug: {
+      awaitRejection: Deferred.await(rejectionObserved),
       print: () =>
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
@@ -462,6 +482,15 @@ const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<Read
     }),
   )
 
+const isRejectedBatchRecovered = (
+  rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+  pendingEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+): boolean =>
+  rejectedEvents.every(
+    (rejectedEvent) =>
+      pendingEvents.some((pendingEvent) => LiveStoreEvent.Client.isEqualEncoded(pendingEvent, rejectedEvent)) === false,
+  )
+
 export interface ClientSessionSyncProcessor {
   boot: Effect.Effect<void, never, Scope.Scope>
   encodeEvents: (
@@ -476,6 +505,8 @@ export interface ClientSessionSyncProcessor {
    */
   syncState: Subscribable.Subscribable<SyncState.SyncState>
   debug: {
+    /** Diagnostic/test barrier completed after the first rejected leader push updates coordinator state. */
+    awaitRejection: Effect.Effect<void>
     print: () => void
     debugInfo: () => {
       rebaseCount: number

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 import { LS_DEV, TRACE_VERBOSE } from '@livestore/utils'
 import {
+  Cause,
   Effect,
   Exit,
   Filter,
@@ -12,7 +13,6 @@ import {
   Stream,
   Subscribable,
   TxQueue,
-  TxRef,
 } from '@livestore/utils/effect'
 
 import type { ClientSession } from '../adapter-types.ts'
@@ -102,27 +102,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
-  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
-  const leaderPushLifecycleState = yield* TxRef.make<LeaderPushLifecycleState>({
-    _tag: 'accepting',
-    activePushCount: 0,
-  })
-
-  const takeNextLeaderPushWorkerAction: Effect.Effect<LeaderPushWorkerAction> = Effect.tx(
-    Effect.gen(function* () {
-      if ((yield* TxQueue.isEmpty(leaderPushQueue)) === false) {
-        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
-        return { _tag: 'push' as const, batch }
-      }
-
-      const lifecycleState = yield* TxRef.get(leaderPushLifecycleState)
-      if (lifecycleState._tag === 'stopping' && lifecycleState.activePushCount === 0) {
-        return { _tag: 'stop' as const }
-      }
-
-      return yield* Effect.txRetry
-    }),
-  )
+  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>()
 
   const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
@@ -147,10 +127,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
-        const action = yield* takeNextLeaderPushWorkerAction
-        if (action._tag === 'stop') return
+        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize).pipe(
+          Effect.catchIf(Cause.isDone, () => Effect.succeed(undefined)),
+        )
+        if (batch === undefined) return
 
-        yield* clientSession.leaderThread.events.push(action.batch).pipe(
+        yield* clientSession.leaderThread.events.push(batch).pipe(
           Effect.catchIf(isRejectedPushError, () => {
             debugInfo.rejectCount++
             return TxQueue.clear(leaderPushQueue)
@@ -168,27 +150,19 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
 
-    // Close admission and let the sole push worker drain every admitted event before it exits. This finalizer is
-    // registered after the FiberHandle so it runs first; once the worker exits, the handle finalizer has nothing
-    // left to interrupt. The pull fiber is registered later and therefore stops before this shutdown begins.
+    // Public Store commits finish synchronously before shutdown closes the Store to new commits. Ending the queue
+    // therefore happens after its final producer and lets the sole push worker drain every buffered batch. This
+    // finalizer is registered after the FiberHandle so the handle only tears down after the graceful drain.
     yield* Effect.addFinalizer((exit) =>
-      Effect.gen(function* () {
-        yield* Effect.tx(
-          TxRef.update(
-            leaderPushLifecycleState,
-            (state): LeaderPushLifecycleState => ({
-              _tag: 'stopping',
-              activePushCount: state.activePushCount,
-            }),
-          ),
-        )
-
-        // A healthy shutdown drains durably. On failure, the leader may already be unavailable or blocked in
-        // the failing push, so waiting would deadlock teardown and cannot provide a durability guarantee.
-        yield* Exit.isSuccess(exit) === true
-          ? FiberHandle.awaitEmpty(leaderPushingFiberHandle)
-          : FiberHandle.clear(leaderPushingFiberHandle)
-      }).pipe(Effect.uninterruptible),
+      Exit.isSuccess(exit) === true
+        ? Effect.gen(function* () {
+            yield* TxQueue.end(leaderPushQueue)
+            yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+          })
+        : Effect.gen(function* () {
+            yield* TxQueue.end(leaderPushQueue)
+            yield* FiberHandle.clear(leaderPushingFiberHandle)
+          }),
     )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
@@ -215,54 +189,60 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             ),
           )
 
-          syncStateRef.current = mergeResult.newSyncState
-
           if (mergeResult._tag === 'rebase') {
-            yield* Effect.spanEvent('merge:pull:rebase', {
-              payloadTag: payload._tag,
-              ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
-              newEventsCount: mergeResult.newEvents.length,
-              rollbackCount: mergeResult.rollbackEvents.length,
-              ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
-            })
+            // Publishing the rebased state, replacing the queue, and restarting its sole worker form one ownership
+            // transition. Finish that short transition before honoring teardown; leader pushes remain interruptible.
+            yield* Effect.gen(function* () {
+              syncStateRef.current = mergeResult.newSyncState
 
-            debugInfo.rebaseCount++
+              yield* Effect.spanEvent('merge:pull:rebase', {
+                payloadTag: payload._tag,
+                ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
+                newEventsCount: mergeResult.newEvents.length,
+                rollbackCount: mergeResult.rollbackEvents.length,
+                ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
+              })
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
+              debugInfo.rebaseCount++
 
-            yield* FiberHandle.clear(leaderPushingFiberHandle)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
+              yield* FiberHandle.clear(leaderPushingFiberHandle)
 
-            // Reset the leader push queue since we're rebasing and will push again
-            yield* TxQueue.clear(leaderPushQueue)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
+              // Reset the leader push queue since we're rebasing and will push again
+              yield* TxQueue.clear(leaderPushQueue)
 
-            if (LS_DEV === true) {
-              yield* Effect.logDebug(
-                'merge:pull:rebase: rollback',
-                mergeResult.rollbackEvents.length,
-                ...mergeResult.rollbackEvents.slice(0, 10).map((_) => _.toJSON()),
-              )
-            }
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
 
-            for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
-              const event = mergeResult.rollbackEvents[i]!
-              if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
-                rollback(event.meta.sessionChangeset.data)
-                event.meta.sessionChangeset = { _tag: 'unset' }
+              if (LS_DEV === true) {
+                yield* Effect.logDebug(
+                  'merge:pull:rebase: rollback',
+                  mergeResult.rollbackEvents.length,
+                  ...mergeResult.rollbackEvents.slice(0, 10).map((_) => _.toJSON()),
+                )
               }
-            }
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
+              for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
+                const event = mergeResult.rollbackEvents[i]!
+                if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
+                  rollback(event.meta.sessionChangeset.data)
+                  event.meta.sessionChangeset = { _tag: 'unset' }
+                }
+              }
 
-            yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
+              yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
 
-            yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
+
+              yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+            }).pipe(Effect.uninterruptible)
           } else {
+            syncStateRef.current = mergeResult.newSyncState
+
             yield* Effect.spanEvent('merge:pull:advance', {
               payloadTag: payload._tag,
               ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
@@ -367,56 +347,37 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
     function* (encodedEvents) {
-      const wasAdmitted = yield* Effect.tx(
-        TxRef.modify(leaderPushLifecycleState, (state): [boolean, LeaderPushLifecycleState] =>
-          state._tag === 'accepting'
-            ? [true, { _tag: 'accepting', activePushCount: state.activePushCount + 1 }]
-            : [false, state],
-        ),
-      )
-
-      if (wasAdmitted === false) {
+      if ((yield* TxQueue.isOpen(leaderPushQueue)) === false) {
         return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
       }
 
-      yield* Effect.gen(function* () {
-        const mergeResult = yield* SyncState.merge({
-          syncState: syncStateRef.current,
-          payload: { _tag: 'local-push', newEvents: encodedEvents },
-          isClientOnlyEvent,
-          isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-        }).pipe(
-          Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
-            Effect.die(new Error('Expected advance from local-push merge')),
-          ),
-        )
-
-        yield* Effect.annotateCurrentSpan({
-          batchSize: encodedEvents.length,
-          mergeResultTag: mergeResult._tag,
-          eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
-            acc[event.name] = (acc[event.name] ?? 0) + 1
-            return acc
-          }, {}),
-          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-        })
-
-        syncStateRef.current = mergeResult.newSyncState
-        yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-        yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      const mergeResult = yield* SyncState.merge({
+        syncState: syncStateRef.current,
+        payload: { _tag: 'local-push', newEvents: encodedEvents },
+        isClientOnlyEvent,
+        isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
       }).pipe(
-        Effect.ensuring(
-          Effect.tx(
-            TxRef.update(
-              leaderPushLifecycleState,
-              (state): LeaderPushLifecycleState => ({
-                ...state,
-                activePushCount: state.activePushCount - 1,
-              }),
-            ),
-          ),
+        Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
+          Effect.die(new Error('Expected advance from local-push merge')),
         ),
       )
+
+      yield* Effect.annotateCurrentSpan({
+        batchSize: encodedEvents.length,
+        mergeResultTag: mergeResult._tag,
+        eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
+          acc[event.name] = (acc[event.name] ?? 0) + 1
+          return acc
+        }, {}),
+        ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+      })
+
+      syncStateRef.current = mergeResult.newSyncState
+      yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+      const rejectedEvents = yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      if (rejectedEvents.length > 0) {
+        return yield* Effect.die('Leader push queue closed while accepting events')
+      }
     },
   )
 
@@ -440,7 +401,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
           console.log('syncState', syncStateRef.current)
-          const pushQueueItems = yield* snapshotTxQueue(leaderPushQueue)
+          const pushQueueItems = yield* snapshotTxQueue(leaderPushQueue).pipe(
+            Effect.catchIf(Cause.isDone, () => Effect.succeed([])),
+          )
           console.log('pushQueueSize', pushQueueItems.length)
           console.log(
             'pushQueueItems',
@@ -452,9 +415,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   } satisfies ClientSessionSyncProcessor
 })
 
-const snapshotTxQueue = <A>(queue: TxQueue.TxQueue<A>): Effect.Effect<ReadonlyArray<A>> =>
+const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<ReadonlyArray<A>, E> =>
   Effect.tx(
     Effect.gen(function* () {
+      // Re-offering a snapshot to a closing queue would reject and lose the cleared items.
+      if ((yield* TxQueue.isOpen(queue)) === false) return []
+
       const items = yield* TxQueue.clear(queue)
       yield* TxQueue.offerAll(queue, items)
       return items
@@ -497,11 +463,3 @@ export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
   }),
 })
 type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type
-
-type LeaderPushLifecycleState =
-  | { readonly _tag: 'accepting'; readonly activePushCount: number }
-  | { readonly _tag: 'stopping'; readonly activePushCount: number }
-
-type LeaderPushWorkerAction =
-  | { readonly _tag: 'push'; readonly batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta> }
-  | { readonly _tag: 'stop' }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -17,7 +17,7 @@ import {
 
 import type { ClientSession } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
-import { isRejectedPushError, type RejectedPushError } from '../leader-thread/RejectedPushError.ts'
+import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
@@ -124,7 +124,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     }
 
     const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
-    let drainRejection: RejectedPushError | undefined
+    let drainFailure: Cause.Cause<never> | undefined
+    let rejectionRevision = 0
+    let rejectionAwaitingPull: { readonly error: Error; readonly revision: number } | undefined
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
@@ -148,7 +150,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
               // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
               // successful durable drain after discarding pending events.
-              if (wasOpen === false) drainRejection = error
+              if (wasOpen === true) rejectionAwaitingPull = { error, revision: ++rejectionRevision }
+              else drainFailure = Cause.die(error)
             })
           }),
         )
@@ -158,21 +161,27 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.tapCauseLogPretty,
       // The worker must exit before shutdown can await it, otherwise a fatal push creates a self-deadlock.
       Effect.catchCause((cause) =>
-        clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid),
+        Cause.hasInterruptsOnly(cause) === true
+          ? Effect.void
+          : Effect.sync(() => {
+              drainFailure = cause
+            }).pipe(
+              Effect.andThen(clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid)),
+            ),
       ),
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
 
-    // Public Store commits finish synchronously before shutdown closes the Store to new commits. Ending the queue
-    // therefore happens after its final producer and lets the sole push worker drain every buffered batch. This
-    // finalizer is registered after the FiberHandle so the handle only tears down after the graceful drain.
+    // Register after the FiberHandle so the push worker drains first, but before pull so LIFO scope teardown stops
+    // pull before deciding whether a rejection was left without a recovery path.
     yield* Effect.addFinalizer((exit) =>
       Exit.isSuccess(exit) === true
         ? Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)
             yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
-            if (drainRejection !== undefined) return yield* Effect.die(drainRejection)
+            if (drainFailure !== undefined) return yield* Effect.failCause(drainFailure)
+            if (rejectionAwaitingPull !== undefined) return yield* Effect.die(rejectionAwaitingPull.error)
           })
         : Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)
@@ -191,6 +200,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (clientSession.devtools.enabled === true) {
             yield* clientSession.devtools.pullLatch.await
           }
+
+          const rejectionAtPullStart = rejectionAwaitingPull
 
           const mergeResult = yield* SyncState.merge({
             syncState: syncStateRef.current,
@@ -253,6 +264,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
               if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
 
+              rejectionAwaitingPull = undefined
               yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
             }).pipe(Effect.uninterruptible)
           } else {
@@ -271,6 +283,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (mergeResult.newEvents.length === 0) {
             // If there are no new events, we need to update the sync state as well
             yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+            // An advance only resolves a cleared transport queue when it confirms every canonical pending event.
+            // Otherwise keep the marker so shutdown cannot claim a durable drain for still-stranded pending events.
+            if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+              rejectionAwaitingPull = undefined
+            }
             return
           }
 
@@ -296,6 +313,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+          if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+            rejectionAwaitingPull = undefined
+          }
         }).pipe(
           Effect.tapCauseLogPretty,
           Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -38,8 +38,6 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -183,8 +181,6 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -328,8 +324,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -473,8 +467,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -618,8 +610,6 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -763,8 +753,13 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
           },
         },
       ],
@@ -974,8 +969,6 @@ exports[`otel > otel 3`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -1281,8 +1274,6 @@ exports[`otel > with thunks 7`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -1422,8 +1413,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -333,7 +333,10 @@ export const createStore = <
         exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
       ) =>
         Effect.gen(function* () {
-          yield* Scope.close(lifetimeScope, exit).pipe(
+          // Time out waiting for teardown, not teardown itself. Interrupting Scope.close can leave its sequential
+          // finalizer chain half-run while the scope is already marked closed and cannot be resumed.
+          const closeFiber = yield* Scope.close(lifetimeScope, exit).pipe(Effect.forkDetach)
+          yield* Fiber.join(closeFiber).pipe(
             Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),
             Effect.timeout(1000),
             Effect.catchTag('TimeoutError', () =>

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -38,8 +38,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
           },
         },
       ],
@@ -312,8 +317,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
           },
         },
       ],

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -702,6 +702,43 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
+  Vitest.it.effect('clears a recovered rejection while newer admitted events remain pending', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const secondPushAccepted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Effect.fail(rejection)
+            : Deferred.succeed(secondPushAccepted, undefined).pipe(Effect.asVoid)
+        },
+      })
+
+      const [rejectedEvent] = yield* pushIds(['rejected-prefix'])
+      yield* processor.debug.awaitRejection
+      yield* pushIds(['newer-admitted'])
+      yield* Deferred.await(secondPushAccepted)
+      // Drain both local notifications so the next one proves the upstream confirmation was processed.
+      yield* processor.syncState.changes.pipe(Stream.take(2), Stream.runDrain)
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedEvent!] }))
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+
+      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+
+      expect(Exit.isSuccess(closeExit)).toBe(true)
+      expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['newer-admitted'])
+    }).pipe(withTestCtx(test)),
+  )
+
   Vitest.it.effect('propagates a fatal leader push from the graceful drain', (test) =>
     Effect.gen(function* () {
       const pushStarted = yield* Deferred.make<void>()

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -36,7 +36,7 @@ import {
   References,
   Result,
   Schema,
-  type Scope,
+  Scope,
   Stream,
   Subscribable,
   SubscriptionRef,
@@ -351,6 +351,112 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       expect(res).toMatchObject([
         { id: 'client_0', text: 't1', completed: false, deletedAt: null },
         { id: 'backend_0', text: 't2', completed: false, deletedAt: null },
+      ])
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('flushes in-flight and queued leader pushes serially before shutdown', (test) =>
+    Effect.gen(function* () {
+      const firstPushStarted = yield* Deferred.make<void>()
+      const releaseFirstPush = yield* Deferred.make<void>()
+      const shutdownStarted = yield* Deferred.make<void>()
+      const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
+      let isFirstPush = true
+      let activePushCount = 0
+      let maxActivePushCount = 0
+
+      const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
+      const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
+        events: {
+          pull: () => Stream.empty,
+          push: (batch) =>
+            Effect.gen(function* () {
+              activePushCount++
+              maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
+
+              if (isFirstPush === true) {
+                isFirstPush = false
+                yield* Deferred.succeed(firstPushStarted, undefined)
+                yield* Deferred.await(releaseFirstPush)
+              }
+
+              persistedBatches.push(batch)
+              activePushCount--
+            }),
+          stream: () => Stream.empty,
+        },
+        initialState: {
+          leaderHead: EventSequenceNumber.Client.ROOT,
+          migrationsReport: { migrations: [] },
+          storageMode: 'persisted',
+        },
+        export: Effect.die(new Error('not implemented')),
+        getEventlogData: Effect.die(new Error('not implemented')),
+        syncState: Subscribable.make({
+          get: Effect.die(new Error('not implemented')),
+          changes: Stream.empty,
+        }),
+        sendDevtoolsMessage: () => Effect.void,
+        networkStatus: Subscribable.make({
+          get: Effect.die(new Error('not implemented')),
+          changes: Stream.empty,
+        }),
+      }
+
+      const clientSession: ClientSession = {
+        sqliteDb: {} as ClientSession['sqliteDb'],
+        devtools: { enabled: false },
+        clientId: 'client-test',
+        sessionId: 'session-test',
+        lockStatus,
+        shutdown: () => Effect.void,
+        leaderThread,
+        debugInstanceId: 'test-instance',
+      }
+
+      const syncProcessor = yield* makeClientSessionSyncProcessor({
+        schema: schema as LiveStoreSchema,
+        clientSession,
+        materializeEvent: () => Effect.die(new Error('not used')),
+        rollback: () => undefined,
+        refreshTables: () => undefined,
+        params: { leaderPushBatchSize: 1 },
+        confirmUnsavedChanges: false,
+      })
+
+      const processorScope = yield* Scope.make()
+      yield* syncProcessor.boot.pipe(Scope.provide(processorScope))
+
+      const [firstEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'first', text: 'first', completed: false }),
+      ])
+      yield* syncProcessor.push([firstEvent!])
+      yield* Deferred.await(firstPushStarted)
+
+      const [secondEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'second', text: 'second', completed: false }),
+      ])
+      yield* syncProcessor.push([secondEvent!])
+      const [thirdEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'third', text: 'third', completed: false }),
+      ])
+      yield* syncProcessor.push([thirdEvent!])
+
+      // This marker runs first during teardown and lets the test release the blocked leader push only after
+      // scope closure has begun. The shutdown path must finish that push before flushing the queued batch.
+      yield* Effect.addFinalizer(() => Deferred.succeed(shutdownStarted, undefined)).pipe(Scope.provide(processorScope))
+      const closeFiber = yield* Scope.close(processorScope, Exit.void).pipe(Effect.forkChild)
+      yield* Deferred.await(shutdownStarted)
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+      yield* Deferred.succeed(releaseFirstPush, undefined)
+      yield* Fiber.join(closeFiber)
+
+      expect(maxActivePushCount).toBe(1)
+      expect(persistedBatches).toMatchObject([
+        [{ args: { id: 'first' } }],
+        [{ args: { id: 'second' } }],
+        [{ args: { id: 'third' } }],
       ])
     }).pipe(withTestCtx(test)),
   )

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -355,7 +355,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.live('flushes in-flight and queued leader pushes serially before shutdown', (test) =>
+  Vitest.live('drains admitted leader pushes serially and closes admission on shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
       const releaseFirstPush = yield* Deferred.make<void>()
@@ -441,16 +441,19 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         events.todoCreated({ id: 'third', text: 'third', completed: false }),
       ])
       yield* syncProcessor.push([thirdEvent!])
+      const [postShutdownEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'post-shutdown', text: 'post-shutdown', completed: false }),
+      ])
 
-      // This marker runs first during teardown and lets the test release the blocked leader push only after
-      // scope closure has begun. The shutdown path must finish that push before flushing the queued batch.
+      // Release the blocked worker only after scope closure begins. Graceful shutdown must let that same worker
+      // finish its owned batch, drain the queued batches, and exit without admitting any later pushes.
       yield* Effect.addFinalizer(() => Deferred.succeed(shutdownStarted, undefined)).pipe(Scope.provide(processorScope))
       const closeFiber = yield* Scope.close(processorScope, Exit.void).pipe(Effect.forkChild)
       yield* Deferred.await(shutdownStarted)
-      yield* Effect.yieldNow
-      yield* Effect.yieldNow
       yield* Deferred.succeed(releaseFirstPush, undefined)
       yield* Fiber.join(closeFiber)
+
+      const postShutdownPushExit = yield* Effect.exit(syncProcessor.push([postShutdownEvent!]))
 
       expect(maxActivePushCount).toBe(1)
       expect(persistedBatches).toMatchObject([
@@ -458,6 +461,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         [{ args: { id: 'second' } }],
         [{ args: { id: 'third' } }],
       ])
+      expect(Exit.isFailure(postShutdownPushExit)).toBe(true)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -27,6 +27,7 @@ import {
   Effect,
   Equal,
   Exit,
+  FastCheck,
   FetchHttpClient,
   Fiber,
   Hash,
@@ -40,6 +41,7 @@ import {
   Stream,
   Subscribable,
   SubscriptionRef,
+  TestClock,
 } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 import { PlatformNode } from '@livestore/utils/node'
@@ -59,6 +61,83 @@ const withTestCtx = Vitest.makeWithTestCtx({
       FetchHttpClient.layer,
       Layer.succeed(References.MinimumLogLevel, 'Debug'),
     ),
+})
+
+type LeaderEvents = ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy['events']
+type ClientProcessorParams = Parameters<typeof makeClientSessionSyncProcessor>[0]
+
+const makeClientProcessorHarness = Effect.fn(function* ({
+  push,
+  pull = () => Stream.empty,
+  rollback = () => undefined,
+  leaderPushBatchSize = 1,
+  simulation,
+}: {
+  push: LeaderEvents['push']
+  pull?: LeaderEvents['pull']
+  rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
+  leaderPushBatchSize?: number
+  simulation?: ClientProcessorParams['params']['simulation']
+}) {
+  const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
+  const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
+    events: { pull, push, stream: () => Stream.empty },
+    initialState: {
+      leaderHead: EventSequenceNumber.Client.ROOT,
+      migrationsReport: { migrations: [] },
+      storageMode: 'persisted',
+    },
+    export: Effect.die(new Error('not implemented')),
+    getEventlogData: Effect.die(new Error('not implemented')),
+    syncState: Subscribable.make({
+      get: Effect.die(new Error('not implemented')),
+      changes: Stream.empty,
+    }),
+    sendDevtoolsMessage: () => Effect.void,
+    networkStatus: Subscribable.make({
+      get: Effect.die(new Error('not implemented')),
+      changes: Stream.empty,
+    }),
+  }
+
+  const clientSession: ClientSession = {
+    sqliteDb: {} as ClientSession['sqliteDb'],
+    devtools: { enabled: false },
+    clientId: 'client-test',
+    sessionId: 'session-test',
+    lockStatus,
+    shutdown: () => Effect.void,
+    leaderThread,
+    debugInstanceId: 'test-instance',
+  }
+
+  const processor = yield* makeClientSessionSyncProcessor({
+    schema: schema as LiveStoreSchema,
+    clientSession,
+    materializeEvent: () =>
+      Effect.succeed({
+        writeTables: new Set<string>(),
+        sessionChangeset: { _tag: 'no-op' as const },
+        materializerHash: Option.none<number>(),
+      }),
+    rollback,
+    refreshTables: () => undefined,
+    params: { leaderPushBatchSize, simulation },
+    confirmUnsavedChanges: false,
+  })
+
+  const scope = yield* Scope.make()
+  yield* processor.boot.pipe(Scope.provide(scope))
+
+  const pushIds = Effect.fn(function* (ids: ReadonlyArray<string>) {
+    const encoded = yield* processor.encodeEvents(
+      ids.map((id) => events.todoCreated({ id, text: id, completed: false })),
+    )
+    yield* processor.push(encoded)
+    return encoded
+  })
+
+  return { processor, pushIds, scope }
 })
 
 // TODO use property tests for simulation params
@@ -355,113 +434,215 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.live('drains admitted leader pushes serially and closes admission on shutdown', (test) =>
+  Vitest.it.effect('drains in-flight and queued leader pushes serially on shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
-      const releaseFirstPush = yield* Deferred.make<void>()
-      const shutdownStarted = yield* Deferred.make<void>()
       const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
       let isFirstPush = true
       let activePushCount = 0
       let maxActivePushCount = 0
 
-      const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
-      const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
-        events: {
-          pull: () => Stream.empty,
-          push: (batch) =>
-            Effect.gen(function* () {
-              activePushCount++
-              maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: (batch) =>
+          Effect.gen(function* () {
+            activePushCount++
+            maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
 
-              if (isFirstPush === true) {
-                isFirstPush = false
-                yield* Deferred.succeed(firstPushStarted, undefined)
-                yield* Deferred.await(releaseFirstPush)
-              }
+            if (isFirstPush === true) {
+              isFirstPush = false
+              yield* Deferred.succeed(firstPushStarted, undefined)
+              yield* Effect.sleep('1 millis')
+            }
 
-              persistedBatches.push(batch)
-              activePushCount--
-            }),
-          stream: () => Stream.empty,
-        },
-        initialState: {
-          leaderHead: EventSequenceNumber.Client.ROOT,
-          migrationsReport: { migrations: [] },
-          storageMode: 'persisted',
-        },
-        export: Effect.die(new Error('not implemented')),
-        getEventlogData: Effect.die(new Error('not implemented')),
-        syncState: Subscribable.make({
-          get: Effect.die(new Error('not implemented')),
-          changes: Stream.empty,
-        }),
-        sendDevtoolsMessage: () => Effect.void,
-        networkStatus: Subscribable.make({
-          get: Effect.die(new Error('not implemented')),
-          changes: Stream.empty,
-        }),
-      }
-
-      const clientSession: ClientSession = {
-        sqliteDb: {} as ClientSession['sqliteDb'],
-        devtools: { enabled: false },
-        clientId: 'client-test',
-        sessionId: 'session-test',
-        lockStatus,
-        shutdown: () => Effect.void,
-        leaderThread,
-        debugInstanceId: 'test-instance',
-      }
-
-      const syncProcessor = yield* makeClientSessionSyncProcessor({
-        schema: schema as LiveStoreSchema,
-        clientSession,
-        materializeEvent: () => Effect.die(new Error('not used')),
-        rollback: () => undefined,
-        refreshTables: () => undefined,
-        params: { leaderPushBatchSize: 1 },
-        confirmUnsavedChanges: false,
+            persistedBatches.push(batch)
+            activePushCount--
+          }),
       })
 
-      const processorScope = yield* Scope.make()
-      yield* syncProcessor.boot.pipe(Scope.provide(processorScope))
-
-      const [firstEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'first', text: 'first', completed: false }),
-      ])
-      yield* syncProcessor.push([firstEvent!])
+      yield* pushIds(['first'])
       yield* Deferred.await(firstPushStarted)
+      yield* pushIds(['second'])
+      yield* pushIds(['third'])
 
-      const [secondEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'second', text: 'second', completed: false }),
-      ])
-      yield* syncProcessor.push([secondEvent!])
-      const [thirdEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'third', text: 'third', completed: false }),
-      ])
-      yield* syncProcessor.push([thirdEvent!])
-      const [postShutdownEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'post-shutdown', text: 'post-shutdown', completed: false }),
-      ])
-
-      // Release the blocked worker only after scope closure begins. Graceful shutdown must let that same worker
-      // finish its owned batch, drain the queued batches, and exit without admitting any later pushes.
-      yield* Effect.addFinalizer(() => Deferred.succeed(shutdownStarted, undefined)).pipe(Scope.provide(processorScope))
-      const closeFiber = yield* Scope.close(processorScope, Exit.void).pipe(Effect.forkChild)
-      yield* Deferred.await(shutdownStarted)
-      yield* Deferred.succeed(releaseFirstPush, undefined)
+      // Drive the close fiber until it is waiting for the sleeping leader push, then release that push. This gives
+      // the test an explicit virtual-time happens-before edge without depending on scheduler yields or wall time.
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+      yield* TestClock.adjust(0)
+      yield* TestClock.adjust('1 millis')
       yield* Fiber.join(closeFiber)
 
-      const postShutdownPushExit = yield* Effect.exit(syncProcessor.push([postShutdownEvent!]))
+      const postShutdownPushExit = yield* Effect.exit(pushIds(['post-shutdown']))
 
       expect(maxActivePushCount).toBe(1)
-      expect(persistedBatches).toMatchObject([
-        [{ args: { id: 'first' } }],
-        [{ args: { id: 'second' } }],
-        [{ args: { id: 'third' } }],
+      expect(persistedBatches.map((batch) => batch.map((event) => event.args.id))).toEqual([
+        ['first'],
+        ['second'],
+        ['third'],
       ])
       expect(Exit.isFailure(postShutdownPushExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.asProp(
+    Vitest.live,
+    'preserves event order and batch bounds through graceful shutdown',
+    [
+      FastCheck.integer({ min: 1, max: 5 }),
+      FastCheck.array(FastCheck.integer({ min: 1, max: 4 }), { minLength: 0, maxLength: 6 }),
+    ] as const,
+    ([leaderPushBatchSize, pushGroupSizes], test) =>
+      Effect.gen(function* () {
+        const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
+
+        const { pushIds, scope } = yield* makeClientProcessorHarness({
+          leaderPushBatchSize,
+          push: (batch) =>
+            Effect.sync(() => {
+              persistedBatches.push(batch)
+            }),
+        })
+
+        const expectedIds: string[] = []
+        for (const groupSize of pushGroupSizes) {
+          const groupIds = Array.from({ length: groupSize }, (_, index) => `event-${expectedIds.length + index}`)
+          expectedIds.push(...groupIds)
+          yield* pushIds(groupIds)
+        }
+
+        yield* Scope.close(scope, Exit.void)
+
+        expect(persistedBatches.flatMap((batch) => batch.map((event) => event.args.id))).toEqual(expectedIds)
+        expect(persistedBatches.every((batch) => batch.length > 0 && batch.length <= leaderPushBatchSize)).toBe(true)
+      }).pipe(withTestCtx(test)),
+    { fastCheck: { numRuns: 50 } },
+  )
+
+  for (const shutdownPoint of [
+    '1_before_leader_push_fiber_interrupt',
+    '3_before_rebase_rollback',
+    '5_before_leader_push_fiber_run',
+  ] as const) {
+    Vitest.it.effect(`does not lose rebased pending events when shutdown reaches ${shutdownPoint}`, (test) =>
+      Effect.gen(function* () {
+        const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+        const firstPushStarted = yield* Deferred.make<void>()
+        const persistedIds: string[] = []
+        let pushCallCount = 0
+
+        const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+          pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+          push: (batch) => {
+            pushCallCount++
+            return pushCallCount === 1
+              ? Deferred.succeed(firstPushStarted, undefined).pipe(Effect.andThen(Effect.never))
+              : Effect.sync(() => persistedIds.push(...batch.map((event) => event.args.id as string)))
+          },
+          simulation: {
+            pull: {
+              '1_before_leader_push_fiber_interrupt': shutdownPoint === '1_before_leader_push_fiber_interrupt' ? 1 : 0,
+              '2_before_leader_push_queue_clear': 0,
+              '3_before_rebase_rollback': shutdownPoint === '3_before_rebase_rollback' ? 1 : 0,
+              '4_before_leader_push_queue_offer': 0,
+              '5_before_leader_push_fiber_run': shutdownPoint === '5_before_leader_push_fiber_run' ? 1 : 0,
+            },
+          },
+        })
+
+        const [localEvent] = yield* pushIds(['local'])
+        localEvent!.meta.sessionChangeset = {
+          _tag: 'sessionChangeset',
+          data: new Uint8Array([1]),
+          debug: {},
+        }
+        yield* Deferred.await(firstPushStarted)
+
+        const [remoteBase] = yield* processor.encodeEvents([
+          events.todoCreated({ id: 'remote', text: 'remote', completed: false }),
+        ])
+        const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+          ...remoteBase!,
+          seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+          parentSeqNum: EventSequenceNumber.Client.ROOT,
+          clientId: 'remote-client',
+          sessionId: 'remote-session',
+        })
+        yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+
+        // Let rebase reach the selected virtual-time barrier, start shutdown there, then finish the handoff.
+        yield* TestClock.adjust(0)
+        const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+        yield* TestClock.adjust(0)
+        yield* TestClock.adjust('1 millis')
+        yield* Fiber.join(closeFiber)
+
+        expect(processor.debug.debugInfo().rebaseCount).toBe(1)
+        expect(persistedIds).toEqual(['local'])
+      }).pipe(withTestCtx(test)),
+    )
+  }
+
+  Vitest.it.effect('interrupts a hung leader push during failed shutdown', (test) =>
+    Effect.gen(function* () {
+      const firstPushStarted = yield* Deferred.make<void>()
+      const firstPushInterrupted = yield* Deferred.make<void>()
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(firstPushStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Deferred.succeed(firstPushInterrupted, undefined)),
+          ),
+      })
+
+      yield* pushIds(['blocked'])
+      yield* Deferred.await(firstPushStarted)
+
+      yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
+
+      expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('store shutdown timeout stops waiting without cancelling teardown', (test) =>
+    Effect.gen(function* () {
+      const { makeStore } = yield* TestContext
+      const pushStarted = yield* Deferred.make<void>()
+      const releasePush = yield* Deferred.make<void>()
+      const pushCompleted = yield* Deferred.make<void>()
+      const pushInterrupted = yield* Deferred.make<void>()
+
+      const store = yield* makeStore({
+        testing: {
+          overrides: {
+            clientSession: {
+              leaderThreadProxy: (leader) => ({
+                ...leader,
+                events: {
+                  ...leader.events,
+                  push: () =>
+                    Deferred.succeed(pushStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releasePush)),
+                      Effect.andThen(Deferred.succeed(pushCompleted, undefined)),
+                      Effect.onInterrupt(() => Deferred.succeed(pushInterrupted, undefined)),
+                    ),
+                },
+              }),
+            },
+          },
+        },
+      })
+
+      store.commit(events.todoCreated({ id: 'blocked', text: 'blocked', completed: false }))
+      yield* Deferred.await(pushStarted)
+
+      const shutdownFiber = yield* store.shutdown().pipe(Effect.forkChild)
+      yield* TestClock.adjust(1000)
+      yield* Fiber.join(shutdownFiber)
+
+      expect(yield* Deferred.isDone(pushCompleted)).toBe(false)
+      expect(yield* Deferred.isDone(pushInterrupted)).toBe(false)
+
+      yield* Deferred.succeed(releasePush, undefined)
+      yield* Deferred.await(pushCompleted)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -5,6 +5,7 @@ import {
   type BootStatus,
   type ClientSession,
   type ClientSessionLeaderThreadProxy,
+  LeaderAheadError,
   makeMockSyncBackend,
   SyncState,
   type UnknownError,
@@ -599,6 +600,36 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('does not report a successful drain when the leader rejects during shutdown', (test) =>
+    Effect.gen(function* () {
+      const pushStarted = yield* Deferred.make<void>()
+      const rejectPush = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(rejectPush)),
+            Effect.andThen(Effect.fail(rejection)),
+          ),
+      })
+
+      yield* pushIds(['rejected'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      // Drive close until it ends queue admission and waits for the in-flight leader response.
+      yield* TestClock.adjust(0)
+      yield* Deferred.succeed(rejectPush, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -71,12 +71,14 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   push,
   pull = () => Stream.empty,
   rollback = () => undefined,
+  shutdown = () => Effect.void,
   leaderPushBatchSize = 1,
   simulation,
 }: {
   push: LeaderEvents['push']
   pull?: LeaderEvents['pull']
   rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
+  shutdown?: ClientSession['shutdown']
   leaderPushBatchSize?: number
   simulation?: ClientProcessorParams['params']['simulation']
 }) {
@@ -107,7 +109,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
     clientId: 'client-test',
     sessionId: 'session-test',
     lockStatus,
-    shutdown: () => Effect.void,
+    shutdown,
     leaderThread,
     debugInstanceId: 'test-instance',
   }
@@ -586,7 +588,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
       const firstPushInterrupted = yield* Deferred.make<void>()
+      let shutdownCalls = 0
       const { pushIds, scope } = yield* makeClientProcessorHarness({
+        shutdown: () =>
+          Effect.sync(() => {
+            shutdownCalls++
+          }),
         push: () =>
           Deferred.succeed(firstPushStarted, undefined).pipe(
             Effect.andThen(Effect.never),
@@ -600,6 +607,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+      expect(shutdownCalls).toBe(0)
     }).pipe(withTestCtx(test)),
   )
 
@@ -630,6 +638,96 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const closeExit = yield* Fiber.join(closeFiber)
 
       expect(Exit.isFailure(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('fails the drain when pull stops before a leader rejection can recover', (test) =>
+    Effect.gen(function* () {
+      const pullStopped = yield* Deferred.make<void>()
+      const pushStarted = yield* Deferred.make<void>()
+      const rejectPush = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.never.pipe(Stream.ensuring(Deferred.succeed(pullStopped, undefined))),
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(rejectPush)),
+            Effect.andThen(Effect.fail(rejection)),
+          ),
+      })
+
+      yield* pushIds(['rejected-after-pull'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      yield* Deferred.await(pullStopped)
+      yield* Deferred.succeed(rejectPush, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('does not treat an unrelated pull advance as recovery from a rejected push', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const pushReturned = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(pushReturned, undefined))),
+      })
+
+      yield* pushIds(['still-pending'])
+      // Drain the local-push notification so the next observed change belongs to the explicit upstream payload.
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Deferred.await(pushReturned)
+      yield* TestClock.adjust(0)
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+
+      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+      expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['still-pending'])
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('propagates a fatal leader push from the graceful drain', (test) =>
+    Effect.gen(function* () {
+      const pushStarted = yield* Deferred.make<void>()
+      const failPush = yield* Deferred.make<void>()
+      const failure = new Error('leader push crashed')
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(failPush)),
+            Effect.andThen(Effect.die(failure)),
+          ),
+      })
+
+      yield* pushIds(['fatal'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      yield* TestClock.adjust(0)
+      yield* Deferred.succeed(failPush, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+      Exit.match(closeExit, {
+        onFailure: (cause) => expect(Cause.squash(cause)).toBe(failure),
+        onSuccess: () => assert.fail('expected graceful drain to fail'),
+      })
     }).pipe(withTestCtx(test)),
   )
 


### PR DESCRIPTION
## Problem

`store.shutdown()` interrupted the background leader-push fiber. With an in-process leader, that could silently lose both a batch already dequeued by `ClientSessionSyncProcessor` and later batches still queued for the leader.

The initial shutdown-time flush introduced a second pusher, which could overlap the worker's in-flight push and violate the leader proxy's serialization contract. A subsequent custom lifecycle state machine avoided that overlap but duplicated queue lifecycle, added substantial sensitive code, and still had interruption holes around rebase.

## Goal

On successful shutdown, persist every completed Store commit through the in-process leader before the client-session processor tears down, with exactly one leader pusher and bounded batches. If the leader rejects after graceful drain has begun, fail teardown rather than falsely report durability. On failed shutdown, close admission and terminate without deadlock.

## Decisions

- Use Effect's native `TxQueue.end` lifecycle. Closing preserves buffered items; the existing worker remains the sole pusher, drains the queue, observes `Cause.Done`, and exits.
- Rely on the real Store invariant: commits run synchronously, and Store shutdown closes public commit admission before processor finalization. Keep defensive checks for direct/post-close processor pushes and rejected queue offers.
- Treat rebase state publication, queue replacement, and worker restart as one uninterruptible ownership transition. This removes every state where authoritative pending events exist without a live worker or queued owner.
- If the leader rejects while the queue is still open, retain the existing pull/rebase recovery. If it rejects after graceful drain closes the queue and pull has stopped, surface that rejection as a failed teardown rather than silently clearing pending events.
- On failed teardown, end the queue and interrupt the worker instead of attempting a durability guarantee against a failing leader.
- Time out waiting for detached `Scope.close`, not `Scope.close` itself. Cancelling sequential scope finalization can leave older finalizers permanently skipped after the scope is already marked closed.
- Extract a reusable black-box processor test harness. Do not introduce a generic production worker abstraction: the client and leader processors have different persistence, retry, and teardown policies.

## Verification

- Exact red/green proof using the final tests against historical runtime files:
  - **Red on `main`:** the in-flight/queued drain test persisted `[]` instead of `first`, `second`, `third`.
  - **Red on previous PR head `04f51213e`:** all three shutdown-during-rebase tests failed; points 3 and 5 lost `local`, and point 1 deadlocked.
  - **Red on the pre-review head `9bf27874d`:** the shutdown-rejection regression expected a failed close but received success.
  - **Red on prior production `d33cc5647`:** pull-stopped rejection, unrelated-advance recovery, and fatal-drain tests all observed successful close instead of the required failure.
  - **Red on the pre-prefix fix `19b939d7d`:** confirming a rejected prefix while a newer admitted event remained pending caused graceful close to fail from a stale rejection marker.
  - **Green on this implementation:** the same deterministic rejection trace now fails teardown as required; all twelve new targeted/property tests passed.
- Deterministic virtual-time coverage, with no `yieldNow` or wall-clock sleeps:
  - in-flight plus queued drain, exact order, and maximum push concurrency of one;
  - shutdown at rebase simulation points 1, 3, and 5;
  - post-close push rejection, rejection after drain linearization, and rejection left unrecovered when pull stops;
  - unrelated upstream advances cannot mask a rejected batch with canonical pending events;
  - fatal non-rejection push causes propagate through graceful close, while expected interrupt-only teardown does not request shutdown;
  - failed-shutdown interruption of a hung leader push;
  - Store timeout stops waiting without cancelling teardown.
- FastCheck property: 50 generated combinations of batch sizes and push groupings preserve event order and batch bounds through graceful shutdown.
- Full processor test file: 24/24 passed.
- `dt ts:check`: passed.
- `dt lint:full:fix`: passed.
- `mono test unit`: all changed/relevant suites passed. One unrelated generated webmesh property failed during the parallel sweep and passed immediately in isolation (1/1, 12.8s).

## Complexity

The sync processor is now +108 net lines versus `main`, down from +84 in the custom state-machine version. Most added volume is isolated test coverage and its shared harness. The only cross-file runtime change is three net lines making the existing Store shutdown timeout non-destructive to scope finalization.

## Trade-offs

- Successful teardown waits for leader persistence. If a leader push never returns, the Store's one-second timeout returns to the caller while detached teardown continues preserving finalizer order.
- A rejection before shutdown still recovers through pull/rebase. A rejection that pull cannot fully recover fails graceful teardown; #1425 tracks the longer-term explicit lifecycle/recovery model.
- Failure teardown prioritizes termination and cleanup over draining because leader availability is no longer guaranteed.
- Rebase's short state/queue/worker ownership transition is uninterruptible; leader network pushes remain interruptible.

## Follow-ups

Issue #1425 tracks the fuller generated command-sequence model and explicit durable lifecycle outcomes for arbitrary push, remote advance/rebase, rejection, transport failure, and shutdown sequences. It will build on the new black-box harness with Deferred/TestClock barriers and remain stacked on this fix.

## References

- Refs #1265
- Downstream reproduction: the Effect v4 upgrade of the `livestore-contrib` single-threaded Node adapter.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 💚 co2-beryl |
| `agent_session_id` | 27bf65f4-8e56-4715-8ed8-d4fe11705e25 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/qq3avrif77r90ypqbdv3hgd3gvwj5s32-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/pjlb3cwf453ghzmc8jj4v8h29sw6p4dg-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-15-fix-flush-leader-push-shutdown |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4b8e1c5 |
</details>
<!-- agent-footer:end -->

