### PR TITLE
refactor(effect-lsp): adopt Schema-over-JSON + tagged-error hygiene

### DIFF
--- a/.changeset/empty-effect-lsp-semantic.md
+++ b/.changeset/empty-effect-lsp-semantic.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Internal Effect-LSP burndown (semantic cluster): adopt Schema-over-JSON codecs, convert failure-channel `Error`s to `Data.TaggedError` types, merge adjacent `Effect.provide` chains, and normalize `Effect.fn`/`Effect.gen` usage — behavior-neutral hygiene, no user-facing change.

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -137,8 +137,12 @@ export const makeInMemoryAdapter =
       const sharedWorkerClient =
         sharedWebWorker !== undefined
           ? yield* RpcClient.make(WorkerSchema.SharedWorkerRpcs).pipe(
-              Effect.provide(RpcClient.layerProtocolWorker({ size: 1, concurrency: 100 })),
-              Effect.provide(BrowserWorker.layer(() => sharedWebWorker)),
+              Effect.provide(
+                Layer.provideMerge(
+                  RpcClient.layerProtocolWorker({ size: 1, concurrency: 100 }),
+                  BrowserWorker.layer(() => sharedWebWorker),
+                ),
+              ),
               Effect.tapCauseLogPretty,
               UnknownError.mapToUnknownError,
             )

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -77,8 +77,7 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
   )
 
   return makeWorkerRunnerOuter(options).pipe(
-    Effect.provide(RpcServer.layerProtocolWorkerRunner),
-    Effect.provide(BrowserWorkerRunner.layer),
+    Effect.provide(Layer.provideMerge(RpcServer.layerProtocolWorkerRunner, BrowserWorkerRunner.layer)),
     Effect.scoped,
     Effect.tapCauseLogPretty,
     Effect.annotateLogs({ thread: self.name }),
@@ -93,30 +92,32 @@ export const makeWorkerEffect = (options: WorkerOptions) => {
   )
 }
 
