### PR TITLE
refactor(effect-lsp): clear duplicatePackage + mechanical diagnostics

### DIFF
--- a/.changeset/effect-lsp-mechanical-burndown.md
+++ b/.changeset/effect-lsp-mechanical-burndown.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Internal Effect-LSP burndown (#811): clear the config + mechanical diagnostics group at source — `duplicatePackage` (allowedDuplicatedPackages whitelist), `effectSucceedWithVoid`, `catchToOrElseSucceed`, `unnecessaryTypeofType`, `schemaSyncInEffect` (encode\*Effect + orDie, behavior-preserving), `redundantOrDie`, `unnecessaryEffectGen`, `unnecessaryFailYieldableError`, `missedPipeableOpportunity`, and a stale `@effect-diagnostics` directive. Behavior-neutral.

--- a/docs/src/content/_assets/code/tsconfig.json
+++ b/docs/src/content/_assets/code/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "rootDir": "./",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "rootDir": "./src",

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -104,12 +104,15 @@ const baseTsconfigCompilerOptions = {
   ...baseTsconfigCompilerOptionsWithoutDefaults,
   // LIVE-MIGRATION BRIDGE tsgo-strict-gate — DELETE at contraction — see live-migrations registry
   // Advisory gate: Effect warnings and suggestions remain visible without failing the exit code.
+  // LiveStore-specific: the internal @livestore/utils duplicate-package diagnostics are an
+  // LSP workspace-resolution artifact (not real duplication), so they are allowed here.
   plugins: [
     {
       ...effectUtilsBaseTsconfigCompilerOptions.plugins[0],
       ignoreEffectWarningsInTscExitCode: true,
       ignoreEffectSuggestionsInTscExitCode: true,
       ignoreEffectErrorsInTscExitCode: false,
+      allowedDuplicatedPackages: ['@livestore/utils'],
     },
   ],
   // LIVE-MIGRATION END tsgo-strict-gate

--- a/packages/@livestore/adapter-cloudflare/tsconfig.json
+++ b/packages/@livestore/adapter-cloudflare/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/adapter-web/tsconfig.json
+++ b/packages/@livestore/adapter-web/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -248,7 +248,6 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
     })
     const effectOrStream = Rpc.isWrapper(handlerResult) === true ? handlerResult.value : handlerResult
 
