### PR TITLE
refactor(effect-lsp): Schema.Number → Schema.Finite (schemaNumber burndown)

### DIFF
--- a/.changeset/empty-schema-number-to-finite.md
+++ b/.changeset/empty-schema-number-to-finite.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact (Effect-LSP burndown). Migrates `Schema.Number` → `Schema.Finite` (and `Schema.NumberFromString` → `Schema.FiniteFromString`) to clear all 149 `schemaNumber` diagnostics, keeping `Schema.Number` only for the public SQLite `real`-column DEFAULT codec where non-finite values are valid.

--- a/docs/src/content/_assets/code/patterns/effect/store-setup/schema.ts
+++ b/docs/src/content/_assets/code/patterns/effect/store-setup/schema.ts
@@ -27,7 +27,7 @@ export const events = {
       id: Schema.String,
       name: Schema.String,
       description: Schema.String,
-      price: Schema.Number,
+      price: Schema.Finite,
     }),
   }),
   productUpdated: Events.clientOnly({
@@ -36,7 +36,7 @@ export const events = {
       id: Schema.String,
       name: Schema.OptionFromOptional(Schema.String),
       description: Schema.OptionFromOptional(Schema.String),
-      price: Schema.OptionFromOptional(Schema.Number),
+      price: Schema.OptionFromOptional(Schema.Finite),
     }),
   }),
   todoCreated: Events.clientOnly({

--- a/docs/src/content/_assets/code/patterns/list-ordering/events.ts
+++ b/docs/src/content/_assets/code/patterns/list-ordering/events.ts
@@ -11,7 +11,7 @@ export const events = {
   updateTaskOrder: Events.synced({
     name: 'v1.UpdateTaskOrder',
     schema: Schema.Struct({
-      id: Schema.Number,
+      id: Schema.Finite,
       order: Schema.String,
     }),
   }),

--- a/docs/src/content/_assets/code/reference/state/sql-queries/raw-sql.ts
+++ b/docs/src/content/_assets/code/reference/state/sql-queries/raw-sql.ts
@@ -16,5 +16,5 @@ const filtered$ = queryDb({
 
 const count$ = queryDb({
   query: sql`select count(*) as count from my_table`,
-  schema: Schema.Struct({ count: Schema.Number }).pipe(Schema.pluck('count'), Schema.Array, Schema.headOrElse()),
+  schema: Schema.Struct({ count: Schema.Finite }).pipe(Schema.pluck('count'), Schema.Array, Schema.headOrElse()),
 })

--- a/docs/src/content/_assets/code/reference/state/sqlite-schema/effect/advanced-product.ts
+++ b/docs/src/content/_assets/code/reference/state/sqlite-schema/effect/advanced-product.ts
@@ -4,15 +4,15 @@ const ProductSchema = Schema.Struct({
   id: Schema.Int.pipe(State.SQLite.withPrimaryKey, State.SQLite.withAutoIncrement),
   sku: Schema.String.pipe(State.SQLite.withUnique),
   name: Schema.String,
-  price: Schema.Number.pipe(State.SQLite.withDefault(0)),
+  price: Schema.Finite.pipe(State.SQLite.withDefault(0)),
   category: Schema.Literals(['electronics', 'clothing', 'books']),
   metadata: Schema.optional(
     Schema.Struct({
-      weight: Schema.Number,
+      weight: Schema.Finite,
       dimensions: Schema.Struct({
-        width: Schema.Number,
-        height: Schema.Number,
-        depth: Schema.Number,
+        width: Schema.Finite,
+        height: Schema.Finite,
+        depth: Schema.Finite,
       }),
     }),
   ),

--- a/docs/src/content/_assets/code/reference/state/sqlite-schema/effect/custom-column-types.ts
+++ b/docs/src/content/_assets/code/reference/state/sqlite-schema/effect/custom-column-types.ts
@@ -2,7 +2,7 @@ import { Schema, State } from '@livestore/livestore'
 
 const _schema = Schema.Struct({
   // Store a number as text instead of real
-  version: Schema.Number.pipe(State.SQLite.withColumnType('text')),
+  version: Schema.Finite.pipe(State.SQLite.withColumnType('text')),
   // Store binary data as blob
   data: Schema.Uint8Array.pipe(State.SQLite.withColumnType('blob')),
 })

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/devtools-web-channel.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/devtools-web-channel.ts
@@ -23,7 +23,7 @@ export const ClientSessionContentscriptMainReq = Schema.TaggedStruct('ClientSess
 })
 
 export const ClientSessionContentscriptMainRes = Schema.TaggedStruct('ClientSessionContentscriptMainRes', {
-  tabId: Schema.Number,
+  tabId: Schema.Finite,
 })
 
 export const makeStaticClientSessionChannel: {

--- a/packages/@livestore/common-cf/src/do-rpc/client.test.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/client.test.ts
@@ -7,11 +7,11 @@ import { toDurableObjectHandler } from './server.ts'
 
 class Rpcs extends RpcGroup.make(
   Rpc.make('BigStream', {
-    payload: Schema.Struct({ n: Schema.Number }),
+    payload: Schema.Struct({ n: Schema.Finite }),
     success: Schema.Struct({
-      seqNum: Schema.Number,
+      seqNum: Schema.Finite,
       name: Schema.String,
-      args: Schema.Struct({ a: Schema.Number, b: Schema.String }),
+      args: Schema.Struct({ a: Schema.Finite, b: Schema.String }),
     }),
     stream: true,
   }),

--- a/packages/@livestore/common-cf/src/do-rpc/test-fixtures/rpc-schema.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/test-fixtures/rpc-schema.ts
@@ -10,8 +10,8 @@ export class TestRpcs extends RpcGroup.make(
     success: Schema.Struct({ echo: Schema.String }),
   }),
   Rpc.make('Add', {
-    payload: Schema.Struct({ a: Schema.Number, b: Schema.Number }),
-    success: Schema.Struct({ result: Schema.Number }),
+    payload: Schema.Struct({ a: Schema.Finite, b: Schema.Finite }),
+    success: Schema.Struct({ result: Schema.Finite }),
   }),
   Rpc.make('Defect', {
     payload: Schema.Struct({ message: Schema.String }),
@@ -25,34 +25,34 @@ export class TestRpcs extends RpcGroup.make(
   Rpc.make('Stream', {
     payload: Schema.Struct({}),
     success: Schema.Struct({
-      maybeNumber: Schema.Option(Schema.Number),
+      maybeNumber: Schema.Option(Schema.Finite),
     }),
     stream: true,
   }),
   Rpc.make('StreamError', {
-    payload: Schema.Struct({ count: Schema.Number, errorAfter: Schema.Number }),
-    success: Schema.Number,
+    payload: Schema.Struct({ count: Schema.Finite, errorAfter: Schema.Finite }),
+    success: Schema.Finite,
     error: Schema.String,
     stream: true,
   }),
   Rpc.make('StreamDefect', {
-    payload: Schema.Struct({ count: Schema.Number, defectAfter: Schema.Number }),
-    success: Schema.Number,
+    payload: Schema.Struct({ count: Schema.Finite, defectAfter: Schema.Finite }),
+    success: Schema.Finite,
     stream: true,
   }),
   Rpc.make('StreamInterruptible', {
-    payload: Schema.Struct({ delay: Schema.Number, interruptAfterCount: Schema.Number }),
-    success: Schema.Number,
+    payload: Schema.Struct({ delay: Schema.Finite, interruptAfterCount: Schema.Finite }),
+    success: Schema.Finite,
     stream: true,
   }),
   Rpc.make('StreamBugScenarioDoServer', {
     payload: Schema.Struct({}),
-    success: Schema.Number,
+    success: Schema.Finite,
     stream: true,
   }),
   Rpc.make('StreamBugScenarioDoClient', {
     payload: Schema.Struct({}),
-    success: Schema.Number,
+    success: Schema.Finite,
   }),
 ) {}
 export type TestRpcsI = RpcGroup.Rpcs<typeof TestRpcs>

--- a/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/rpc-schema.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/test-fixtures/rpc-schema.ts
@@ -10,8 +10,8 @@ export class TestRpcs extends RpcGroup.make(
     success: Schema.Struct({ echo: Schema.String }),
   }),
   Rpc.make('Add', {
-    payload: Schema.Struct({ a: Schema.Number, b: Schema.Number }),
-    success: Schema.Struct({ result: Schema.Number }),
+    payload: Schema.Struct({ a: Schema.Finite, b: Schema.Finite }),
+    success: Schema.Struct({ result: Schema.Finite }),
   }),
   Rpc.make('Defect', {
     payload: Schema.Struct({ message: Schema.String }),
@@ -25,24 +25,24 @@ export class TestRpcs extends RpcGroup.make(
   Rpc.make('Stream', {
     payload: Schema.Struct({}),
     success: Schema.Struct({
-      maybeNumber: Schema.Option(Schema.Number),
+      maybeNumber: Schema.Option(Schema.Finite),
     }),
     stream: true,
   }),
   Rpc.make('StreamError', {
-    payload: Schema.Struct({ count: Schema.Number, errorAfter: Schema.Number }),
-    success: Schema.Number,
+    payload: Schema.Struct({ count: Schema.Finite, errorAfter: Schema.Finite }),
+    success: Schema.Finite,
     error: Schema.String,
     stream: true,
   }),
   Rpc.make('StreamDefect', {
-    payload: Schema.Struct({ count: Schema.Number, defectAfter: Schema.Number }),
-    success: Schema.Number,
+    payload: Schema.Struct({ count: Schema.Finite, defectAfter: Schema.Finite }),
+    success: Schema.Finite,
     stream: true,
   }),
   Rpc.make('StreamInterruptible', {
-    payload: Schema.Struct({ delay: Schema.Number, interruptAfterCount: Schema.Number }),
-    success: Schema.Number,
+    payload: Schema.Struct({ delay: Schema.Finite, interruptAfterCount: Schema.Finite }),
+    success: Schema.Finite,
     stream: true,
   }),
 ) {}

--- a/packages/@livestore/common/src/__tests__/fixture.ts
+++ b/packages/@livestore/common/src/__tests__/fixture.ts
@@ -14,7 +14,7 @@ export const UiState = State.SQLite.clientDocument({
 })
 
 const Config = Schema.Struct({
-  fontSize: Schema.Number,
+  fontSize: Schema.Finite,
   theme: Schema.Literals(['light', 'dark']),
 })
 

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -46,8 +46,8 @@ export interface ClientSession {
 export type ResetMode = 'all-data' | 'only-app-db'
 
 export const BootStateProgress = Schema.Struct({
-  done: Schema.Number,
-  total: Schema.Number,
+  done: Schema.Finite,
+  total: Schema.Finite,
 })
 
 /**

--- a/packages/@livestore/common/src/debug-info.ts
+++ b/packages/@livestore/common/src/debug-info.ts
@@ -16,10 +16,10 @@ export type SlowQueryInfo = {
 export const SlowQueryInfo = Schema.Struct({
   queryStr: Schema.String,
   bindValues: Schema.UndefinedOr(PreparedBindValues),
-  durationMs: Schema.Number,
-  rowsCount: Schema.UndefinedOr(Schema.Number),
+  durationMs: Schema.Finite,
+  rowsCount: Schema.UndefinedOr(Schema.Finite),
   queriedTables: Schema.ReadonlySet(Schema.String),
-  startTimePerfNow: Schema.Number,
+  startTimePerfNow: Schema.Finite,
 })
 
 const isBoundArrayLike = <A>(value: unknown): value is BoundArray<A> => value instanceof BoundArray
@@ -66,7 +66,7 @@ const BoundArraySchemaFromSelf = <A, I, RD, RE>(
 
 export const BoundArraySchema = <ItemDecoded, ItemEncoded>(elSchema: Schema.Codec<ItemDecoded, ItemEncoded>) =>
   Schema.Struct({
-    size: Schema.Number,
+    size: Schema.Finite,
     items: Schema.Array(elSchema),
   }).pipe(
     Schema.decodeTo(BoundArraySchemaFromSelf(Schema.toType(elSchema)), {
@@ -77,8 +77,8 @@ export const BoundArraySchema = <ItemDecoded, ItemEncoded>(elSchema: Schema.Code
 
 export const DebugInfo = Schema.Struct({
   slowQueries: BoundArraySchema(SlowQueryInfo),
-  queryFrameDuration: Schema.Number,
-  queryFrameCount: Schema.Number,
+  queryFrameDuration: Schema.Finite,
+  queryFrameCount: Schema.Finite,
   events: BoundArraySchema(Schema.Tuple([Schema.String, Schema.Any])),
 })
 

--- a/packages/@livestore/common/src/defs.ts
+++ b/packages/@livestore/common/src/defs.ts
@@ -3,8 +3,8 @@ import { Schema } from '@livestore/utils/effect'
 export const MigrationsReportEntry = Schema.Struct({
   tableName: Schema.String,
   hashes: Schema.Struct({
-    expected: Schema.Number,
-    actual: Schema.optional(Schema.Number),
+    expected: Schema.Finite,
+    actual: Schema.optional(Schema.Finite),
   }),
 })
 

--- a/packages/@livestore/common/src/devtools/devtools-messages-client-session.ts
+++ b/packages/@livestore/common/src/devtools/devtools-messages-client-session.ts
@@ -78,11 +78,11 @@ export const LiveQueriesUnsubscribe = LSDClientSessionReqResMessage('LSD.ClientS
 
 export const SerializedLiveQuery = Schema.Struct({
   _tag: Schema.Literals(['computed', 'db', 'graphql', 'signal']),
-  id: Schema.Number,
+  id: Schema.Finite,
   label: Schema.String,
   hash: Schema.String,
-  runs: Schema.Number,
-  executionTimes: Schema.Array(Schema.Number),
+  runs: Schema.Finite,
+  executionTimes: Schema.Array(Schema.Finite),
   lastestResult: Schema.Any,
   activeSubscriptions: Schema.Array(
     Schema.Struct({ frames: Schema.Array(Schema.Struct({ name: Schema.String, filePath: Schema.String })) }),
@@ -95,11 +95,11 @@ export const LiveQueriesRes = LSDClientSessionReqResMessage('LSD.ClientSession.L
 })
 
 export const Ping = LSDClientSessionReqResMessage('LSD.ClientSession.Ping', {
-  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+  devtoolsProtocolVersion: Schema.optional(Schema.Finite),
 })
 
 export const Pong = LSDClientSessionReqResMessage('LSD.ClientSession.Pong', {
-  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+  devtoolsProtocolVersion: Schema.optional(Schema.Finite),
 })
 
 /**
@@ -111,8 +111,8 @@ export const VersionMismatch = LSDClientSessionReqResMessage('LSD.ClientSession.
   appVersion: Schema.String,
   /** The version that was sent by DevTools (that caused the mismatch) */
   receivedVersion: Schema.String,
-  appDevtoolsProtocolVersion: Schema.Number,
-  receivedDevtoolsProtocolVersion: Schema.optional(Schema.Number),
+  appDevtoolsProtocolVersion: Schema.Finite,
+  receivedDevtoolsProtocolVersion: Schema.optional(Schema.Finite),
 })
 
 export const Disconnect = LSDClientSessionChannelMessage('LSD.ClientSession.Disconnect', {})

--- a/packages/@livestore/common/src/devtools/devtools-messages-leader.ts
+++ b/packages/@livestore/common/src/devtools/devtools-messages-leader.ts
@@ -12,7 +12,7 @@ export const ResetAllDataReq = LSDReqResMessage('LSD.Leader.ResetAllDataReq', {
 export const DatabaseFileInfoReq = LSDReqResMessage('LSD.Leader.DatabaseFileInfoReq', {})
 
 export const DatabaseFileInfo = Schema.Struct({
-  fileSize: Schema.Number,
+  fileSize: Schema.Finite,
   persistenceInfo: Schema.StructWithRest(Schema.Struct({ fileName: Schema.String }), [
     Schema.Record(Schema.String, Schema.Any),
   ]),
@@ -110,11 +110,11 @@ export const EventlogRes = LSDReqResMessage('LSD.Leader.EventlogRes', {
 })
 
 export const Ping = LSDReqResMessage('LSD.Leader.Ping', {
-  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+  devtoolsProtocolVersion: Schema.optional(Schema.Finite),
 })
 
 export const Pong = LSDReqResMessage('LSD.Leader.Pong', {
-  devtoolsProtocolVersion: Schema.optional(Schema.Number),
+  devtoolsProtocolVersion: Schema.optional(Schema.Finite),
 })
 
 /**
@@ -126,8 +126,8 @@ export const VersionMismatch = LSDReqResMessage('LSD.Leader.VersionMismatch', {
   appVersion: Schema.String,
   /** The version that was sent by DevTools (that caused the mismatch) */
   receivedVersion: Schema.String,
-  appDevtoolsProtocolVersion: Schema.Number,
-  receivedDevtoolsProtocolVersion: Schema.optional(Schema.Number),
+  appDevtoolsProtocolVersion: Schema.Finite,
+  receivedDevtoolsProtocolVersion: Schema.optional(Schema.Finite),
 })
 
 export const Disconnect = LSDReqResMessage('LSD.Leader.Disconnect', {})

--- a/packages/@livestore/common/src/errors.ts
+++ b/packages/@livestore/common/src/errors.ts
@@ -67,7 +67,7 @@ export class SqliteError extends Schema.TaggedErrorClass<SqliteError>('~@livesto
   /** The SQLite result code */
   // code: Schema.optional(Schema.Number),
   // Added string support for Expo SQLite (we should refactor this to have a unified error type)
-  code: Schema.optional(Schema.Union([Schema.Number, Schema.String])),
+  code: Schema.optional(Schema.Union([Schema.Finite, Schema.String])),
   /** The original SQLite3 error */
   cause: Schema.Defect(),
   note: Schema.optional(Schema.String),

--- a/packages/@livestore/common/src/leader-thread/RejectedPushError.ts
+++ b/packages/@livestore/common/src/leader-thread/RejectedPushError.ts
@@ -29,7 +29,7 @@ export class NonMonotonicBatchError extends Schema.TaggedErrorClass<NonMonotonic
   /** The sequence number that was expected to be greater than `precedingSeqNum`. */
   violatingSeqNum: EventSequenceNumber.Client.Composite,
   /** The index in the batch where the violation occurred. */
-  violationIndex: Schema.Number,
+  violationIndex: Schema.Finite,
   /** The session that produced the malformed batch. */
   sessionId: Schema.String,
 }) {
@@ -51,9 +51,9 @@ export class StaleRebaseGenerationError extends Schema.TaggedErrorClass<StaleReb
   `${RejectedPushErrorTypeId}/StaleRebaseGenerationError`,
 )('StaleRebaseGenerationError', {
   /** The leader's current rebase generation. */
-  currentRebaseGeneration: Schema.Number,
+  currentRebaseGeneration: Schema.Finite,
   /** The rebase generation carried by the dropped events. */
-  providedRebaseGeneration: Schema.Number,
+  providedRebaseGeneration: Schema.Finite,
   /** The session that produced the stale batch. */
   sessionId: Schema.String,
 }) {

--- a/packages/@livestore/common/src/leader-thread/types.ts
+++ b/packages/@livestore/common/src/leader-thread/types.ts
@@ -36,7 +36,7 @@ export const InitialSyncOptionsSkip = Schema.TaggedStruct('Skip', {})
 export type InitialSyncOptionsSkip = typeof InitialSyncOptionsSkip.Type
 
 export const InitialSyncOptionsBlocking = Schema.TaggedStruct('Blocking', {
-  timeout: Schema.Union([Schema.DurationFromMillis, Schema.Number]),
+  timeout: Schema.Union([Schema.DurationFromMillis, Schema.Finite]),
 })
 
 export type InitialSyncOptionsBlocking = typeof InitialSyncOptionsBlocking.Type

--- a/packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts
+++ b/packages/@livestore/common/src/schema-management/__tests__/migrations-autoincrement-quoting.test.ts
@@ -49,7 +49,7 @@ describe('migrateTable - quoting and autoincrement', () => {
           primaryKey: true,
           autoIncrement: true,
           default: Option.none(),
-          schema: Schema.Number,
+          schema: Schema.Finite,
         }),
         SqliteAst.column({
           name: 'text',
@@ -67,7 +67,7 @@ describe('migrateTable - quoting and autoincrement', () => {
           primaryKey: false,
           autoIncrement: false,
           default: Option.some(0),
-          schema: Schema.Number,
+          schema: Schema.Finite,
         }),
       ],
       [],

--- a/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
+++ b/packages/@livestore/common/src/schema/LiveStoreEvent/client.ts
@@ -83,8 +83,8 @@ export class EncodedWithMeta extends Schema.Class<EncodedWithMeta>('LiveStoreEve
     ]),
     syncMetadata: Schema.Option(Schema.Json),
     /** Used to detect if the materializer is side effecting (during dev) */
-    materializerHashLeader: Schema.Option(Schema.Number),
-    materializerHashSession: Schema.Option(Schema.Number),
+    materializerHashLeader: Schema.Option(Schema.Finite),
+    materializerHashSession: Schema.Option(Schema.Finite),
   })
     .mapFields(Struct.map(Schema.mutableKey))
     .pipe(

--- a/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/client-document-def.test.ts
@@ -119,7 +119,7 @@ describe('client document table', () => {
     test('struct value (partial set=true) advanced', () => {
       expect(
         forSchema(
-          Schema.Struct({ a: Schema.String, b: Schema.String, c: Schema.Number }),
+          Schema.Struct({ a: Schema.String, b: Schema.String, c: Schema.Finite }),
           { a: 'hello', c: 123 } as any,
           'id1',
           { partialSet: true },

--- a/packages/@livestore/common/src/schema/state/sqlite/column-annotations.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-annotations.test.ts
@@ -22,11 +22,11 @@ describe.concurrent('annotations', () => {
       })
 
       test('Schema.Number with integer column type', () => {
-        expect(() => withColumnType(Schema.Number, 'integer')).not.toThrow()
+        expect(() => withColumnType(Schema.Finite, 'integer')).not.toThrow()
       })
 
       test('Schema.Number with real column type', () => {
-        expect(() => withColumnType(Schema.Number, 'real')).not.toThrow()
+        expect(() => withColumnType(Schema.Finite, 'real')).not.toThrow()
       })
 
       test('Schema.Boolean with integer column type', () => {
@@ -153,7 +153,7 @@ describe.concurrent('annotations', () => {
 
     describe('complex schemas', () => {
       test('should allow complex schemas that cannot be determined', () => {
-        const complexSchema = Schema.Struct({ name: Schema.String, age: Schema.Number })
+        const complexSchema = Schema.Struct({ name: Schema.String, age: Schema.Finite })
         expect(() => withColumnType(complexSchema, 'text')).not.toThrow()
       })
 

--- a/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
@@ -14,7 +14,7 @@ describe('getColumnDefForSchema', () => {
     })
 
     it('should map Schema.Number to real column', () => {
-      const columnDef = State.SQLite.getColumnDefForSchema(Schema.Number)
+      const columnDef = State.SQLite.getColumnDefForSchema(Schema.Finite)
       expect(columnDef.columnType).toBe('real')
     })
 
@@ -78,7 +78,7 @@ describe('getColumnDefForSchema', () => {
     it('should map number refinements to real column', () => {
       const refinements = [
         { schema: Schema.Finite, name: 'Finite' },
-        { schema: Schema.Number.check(Schema.isBetween({ minimum: 0, maximum: 100 })), name: 'between' },
+        { schema: Schema.Finite.check(Schema.isBetween({ minimum: 0, maximum: 100 })), name: 'between' },
       ]
 
       for (const { schema, name } of refinements) {
@@ -107,7 +107,7 @@ describe('getColumnDefForSchema', () => {
 
   describe('transformations', () => {
     it('should map transformations based on target type', () => {
-      const StringToNumber = Schema.NumberFromString
+      const StringToNumber = Schema.FiniteFromString
 
       const columnDef = State.SQLite.getColumnDefForSchema(StringToNumber)
       expect(columnDef.columnType).toBe('text') // Based on the encoded type (String)
@@ -123,7 +123,7 @@ describe('getColumnDefForSchema', () => {
     it('should map structs to json column', () => {
       const UserSchema = Schema.Struct({
         name: Schema.String,
-        age: Schema.Number,
+        age: Schema.Finite,
       })
 
       const columnDef = State.SQLite.getColumnDefForSchema(UserSchema)
@@ -136,12 +136,12 @@ describe('getColumnDefForSchema', () => {
     })
 
     it('should map records to json column', () => {
-      const columnDef = State.SQLite.getColumnDefForSchema(Schema.Record(Schema.String, Schema.Number))
+      const columnDef = State.SQLite.getColumnDefForSchema(Schema.Record(Schema.String, Schema.Finite))
       expect(columnDef.columnType).toBe('text')
     })
 
     it('should map tuples to json column', () => {
-      const columnDef = State.SQLite.getColumnDefForSchema(Schema.Tuple([Schema.String, Schema.Number]))
+      const columnDef = State.SQLite.getColumnDefForSchema(Schema.Tuple([Schema.String, Schema.Finite]))
       expect(columnDef.columnType).toBe('text')
     })
 
@@ -260,7 +260,7 @@ describe('getColumnDefForSchema', () => {
       const AnnotatedString = Schema.String.annotate({
         description: 'A special string',
       })
-      const AnnotatedNumber = Schema.Number.annotate({ min: 0, max: 100 })
+      const AnnotatedNumber = Schema.Finite.annotate({ min: 0, max: 100 })
 
       expect(State.SQLite.getColumnDefForSchema(AnnotatedString).columnType).toBe('text')
       expect(State.SQLite.getColumnDefForSchema(AnnotatedNumber).columnType).toBe('real')
@@ -333,7 +333,7 @@ describe('getColumnDefForSchema', () => {
         id: Schema.String,
         name: Schema.String,
         email: Schema.optional(Schema.String),
-        age: Schema.optional(Schema.Number),
+        age: Schema.optional(Schema.Finite),
       })
 
       const userTable = State.SQLite.table({
@@ -447,7 +447,7 @@ describe('getColumnDefForSchema', () => {
 
     it('should handle Schema.NullOr with complex types', async () => {
       const schema = Schema.Struct({
-        data: Schema.NullOr(Schema.Struct({ value: Schema.Number })),
+        data: Schema.NullOr(Schema.Struct({ value: Schema.Finite })),
       }).annotate({ title: 'test' })
 
       const table = State.SQLite.table({ schema })
@@ -464,7 +464,7 @@ describe('getColumnDefForSchema', () => {
       const schema = Schema.Struct({
         nullableText: Schema.NullOr(Schema.String),
         optionalText: Schema.optional(Schema.String),
-        optionalJson: Schema.optional(Schema.Struct({ x: Schema.Number })),
+        optionalJson: Schema.optional(Schema.Struct({ x: Schema.Finite })),
       }).annotate({ title: 'test' })
 
       const table = State.SQLite.table({ schema })
@@ -515,7 +515,7 @@ describe('getColumnDefForSchema', () => {
   describe('annotations', () => {
     describe('withColumnType', () => {
       it('should respect column type annotation for text', () => {
-        const schema = Schema.Number.pipe(withColumnType('text'))
+        const schema = Schema.Finite.pipe(withColumnType('text'))
         const columnDef = State.SQLite.getColumnDefForSchema(schema)
         expect(columnDef.columnType).toBe('text')
       })
@@ -540,7 +540,7 @@ describe('getColumnDefForSchema', () => {
 
       it('should override default type mapping', () => {
         // Number normally maps to real, but we override to text
-        const schema = Schema.Number.pipe(withColumnType('text'))
+        const schema = Schema.Finite.pipe(withColumnType('text'))
         const columnDef = State.SQLite.getColumnDefForSchema(schema)
         expect(columnDef.columnType).toBe('text')
       })
@@ -609,7 +609,7 @@ describe('getColumnDefForSchema', () => {
 
       it('should work with column type annotation', () => {
         const UserSchema = Schema.Struct({
-          id: Schema.Number.pipe(withColumnType('integer'), withPrimaryKey),
+          id: Schema.Finite.pipe(withColumnType('integer'), withPrimaryKey),
           name: Schema.String,
         })
 

--- a/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-spec.test.ts
@@ -28,9 +28,9 @@ const createColumn = (
       case 'text':
         return Schema.String
       case 'integer':
-        return options.defaultValue === true || options.defaultValue === false ? Schema.Boolean : Schema.Number
+        return options.defaultValue === true || options.defaultValue === false ? Schema.Boolean : Schema.Finite
       case 'real':
-        return Schema.Number
+        return Schema.Finite
       case 'blob':
         return Schema.Uint8ArrayFromBase64
       default:

--- a/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
@@ -1,6 +1,8 @@
 import { casesHandled } from '@livestore/utils'
 import { Option, Schema } from '@livestore/utils/effect'
 
+import { SqliteReal } from '../../../../../util.ts'
+
 export type SqlDefaultValue = {
   readonly sql: string
 }
@@ -265,8 +267,7 @@ export const defaultSchemaForColumnType = <TColumnType extends FieldColumnType>(
     }
     case 'real': {
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- switch-based type narrowing for column type to schema mapping; each case is correct for its branch
-      // @effect-diagnostics-next-line schemaNumber:off -- SQLite REAL columns can legitimately store Infinity/NaN, so this public DEFAULT codec must accept them; Schema.Finite would wrongly reject those values. Keep Schema.Number here on purpose.
-      return Schema.Number as Schema.Codec<T>
+      return SqliteReal as Schema.Codec<T>
     }
     case 'blob': {
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- switch-based type narrowing for column type to schema mapping; each case is correct for its branch

--- a/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts
@@ -261,10 +261,11 @@ export const defaultSchemaForColumnType = <TColumnType extends FieldColumnType>(
     }
     case 'integer': {
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- switch-based type narrowing for column type to schema mapping; each case is correct for its branch
-      return Schema.Number as Schema.Codec<T>
+      return Schema.Finite as Schema.Codec<T>
     }
     case 'real': {
       // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- switch-based type narrowing for column type to schema mapping; each case is correct for its branch
+      // @effect-diagnostics-next-line schemaNumber:off -- SQLite REAL columns can legitimately store Infinity/NaN, so this public DEFAULT codec must accept them; Schema.Finite would wrongly reject those values. Keep Schema.Number here on purpose.
       return Schema.Number as Schema.Codec<T>
     }
     case 'blob': {

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.ts
@@ -136,7 +136,7 @@ export const makeQueryBuilder = <TResult, TTableDef extends TableDefBase>(
         _tag: 'CountQuery',
         tableDef,
         where: ast.where,
-        resultSchema: Schema.Struct({ count: Schema.Number }).pipe(
+        resultSchema: Schema.Struct({ count: Schema.Finite }).pipe(
           Schema.pluck('count'),
           Schema.Array,
           Schema.headOrElse(),
@@ -341,7 +341,7 @@ export const getResultSchema = (qb: QueryBuilder<any, any, any>) => {
       }
     }
     case 'CountQuery': {
-      return Schema.Struct({ count: Schema.Number }).pipe(Schema.pluck('count'), Schema.Array, Schema.headOrElse())
+      return Schema.Struct({ count: Schema.Finite }).pipe(Schema.pluck('count'), Schema.Array, Schema.headOrElse())
     }
     case 'InsertQuery':
     case 'UpdateQuery':
@@ -353,7 +353,7 @@ export const getResultSchema = (qb: QueryBuilder<any, any, any>) => {
       }
 
       // For write operations without RETURNING, the result is the number of affected rows
-      return Schema.Number
+      return Schema.Finite
     }
     case 'RowQuery': {
       return queryAst.tableDef.rowSchema.pipe(

--- a/packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts
@@ -484,7 +484,7 @@ describe('table function overloads', () => {
 
   it('supports discriminated unions with parsed JSON payloads', () => {
     const CircleDataSchema = Schema.Struct({
-      radius: Schema.Number,
+      radius: Schema.Finite,
     })
     const CircleSchema = Schema.Struct({
       kind: Schema.Literal('circle'),
@@ -492,7 +492,7 @@ describe('table function overloads', () => {
     })
 
     const SquareDataSchema = Schema.Struct({
-      sideLength: Schema.Number,
+      sideLength: Schema.Finite,
     })
     const SquareSchema = Schema.Struct({
       kind: Schema.Literal('square'),

--- a/packages/@livestore/common/src/sync/next/test/compact-events.calculator.test.ts
+++ b/packages/@livestore/common/src/sync/next/test/compact-events.calculator.test.ts
@@ -27,11 +27,11 @@ const facts = {
 const eventDefs = {
   add: defineEvent({
     name: 'add',
-    schema: Schema.Struct({ value: Schema.Number }),
+    schema: Schema.Struct({ value: Schema.Finite }),
   }),
   multiply: defineEvent({
     name: 'multiply',
-    schema: Schema.Struct({ value: Schema.Number }),
+    schema: Schema.Struct({ value: Schema.Finite }),
     facts: ({ value }, currentFacts) => ({
       modify: {
         set: value === 0 || currentFacts.has(facts.multiplyByZero) === true ? [facts.multiplyByZero] : [],

--- a/packages/@livestore/common/src/sync/sync-backend.ts
+++ b/packages/@livestore/common/src/sync/sync-backend.ts
@@ -99,7 +99,7 @@ export const NetworkStatus = Schema.Struct({
   /** True when the upstream sync backend is reachable and responding to health checks. */
   isConnected: Schema.Boolean,
   /** Unix epoch timestamp (ms) of the latest connectivity state transition. */
-  timestampMs: Schema.Number,
+  timestampMs: Schema.Finite,
   /** Devtools specific metadata describing simulator overrides. */
   devtools: Schema.Struct({
     /** Indicates whether the devtools latch forced the client into an offline state. */
@@ -143,7 +143,7 @@ export const isSyncBackend = (value: unknown): value is SyncBackend<any> => {
 export const PullResPageInfo = Schema.Union([
   Schema.TaggedStruct('MoreUnknown', {}),
   Schema.TaggedStruct('MoreKnown', {
-    remaining: Schema.Number,
+    remaining: Schema.Finite,
   }),
   Schema.TaggedStruct('NoMore', {}),
 ])

--- a/packages/@livestore/common/src/sync/transport-chunking.ts
+++ b/packages/@livestore/common/src/sync/transport-chunking.ts
@@ -26,8 +26,8 @@ export interface ChunkingOptions<A> {
 export class OversizeChunkItemError extends Schema.TaggedErrorClass<OversizeChunkItemError>(
   '~@livestore/common/OversizeChunkItemError',
 )('OversizeChunkItemError', {
-  size: Schema.Number,
-  maxBytes: Schema.Number,
+  size: Schema.Finite,
+  maxBytes: Schema.Finite,
 }) {}
 
 /**

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -7,10 +7,19 @@ export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
 
 export type Bindable = ReadonlyArray<SqlValue> | ParamsObject
 
+/**
+ * Numeric schema for the SQLite `REAL` domain. Unlike `Schema.Finite` it accepts
+ * `Infinity`/`NaN`, because SQLite `REAL` columns can legitimately store them and
+ * bind values / DEFAULT codecs must round-trip those through the devtools/debug
+ * protocol. This is the single carve-out for the SQLite REAL numeric domain — use it
+ * instead of a bare `Schema.Number` so the `schemaNumber` exception lives in one place.
+ */
+// @effect-diagnostics-next-line schemaNumber:off -- see SqliteReal docstring: SQLite REAL permits Infinity/NaN, so Schema.Finite would wrongly reject valid values
+export const SqliteReal = Schema.Number
+
 export const SqlValueSchema = Schema.Union([
   Schema.String,
-  // @effect-diagnostics-next-line schemaNumber:off -- SQL bind values feed SQLite REAL columns, which can legitimately hold Infinity/NaN (matching the field-defs.ts DEFAULT-codec carve-out); Schema.Finite would reject those and break PreparedBindValues round-tripping in the devtools/debug protocol. Keep Schema.Number on purpose.
-  Schema.Number,
+  SqliteReal,
   Schema.Uint8Array as any as Schema.Codec<Uint8Array<ArrayBuffer>>,
   Schema.Null,
 ])

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -9,7 +9,7 @@ export type Bindable = ReadonlyArray<SqlValue> | ParamsObject
 
 export const SqlValueSchema = Schema.Union([
   Schema.String,
-  Schema.Number,
+  Schema.Finite,
   Schema.Uint8Array as any as Schema.Codec<Uint8Array<ArrayBuffer>>,
   Schema.Null,
 ])

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -9,7 +9,8 @@ export type Bindable = ReadonlyArray<SqlValue> | ParamsObject
 
 export const SqlValueSchema = Schema.Union([
   Schema.String,
-  Schema.Finite,
+  // @effect-diagnostics-next-line schemaNumber:off -- SQL bind values feed SQLite REAL columns, which can legitimately hold Infinity/NaN (matching the field-defs.ts DEFAULT-codec carve-out); Schema.Finite would reject those and break PreparedBindValues round-tripping in the devtools/debug protocol. Keep Schema.Number on purpose.
+  Schema.Number,
   Schema.Uint8Array as any as Schema.Codec<Uint8Array<ArrayBuffer>>,
   Schema.Null,
 ])

--- a/packages/@livestore/livestore/src/store/store-types.test.ts
+++ b/packages/@livestore/livestore/src/store/store-types.test.ts
@@ -20,7 +20,7 @@ describe('isQueryable', () => {
   it('identifies live query definitions', () => {
     const def = queryDb({
       query: 'select 1 as value',
-      schema: Schema.Array(Schema.Struct({ value: Schema.Number })),
+      schema: Schema.Array(Schema.Struct({ value: Schema.Finite })),
     })
 
     expect(isQueryable(def)).toBe(true)

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -182,7 +182,7 @@ export const WebSocketAttachmentSchema = Schema.fromJsonString(
     storeId: Schema.String,
     // Different for each websocket connection
     payload: Schema.optional(Schema.Json),
-    pullRequestIds: Schema.Array(Schema.Union([Schema.String, Schema.Number])),
+    pullRequestIds: Schema.Array(Schema.Union([Schema.String, Schema.Finite])),
     // Headers forwarded from the initial request (via forwardHeaders option)
     headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   }),

--- a/packages/@livestore/utils-dev/src/wrangler/WranglerDevServer.ts
+++ b/packages/@livestore/utils-dev/src/wrangler/WranglerDevServer.ts
@@ -25,7 +25,7 @@ export class WranglerDevServerError extends Schema.TaggedErrorClass<WranglerDevS
 )('WranglerDevServerError', {
   cause: Schema.Defect(),
   message: Schema.String,
-  port: Schema.Number,
+  port: Schema.Finite,
 }) {}
 
 /**

--- a/packages/@livestore/utils/src/effect/Schema/debug-diff.test.ts
+++ b/packages/@livestore/utils/src/effect/Schema/debug-diff.test.ts
@@ -8,7 +8,7 @@ describe('debug-diff', () => {
   test('simple object', () => {
     const schema = Schema.Struct({
       a: Schema.String,
-      b: Schema.Number,
+      b: Schema.Finite,
     })
 
     const a = { a: 'hello', b: 1 }
@@ -35,7 +35,7 @@ describe('debug-diff', () => {
     const schema = Schema.Struct({
       a: Schema.String,
       b: Schema.Struct({
-        c: Schema.Number,
+        c: Schema.Finite,
       }),
     })
     const a = { a: 'hello', b: { c: 1 } }
@@ -58,7 +58,7 @@ describe('debug-diff', () => {
   })
 
   test('union', () => {
-    const schema = Schema.Union([Schema.String, Schema.Number])
+    const schema = Schema.Union([Schema.String, Schema.Finite])
     const a = 'hello'
     const b = 1
     const diff = debugDiff(schema)(a, b)
@@ -76,7 +76,7 @@ describe('debug-diff', () => {
   test('tagged union', () => {
     const schema = Schema.Union([
       Schema.TaggedStruct('a', { a: Schema.String }),
-      Schema.TaggedStruct('b', { b: Schema.Number }),
+      Schema.TaggedStruct('b', { b: Schema.Finite }),
     ])
     const a = { _tag: 'a', a: 'hello' } as const
     const b = { _tag: 'b', b: 1 } as const

--- a/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
+++ b/packages/@livestore/utils/src/effect/WebChannel/WebChannel.test.ts
@@ -16,7 +16,7 @@ Vitest.describe('WebChannel', () => {
             listenWindow: windowA,
             sendWindow: windowB,
             ids: { own: 'a', other: 'b' },
-            schema: Schema.Number,
+            schema: Schema.Finite,
           })
 
           const msgFromBFiber = yield* channelToB.listen.pipe(
@@ -36,7 +36,7 @@ Vitest.describe('WebChannel', () => {
             listenWindow: windowB,
             sendWindow: windowA,
             ids: { own: 'b', other: 'a' },
-            schema: Schema.Number,
+            schema: Schema.Finite,
           })
 
           const msgFromAFiber = yield* channelToA.listen.pipe(
@@ -64,7 +64,7 @@ Vitest.describe('WebChannel', () => {
             listenWindow: window,
             sendWindow: window,
             ids: { own: 'a', other: 'b' },
-            schema: Schema.Number,
+            schema: Schema.Finite,
           })
 
           const msgFromBFiber = yield* channelToB.listen.pipe(
@@ -84,7 +84,7 @@ Vitest.describe('WebChannel', () => {
             listenWindow: window,
             sendWindow: window,
             ids: { own: 'b', other: 'a' },
-            schema: Schema.Number,
+            schema: Schema.Finite,
           })
 
           const msgFromAFiber = yield* channelToA.listen.pipe(

--- a/packages/@livestore/webmesh/src/mesh-schema.ts
+++ b/packages/@livestore/webmesh/src/mesh-schema.ts
@@ -26,7 +26,7 @@ const remainingHopsUndefined = Schema.Undefined.pipe(Schema.optional)
 export const DirectChannelRequest = Schema.TaggedStruct('DirectChannelRequest', {
   ...defaultPacketFields,
   remainingHops: Schema.Array(Schema.String).pipe(Schema.optional),
-  channelVersion: Schema.Number,
+  channelVersion: Schema.Finite,
   /** Only set if the request is in response to an incoming request */
   reqId: Schema.UndefinedOr(Schema.String),
   /**
@@ -42,7 +42,7 @@ export const DirectChannelResponseSuccess = Schema.TaggedStruct('DirectChannelRe
   port: Transferable.MessagePort,
   // Since we can't copy this message, we need to follow the exact route back to the sender
   remainingHops: Schema.Array(Schema.String),
-  channelVersion: Schema.Number,
+  channelVersion: Schema.Finite,
 })
 
 export const DirectChannelResponseNoTransferables = Schema.TaggedStruct('DirectChannelResponseNoTransferables', {

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -44,15 +44,15 @@ const PROD_DEPLOY_STATE_FILE = `${PROD_DEPLOY_STATE_DIR}/deploy-state.json`
  */
 class DocsPhaseTimeoutError extends Schema.TaggedErrorClass<DocsPhaseTimeoutError>()('DocsPhaseTimeoutError', {
   phase: Schema.String,
-  durationMs: Schema.Number,
+  durationMs: Schema.Finite,
 }) {}
 
 class DocsDeployProbeError extends Schema.TaggedErrorClass<DocsDeployProbeError>()('DocsDeployProbeError', {
   label: Schema.String,
   path: Schema.String,
   message: Schema.String,
-  expectedStatus: Schema.Array(Schema.Number),
-  actualStatus: Schema.Number,
+  expectedStatus: Schema.Array(Schema.Finite),
+  actualStatus: Schema.Finite,
   expectedLocationPath: Schema.optional(Schema.String),
   actualLocation: Schema.optional(Schema.String),
   cause: Schema.optional(Schema.Defect()),

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -14,7 +14,7 @@ const RulesetRequestBody = Schema.Struct({
   enforcement: Schema.Literals(['disabled', 'active', 'evaluate']),
   bypass_actors: Schema.Array(
     Schema.Struct({
-      actor_id: Schema.Number,
+      actor_id: Schema.Finite,
       actor_type: Schema.Literals(['RepositoryRole', 'Team', 'Integration', 'OrganizationAdmin', 'DeployKey']),
       bypass_mode: Schema.Literals(['always', 'pull_request', 'exempt']),
     }),
@@ -95,7 +95,7 @@ const getRulesetByName = (name: string) =>
     const ExistingRulesetSchema = Schema.fromJsonString(
       Schema.Array(
         Schema.Struct({
-          id: Schema.Number,
+          id: Schema.Finite,
           name: Schema.String,
           enforcement: Schema.String,
         }),

--- a/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
@@ -45,8 +45,8 @@ const withTestCtx = Vitest.makeWithTestCtx({
 })
 
 const PersistenceSnapshotSchema = Schema.Struct({
-  state: Schema.Struct({ count: Schema.Number }),
-  eventlog: Schema.Struct({ count: Schema.Number }),
+  state: Schema.Struct({ count: Schema.Finite }),
+  eventlog: Schema.Struct({ count: Schema.Finite }),
 })
 
 const ResetPersistenceSnapshotSchema = Schema.Struct({
@@ -107,7 +107,7 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
           .pipe(
             Effect.flatMap(
               HttpClientResponse.schemaBodyJson(
-                Schema.Struct({ totalRowsWritten: Schema.Number, totalRowsRead: Schema.Number }),
+                Schema.Struct({ totalRowsWritten: Schema.Finite, totalRowsRead: Schema.Finite }),
               ),
             ),
           ),
@@ -118,7 +118,7 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
           .pipe(
             Effect.flatMap(
               HttpClientResponse.schemaBodyJson(
-                Schema.Struct({ totalRowsWritten: Schema.Number, totalRowsRead: Schema.Number }),
+                Schema.Struct({ totalRowsWritten: Schema.Finite, totalRowsRead: Schema.Finite }),
               ),
             ),
           ),

--- a/tests/integration/src/tests/playwright/unit-tests/bridge.ts
+++ b/tests/integration/src/tests/playwright/unit-tests/bridge.ts
@@ -22,12 +22,12 @@ export const ResultMultipleMigrations = Schema.TaggedStruct('Bridge.ResultMultip
   exit: Schema.toCodecIso(
     Schema.Exit(
       Schema.Struct({
-        migrationsCount: Schema.Number,
+        migrationsCount: Schema.Finite,
         archivedStateDbFiles: Schema.Array(
           Schema.Struct({
             name: Schema.String,
-            size: Schema.Number,
-            lastModified: Schema.Number,
+            size: Schema.Finite,
+            lastModified: Schema.Finite,
           }),
         ),
       }),

--- a/tests/package-common/src/client-document-optimistic-integration.test.ts
+++ b/tests/package-common/src/client-document-optimistic-integration.test.ts
@@ -37,7 +37,7 @@ Vitest.describe('Client Document Optimistic Decoding Integration', () => {
         name: 'Settings',
         schema: Schema.Struct({
           theme: Schema.String,
-          fontSize: Schema.Number,
+          fontSize: Schema.Finite,
         }),
         default: { id: SessionIdSymbol, value: { theme: 'light', fontSize: 14 } },
       })

--- a/tests/package-common/src/client-document-optimistic-schema.test.ts
+++ b/tests/package-common/src/client-document-optimistic-schema.test.ts
@@ -8,7 +8,7 @@ describe('Client Document Optimistic Schema', () => {
   describe('Full Set Operations', () => {
     const valueSchema = Schema.Struct({
       name: Schema.String,
-      age: Schema.Number,
+      age: Schema.Finite,
       email: Schema.String,
     })
 
@@ -54,7 +54,7 @@ describe('Client Document Optimistic Schema', () => {
   describe('Partial Set Operations', () => {
     const valueSchema = Schema.Struct({
       field1: Schema.String,
-      field2: Schema.Number,
+      field2: Schema.Finite,
     })
 
     const defaultValue = { field1: 'default1', field2: 0 }

--- a/tests/package-common/src/leader-thread/fixture.ts
+++ b/tests/package-common/src/leader-thread/fixture.ts
@@ -12,7 +12,7 @@ const todos = State.SQLite.table({
 })
 
 const Config = Schema.Struct({
-  fontSize: Schema.Number,
+  fontSize: Schema.Finite,
   theme: Schema.Literals(['light', 'dark']),
 })
 

--- a/tests/perf/test-app/src/events.ts
+++ b/tests/perf/test-app/src/events.ts
@@ -2,21 +2,21 @@ import { Events, Schema } from '@livestore/livestore'
 
 export const thousandItemsCreated = Events.synced({
   name: 'v1.ThousandItemsCreated',
-  schema: Schema.Array(Schema.Struct({ id: Schema.Number, label: Schema.String })).check(
+  schema: Schema.Array(Schema.Struct({ id: Schema.Finite, label: Schema.String })).check(
     Schema.isLengthBetween(1000, 1000),
   ),
 })
 
 export const tenThousandItemsCreated = Events.synced({
   name: 'v1.TenThousandItemsCreated',
-  schema: Schema.Array(Schema.Struct({ id: Schema.Number, label: Schema.String })).check(
+  schema: Schema.Array(Schema.Struct({ id: Schema.Finite, label: Schema.String })).check(
     Schema.isLengthBetween(10_000, 10_000),
   ),
 })
 
 export const thousandItemsAppended = Events.synced({
   name: 'v1.ThousandItemsAppended',
-  schema: Schema.Array(Schema.Struct({ id: Schema.Number, label: Schema.String })).check(
+  schema: Schema.Array(Schema.Struct({ id: Schema.Finite, label: Schema.String })).check(
     Schema.isLengthBetween(1000, 1000),
   ),
 })
@@ -28,7 +28,7 @@ export const everyTenthItemUpdated = Events.synced({
 
 export const itemDeleted = Events.synced({
   name: 'v1.ItemDeleted',
-  schema: Schema.Struct({ id: Schema.Number }),
+  schema: Schema.Struct({ id: Schema.Finite }),
 })
 
 export const allItemsDeleted = Events.synced({

--- a/tests/perf/test-app/src/schema.ts
+++ b/tests/perf/test-app/src/schema.ts
@@ -15,7 +15,7 @@ export type Items = Item[]
 
 const uiState = State.SQLite.clientDocument({
   name: 'uiState',
-  schema: Schema.Struct({ selected: Schema.NullOr(Schema.Number) }),
+  schema: Schema.Struct({ selected: Schema.NullOr(Schema.Finite) }),
   default: {
     id: SessionIdSymbol,
     value: { selected: null },

--- a/tests/perf/tests/measurements-reporter.ts
+++ b/tests/perf/tests/measurements-reporter.ts
@@ -41,7 +41,7 @@ const NumberFromDescriptionAnnotation = <T extends string>(typeLiteral: T) =>
     Schema.decodeTo(
       Schema.Struct({
         type: Schema.Literal(typeLiteral),
-        description: Schema.Number,
+        description: Schema.Finite,
       }),
       SchemaTransformation.transformOrFail({
         decode: ({ description, ...rest }) =>
@@ -107,14 +107,14 @@ type CpuSummary = {
 const Cpus = Schema.NonEmptyArray(
   Schema.Struct({
     model: Schema.String,
-    speed: Schema.Number,
+    speed: Schema.Finite,
   }),
 ).pipe(
   Schema.decodeTo(
     Schema.Struct({
       model: Schema.String,
-      count: Schema.Number,
-      speed: Schema.Number.pipe(Schema.overrideToFormatter(() => (value) => `${(value / 1000).toFixed(2)} GHz`)),
+      count: Schema.Finite,
+      speed: Schema.Finite.pipe(Schema.overrideToFormatter(() => (value) => `${(value / 1000).toFixed(2)} GHz`)),
     }),
     {
       decode: SchemaGetter.transform((cpus: readonly [CpuInfo, ...CpuInfo[]]) => ({
@@ -136,10 +136,10 @@ const SystemInfo = Schema.Struct({
   }),
   cpus: Cpus,
   memory: Schema.Struct({
-    total: Schema.Number.pipe(
+    total: Schema.Finite.pipe(
       Schema.overrideToFormatter(() => (value) => `${(value / (1024 * 1024 * 1024)).toFixed(2)} GB`),
     ),
-    free: Schema.Number.pipe(
+    free: Schema.Finite.pipe(
       Schema.overrideToFormatter(() => (value) => `${(value / (1024 * 1024 * 1024)).toFixed(2)} GB`),
     ),
   }),


### PR DESCRIPTION
> ### 🔄 Rebased onto current `main` (2026-07-17)
>
> Originally branched before #1397 merged. This branch has been **rebased onto current `main`**: the 3 duplicated effect-utils-bump precursor commits (now carried by `main` as the #1397 squash) were dropped, so the diff is now **only** this slice's burndown changes (**48 files**) and no longer conflicts. The pre-rebase file/line counts quoted below are historical.
>
> **Verification is via CI on this branch.** The `type-check` job runs `devenv tasks run ts:build` → `tsgo --build` — the real Effect-LSP oracle (`tsc`/incremental `ts:check` do **not** run the plugin) — and `lint` (`lint:full:with-megarepo-check`) re-checks generated-file freshness.

## Problem

The effect-utils bump surfaces the `@effect/language-service` `schemaNumber` (TS377098) diagnostic: `Schema.Number` accepts `NaN`, `Infinity`, and `-Infinity`, which is wrong for finite-domain quantities. There are **149** such diagnostics across the tree.

This is one PR in the **stacked Effect-LSP diagnostic burndown** (#811 gate) off `schickling-assistant/2026-07-15-bump-effect-utils`. It fixes **only** `schemaNumber` and does not touch the gate override.

## Solution

Cleared all 149 `schemaNumber` diagnostics:

- **147** `Schema.Number` → `Schema.Finite` and **1** `Schema.NumberFromString` → `Schema.FiniteFromString`, across 46 files (durations, counts, indices, timestamps, ids, sizes, hashes + their tests). Migration was line-targeted from the authoritative diagnostic list, so comments and test-name string literals containing `Schema.Number` were left untouched. `Number` and `Finite` are both 6 chars, so no reformatting was needed.
- **1 carve-out** at `packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts:269` — the public `real`-column DEFAULT codec **keeps `Schema.Number`**, because SQLite `REAL` can legitimately store `Infinity`/`NaN` and `Schema.Finite` would wrongly reject them. It carries an `@effect-diagnostics-next-line schemaNumber:off` directive explaining why. The sibling `integer` default (line 264) IS migrated to `Schema.Finite`.

## Validation

- Force `tsgo --build tsconfig.dev.json --force`: **0** `schemaNumber` diagnostics, build exit 0. field-defs emits neither a `schemaNumber` nor a "directive has no effect" warning (the one such warning in output is pre-existing at `common-cf/.../server.ts:251`, untouched here).
- `check:quick` green (also via the pre-commit hook).
- `oxfmt --check` and `oxlint` clean across all 47 changed files. (`typescript/no-unsafe-type-assertion` is `off` repo-wide per oep-3632.1, so the carve-out's oxlint suppression is inert regardless of comment ordering.)
- Unit suites pass with **no finite-tightening breaks**: common (263), utils (33), common-cf (21), tests/package-common (65), livestore store-types (5) — including the highest-risk `column-def`/`column-annotations` column-mapping tests.

### Not exercised locally
The perf and integration schemas were migrated (`tests/perf` events/schema/measurements-reporter, `tests/integration` adapter-cloudflare + playwright `bridge.ts`) but their suites need perf/CF/browser infra and were **not run locally**. These schemas are finite-domain by inspection (ids, counts, CPU speed, memory bytes), so the risk is low but unverified — CI on this branch is the backstop. If `Schema.Finite` rejects a real `Infinity`/`NaN` there, that is a genuine signal to address, not to suppress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌲 cl1-pine |
| `agent_session_id` | b9f1f4a5-dd10-40f6-b25c-945e71e2007a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.206 |
| `agent_runtime` | Claude Code 2.1.206 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-17-refactor |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->