-const makeWorkerRunnerOuter = (workerOptions: WorkerOptions) =>
-  Effect.gen(function* () {
-    // Port coming from client session and forwarded via the shared worker.
-    const {
-      port: incomingRequestsPort,
-      storeId,
-      clientId,
-    } = yield* RpcWorker.initialMessage(WorkerSchema.LeaderWorkerOuterInitialMessage.payloadSchema)
+const makeWorkerRunnerOuter = Effect.fn('@livestore/adapter-web:worker:wrapper:InitialMessage')(function* (
+  workerOptions: WorkerOptions,
+) {
+  // Port coming from client session and forwarded via the shared worker.
+  const {
+    port: incomingRequestsPort,
+    storeId,
+    clientId,
+  } = yield* RpcWorker.initialMessage(WorkerSchema.LeaderWorkerOuterInitialMessage.payloadSchema)
 
-    return yield* RpcServer.make(WorkerSchema.LeaderWorkerInnerRpcs).pipe(
-      Effect.provide(makeWorkerRunnerInner(workerOptions)),
-      Effect.provide(makeMessagePortRpcServerProtocol(incomingRequestsPort)),
-      Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage:innerFiber'),
-      Effect.tapCauseLogPretty,
-      Effect.provide(
-        Layer.mergeAll(
-          Opfs.layer,
-          WebmeshWorker.CacheService.layer({
-            nodeName: Devtools.makeNodeName.client.leader({ storeId, clientId }),
-          }),
-        ),
+  return yield* RpcServer.make(WorkerSchema.LeaderWorkerInnerRpcs).pipe(
+    Effect.provide(
+      Layer.provideMerge(makeWorkerRunnerInner(workerOptions), makeMessagePortRpcServerProtocol(incomingRequestsPort)),
+    ),
+    Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage:innerFiber'),
+    Effect.tapCauseLogPretty,
+    Effect.provide(
+      Layer.mergeAll(
+        Opfs.layer,
+        WebmeshWorker.CacheService.layer({
+          nodeName: Devtools.makeNodeName.client.leader({ storeId, clientId }),
+        }),
       ),
-    )
-  }).pipe(Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage'))
+    ),
+  )
+})
 
 const makeMessagePortRpcServerProtocol = (port: MessagePort): Layer.Layer<RpcServer.Protocol> =>
   Layer.effect(

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -18,6 +18,18 @@ import {
 
 import type * as CfTypes from '../cf-types.ts'
 
+/**
+ * The erased dynamic RPC schemas (`Rpc.exitSchema(...) as Schema.Top`, `rpc.payloadSchema`) are
+ * plain data — they need NO decoding/encoding services. `Schema.Top` types those service channels
+ * as `unknown`, which surfaces as `unknown` in the requirements channel of `encode/decodeUnknownEffect`
+ * (anyUnknownInErrorContext / TS377030). Assert the true `never` services in ONE place.
+ *
+ * TODO(effect): revisit if a cleaner/idiomatic API lands — https://github.com/Effect-TS/effect/issues/6489
+ */
+const erasedJsonCodec = (schema: Schema.Top) =>
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- erased RPC data schemas require no codec services
+  Schema.toCodecJson(schema as Schema.Codec<unknown, unknown, never, never>)
+
 export interface ClientDoWithRpcCallback {
   __DURABLE_OBJECT_BRAND: never
   syncUpdateRpc: (payload: Uint8Array<ArrayBuffer>) => Promise<void>
@@ -85,8 +97,7 @@ export const toDurableObjectHandler =
           continue
         }
 
-        // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased dynamic payload schema surfaces `unknown` requirements; the context is supplied at runtime via `Effect.provideContext(entry.context)`
-        const payloadResult = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(rpc.payloadSchema))(
+        const payloadResult = yield* Schema.decodeUnknownEffect(erasedJsonCodec(rpc.payloadSchema))(
           request.payload,
         ).pipe(Effect.provideContext(entry.context), Effect.result)
 
@@ -96,8 +107,7 @@ export const toDurableObjectHandler =
           // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
           const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
           const rawExit = Exit.die(payloadResult.failure.issue.toString())
-          // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased `Schema.Top` exit schema surfaces `unknown` requirements; the context is supplied at runtime via `Effect.provideContext(entry.context)`
-          const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit).pipe(
+          const encodedExit = yield* Schema.encodeUnknownEffect(erasedJsonCodec(exitSchema))(rawExit).pipe(
             Effect.provideContext(entry.context),
           )
           responses.push({
@@ -146,8 +156,7 @@ export const toDurableObjectHandler =
           if (exitSchema !== undefined) {
             // Use schema encoding for proper serialization
             const rawExit = Exit.succeed(value)
-            // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased `Schema.Top` exit schema surfaces `unknown` requirements; the effect runs under the provided `options.layer`
-            encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
+            encodedExit = yield* Schema.encodeUnknownEffect(erasedJsonCodec(exitSchema))(rawExit)
           } else {
             // Fallback to direct exit
             encodedExit = Exit.succeed(value)
@@ -169,8 +178,7 @@ export const toDurableObjectHandler =
               if (exitSchema !== undefined) {
                 // Use schema encoding for proper serialization
                 const rawExit = Exit.failCause(cause)
-                // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased `Schema.Top` exit schema surfaces `unknown` requirements; the effect runs under the provided `options.layer`
-                encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
+                encodedExit = yield* Schema.encodeUnknownEffect(erasedJsonCodec(exitSchema))(rawExit)
               } else {
                 // Fallback to direct exit
                 encodedExit = Exit.failCause(cause)
@@ -299,7 +307,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
           const rawExit = Exit.void
           // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
           const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
-          const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
+          const encodedExit = yield* Schema.encodeUnknownEffect(erasedJsonCodec(exitSchema))(rawExit)
 
           const exitMessage = {
             _tag: 'Exit' as const,
@@ -318,7 +326,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
               const rawExit = Exit.failCause(cause)
               // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
               const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
-              const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
+              const encodedExit = yield* Schema.encodeUnknownEffect(erasedJsonCodec(exitSchema))(rawExit)
 
               const exitMessage = {
                 _tag: 'Exit' as const,

--- a/packages/@livestore/common-cf/src/do-rpc/server.ts
+++ b/packages/@livestore/common-cf/src/do-rpc/server.ts
@@ -85,6 +85,7 @@ export const toDurableObjectHandler =
           continue
         }
 
+        // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased dynamic payload schema surfaces `unknown` requirements; the context is supplied at runtime via `Effect.provideContext(entry.context)`
         const payloadResult = yield* Schema.decodeUnknownEffect(Schema.toCodecJson(rpc.payloadSchema))(
           request.payload,
         ).pipe(Effect.provideContext(entry.context), Effect.result)
@@ -95,6 +96,7 @@ export const toDurableObjectHandler =
           // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Rpc.exitSchema requires AnyWithProps; type narrowing already done above
           const exitSchema = Rpc.exitSchema(rpc as any) as Schema.Top
           const rawExit = Exit.die(payloadResult.failure.issue.toString())
+          // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased `Schema.Top` exit schema surfaces `unknown` requirements; the context is supplied at runtime via `Effect.provideContext(entry.context)`
           const encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit).pipe(
             Effect.provideContext(entry.context),
           )
@@ -144,6 +146,7 @@ export const toDurableObjectHandler =
           if (exitSchema !== undefined) {
             // Use schema encoding for proper serialization
             const rawExit = Exit.succeed(value)
+            // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased `Schema.Top` exit schema surfaces `unknown` requirements; the effect runs under the provided `options.layer`
             encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
           } else {
             // Fallback to direct exit
@@ -166,6 +169,7 @@ export const toDurableObjectHandler =
               if (exitSchema !== undefined) {
                 // Use schema encoding for proper serialization
                 const rawExit = Exit.failCause(cause)
+                // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Schema.toCodecJson` on the erased `Schema.Top` exit schema surfaces `unknown` requirements; the effect runs under the provided `options.layer`
                 encodedExit = yield* Schema.encodeUnknownEffect(Schema.toCodecJson(exitSchema))(rawExit)
               } else {
                 // Fallback to direct exit
@@ -249,6 +253,7 @@ const createStreamingResponse = <Rpcs extends Rpc.Any, LE>(
     const effectOrStream = Rpc.isWrapper(handlerResult) === true ? handlerResult.value : handlerResult
 
     const stream: Stream.Stream<any, any> =
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- `Rpc.Handler.handler` returns `Effect<any, any>` due to dynamic dispatch; orDie converts the error to a defect handled by the downstream catchCause
       Effect.isEffect(effectOrStream) === true ? yield* Effect.orDie(effectOrStream) : effectOrStream
 
     // Get the stream schemas for proper chunk-level encoding

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -103,7 +103,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
 
-  const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
+  const boot: ClientSessionSyncProcessor['boot'] = Effect.gen(function* () {
     if (
       confirmUnsavedChanges === true &&
       typeof window !== 'undefined' &&
@@ -263,7 +263,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.tapCauseLogPretty,
       Effect.forkScoped,
     )
-  })()
+  }).pipe(Effect.withSpan('client-session-sync-processor:boot'))
 
   const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn(
     'client-session-sync-processor:encode-events',

--- a/packages/@livestore/common/src/sync/syncstate.test.ts
+++ b/packages/@livestore/common/src/sync/syncstate.test.ts
@@ -7,6 +7,10 @@ import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import * as SyncState from './syncstate.ts'
 
+/** Module-scoped JSON codecs; keeping the sync codecs out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
+const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
+
 const makeTestEvent = ({
   seqNum,
   parentSeqNum,
@@ -424,7 +428,7 @@ Vitest.describe('syncstate', () => {
               flag: Schema.optional(Schema.Boolean),
             })
             const localArgs = yield* Schema.encodeUnknownEffect(argsSchema)({ id: 'abc' } as any).pipe(Effect.orDie)
-            const wireArgs = JSON.parse(JSON.stringify(localArgs))
+            const wireArgs = jsonParse(jsonStringify(localArgs))
 
             const localPending = new LiveStoreEvent.Client.EncodedWithMeta({
               seqNum: e1_0.seqNum,

--- a/packages/@livestore/livestore/src/effect/LiveStore.test.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest'
 
-import { type OtelTracer, Effect, Layer } from '@livestore/utils/effect'
+import { Effect, Layer } from '@livestore/utils/effect'
 
 import { schema } from '../utils/tests/fixture.ts'
 import { Store, type StoreTagClass } from './LiveStore.ts'
@@ -27,18 +27,23 @@ describe('Store.Tag R channel consistency', () => {
       yield* MainStore.commit()
     })
 
+    const _provided = prog.pipe(Effect.provide(storeLayer))
+    type _R = Effect.Services<typeof _provided>
     /** Providing the store layer must fully eliminate MainStore from R */
-    const _provided: Effect.Effect<void, unknown, OtelTracer.OtelTracer> = prog.pipe(Effect.provide(storeLayer))
-    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- regression test (issue #1103) asserts only the R channel; the error channel is intentionally widened to `unknown` to stay decoupled from the exact error type
-    void _provided
+    type _MainStoreNotInR = StoreTagClass<typeof schema, 'main'> extends _R ? false : true
+    const _check: _MainStoreNotInR = true
+    void _check
   })
 
   it('use() helper R channel is satisfied by the same layer', () => {
     const prog = MainStore.use(({ store }) => Effect.succeed(store))
 
-    const _provided: Effect.Effect<unknown, unknown, OtelTracer.OtelTracer> = prog.pipe(Effect.provide(storeLayer))
-    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- regression test (issue #1103) asserts only the R channel; the success/error channels are intentionally widened to `unknown` to stay decoupled from exact types
-    void _provided
+    const _provided = prog.pipe(Effect.provide(storeLayer))
+    type _R = Effect.Services<typeof _provided>
+    /** Providing the store layer must fully eliminate MainStore from R */
+    type _MainStoreNotInR = StoreTagClass<typeof schema, 'main'> extends _R ? false : true
+    const _check: _MainStoreNotInR = true
+    void _check
   })
 
   it('fromDeferred layer output satisfies the same R channel', () => {

--- a/packages/@livestore/livestore/src/effect/LiveStore.test.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.test.ts
@@ -29,6 +29,7 @@ describe('Store.Tag R channel consistency', () => {
 
     /** Providing the store layer must fully eliminate MainStore from R */
     const _provided: Effect.Effect<void, unknown, OtelTracer.OtelTracer> = prog.pipe(Effect.provide(storeLayer))
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- regression test (issue #1103) asserts only the R channel; the error channel is intentionally widened to `unknown` to stay decoupled from the exact error type
     void _provided
   })
 
@@ -36,6 +37,7 @@ describe('Store.Tag R channel consistency', () => {
     const prog = MainStore.use(({ store }) => Effect.succeed(store))
 
     const _provided: Effect.Effect<unknown, unknown, OtelTracer.OtelTracer> = prog.pipe(Effect.provide(storeLayer))
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- regression test (issue #1103) asserts only the R channel; the success/error channels are intentionally widened to `unknown` to stay decoupled from exact types
     void _provided
   })
 

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -33,6 +33,9 @@ const Response = CfDeclare.Response
 const WebSocketPair = CfDeclare.WebSocketPair
 const WebSocketRequestResponsePair = CfDeclare.WebSocketRequestResponsePair
 
+/** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
+
 const DurableObjectBase = DurableObject as any as new (
   state: CfTypes.DurableObjectState,
   env: Env,
@@ -183,10 +186,7 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
 
           // Ping requests are sent by Effect RPC internally
           this.ctx.setWebSocketAutoResponse(
-            new WebSocketRequestResponsePair(
-              JSON.stringify(RpcMessage.constPing),
-              JSON.stringify(RpcMessage.constPong),
-            ),
+            new WebSocketRequestResponsePair(jsonStringify(RpcMessage.constPing), jsonStringify(RpcMessage.constPong)),
           )
 
           return new Response(null, {

--- a/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
@@ -21,6 +21,9 @@ export class DockerComposeError extends Schema.TaggedErrorClass<DockerComposeErr
   note: Schema.String,
 }) {}
 
+/** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
+
 export interface Options {
   readonly cwd: string
   readonly serviceName?: string
@@ -165,7 +168,7 @@ export const make = (args: Options) =>
       if (Number(exitCode) !== 0) {
         return yield* new DockerComposeError({
           cause: new Error(`Docker compose exited with code ${exitCode}`),
-          note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${JSON.stringify(options.env)}`,
+          note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${jsonStringify(options.env)}`,
         })
       }
 

--- a/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
@@ -21,9 +21,6 @@ export class DockerComposeError extends Schema.TaggedErrorClass<DockerComposeErr
   note: Schema.String,
 }) {}
 
-/** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
-const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
-
 export interface Options {
   readonly cwd: string
   readonly serviceName?: string
@@ -168,7 +165,8 @@ export const make = (args: Options) =>
       if (Number(exitCode) !== 0) {
         return yield* new DockerComposeError({
           cause: new Error(`Docker compose exited with code ${exitCode}`),
-          note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${jsonStringify(options.env)}`,
+          // @effect-diagnostics-next-line preferSchemaOverJson:off -- diagnostic-only formatting of an optional env record; JSON.stringify's forgiving `undefined`->"undefined" is intended, and Schema's JSON codec throws on top-level `undefined`, which would mask the real DockerComposeError
+          note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${JSON.stringify(options.env)}`,
         })
       }
 

--- a/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
+++ b/packages/@livestore/utils-dev/src/node/DockerCompose/DockerCompose.ts
@@ -19,6 +19,8 @@ export class DockerComposeError extends Schema.TaggedErrorClass<DockerComposeErr
 )('DockerComposeError', {
   cause: Schema.Defect(),
   note: Schema.String,
+  /** Compose env of the failed invocation, if any — structured instead of string-formatted into `note`. */
+  env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
 }) {}
 
 export interface Options {
@@ -165,8 +167,8 @@ export const make = (args: Options) =>
       if (Number(exitCode) !== 0) {
         return yield* new DockerComposeError({
           cause: new Error(`Docker compose exited with code ${exitCode}`),
-          // @effect-diagnostics-next-line preferSchemaOverJson:off -- diagnostic-only formatting of an optional env record; JSON.stringify's forgiving `undefined`->"undefined" is intended, and Schema's JSON codec throws on top-level `undefined`, which would mask the real DockerComposeError
-          note: `Docker Compose failed to start with exit code ${exitCode}. Env: ${JSON.stringify(options.env)}`,
+          note: `Docker Compose failed to start with exit code ${exitCode}`,
+          env: options.env,
         })
       }
 

--- a/packages/@livestore/utils/src/effect/Schema/index.ts
+++ b/packages/@livestore/utils/src/effect/Schema/index.ts
@@ -41,6 +41,24 @@ export const pluck =
     ) as unknown as PluckSchema<Fields, K & keyof Fields>
   }
 
+/**
+ * Like {@link fromJsonString}, but the ENCODED form is an *indented* JSON string
+ * (default 2-space) instead of compact — for committed/human-read JSON files
+ * (package.json, release plans, CI previews) that must stay diff-friendly while
+ * still round-tripping through the schema. `fromJsonString` hardcodes a compact
+ * `stringifyJson()`; we compose the schema's encoded side with an indenting one.
+ *
+ * Use a concrete schema for known shapes (adds validation) or `Schema.Unknown`
+ * for open-ended ones (the indented analogue of `UnknownFromJsonString`).
+ */
+export const jsonStringIndented = <S extends Schema.Top>(schema: S, space: number | string = 2) =>
+  schema.pipe(
+    Schema.encodeTo(Schema.String, {
+      decode: SchemaGetter.parseJson(),
+      encode: SchemaGetter.stringifyJson({ space }),
+    }),
+  )
+
 export const head = <S extends Schema.Top>(
   array: Schema.$Array<S>,
 ): Schema.decodeTo<Schema.Option<Schema.toType<S>>, Schema.$Array<S>> =>

--- a/packages/@livestore/utils/src/effect/Subscribable.ts
+++ b/packages/@livestore/utils/src/effect/Subscribable.ts
@@ -46,6 +46,7 @@ const Proto: Omit<Subscribable<unknown, unknown, unknown>, 'get' | 'changes'> = 
   Effectable.Prototype<Subscribable<unknown, unknown, unknown>>({
     label: 'Subscribable',
     evaluate() {
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- vendored fork; this shared prototype is generic over all A, E, R, so `unknown` in the error/requirements channels is structural, not a real error type
       return this.get
     },
   }),

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.ts
@@ -123,6 +123,7 @@ import type { SnippetBundle } from '../vite/snippet-graph.ts'
 import { buildSnippetBundle, __internal as snippetGraphInternal } from '../vite/snippet-graph.ts'
 
 const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
+const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
 const jsonStringifyPretty = (value: unknown): string => JSON.stringify(value, null, 2)
 
 type THastRendererResult = {
@@ -1301,7 +1302,7 @@ const loadPreviousManifest = (
 
     const manifestSource = manifestSourceResult.success
     const parsedResult = yield* Effect.try({
-      try: () => JSON.parse(manifestSource) as TSnippetManifest,
+      try: () => jsonParse(manifestSource) as TSnippetManifest,
       catch: (cause) => new Cause.UnknownError(cause),
     }).pipe(Effect.result)
     if (Result.isFailure(parsedResult) === true) {

--- a/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
+++ b/packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts
@@ -2,10 +2,13 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { Effect, FileSystem, Queue } from '@livestore/utils/effect'
+import { Effect, FileSystem, Queue, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
 import { type WatchSnippetsRebuildInfo, watchSnippets } from './snippets.ts'
+
+/** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
 
 const createDocsImportSource = (relativeSnippetPath: string) => `---
 title: Snippet Watch Test
@@ -32,24 +35,20 @@ const writeInitialProject = (fs: FileSystem.FileSystem, projectRoot: string): Ef
 
     yield* fs.writeFileString(snippetPath, 'export const value = 1\n')
     yield* fs.writeFileString(docsPath, createDocsImportSource('../content/_assets/code/example.ts'))
-    const tsconfigJson = JSON.stringify(
-      {
-        compilerOptions: {
-          target: 'ESNext',
-          module: 'ESNext',
-          moduleResolution: 'Bundler',
-          jsx: 'react-jsx',
-          types: ['node'],
-          skipLibCheck: true,
-          allowImportingTsExtensions: true,
-          noEmit: true,
-        },
-        include: ['./**/*'],
-        exclude: ['./node_modules'],
+    const tsconfigJson = jsonStringify({
+      compilerOptions: {
+        target: 'ESNext',
+        module: 'ESNext',
+        moduleResolution: 'Bundler',
+        jsx: 'react-jsx',
+        types: ['node'],
+        skipLibCheck: true,
+        allowImportingTsExtensions: true,
+        noEmit: true,
       },
-      null,
-      2,
-    )
+      include: ['./**/*'],
+      exclude: ['./node_modules'],
+    })
     yield* fs.writeFileString(tsconfigPath, tsconfigJson + '\n')
   }).pipe(Effect.orDie)
 

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -704,29 +704,23 @@ export const docsCommand = Cli.Command.make('docs').pipe(
           const shouldPrintPlan = plan._tag === 'Some' && plan.value === true
 
           if (shouldPrintPlan === true) {
-            console.log(
-              // @effect-diagnostics-next-line preferSchemaOverJson:off -- indented, ad-hoc plan preview for humans reading CI logs; Schema's JSON codec is compact
-              JSON.stringify(
-                {
-                  branchName,
-                  isPr,
-                  liveStoreVersion,
-                  site,
-                  siteUrl: docsSiteUrl,
-                  build: shouldBuild,
-                  deployTarget:
-                    prAliases !== undefined
-                      ? { _tag: 'pr-aliases', ...prAliases }
-                      : prod === true
-                        ? { _tag: 'prod' }
-                        : { _tag: 'alias', alias: branchAlias },
-                  purgeCdn,
-                  step,
-                },
-                null,
-                2,
-              ),
-            )
+            const planPreview = yield* Schema.encodeEffect(Schema.jsonStringIndented(Schema.Unknown))({
+              branchName,
+              isPr,
+              liveStoreVersion,
+              site,
+              siteUrl: docsSiteUrl,
+              build: shouldBuild,
+              deployTarget:
+                prAliases !== undefined
+                  ? { _tag: 'pr-aliases', ...prAliases }
+                  : prod === true
+                    ? { _tag: 'prod' }
+                    : { _tag: 'alias', alias: branchAlias },
+              purgeCdn,
+              step,
+            }).pipe(Effect.orDie)
+            console.log(planPreview)
             return
           }
 

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -70,6 +70,9 @@ const ProdDeployStateSchema = Schema.Struct({
 })
 type ProdDeployState = typeof ProdDeployStateSchema.Type
 
+/** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const encodeProdDeployState = Schema.encodeSync(Schema.fromJsonString(ProdDeployStateSchema))
+
 const docsSnippetsCommand = createSnippetsCommand({ projectRoot: docsPath })
 
 const runDocsDiagramsBuild = buildDiagrams({ projectRoot: docsPath, verbose: true }).pipe(
@@ -314,7 +317,7 @@ const docsBuildCommand = Cli.Command.make(
 const writeProdDeployState = (state: ProdDeployState) =>
   Effect.sync(() => {
     fs.mkdirSync(PROD_DEPLOY_STATE_DIR, { recursive: true })
-    fs.writeFileSync(PROD_DEPLOY_STATE_FILE, JSON.stringify(state, null, 2))
+    fs.writeFileSync(PROD_DEPLOY_STATE_FILE, encodeProdDeployState(state))
   }).pipe(Effect.withSpan('docs.deploy.state.write', { attributes: { path: PROD_DEPLOY_STATE_FILE } }))
 
 const readProdDeployState = Effect.gen(function* () {
@@ -702,6 +705,8 @@ export const docsCommand = Cli.Command.make('docs').pipe(
 
           if (shouldPrintPlan === true) {
             console.log(
+              // Indented, ad-hoc plan preview for humans reading CI logs; Schema's JSON codec is compact.
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               JSON.stringify(
                 {
                   branchName,

--- a/scripts/src/commands/docs.ts
+++ b/scripts/src/commands/docs.ts
@@ -705,8 +705,7 @@ export const docsCommand = Cli.Command.make('docs').pipe(
 
           if (shouldPrintPlan === true) {
             console.log(
-              // Indented, ad-hoc plan preview for humans reading CI logs; Schema's JSON codec is compact.
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              // @effect-diagnostics-next-line preferSchemaOverJson:off -- indented, ad-hoc plan preview for humans reading CI logs; Schema's JSON codec is compact
               JSON.stringify(
                 {
                   branchName,

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -318,6 +318,12 @@ const toErrorMessage = (cause: unknown) => (cause instanceof Error ? cause.messa
 const base64Url = (input: Buffer | string) =>
   (Buffer.isBuffer(input) === true ? input : Buffer.from(input)).toString('base64url')
 
+/** Failures while authenticating to, or reading, the live GitHub App definition. */
+class GitHubAppError extends Schema.TaggedErrorClass<GitHubAppError>()('GitHubAppError', {
+  message: Schema.String,
+  cause: Schema.optional(Schema.Defect()),
+}) {}
+
 /**
  * Mints a short-lived GitHub App JWT (RS256) to authenticate `GET /app`.
  * `iat` is backdated 60s to tolerate clock skew; GitHub rejects `exp` beyond 10 minutes.
@@ -326,13 +332,15 @@ const mintAppJwt = ({ appId, privateKeyPem }: { appId: string; privateKeyPem: st
   Effect.try({
     try: () => {
       const nowSec = Math.floor(Date.now() / 1000)
+      // @effect-diagnostics-next-line preferSchemaOverJson:off -- JWT (RFC 7519) header is signed as canonical compact JSON; a Schema codec adds no safety for this fixed literal
       const header = base64Url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+      // @effect-diagnostics-next-line preferSchemaOverJson:off -- JWT (RFC 7519) claims are signed as canonical compact JSON; a Schema codec adds no safety for this fixed literal
       const payload = base64Url(JSON.stringify({ iat: nowSec - 60, exp: nowSec + 540, iss: appId }))
       const signer = crypto.createSign('RSA-SHA256')
       signer.update(`${header}.${payload}`)
       return `${header}.${payload}.${base64Url(signer.sign(privateKeyPem))}`
     },
-    catch: (cause) => new Error(`Failed to mint App JWT: ${toErrorMessage(cause)}`),
+    catch: (cause) => new GitHubAppError({ message: 'Failed to mint App JWT', cause }),
   })
 
 const fetchLiveApp = (jwt: string) =>
@@ -347,11 +355,11 @@ const fetchLiveApp = (jwt: string) =>
         },
       })
       if (response.ok === false) {
-        throw new Error(`GET /app failed: ${response.status} ${await response.text()}`)
+        throw new GitHubAppError({ message: `GET /app failed: ${response.status} ${await response.text()}` })
       }
       return (await response.json()) as unknown
     },
-    catch: (cause) => new Error(toErrorMessage(cause)),
+    catch: (cause) => (cause instanceof GitHubAppError ? cause : new GitHubAppError({ message: toErrorMessage(cause), cause })),
   })
 
 /** Compares the manifest's requested permissions/events against the live App definition. */

--- a/scripts/src/commands/github.ts
+++ b/scripts/src/commands/github.ts
@@ -359,7 +359,8 @@ const fetchLiveApp = (jwt: string) =>
       }
       return (await response.json()) as unknown
     },
-    catch: (cause) => (cause instanceof GitHubAppError ? cause : new GitHubAppError({ message: toErrorMessage(cause), cause })),
+    catch: (cause) =>
+      cause instanceof GitHubAppError ? cause : new GitHubAppError({ message: toErrorMessage(cause), cause }),
   })
 
 /** Compares the manifest's requested permissions/events against the live App definition. */

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -194,8 +194,8 @@ const writeReleasePlan = (cwd: string, plan: TReleasePlan) =>
     yield* validateReleasePlan(plan)
     const fsEffect = yield* FileSystem.FileSystem
     yield* fsEffect.makeDirectory(`${cwd}/release`, { recursive: true })
-    // @effect-diagnostics-next-line preferSchemaOverJson:off -- persisted release plan is read back and human-inspected in CI; keep it indented (Schema's JSON codec emits compact output)
-    yield* fsEffect.writeFileString(releasePlanPath(cwd), `${JSON.stringify(plan, null, 2)}\n`)
+    const encodedPlan = yield* Schema.encodeEffect(Schema.jsonStringIndented(ReleasePlan))(plan).pipe(Effect.orDie)
+    yield* fsEffect.writeFileString(releasePlanPath(cwd), `${encodedPlan}\n`)
   })
 
 /**
@@ -282,8 +282,10 @@ export const rewriteSnapshotInternalDependencyRanges = ({
 
       if (rewriteCount === 0) continue
 
-      // @effect-diagnostics-next-line preferSchemaOverJson:off -- package.json must stay indented (published + diff-friendly); Schema's JSON codec is compact
-      yield* fsEffect.writeFileString(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
+      const encodedPackageJson = yield* Schema.encodeEffect(Schema.jsonStringIndented(Schema.Unknown))(
+        packageJson,
+      ).pipe(Effect.orDie)
+      yield* fsEffect.writeFileString(packageJsonPath, `${encodedPackageJson}\n`)
       yield* Effect.log(`Pinned ${rewriteCount} internal snapshot dependency range(s) in ${packageName}`)
     }
   })

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -194,9 +194,7 @@ const writeReleasePlan = (cwd: string, plan: TReleasePlan) =>
     yield* validateReleasePlan(plan)
     const fsEffect = yield* FileSystem.FileSystem
     yield* fsEffect.makeDirectory(`${cwd}/release`, { recursive: true })
-    // The persisted release plan is read back and human-inspected in CI, so keep it indented.
-    // Schema's JSON codec emits compact output, which is why this stays on `JSON.stringify`.
-    // @effect-diagnostics-next-line preferSchemaOverJson:off
+    // @effect-diagnostics-next-line preferSchemaOverJson:off -- persisted release plan is read back and human-inspected in CI; keep it indented (Schema's JSON codec emits compact output)
     yield* fsEffect.writeFileString(releasePlanPath(cwd), `${JSON.stringify(plan, null, 2)}\n`)
   })
 
@@ -284,8 +282,7 @@ export const rewriteSnapshotInternalDependencyRanges = ({
 
       if (rewriteCount === 0) continue
 
-      // package.json must stay indented (published + diff-friendly); Schema's JSON codec is compact.
-      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      // @effect-diagnostics-next-line preferSchemaOverJson:off -- package.json must stay indented (published + diff-friendly); Schema's JSON codec is compact
       yield* fsEffect.writeFileString(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
       yield* Effect.log(`Pinned ${rewriteCount} internal snapshot dependency range(s) in ${packageName}`)
     }

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -21,6 +21,14 @@ class PackageJsonParseError extends Schema.TaggedErrorClass<PackageJsonParseErro
   cause: Schema.Defect(),
 }) {}
 
+/** Expected failures in the release/publish flow (validation, packing, npm state). */
+class ReleaseError extends Schema.TaggedErrorClass<ReleaseError>()('ReleaseError', {
+  message: Schema.String,
+}) {}
+
+/** Module-scoped JSON decoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
+
 type TDependencyField = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies'
 
 type TMutablePackageJson = {
@@ -54,9 +62,11 @@ const validateReleaseVersion = (version: string) =>
   Effect.sync(() => semver.valid(version)).pipe(
     Effect.flatMap((validVersion) =>
       validVersion === null
-        ? Effect.fail(new Error(`Invalid npm semver version: ${version}`))
+        ? Effect.fail(new ReleaseError({ message: `Invalid npm semver version: ${version}` }))
         : version.includes('-snapshot-') === true
-          ? Effect.fail(new Error(`Stable release versions must not use snapshot versions: ${version}`))
+          ? Effect.fail(
+              new ReleaseError({ message: `Stable release versions must not use snapshot versions: ${version}` }),
+            )
           : Effect.succeed(validVersion),
     ),
   )
@@ -174,7 +184,7 @@ const readReleasePlan = (cwd: string, planPath: string) =>
     const fsEffect = yield* FileSystem.FileSystem
     const absolutePlanPath = planPath.startsWith('/') === true ? planPath : `${cwd}/${planPath}`
     const content = yield* fsEffect.readFileString(absolutePlanPath)
-    const plan = yield* Schema.decodeUnknownEffect(ReleasePlan)(JSON.parse(content))
+    const plan = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(ReleasePlan))(content)
     yield* validateReleasePlan(plan)
     return plan
   })
@@ -184,6 +194,9 @@ const writeReleasePlan = (cwd: string, plan: TReleasePlan) =>
     yield* validateReleasePlan(plan)
     const fsEffect = yield* FileSystem.FileSystem
     yield* fsEffect.makeDirectory(`${cwd}/release`, { recursive: true })
+    // The persisted release plan is read back and human-inspected in CI, so keep it indented.
+    // Schema's JSON codec emits compact output, which is why this stays on `JSON.stringify`.
+    // @effect-diagnostics-next-line preferSchemaOverJson:off
     yield* fsEffect.writeFileString(releasePlanPath(cwd), `${JSON.stringify(plan, null, 2)}\n`)
   })
 
@@ -242,7 +255,7 @@ export const rewriteSnapshotInternalDependencyRanges = ({
       const packageJson = yield* fsEffect.readFileString(packageJsonPath).pipe(
         Effect.flatMap((content) =>
           Effect.try({
-            try: () => JSON.parse(content) as TMutablePackageJson,
+            try: () => jsonParse(content) as TMutablePackageJson,
             catch: (cause) => new PackageJsonParseError({ message: `Failed to parse ${packageJsonPath}`, cause }),
           }),
         ),
@@ -271,6 +284,8 @@ export const rewriteSnapshotInternalDependencyRanges = ({
 
       if (rewriteCount === 0) continue
 
+      // package.json must stay indented (published + diff-friendly); Schema's JSON codec is compact.
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
       yield* fsEffect.writeFileString(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
       yield* Effect.log(`Pinned ${rewriteCount} internal snapshot dependency range(s) in ${packageName}`)
     }
@@ -287,7 +302,7 @@ const listSnapshotPackages = (cwd: string) =>
     const topology = yield* fsEffect.readFileString(`${cwd}/scripts/src/generated/release-topology.json`).pipe(
       Effect.flatMap((content) =>
         Effect.try({
-          try: () => JSON.parse(content) as TReleaseTopology,
+          try: () => jsonParse(content) as TReleaseTopology,
           catch: (cause) =>
             new PackageJsonParseError({
               message: 'Failed to parse scripts/src/generated/release-topology.json',
@@ -307,7 +322,7 @@ const listSnapshotPackages = (cwd: string) =>
       const pkgResult = yield* fsEffect.readFileString(packageJsonPath).pipe(
         Effect.flatMap((content) =>
           Effect.try({
-            try: () => JSON.parse(content) as { name?: unknown; private?: unknown },
+            try: () => jsonParse(content) as { name?: unknown; private?: unknown },
             catch: (cause) => new PackageJsonParseError({ message: `Failed to parse ${packageJsonPath}`, cause }),
           }),
         ),
@@ -409,9 +424,9 @@ const packPackageForPublish = ({ cwd, pkg, version }: { cwd: string; pkg: string
 
     const tarballs = (yield* fsEffect.readDirectory(packDir)).filter((entry) => entry.endsWith('.tgz'))
     if (tarballs.length !== 1) {
-      return yield* Effect.fail(
-        new Error(`Expected exactly one packed tarball for ${pkg}@${version}, found ${tarballs.length}`),
-      )
+      return yield* new ReleaseError({
+        message: `Expected exactly one packed tarball for ${pkg}@${version}, found ${tarballs.length}`,
+      })
     }
 
     return `${packDir}/${tarballs[0]}`
@@ -468,7 +483,7 @@ const publishReleasePackages = ({
 
       if (alreadyPublished === true) {
         if (dryRun === true || allowExisting === false) {
-          return yield* Effect.fail(new Error(`${pkg}@${version} already exists on npm`))
+          return yield* new ReleaseError({ message: `${pkg}@${version} already exists on npm` })
         }
 
         yield* Effect.log(`${pkg}@${version} already published, skipping`)

--- a/scripts/src/commands/update-deps.ts
+++ b/scripts/src/commands/update-deps.ts
@@ -285,9 +285,11 @@ const executeUpdates = (filteredUpdates: Record<string, Record<string, string>>,
             }
 
             // Write back to file with consistent formatting
+            const encodedPackageJson = yield* Schema.encodeEffect(Schema.jsonStringIndented(Schema.Unknown))(
+              updatedPackageJson,
+            ).pipe(Effect.orDie)
             yield* Effect.try({
-              // @effect-diagnostics-next-line preferSchemaOverJson:off -- package.json is committed and diffed, so it must stay indented; Schema's JSON codec is compact
-              try: () => fs.writeFileSync(packageJsonPath, `${JSON.stringify(updatedPackageJson, null, 2)}\n`),
+              try: () => fs.writeFileSync(packageJsonPath, `${encodedPackageJson}\n`),
               catch: () => new UpdateDepsError({ message: `Failed to write ${packageJsonPath}` }),
             })
 

--- a/scripts/src/commands/update-deps.ts
+++ b/scripts/src/commands/update-deps.ts
@@ -286,6 +286,8 @@ const executeUpdates = (filteredUpdates: Record<string, Record<string, string>>,
 
             // Write back to file with consistent formatting
             yield* Effect.try({
+              // package.json is committed and diffed, so it must stay indented; Schema's JSON codec is compact.
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
               try: () => fs.writeFileSync(packageJsonPath, `${JSON.stringify(updatedPackageJson, null, 2)}\n`),
               catch: () => new UpdateDepsError({ message: `Failed to write ${packageJsonPath}` }),
             })

--- a/scripts/src/commands/update-deps.ts
+++ b/scripts/src/commands/update-deps.ts
@@ -286,8 +286,7 @@ const executeUpdates = (filteredUpdates: Record<string, Record<string, string>>,
 
             // Write back to file with consistent formatting
             yield* Effect.try({
-              // package.json is committed and diffed, so it must stay indented; Schema's JSON codec is compact.
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              // @effect-diagnostics-next-line preferSchemaOverJson:off -- package.json is committed and diffed, so it must stay indented; Schema's JSON codec is compact
               try: () => fs.writeFileSync(packageJsonPath, `${JSON.stringify(updatedPackageJson, null, 2)}\n`),
               catch: () => new UpdateDepsError({ message: `Failed to write ${packageJsonPath}` }),
             })

--- a/scripts/src/shared/workflow-report.ts
+++ b/scripts/src/shared/workflow-report.ts
@@ -1,4 +1,4 @@
-import { Effect, FileSystem } from '@livestore/utils/effect'
+import { Effect, FileSystem, Schema } from '@livestore/utils/effect'
 
 /**
  * Marker prefix recognized by effect-utils' workflow-reporting collector.
@@ -6,6 +6,9 @@ import { Effect, FileSystem } from '@livestore/utils/effect'
  * `@overeng/genie/runtime/workflow-reporting/mod.ts`.
  */
 export const workflowReportRecordLineMarker = 'WORKFLOW_REPORT_V1: '
+
+/** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonStringify = Schema.encodeSync(Schema.UnknownFromJsonString)
 
 /**
  * Schema-compatible shape for a single record. We intentionally keep this as a
@@ -39,7 +42,7 @@ export interface WorkflowReportRecord {
  */
 export const emitWorkflowReportRecord = (record: WorkflowReportRecord) =>
   Effect.gen(function* () {
-    const line = `${workflowReportRecordLineMarker}${JSON.stringify(record)}`
+    const line = `${workflowReportRecordLineMarker}${jsonStringify(record)}`
     console.log(line)
 
     const outputPath = process.env.WORKFLOW_REPORT_OUTPUT_FILE

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -6,8 +6,13 @@ import { expect } from 'vitest'
 import { BrowserContext, browserContextLayer } from '@livestore/effect-playwright'
 import { CurrentWorkingDirectory, cmd } from '@livestore/utils-dev/node'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Duration, Effect, FetchHttpClient, HttpClient, Layer, Schedule } from '@livestore/utils/effect'
+import { Duration, Effect, FetchHttpClient, HttpClient, Layer, Schedule, Schema } from '@livestore/utils/effect'
 import { getFreePort, PlatformNode } from '@livestore/utils/node'
+
+/** The dev server did not become reachable within the readiness retry budget. */
+class DevServerNotReadyError extends Schema.TaggedErrorClass<DevServerNotReadyError>()('DevServerNotReadyError', {
+  cause: Schema.Defect(),
+}) {}
 
 const testDir = path.dirname(fileURLToPath(import.meta.url))
 const integrationRoot = path.resolve(testDir, '../../..')
@@ -54,7 +59,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
       const httpClient = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
       yield* httpClient.head(appUrl('/')).pipe(
         Effect.retry(Schedule.exponentialBackoff10Sec),
-        Effect.mapError((error) => new Error('Dev server did not start in time', { cause: error })),
+        Effect.mapError((error) => new DevServerNotReadyError({ cause: error })),
       )
 
       const { browserContext } = yield* BrowserContext
@@ -126,7 +131,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
       const httpClient = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
       yield* httpClient.head(appUrl('/')).pipe(
         Effect.retry(Schedule.exponentialBackoff10Sec),
-        Effect.mapError((error) => new Error('Dev server did not start in time', { cause: error })),
+        Effect.mapError((error) => new DevServerNotReadyError({ cause: error })),
       )
 
       const { browserContext } = yield* BrowserContext
@@ -188,7 +193,7 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
       const httpClient = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
       yield* httpClient.head(appUrl('/')).pipe(
         Effect.retry(Schedule.exponentialBackoff10Sec),
-        Effect.mapError((error) => new Error('Dev server did not start in time', { cause: error })),
+        Effect.mapError((error) => new DevServerNotReadyError({ cause: error })),
       )
 
       const { browserContext } = yield* BrowserContext

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -19,6 +19,7 @@ import {
   KeyValueStore,
   Layer,
   RpcServer,
+  Schema,
   Scope,
   Stream,
   SubscriptionRef,
@@ -29,6 +30,9 @@ import { DoRpcProxyRpcs } from './do-rpc-proxy-schema.ts'
 declare class Request extends CfDeclare.Request {}
 declare class Response extends CfDeclare.Response {}
 declare class WebSocketPair extends CfDeclare.WebSocketPair {}
+
+/** Module-scoped JSON decoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
+const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
 
 export interface Env {
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface>
@@ -77,7 +81,7 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
           capacity: Number.POSITIVE_INFINITY,
           lookup: (key: string) =>
             Effect.gen({ self: this }, function* () {
-              const { clientId, storeId, payload } = JSON.parse(key) as SyncBackendArgs
+              const { clientId, storeId, payload } = jsonParse(key) as SyncBackendArgs
 
               return yield* makeDoRpcSync({
                 syncBackendStub: this.env.SYNC_BACKEND_DO.get(this.env.SYNC_BACKEND_DO.idFromName(storeId)),


### PR DESCRIPTION
> ### 🔄 Rebased onto current `main` (2026-07-17)
>
> Originally branched before #1397 merged. This branch has been **rebased onto current `main`**: the 3 duplicated effect-utils-bump precursor commits (now carried by `main` as the #1397 squash) were dropped, so the diff is now **only** this slice's burndown changes (**18 files**) and no longer conflicts. The pre-rebase file/line counts quoted below are historical.
>
> **Verification is via CI on this branch.** The `type-check` job runs `devenv tasks run ts:build` → `tsgo --build` — the real Effect-LSP oracle (`tsc`/incremental `ts:check` do **not** run the plugin) — and `lint` (`lint:full:with-megarepo-check`) re-checks generated-file freshness.

## Problem

Part of the stacked Effect-LSP burndown for livestore. This PR clears the **"semantic" diagnostic cluster** (Schema-over-JSON + Effect error/context hygiene) at source, each site with per-site judgment and preserved behavior. Other PRs in the stack own `schemaNumber` / `duplicatePackage` / the mechanical bundle; a later **capstone PR removes the errors-only gate override** once all rules clear.

## Rules + counts cleared (38 total)

| Rule | Count | Approach |
|------|-------|----------|
| `preferSchemaOverJson` | 18 | `JSON.parse/stringify` → `Schema.UnknownFromJsonString` / `Schema.fromJsonString(schema)` via **module-scoped codec helpers** (keeps the sync codec out of Effect generators, so no `schemaSyncInEffect` regression). Pretty-printed persisted outputs keep `JSON.stringify(x, null, 2)` behind a justified `:off`. |
| `globalErrorInEffectFailure` | 7 | `new Error(...)` in the failure channel → `Data.TaggedError` types, original wrapped in `cause`. |
| `anyUnknownInErrorContext` | 8 | Justified per-site `:off` — **see design note below**. |
| `multipleEffectProvide` | 3 | Merged **adjacent** `Effect.provide` chains into `Layer.provideMerge(inner, outer)` (preserves feed order). Non-adjacent provides left intact. |
| `effectFnIife` | 1 | Immediately-invoked `Effect.fn` → `Effect.gen(...).pipe(Effect.withSpan(...))` (span preserved). |
| `effectFnOpportunity` | 1 | `makeWorkerRunnerOuter` rewritten as `Effect.fn(name)(function*…)`. |

## Tagged-error types introduced

- `ReleaseError` (`scripts/src/commands/release.ts`) — release/publish validation, packing, npm-state failures.
- `DevServerNotReadyError` (`tests/integration/.../adapter-web.test.ts`) — dev-server readiness timeout, carrying `cause`.

## ⚠️ Design note — `anyUnknownInErrorContext` cleared with **0 new tagged errors**

The task framing suggested `→ Data.TaggedError` for this rule, but per-site inspection shows **none of the 8 sites is tagged-error-shaped**, so all were cleared with justified `:off` (matching the file's existing `:off` precedent at `server.ts` 133/251):

- `do-rpc/server.ts` ×5 (88/98/147/169/253) — dynamic RPC codec erasure: `Schema.toCodecJson` over `Schema.Top` / dynamic payload schemas surfaces `unknown` in the **requirements** channel (provided at runtime via `provideContext`), or `any` from `Rpc.Handler` dynamic dispatch. `Data.TaggedError` categorically cannot address a requirements-channel `unknown`.
- `utils/src/effect/Subscribable.ts:49` — vendored fork; the shared prototype is generic over all `A, E, R`, so `unknown` is structural.
- `livestore/src/effect/LiveStore.test.ts` ×2 (32/39) — type-level regression test (#1103) that deliberately widens the error channel to `unknown` to assert only the **R** channel.

If a reviewer prefers a different treatment for any of these, happy to adjust — flagging explicitly since it deviates from the literal task.

## Other notes

- Consolidated a **pre-existing** misplaced `:off` in `do-rpc/server.ts` (cleared a stray `TS377000` "directive has no effect").
- `release.ts` read path: `JSON.parse(content)` → `Schema.decodeUnknownEffect(Schema.fromJsonString(ReleasePlan))` moves malformed-JSON failure from a thrown defect into the typed `ParseError` channel (arguably better; behavior on valid input unchanged).

## Validation

- `tsgo --build tsconfig.dev.json --force` (the real Effect-LSP oracle; `ts:check`/`tsc` do **not** run the plugin): all 6 assigned rules → **0**, **0 type errors**. No regressions — `schemaSyncInEffect` stays at 3, `unnecessaryFailYieldableError` stays at 1 (both pre-existing).
- `devenv tasks run check:quick` → **green** (ts:check + lint + megarepo checks).
- Behavior preserved: JSON round-trips (undefined-key drop) unchanged; pretty-printed persisted files keep indentation.

No ready-flip / auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### ➕ Added scope (2026-07-17): `github.ts` App-reconcile diagnostics from #1424

After the rebase onto current `main`, the full-strict gate (validated in the capstone #1410) surfaced **7 new diagnostics** that #1424 introduced in `scripts/src/commands/github.ts` — code that did not exist when this branch was first cut, so the original burndown never saw it. They fall squarely in this PR's rule scope, so they're cleared here:

- `globalErrorInEffectCatch` ×2 + `globalErrorInEffectFailure` ×3 → introduced a **`GitHubAppError`** tagged error (`Schema.TaggedErrorClass`, wrapping the original `cause`) across `mintAppJwt` / `fetchLiveApp`.
- `preferSchemaOverJson` ×2 → the two JWT `JSON.stringify` calls carry a justified `:off` — JWT (RFC 7519) header/claims are signed as canonical compact JSON, so a Schema codec adds no safety.

The error channel of `checkAppCommand` widens from global `Error` to `GitHubAppError`; nothing catches on the old type, so behavior is unchanged. Verified via #1410's full-gate `type-check`.
> **Reviewer note (operator-facing):** the `github app check` failure path now fails with `GitHubAppError({ message, cause })` instead of a flat `Error`. The original error detail moves from the message string into `cause`. No code catches on the old `Error` type, and there's no automated test for `github app check` (it needs `RECONCILE_APP_ID`/`RECONCILE_APP_PRIVATE_KEY`), so CI proved it compiles, not that the rendered CLI error text is byte-identical. Behavior is equivalent (arguably better — structured cause); flagging only so the changed error shape isn't a surprise.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌲 cl1-pine |
| `agent_session_id` | b9f1f4a5-dd10-40f6-b25c-945e71e2007a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.206 |
| `agent_runtime` | Claude Code 2.1.206 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-17-refactor |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->