-    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Rpc.Handler.handler` returns `Effect<any, any>` due to dynamic dispatch; orDie converts the error to a defect handled by the downstream catchCause
     const stream: Stream.Stream<any, any> =
       Effect.isEffect(effectOrStream) === true ? yield* Effect.orDie(effectOrStream) : effectOrStream
 

--- a/packages/@livestore/common-cf/tsconfig.json
+++ b/packages/@livestore/common-cf/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/common/src/schema/state/sqlite/table-def.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/table-def.ts
@@ -199,7 +199,7 @@ export function table<
     columns = SqliteDsl.isColumnDefinition(columnOrColumns) === true ? { value: columnOrColumns } : columnOrColumns
     additionalIndexes = []
   } else if ('schema' in args) {
-    const result = schemaFieldsToColumns(getSqlitePropertySignatures(args.schema))
+    const result = args.schema.pipe(getSqlitePropertySignatures, schemaFieldsToColumns)
     columns = result.columns
 
     // We'll set tableName first, then use it for index names

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -278,17 +278,18 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           rebaseGeneration: baseEventSequenceNumber.rebaseGeneration,
         })
         baseEventSequenceNumber = nextNumPair.seqNum
-        return new LiveStoreEvent.Client.EncodedWithMeta(
-          Schema.encodeUnknownSync(eventSchema)({
-            name,
-            // Client-document events expose SessionIdSymbol as an input placeholder, but encoded events are persisted
-            // and replayed by concrete id. Resolve during schema encoding so commit never mutates the caller's event.
-            args: resolveSessionIdSymbolInEventArgs(args, clientSession.sessionId),
-            ...nextNumPair,
-            clientId: clientSession.clientId,
-            sessionId: clientSession.sessionId,
-          }),
-        )
+        // Encoding known-valid domain data: an encode failure is an invariant violation (a defect),
+        // so `Effect.orDie` is the correct modeling — it keeps the typed error channel narrow.
+        const encoded = yield* Schema.encodeUnknownEffect(eventSchema)({
+          name,
+          // Client-document events expose SessionIdSymbol as an input placeholder, but encoded events are persisted
+          // and replayed by concrete id. Resolve during schema encoding so commit never mutates the caller's event.
+          args: resolveSessionIdSymbolInEventArgs(args, clientSession.sessionId),
+          ...nextNumPair,
+          clientId: clientSession.clientId,
+          sessionId: clientSession.sessionId,
+        }).pipe(Effect.orDie)
+        return new LiveStoreEvent.Client.EncodedWithMeta(encoded)
       }),
     )
   })

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -686,20 +686,20 @@ const expectEventArraysEqual = (
   })
 }
 
-const expectAdvance: (
-  result: typeof SyncState.MergeResult.Type,
-) => asserts result is typeof SyncState.MergeResultAdvance.Type = (result) => {
+const expectAdvance: (result: typeof SyncState.MergeResult.Type) => asserts result is SyncState.MergeResultAdvance = (
+  result,
+) => {
   expect(result._tag).toBe('advance')
 }
 
-const expectRebase: (
-  result: typeof SyncState.MergeResult.Type,
-) => asserts result is typeof SyncState.MergeResultRebase.Type = (result) => {
+const expectRebase: (result: typeof SyncState.MergeResult.Type) => asserts result is SyncState.MergeResultRebase = (
+  result,
+) => {
   expect(result._tag, `Expected rebase, got ${result._tag}`).toBe('rebase')
 }
 
-const expectReject: (
-  result: typeof SyncState.MergeResult.Type,
-) => asserts result is typeof SyncState.MergeResultReject.Type = (result) => {
+const expectReject: (result: typeof SyncState.MergeResult.Type) => asserts result is SyncState.MergeResultReject = (
+  result,
+) => {
   expect(result._tag).toBe('reject')
 }

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -423,7 +423,7 @@ Vitest.describe('syncstate', () => {
               id: Schema.String,
               flag: Schema.optional(Schema.Boolean),
             })
-            const localArgs = Schema.encodeUnknownSync(argsSchema)({ id: 'abc' } as any)
+            const localArgs = yield* Schema.encodeUnknownEffect(argsSchema)({ id: 'abc' } as any).pipe(Effect.orDie)
             const wireArgs = JSON.parse(JSON.stringify(localArgs))
 
             const localPending = new LiveStoreEvent.Client.EncodedWithMeta({

--- a/packages/@livestore/common/src/sync/syncstate.ts
+++ b/packages/@livestore/common/src/sync/syncstate.ts
@@ -162,7 +162,7 @@ export class MergeResultReject extends Schema.Class<MergeResultReject>('MergeRes
 export const MergeResult = Schema.Union([MergeResultAdvance, MergeResultRebase, MergeResultReject])
 
 export const payloadFromMergeResult = (
-  mergeResult: typeof MergeResultAdvance.Type | typeof MergeResultRebase.Type,
+  mergeResult: MergeResultAdvance | MergeResultRebase,
 ): typeof PayloadUpstream.Type =>
   Match.value(mergeResult).pipe(
     Match.tag('advance', (result) => ({

--- a/packages/@livestore/common/tsconfig.json
+++ b/packages/@livestore/common/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/effect-playwright/tsconfig.json
+++ b/packages/@livestore/effect-playwright/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/framework-toolkit/tsconfig.json
+++ b/packages/@livestore/framework-toolkit/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/livestore/src/effect/LiveStore.test.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.test.ts
@@ -40,9 +40,7 @@ describe('Store.Tag R channel consistency', () => {
   })
 
   it('fromDeferred layer output satisfies the same R channel', () => {
-    const prog = Effect.gen(function* () {
-      yield* MainStore
-    })
+    const prog = MainStore
 
     /** fromDeferred + DeferredLayer should satisfy MainStore in R */
     const _provided = prog.pipe(Effect.provide(Layer.merge(MainStore.fromDeferred, MainStore.DeferredLayer)))

--- a/packages/@livestore/livestore/src/store/devtools.ts
+++ b/packages/@livestore/livestore/src/store/devtools.ts
@@ -61,7 +61,7 @@ export const connectDevtoolsToStore = Effect.fn('LSD.devtools.connectStoreToDevt
   const sendToDevtools = (message: Devtools.ClientSession.MessageFromApp) =>
     storeDevtoolsChannel.send(message).pipe(Effect.tapCauseLogPretty, Effect.runFork)
 
-  const onMessage = (decodedMessage: typeof Devtools.ClientSession.MessageToApp.Type) => {
+  const onMessage = (decodedMessage: Devtools.ClientSession.MessageToApp) => {
     // console.debug('@livestore/livestore:store:devtools:onMessage', decodedMessage)
 
     if (decodedMessage.clientId !== clientId || decodedMessage.sessionId !== sessionId) {

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -659,7 +659,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     Stream.callback<TResult>((emit) =>
       Effect.gen({ self: this }, function* () {
         const otelSpan = yield* OtelTracer.currentOtelSpan.pipe(
-          Effect.catchTag('NoSuchElementError', () => Effect.succeed(undefined)),
+          Effect.catchTag('NoSuchElementError', () => Effect.void),
         )
         const otelContext =
           otelSpan !== undefined ? otel.trace.setSpan(otel.context.active(), otelSpan) : otel.context.active()

--- a/packages/@livestore/livestore/tsconfig.json
+++ b/packages/@livestore/livestore/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/react/tsconfig.json
+++ b/packages/@livestore/react/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/sqlite-wasm/tsconfig.json
+++ b/packages/@livestore/sqlite-wasm/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -166,9 +166,16 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
 
           // Since we're using websocket hibernation, we need to remember the storeId for subsequent `webSocketMessage` calls
           // Also store forwarded headers so they're available after hibernation resume
-          server.serializeAttachment(
-            Schema.encodeSync(WebSocketAttachmentSchema)({ storeId, payload, pullRequestIds: [], headers }),
-          )
+          // Encoding known-valid domain data: an encode failure is an invariant violation (a defect),
+          // so `Effect.orDie` is the correct modeling. serializeAttachment takes the value synchronously,
+          // so resolve the encoded value first, then pass it in.
+          const attachment = yield* Schema.encodeEffect(WebSocketAttachmentSchema)({
+            storeId,
+            payload,
+            pullRequestIds: [],
+            headers,
+          }).pipe(Effect.orDie)
+          server.serializeAttachment(attachment)
 
           // See https://developers.cloudflare.com/durable-objects/examples/websocket-hibernation-server
 

--- a/packages/@livestore/sync-cf/tsconfig.json
+++ b/packages/@livestore/sync-cf/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
@@ -280,7 +280,7 @@ const performHealthCheck = ({
 
     const checkHealth = spawner.exitCode(ChildProcess.make('curl', ['-f', '-s', url])).pipe(
       Effect.map((code: number) => code === 0),
-      Effect.catch(() => Effect.succeed(false)),
+      Effect.orElseSucceed(() => false),
     )
 
     const healthCheck = checkHealth.pipe(

--- a/packages/@livestore/utils-dev/src/node/cmd.ts
+++ b/packages/@livestore/utils-dev/src/node/cmd.ts
@@ -274,7 +274,7 @@ const runWithLogging = ({
 
       // Dump any buffered data and finish both stream fibers before we return.
       const flushOutputs = Effect.gen(function* () {
-        const stillRunning = yield* runningProcess.isRunning.pipe(Effect.catch(() => Effect.succeed(false)))
+        const stillRunning = yield* runningProcess.isRunning.pipe(Effect.orElseSucceed(() => false))
         if (stillRunning === true) {
           yield* Effect.ignore(runningProcess.kill())
         }

--- a/packages/@livestore/utils-dev/src/node/mod.ts
+++ b/packages/@livestore/utils-dev/src/node/mod.ts
@@ -142,7 +142,7 @@ const logTraceUiUrlForTraceId = (printMsg?: (url: string) => string) => (traceId
 
 export const getTracingBackendUrl = (traceIdOrSpan: string | otel.Span) =>
   Effect.gen(function* () {
-    const endpoint = yield* Config.string('GRAFANA_ENDPOINT').pipe(Config.option, Effect.orDie)
+    const endpoint = yield* Config.string('GRAFANA_ENDPOINT').pipe(Config.option)
     if (endpoint._tag === 'None') return
 
     const traceId = typeof traceIdOrSpan === 'string' ? traceIdOrSpan : traceIdOrSpan.spanContext().traceId
@@ -154,7 +154,7 @@ export const getTracingBackendUrl = (traceIdOrSpan: string | otel.Span) =>
       datasource: 'tempo',
       queries: [{ query: traceId, queryType: 'traceql', refId: 'A' }],
       range: { from: 'now-1h', to: 'now' },
-    }).pipe(Effect.orDie)
+    })
     const searchParams = new URLSearchParams({
       orgId: '1',
       left,
@@ -162,7 +162,7 @@ export const getTracingBackendUrl = (traceIdOrSpan: string | otel.Span) =>
 
     // TODO make dynamic via env var
     return `${grafanaEndpoint}/explore?${searchParams.toString()}`
-  })
+  }).pipe(Effect.orDie)
 
 /**
  * Compute absolute start/end timestamps for the Node.js bootstrap span in a

--- a/packages/@livestore/utils-dev/tsconfig.json
+++ b/packages/@livestore/utils-dev/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/utils/src/browser/Opfs/utils.ts
+++ b/packages/@livestore/utils/src/browser/Opfs/utils.ts
@@ -164,7 +164,7 @@ export const exists = Effect.fn('@livestore/utils:Opfs.exists')(function* (path:
   const { parentSegments, leafSegment: targetName } = splitPathSegments(pathSegments)
 
   const parentDirHandle = yield* traverseDirectoryPath(parentSegments, { create: false }).pipe(
-    Effect.catchTag('NotFoundError', () => Effect.succeed(undefined)),
+    Effect.catchTag('NotFoundError', () => Effect.void),
   )
 
   if (parentDirHandle === undefined) return false

--- a/packages/@livestore/utils/src/browser/WebLock.ts
+++ b/packages/@livestore/utils/src/browser/WebLock.ts
@@ -119,7 +119,7 @@ export const waitForLock = (lockName: string) =>
     if (signal.aborted === true) return
 
     navigator.locks.request(lockName, { mode: 'shared', signal, ifAvailable: false }, (_lock: Lock | null) => {
-      cb(Effect.succeed(void 0))
+      cb(Effect.void)
     })
   })
 
@@ -132,7 +132,7 @@ export const getLockAndWaitForSteal = (lockName: string) =>
       .request(lockName, { mode: 'exclusive', ifAvailable: true }, async (lock: Lock | null) => {
         if (lock === null) {
           // Lock wasn't available, resolve immediately
-          cb(Effect.succeed(void 0))
+          cb(Effect.void)
           return
         }
 
@@ -150,7 +150,7 @@ export const getLockAndWaitForSteal = (lockName: string) =>
           return Promise.race([holdLock, signal.aborted === true ? Promise.resolve() : holdLock]).catch(() => {})
         }).catch(() => {})
 
-        cb(Effect.succeed(void 0))
+        cb(Effect.void)
       })
       .catch((error) => {
         if (
@@ -160,7 +160,7 @@ export const getLockAndWaitForSteal = (lockName: string) =>
         ) {
           // Given signal interruption is handled via Effect, we can ignore this case
           // or the case when the lock is stolen
-          cb(Effect.succeed(void 0))
+          cb(Effect.void)
         } else {
           console.error('[@livestore/utils:WebLock] getLockAndWaitForSteal. error', error)
           throw error

--- a/packages/@livestore/utils/src/effect/Effect.ts
+++ b/packages/@livestore/utils/src/effect/Effect.ts
@@ -85,9 +85,7 @@ export const tapCauseLogPretty = <R, E, A>(eff: Effect.Effect<A, E, R>): Effect.
     Effect.gen(function* () {
       if (Cause.hasInterruptsOnly(cause) === true) return
 
-      const span = yield* OtelTracer.currentOtelSpan.pipe(
-        Effect.catchTag('NoSuchElementError', (_) => Effect.succeed(undefined)),
-      )
+      const span = yield* OtelTracer.currentOtelSpan.pipe(Effect.catchTag('NoSuchElementError', (_) => Effect.void))
 
       const firstErrLine = cause.toString().split('\n')[0]
       yield* Effect.logError(firstErrLine, cause).pipe((_) =>

--- a/packages/@livestore/utils/tsconfig.json
+++ b/packages/@livestore/utils/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/wa-sqlite/tsconfig.json
+++ b/packages/@livestore/wa-sqlite/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@livestore/webmesh/tsconfig.json
+++ b/packages/@livestore/webmesh/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@local/astro-tldraw/src/cache.ts
+++ b/packages/@local/astro-tldraw/src/cache.ts
@@ -83,12 +83,10 @@ export const loadManifest = (
       const manifest = yield* fs.readFileString(manifestPath).pipe(
         Effect.map((content) => JSON.parse(content) as DiagramManifest),
         Effect.mapError((cause) => new FileSystemError({ path: manifestPath, operation: 'read manifest', cause })),
-        Effect.catch(() =>
-          Effect.succeed({
-            entries: [],
-            version: CACHE_VERSION,
-          }),
-        ),
+        Effect.orElseSucceed(() => ({
+          entries: [],
+          version: CACHE_VERSION,
+        })),
       )
 
       return manifest

--- a/packages/@local/astro-tldraw/src/cli.ts
+++ b/packages/@local/astro-tldraw/src/cli.ts
@@ -301,7 +301,7 @@ const watchDiagramsInternal = (
     const fs = yield* FileSystem.FileSystem
     const paths = resolveCachePaths(options.projectRoot)
 
-    const diagramsRootExists = yield* fs.exists(paths.diagramsRoot).pipe(Effect.catch(() => Effect.succeed(false)))
+    const diagramsRootExists = yield* fs.exists(paths.diagramsRoot).pipe(Effect.orElseSucceed(() => false))
 
     if (diagramsRootExists === false) {
       yield* Effect.logWarning(`Diagrams watch: diagrams root does not exist at ${paths.diagramsRoot}`)

--- a/packages/@local/astro-tldraw/tsconfig.json
+++ b/packages/@local/astro-tldraw/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.ts
@@ -1656,8 +1656,8 @@ const watchSnippetsInternal = (
     const fs = yield* FileSystem.FileSystem
     const { paths } = resolved
 
-    const snippetRootExists = yield* fs.exists(paths.snippetAssetsRoot).pipe(Effect.catch(() => Effect.succeed(false)))
-    const sourceRootExists = yield* fs.exists(paths.srcRoot).pipe(Effect.catch(() => Effect.succeed(false)))
+    const snippetRootExists = yield* fs.exists(paths.snippetAssetsRoot).pipe(Effect.orElseSucceed(() => false))
+    const sourceRootExists = yield* fs.exists(paths.srcRoot).pipe(Effect.orElseSucceed(() => false))
 
     const watchStreams: Array<Stream.Stream<WatchEventSummary, PlatformError.PlatformError>> = []
     if (snippetRootExists === true) {

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
@@ -23,15 +23,15 @@ const writeInitialProject = (fs: FileSystem.FileSystem, projectRoot: string): Ef
     const snippetDir = path.join(projectRoot, 'src', 'content', '_assets', 'code')
     const docsDir = path.join(projectRoot, 'src', 'pages')
 
-    yield* fs.makeDirectory(snippetDir, { recursive: true }).pipe(Effect.orDie)
-    yield* fs.makeDirectory(docsDir, { recursive: true }).pipe(Effect.orDie)
+    yield* fs.makeDirectory(snippetDir, { recursive: true })
+    yield* fs.makeDirectory(docsDir, { recursive: true })
 
     const snippetPath = path.join(snippetDir, 'example.ts')
     const docsPath = path.join(docsDir, 'guide.mdx')
     const tsconfigPath = path.join(snippetDir, 'tsconfig.json')
 
-    yield* fs.writeFileString(snippetPath, 'export const value = 1\n').pipe(Effect.orDie)
-    yield* fs.writeFileString(docsPath, createDocsImportSource('../content/_assets/code/example.ts')).pipe(Effect.orDie)
+    yield* fs.writeFileString(snippetPath, 'export const value = 1\n')
+    yield* fs.writeFileString(docsPath, createDocsImportSource('../content/_assets/code/example.ts'))
     const tsconfigJson = JSON.stringify(
       {
         compilerOptions: {
@@ -50,8 +50,8 @@ const writeInitialProject = (fs: FileSystem.FileSystem, projectRoot: string): Ef
       null,
       2,
     )
-    yield* fs.writeFileString(tsconfigPath, tsconfigJson + '\n').pipe(Effect.orDie)
-  })
+    yield* fs.writeFileString(tsconfigPath, tsconfigJson + '\n')
+  }).pipe(Effect.orDie)
 
 describe('watchSnippets', () => {
   it('rebuilds when snippet assets change', async () => {

--- a/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "rootDir": "./",

--- a/packages/@local/astro-twoslash-code/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/packages/@local/shared/tsconfig.json
+++ b/packages/@local/shared/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/scripts/src/commands/examples/deploy-examples.ts
+++ b/scripts/src/commands/examples/deploy-examples.ts
@@ -64,7 +64,7 @@ export const readExampleSlugs = Effect.fn('deploy-examples/readExampleSlugs')(fu
   for (const entry of entries) {
     const info = yield* fs.stat(`${examplesDir}/${entry}`).pipe(
       Effect.map((stat) => stat.type === 'Directory'),
-      Effect.catch(() => Effect.succeed(false)),
+      Effect.orElseSucceed(() => false),
     )
 
     if (info === true) {
@@ -101,7 +101,7 @@ export const runExampleTests = (examples: ReadonlyArray<string>, options: { skip
     for (const example of examples) {
       const isDirectory = yield* fs.stat(`${examplesDir}/${example}`).pipe(
         Effect.map((stat) => stat.type === 'Directory'),
-        Effect.catch(() => Effect.succeed(false)),
+        Effect.orElseSucceed(() => false),
       )
 
       if (isDirectory === false) {

--- a/scripts/src/commands/update-deps.ts
+++ b/scripts/src/commands/update-deps.ts
@@ -383,7 +383,7 @@ export const updateDepsCommand = Cli.Command.make(
       const expoExamples = yield* cmdText('find examples -name "expo" -type d -o -name "*expo*" -type d').pipe(
         Effect.provide(LivestoreWorkspace.toCwd()),
         Effect.map((output) => output.trim().split('\n').filter(Boolean)),
-        Effect.catch(() => Effect.succeed([])),
+        Effect.orElseSucceed(() => []),
       )
 
       for (const exampleDir of expoExamples) {

--- a/scripts/src/shared/peer-deps.ts
+++ b/scripts/src/shared/peer-deps.ts
@@ -82,12 +82,10 @@ export const checkPeerDependencies = Effect.gen(function* () {
 
   const exists = yield* fs.exists(lockfilePath)
   if (exists === false) {
-    return yield* Effect.fail(
-      new PeerDepCheckError({
-        message:
-          'Missing repo-root pnpm-lock.yaml. Run pnpm install from the repo root to refresh the authoritative lockfile.',
-      }),
-    )
+    return yield* new PeerDepCheckError({
+      message:
+        'Missing repo-root pnpm-lock.yaml. Run pnpm install from the repo root to refresh the authoritative lockfile.',
+    })
   }
 
   // Read and parse the lockfile

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "noEmit": true

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -139,7 +139,7 @@ export const runDevtoolsTest = Effect.fn('test:devtools')(function* ({
 
     const spanContext = yield* OtelTracer.currentOtelSpan.pipe(
       Effect.map((span) => JSON.stringify(span.spanContext())),
-      Effect.catch(() => Effect.succeed(undefined)),
+      Effect.orElseSucceed(() => undefined),
     )
 
     if (mode === 'dev-server') {

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -91,7 +91,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
           catch: () => false,
         }).pipe(
           Effect.map(() => true),
-          Effect.catch(() => Effect.succeed(false)),
+          Effect.orElseSucceed(() => false),
         )
 
       const [boot1, boot2] = yield* Effect.all([didBoot(page1), didBoot(page2)])
@@ -151,7 +151,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
         catch: () => false,
       }).pipe(
         Effect.map(() => true),
-        Effect.catch(() => Effect.succeed(false)),
+        Effect.orElseSucceed(() => false),
       )
 
       expect(didBoot).toBe(true)
@@ -227,7 +227,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
           catch: () => false,
         }).pipe(
           Effect.map(() => true),
-          Effect.catch(() => Effect.succeed(false)),
+          Effect.orElseSucceed(() => false),
         )
 
       const [boot1, boot2] = yield* Effect.all([didBoot(page1), didBoot(page2)])

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/tests/package-common/tsconfig.json
+++ b/tests/package-common/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/tests/perf-eventlog/test-app/tsconfig.json
+++ b/tests/perf-eventlog/test-app/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "noEmit": true,

--- a/tests/perf-eventlog/tsconfig.json
+++ b/tests/perf-eventlog/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "noEmit": true,

--- a/tests/perf/tsconfig.json
+++ b/tests/perf/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "noEmit": true,

--- a/tests/sync-provider/tsconfig.json
+++ b/tests/sync-provider/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "composite": true,

--- a/tests/wa-sqlite/tsconfig.json
+++ b/tests/wa-sqlite/tsconfig.json
@@ -33,7 +33,8 @@
           "schemaUnionOfLiterals": "warning",
           "anyUnknownInErrorContext": "warning",
           "preferSchemaOverJson": "warning"
-        }
+        },
+        "allowedDuplicatedPackages": ["@livestore/utils"]
       }
     ],
     "noEmit": true,


### PR DESCRIPTION
> ### 🔄 Rebased onto current `main` (2026-07-17)
>
> Originally branched before #1397 merged. This branch has been **rebased onto current `main`**: the 3 duplicated effect-utils-bump precursor commits (now carried by `main` as the #1397 squash) were dropped, so the diff is now **only** this slice's burndown changes (**54 files**) and no longer conflicts. The pre-rebase file/line counts quoted below are historical.
>
> **Verification is via CI on this branch.** The `type-check` job runs `devenv tasks run ts:build` → `tsgo --build` — the real Effect-LSP oracle (`tsc`/incremental `ts:check` do **not** run the plugin) — and `lint` (`lint:full:with-megarepo-check`) re-checks generated-file freshness.

## Problem

Part of the stacked **#811 Effect-LSP burndown**. The effect-utils bump surfaced ~406 advisory Effect-LSP diagnostics across the LiveStore tree. This PR clears the **config + mechanical** group at source so `tsgo --build` stops emitting them. The errors-only gate override in `genie/repo.ts` is intentionally **kept** — a later capstone PR removes it once every rule is clear.

## What's cleared (36 diagnostics + config)

Verified with a forced `tsgo --build --force tsconfig.dev.json` before/after: **223 → 187** diagnostics; **zero** of the rules below remain, and **no new** diagnostics were introduced (a couple of pre-existing warnings shift line numbers where edits added/removed lines).

| Rule | Count | Fix |
|------|-------|-----|
| `duplicatePackage` | config (183 instances) | `allowedDuplicatedPackages: ['@livestore/utils']` on the `@effect/language-service` plugin override; regenerated all tsconfigs via `genie:run` |
| `effectSucceedWithVoid` | 8 | `Effect.succeed(undefined \| void 0)` → `Effect.void` |
| `catchToOrElseSucceed` | 13 | `Effect.catch(() => Effect.succeed(x))` → `Effect.orElseSucceed(() => x)` |
| `unnecessaryTypeofType` | 6 | `typeof X.Type` → `X` (all `Schema.Class`, so the name is the type) |
| `schemaSyncInEffect` | 3 | `Schema.encode{Unknown,}Sync(...)` → `Schema.encode{Unknown,}Effect(...).pipe(Effect.orDie)` |
| `redundantOrDie` | 2 | hoist per-yield `Effect.orDie` to the generator result (`.pipe(Effect.orDie)`) |
| `unnecessaryEffectGen` | 1 | single-yield gen → the yielded effect directly |
| `unnecessaryFailYieldableError` | 1 | `yield* Effect.fail(e)` → `yield* e` |
| `missedPipeableOpportunity` | 1 | nested calls → `.pipe()` |
| `TS377000` | 1 | delete stale `@effect-diagnostics` directive in `do-rpc/server.ts` |

### Note on `schemaSyncInEffect` (behavior-preserving)

These 3 sites encode **known-valid domain data**, so an encode failure is an invariant violation — a **defect**, not a recoverable error. The `.pipe(Effect.orDie)` modeling is deliberate: it clears the lint (no sync-throw inside a gen), keeps the failure a defect (identical runtime behavior to the prior sync throw), and does **not** widen the typed error channel — so the explicit `ClientSessionSyncProcessor['encodeEvents']` interface and the Durable Object fetch handler are unaffected. Matches the existing idiom at `utils-dev/src/node/mod.ts`. For `durable-object.ts` the encoded value is resolved to a const first, then passed to the synchronous `serializeAttachment`.

### Note on `TS377000`

The deleted directive genuinely had no effect — it targeted `const stream: …` while the `anyUnknownInErrorContext` warning it appeared to suppress is on the *following* line (the `Effect.orDie(effectOrStream)` expression) and was already unsuppressed. That warning is pre-existing and unchanged (it just shifts up one line).

## Validation

- Forced `tsgo --build --force`: **223 → 187** diagnostics, all target rules cleared (0 `schemaSyncInEffect` remain), no new diagnostics, no new type errors. (Effect-LSP lints only emit via `tsgo`, not JS `tsc` / incremental `ts:check`.)
- `check:quick`: **GREEN**.
- Empty changeset added (no release impact; behavior-neutral internal refactor).
- Behavior-neutral throughout (no user-facing change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌲 cl1-pine |
| `agent_session_id` | b9f1f4a5-dd10-40f6-b25c-945e71e2007a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.206 |
| `agent_runtime` | Claude Code 2.1.206 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-17-refactor |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->
