### PR TITLE
refactor(effect-lsp)!: adopt effect-utils full-strict Effect-LSP gate (remove errors-only override)

### DIFF
--- a/.changeset/empty-effect-lsp-full-strict-gate.md
+++ b/.changeset/empty-effect-lsp-full-strict-gate.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. CI-contract change (#811 capstone): remove LiveStore's temporary errors-only Effect-LSP override in `genie/repo.ts` so the inherited effect-utils `effectDiagnosticsGate` applies in full — Effect warnings AND suggestions (not just errors) now fail `tsgo --build`. Regenerates the 28 package tsconfigs to the full gate. Clears the diagnostics this surfaces: a `globalErrorInEffectFailure:off` on the synthetic shutdown-failure signal in the ClientSessionSyncProcessor test, and the snapshot-release validation/IO failures in `scripts/src/commands/release.ts` (from #1458) rerouted through the existing `ReleaseError` tagged error. Behavior-neutral.

--- a/docs/src/content/_assets/code/tsconfig.json
+++ b/docs/src/content/_assets/code/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -102,20 +102,17 @@ const {
 
 const baseTsconfigCompilerOptions = {
   ...baseTsconfigCompilerOptionsWithoutDefaults,
-  // LIVE-MIGRATION BRIDGE tsgo-strict-gate — DELETE at contraction — see live-migrations registry
-  // Advisory gate: Effect warnings and suggestions remain visible without failing the exit code.
+  // Full-strict Effect-LSP gate (#811 capstone): LiveStore inherits effect-utils' effectDiagnosticsGate
+  // unchanged — Effect warnings AND suggestions fail `tsgo --build`, not just errors. The advisory
+  // LIVE-MIGRATION BRIDGE that kept the gate errors-only during the burndown is intentionally removed.
   // LiveStore-specific: the internal @livestore/utils duplicate-package diagnostics are an
   // LSP workspace-resolution artifact (not real duplication), so they are allowed here.
   plugins: [
     {
       ...effectUtilsBaseTsconfigCompilerOptions.plugins[0],
-      ignoreEffectWarningsInTscExitCode: true,
-      ignoreEffectSuggestionsInTscExitCode: true,
-      ignoreEffectErrorsInTscExitCode: false,
       allowedDuplicatedPackages: ['@livestore/utils'],
     },
   ],
-  // LIVE-MIGRATION END tsgo-strict-gate
 } as const
 
 /**
@@ -355,7 +352,10 @@ const setupMegarepoRun = (run: string) =>
     ].join(' '),
   )
 
-const withNixRetry = <TStep extends { readonly name: string; readonly run: string }>(step: TStep, run = step.run): TStep => ({
+const withNixRetry = <TStep extends { readonly name: string; readonly run: string }>(
+  step: TStep,
+  run = step.run,
+): TStep => ({
   ...step,
   run: [
     `__genie_ci_retry_script='\${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'`,

--- a/packages/@livestore/adapter-cloudflare/tsconfig.json
+++ b/packages/@livestore/adapter-cloudflare/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/adapter-web/tsconfig.json
+++ b/packages/@livestore/adapter-web/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/common-cf/tsconfig.json
+++ b/packages/@livestore/common-cf/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/common/tsconfig.json
+++ b/packages/@livestore/common/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/effect-playwright/tsconfig.json
+++ b/packages/@livestore/effect-playwright/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/framework-toolkit/tsconfig.json
+++ b/packages/@livestore/framework-toolkit/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/livestore/tsconfig.json
+++ b/packages/@livestore/livestore/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/react/tsconfig.json
+++ b/packages/@livestore/react/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/sqlite-wasm/tsconfig.json
+++ b/packages/@livestore/sqlite-wasm/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/sync-cf/tsconfig.json
+++ b/packages/@livestore/sync-cf/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/utils-dev/tsconfig.json
+++ b/packages/@livestore/utils-dev/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/utils/tsconfig.json
+++ b/packages/@livestore/utils/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/wa-sqlite/tsconfig.json
+++ b/packages/@livestore/wa-sqlite/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@livestore/webmesh/tsconfig.json
+++ b/packages/@livestore/webmesh/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@local/astro-tldraw/tsconfig.json
+++ b/packages/@local/astro-tldraw/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/src/cli/test-fixtures/catalog/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@local/astro-twoslash-code/tsconfig.json
+++ b/packages/@local/astro-twoslash-code/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/packages/@local/shared/tsconfig.json
+++ b/packages/@local/shared/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -27,6 +27,7 @@ class PackageJsonParseError extends Schema.TaggedErrorClass<PackageJsonParseErro
 /** Expected failures in the release/publish flow (validation, packing, npm state). */
 class ReleaseError extends Schema.TaggedErrorClass<ReleaseError>()('ReleaseError', {
   message: Schema.String,
+  cause: Schema.optional(Schema.Defect()),
 }) {}
 
 /** Module-scoped JSON decoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
@@ -687,19 +688,19 @@ export const packSnapshot = Effect.fn(function* ({
   tscBin?: string
 }) {
   if (/^[0-9a-f]{40}$/.test(gitSha) === false) {
-    return yield* Effect.fail(
-      new Error(`Snapshot Git SHA must be exactly 40 lowercase hexadecimal characters: ${gitSha}`),
-    )
+    return yield* new ReleaseError({
+      message: `Snapshot Git SHA must be exactly 40 lowercase hexadecimal characters: ${gitSha}`,
+    })
   }
   if (Number.isSafeInteger(prNumber) === false || prNumber < 1) {
-    return yield* Effect.fail(new Error(`Snapshot PR number must be a positive integer: ${prNumber}`))
+    return yield* new ReleaseError({ message: `Snapshot PR number must be a positive integer: ${prNumber}` })
   }
 
   const version = `0.0.0-snapshot-pr.${prNumber}.${gitSha}`
   const packages = yield* listSnapshotPackages(cwd)
 
   if (packages.length === 0) {
-    return yield* Effect.fail(new Error('Snapshot package topology is empty'))
+    return yield* new ReleaseError({ message: 'Snapshot package topology is empty' })
   }
 
   yield* Effect.tryPromise({
@@ -707,7 +708,7 @@ export const packSnapshot = Effect.fn(function* ({
       await rm(outDir, { recursive: true, force: true })
       await mkdir(outDir, { recursive: true })
     },
-    catch: (cause) => new Error(`Failed to prepare snapshot artifact directory ${outDir}`, { cause }),
+    catch: (cause) => new ReleaseError({ message: `Failed to prepare snapshot artifact directory ${outDir}`, cause }),
   })
 
   const tarballs = yield* Effect.gen(function* () {
@@ -730,7 +731,7 @@ export const packSnapshot = Effect.fn(function* ({
         await copyFile(tarball, path.join(outDir, path.basename(tarball)))
       }
     },
-    catch: (cause) => new Error(`Failed to stage snapshot tarballs in ${outDir}`, { cause }),
+    catch: (cause) => new ReleaseError({ message: `Failed to stage snapshot tarballs in ${outDir}`, cause }),
   })
 
   yield* Effect.log(`Packed ${tarballs.length} package(s) as ${version} in ${outDir}`)

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -607,6 +607,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['blocked'])
       yield* Deferred.await(firstPushStarted)
 
+      // @effect-diagnostics-next-line globalErrorInEffectFailure:off -- test-only synthetic shutdown failure fed to Scope.close; a tagged error adds no value for this throwaway test signal
       yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)

--- a/tests/package-common/tsconfig.json
+++ b/tests/package-common/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/perf-eventlog/test-app/tsconfig.json
+++ b/tests/perf-eventlog/test-app/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/perf-eventlog/tsconfig.json
+++ b/tests/perf-eventlog/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/perf/tsconfig.json
+++ b/tests/perf/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/sync-provider/tsconfig.json
+++ b/tests/sync-provider/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,

--- a/tests/wa-sqlite/tsconfig.json
+++ b/tests/wa-sqlite/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "ignoreEffectWarningsInTscExitCode": true,
-        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "includeSuggestionsInTsc": true,
         "pipeableMinArgCount": 2,


### PR DESCRIPTION
> ### 🔄 Rebased onto current `main` (2026-07-17)
>
> Originally branched before #1397 merged. This branch has been **rebased onto current `main`**: the 3 duplicated effect-utils-bump precursor commits (now carried by `main` as the #1397 squash) were dropped, so the diff is now **only** this slice's burndown changes (**110 files**) and no longer conflicts. The pre-rebase file/line counts quoted below are historical.
>
> **Verification is via CI on this branch.** The `type-check` job runs `devenv tasks run ts:build` → `tsgo --build` — the real Effect-LSP oracle (`tsc`/incremental `ts:check` do **not** run the plugin) — and `lint` (`lint:full:with-megarepo-check`) re-checks generated-file freshness.
>
> **Merge order:** this capstone merges **last** (after #1407 → #1408 → #1409). It carries the union of all three slices' fixes **plus** the errors-only-override removal, so its `type-check` job runs under the **full** gate — that green check is the acceptance test for #1399. As the slices land, rebasing this branch onto `main` will shrink its diff toward just the override removal.

## Problem

The effect-utils bump adopted `@effect/language-service` with `effectDiagnosticsGate = { warnings: true, suggestions: true }`, which fails `tsgo --build` on every Effect **error, warning, and suggestion** — not just errors. That surfaced ~406 pre-existing advisory diagnostics across the LiveStore tree, so the bump PR (#1397) shipped a temporary **errors-only override** in `genie/repo.ts` (flipping `ignoreEffectWarningsInTscExitCode` / `ignoreEffectSuggestionsInTscExitCode` to `true`) to keep the tree green while the burndown landed separately.

## Approach

This is the **capstone** of the #811 Effect-LSP burndown. It:

1. **Integrates the three burndown branches** (each cleared one rule-group while the gate was still advisory):
   - **#1407 — mechanical**: `duplicatePackage` config (`allowedDuplicatedPackages: ['@livestore/utils']`) + 36 mechanical fixes (incl. `schemaSyncInEffect` → `encode*Effect` + `orDie`)
   - **#1408 — schema**: 149 `Schema.Number` → `Schema.Finite` (+ 1 justified `field-defs.ts:268` carve-out)
   - **#1409 — semantic**: 38 semantic fixes (`preferSchemaOverJson`, tagged-error hygiene) + justified `:off` for `anyUnknownInErrorContext`
2. **Removes the errors-only override** in `genie/repo.ts` so LiveStore inherits effect-utils' full `effectDiagnosticsGate` unchanged. The LiveStore-specific `allowedDuplicatedPackages: ['@livestore/utils']` is **folded into the base plugin config** so it survives the override removal (otherwise 183 `duplicatePackage` diagnostics would return).
3. **Regenerates all 28 package tsconfigs** via `genie:run` — every generated tsconfig now carries `ignoreEffectWarningsInTscExitCode: false` / `ignoreEffectSuggestionsInTscExitCode: false` (full gate) while keeping `allowedDuplicatedPackages`.

### Merge conflict resolution

Two `.test.ts` files were touched by both bd-mechanical and bd-semantic; both were resolved preserving **both** independent fixes (and validated by the now-fatal gate building clean):

- `packages/@livestore/common/src/sync/syncstate.test.ts` — kept mechanical's `yield* Schema.encodeUnknownEffect(...).pipe(Effect.orDie)` (schemaSyncInEffect) **and** semantic's `jsonParse(jsonStringify(...))` helper (preferSchemaOverJson).
- `packages/@local/astro-twoslash-code/src/cli/snippets.watch.test.ts` — kept mechanical's consolidated block-level `}).pipe(Effect.orDie)` **and** semantic's module-scoped `jsonStringify` helper.

## Acceptance test (the point of this PR)

With the override **removed** and the full gate active:

- `tsgo --build --force tsconfig.dev.json` → **builds all 32 projects, exits 0, zero Effect diagnostics**.
- `devenv tasks run ts:check` → **green (exit 0)**.
- `devenv tasks run check:quick` → **green (exit 0)**.

Every remaining Effect warning/suggestion is either fixed or carries a justified inline `:off`.

## Justified `:off` exemptions (reviewer audit)

Carried in from the burndown branches; all inline-annotated with rationale:

**`anyUnknownInErrorContext`** (#1409 — dynamic dispatch / vendored fork / regression tests):
- `packages/@livestore/common-cf/src/do-rpc/server.ts` — lines 88, 99, 135, 149, 172, 256 (`Schema.toCodecJson` on erased dynamic schemas / `Rpc.Handler.handler` dynamic dispatch; context provided at runtime)
- `packages/@livestore/livestore/src/effect/LiveStore.test.ts` — lines 32, 40 (regression test #1103 intentionally widens channels to `unknown`)
- `packages/@livestore/utils/src/effect/Subscribable.ts` — line 49 (vendored fork; `unknown` is structural over generic `A, E, R`)

**`schemaNumber`** (#1408 — SQLite REAL columns legitimately store Infinity/NaN):
- `packages/@livestore/common/src/schema/state/sqlite/db-schema/dsl/field-defs.ts` — line 268 (public DEFAULT codec must accept non-finite; `Schema.Finite` would wrongly reject)

**`preferSchemaOverJson`** (#1409 — committed/human-inspected JSON must stay indented; Schema's JSON codec emits compact):
- `scripts/src/commands/docs.ts` — line 708
- `scripts/src/commands/release.ts` — lines 188, 276
- `scripts/src/commands/update-deps.ts` — line 289

## Notes

- Breaking-change marker (`!`) reflects the CI-contract change: warnings/suggestions now gate the build.
- No `pnpm-lock.yaml` / `repos/` changes.
- Draft PR — no ready-flip / auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌲 cl1-pine |
| `agent_session_id` | b9f1f4a5-dd10-40f6-b25c-945e71e2007a |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.206 |
| `agent_runtime` | Claude Code 2.1.206 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-17-refactor |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->
