### PR TITLE
Harden sync durability across rebase, RPC, and shutdown

### DIFF
--- a/.changeset/fix-leader-push-shutdown-event-loss.md
+++ b/.changeset/fix-leader-push-shutdown-event-loss.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Fixed event loss on `store.shutdown()` when the leader runs in-process (for example the single-threaded node adapter). Shutting down could interrupt an in-flight leader push and drop events still queued for the leader. LiveStore now completes the in-flight push and flushes the remaining queued events before the client session sync processor tears down.

--- a/.changeset/harden-sync-shutdown-lifecycle.md
+++ b/.changeset/harden-sync-shutdown-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@livestore/common": patch
+"@livestore/livestore": patch
+---
+
+Hardened client-to-leader synchronization across rebases and shutdown. Leader pushes are now acknowledged only after durable processing, repeated rebase recovery preserves pending event order, and concurrent shutdown callers share one cleanup operation without cancelling cleanup after the wait timeout.

--- a/.changeset/harden-sync-shutdown-lifecycle.md
+++ b/.changeset/harden-sync-shutdown-lifecycle.md
@@ -1,6 +1,7 @@
 ---
 "@livestore/common": patch
 "@livestore/livestore": patch
+"@livestore/adapter-web": patch
 ---
 
-Hardened client-to-leader synchronization across rebases and shutdown. Leader pushes are now acknowledged only after durable processing, repeated rebase recovery preserves pending event order, and concurrent shutdown callers share one cleanup operation without cancelling cleanup after the wait timeout.
+Hardened client-to-leader synchronization across rebases, worker RPC boundaries, and shutdown. Leader pushes are now acknowledged only after durable processing, repeated rebase recovery preserves pending event order, worker failures remain scoped to their request, and concurrent shutdown callers share one cleanup operation without cancelling cleanup after the wait timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 > for more info. LiveStore is following a semver-like release strategy where
 > breaking changes are released in minor versions before the 1.0 release.
 
+## Upcoming
+
+See the [development documentation](https://dev.docs.livestore.dev/) for the latest features. To test the development build, keep all LiveStore packages on the `dev` tag:
+
+```bash
+pnpm add @livestore/livestore@dev @livestore/adapter-web@dev @livestore/wa-sqlite@dev @livestore/react@dev
+```
+
+### Bug Fixes
+
+- **Concurrency & Lifecycle:** Hardened client-to-leader event delivery across rebases and shutdown. Repeated recovery preserves pending event order, leader pushes acknowledge only committed work, and concurrent shutdown callers share one cleanup operation ([#1425](https://github.com/livestorejs/livestore/issues/1425)).
+
 ## 0.4.0 - 2026-06-02
 
 > **Installing v0.4.0:** Make sure all LiveStore packages use the same version:

--- a/packages/@livestore/adapter-web/src/web-worker/common/rpc-server-options.test.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/rpc-server-options.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from 'vitest'
+
+import { MaterializeError, SqliteError } from '@livestore/common'
+import {
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Rpc,
+  RpcClient,
+  RpcGroup,
+  RpcServer,
+  Schema,
+} from '@livestore/utils/effect'
+
+import { requestScopedCauseRpcServerOptions } from './rpc-server-options.ts'
+import { LeaderWorkerInnerPushToLeader } from './worker-schema.ts'
+
+class Push extends Rpc.make('Push', {
+  payload: { mode: Schema.Literals(['pure', 'mixed']) },
+  success: Schema.Void,
+  error: MaterializeError,
+}) {}
+
+class Ping extends Rpc.make('Ping', { success: Schema.Void }) {}
+
+class TestRpcs extends RpcGroup.make(Push, Ping) {}
+type TestRpc = RpcGroup.Rpcs<typeof TestRpcs>
+
+const materializeFailure = MaterializeError.make({
+  cause: SqliteError.make({ cause: new Error('materialization failed') }),
+})
+const companionDefect = new Error('companion defect')
+const mixedCause = Cause.fromReasons([Cause.makeFailReason(materializeFailure), Cause.makeDieReason(companionDefect)])
+
+const expectMaterializeCause = (exit: Exit.Exit<void, MaterializeError>, expectedMixed: boolean) => {
+  expect(Exit.isFailure(exit)).toBe(true)
+  if (Exit.isFailure(exit) === false) return
+
+  const failures = exit.cause.reasons.filter(Cause.isFailReason)
+  const defects = exit.cause.reasons.filter(Cause.isDieReason)
+  expect(failures.map((reason) => reason.error._tag)).toEqual(['MaterializeError'])
+  expect(defects.map((reason) => (reason.defect as Error).message)).toEqual(
+    expectedMixed === true ? ['companion defect'] : [],
+  )
+}
+
+const makeClient = Effect.fnUntraced(function* (handlers: {
+  readonly Push: (payload: typeof Push.payloadSchema.Type) => Effect.Effect<void, MaterializeError>
+  readonly Ping: () => Effect.Effect<void>
+}) {
+  // oxlint-disable-next-line prefer-const -- the server callback closes over the client initialized immediately below
+  let client!: Effect.Success<ReturnType<typeof RpcClient.makeNoSerialization<TestRpc, never>>>
+  const server = yield* RpcServer.makeNoSerialization(TestRpcs, {
+    ...requestScopedCauseRpcServerOptions,
+    onFromServer: (response) => client.write(response),
+  }).pipe(Effect.provide(TestRpcs.toLayer(handlers)))
+  client = yield* RpcClient.makeNoSerialization(TestRpcs, {
+    supportsAck: true,
+    onFromClient: ({ message }) => server.write(0, message),
+  })
+  return client.client
+})
+
+const runRequestRoutingProof = (hops: 1 | 2) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const releasePing = yield* Deferred.make<void>()
+      const innerClient = yield* makeClient({
+        Push: ({ mode }) => (mode === 'pure' ? Effect.fail(materializeFailure) : Effect.failCause(mixedCause)),
+        Ping: () => Deferred.await(releasePing),
+      })
+      const client =
+        hops === 1
+          ? innerClient
+          : yield* makeClient({
+              Push: (payload) => innerClient.Push(payload),
+              Ping: () => innerClient.Ping(undefined),
+            })
+
+      const pingFiber = yield* client.Ping(undefined).pipe(Effect.forkChild)
+      expectMaterializeCause(yield* client.Push({ mode: 'pure' }).pipe(Effect.exit), false)
+      expectMaterializeCause(yield* client.Push({ mode: 'mixed' }).pipe(Effect.exit), true)
+
+      // A handler defect belongs to its request and must not poison unrelated in-flight requests on either hop.
+      expect(pingFiber.pollUnsafe()).toBeUndefined()
+      yield* Deferred.succeed(releasePing, undefined)
+      expect(Exit.isSuccess(yield* Fiber.await(pingFiber))).toBe(true)
+    }),
+  )
+
+test('keeps pure and mixed materialization causes request-scoped across one RPC hop', async () => {
+  await Effect.runPromise(runRequestRoutingProof(1))
+})
+
+test('keeps pure and mixed materialization causes request-scoped across two RPC hops', async () => {
+  await Effect.runPromise(runRequestRoutingProof(2))
+})
+
+test('round-trips a mixed PushToLeader cause through its JSON wire schema', async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const exitSchema = Schema.toCodecJson(Rpc.exitSchema(LeaderWorkerInnerPushToLeader))
+      const encoded = yield* Schema.encodeUnknownEffect(exitSchema)(Exit.failCause(mixedCause))
+      const decoded = yield* Schema.decodeUnknownEffect(exitSchema)(encoded)
+
+      expect(Exit.isFailure(decoded)).toBe(true)
+      if (Exit.isFailure(decoded) === false) return
+      const failures = decoded.cause.reasons.filter(Cause.isFailReason)
+      const defects = decoded.cause.reasons.filter(Cause.isDieReason)
+      expect(failures.map((reason) => reason.error._tag)).toEqual(['MaterializeError'])
+      expect(defects.map((reason) => (reason.defect as Error).message)).toEqual(['companion defect'])
+    }),
+  )
+})

--- a/packages/@livestore/adapter-web/src/web-worker/common/rpc-server-options.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/rpc-server-options.ts
@@ -1,0 +1,10 @@
+/**
+ * Worker handlers share a trusted, same-origin boundary with their clients. Keeping handler defects request-scoped
+ * lets RPC encode the complete `Cause` (including mixed typed failures and defects) instead of broadcasting one
+ * squashed defect and cancelling every in-flight request on the connection.
+ *
+ * Protocol and decoding failures remain protocol failures; this only changes how completed handler causes are sent.
+ */
+export const requestScopedCauseRpcServerOptions = {
+  disableFatalDefects: true,
+} as const

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -2,6 +2,7 @@ import {
   BootStatus,
   Devtools,
   liveStoreVersion,
+  MaterializeError,
   MigrationsReport,
   RejectedPushError,
   SyncBackend,
@@ -79,7 +80,7 @@ export class LeaderWorkerInnerPushToLeader extends Rpc.make('PushToLeader', {
     batch: Schema.Array(Schema.toType(LiveStoreEvent.Client.Encoded)),
   },
   success: Schema.Void,
-  error: RejectedPushError,
+  error: Schema.Union([RejectedPushError, MaterializeError]),
 }) {}
 
 export class LeaderWorkerInnerPullStream extends Rpc.make('PullStream', {

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -36,6 +36,7 @@ import { BrowserWorkerRunner, Opfs, WebError } from '@livestore/utils/effect/bro
 import * as WebmeshWorker from '@livestore/webmesh/worker'
 
 import { cleanupOldStateDbFiles, getStateDbFileName, sanitizeOpfsDir } from '../common/persisted-sqlite.ts'
+import { requestScopedCauseRpcServerOptions } from '../common/rpc-server-options.ts'
 import { makeShutdownChannel } from '../common/shutdown-channel.ts'
 import * as WorkerSchema from '../common/worker-schema.ts'
 
@@ -102,7 +103,7 @@ const makeWorkerRunnerOuter = (workerOptions: WorkerOptions) =>
       clientId,
     } = yield* RpcWorker.initialMessage(WorkerSchema.LeaderWorkerOuterInitialMessage.payloadSchema)
 
-    return yield* RpcServer.make(WorkerSchema.LeaderWorkerInnerRpcs).pipe(
+    return yield* RpcServer.make(WorkerSchema.LeaderWorkerInnerRpcs, requestScopedCauseRpcServerOptions).pipe(
       Effect.provide(makeWorkerRunnerInner(workerOptions)),
       Effect.provide(makeMessagePortRpcServerProtocol(incomingRequestsPort)),
       Effect.withSpan('@livestore/adapter-web:worker:wrapper:InitialMessage:innerFiber'),

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -22,6 +22,7 @@ import {
 import { BrowserWorker, BrowserWorkerRunner } from '@livestore/utils/effect/browser'
 import * as WebmeshWorker from '@livestore/webmesh/worker'
 
+import { requestScopedCauseRpcServerOptions } from '../common/rpc-server-options.ts'
 import { dieOnRpcClientError, dieOnRpcClientErrorStream, makeWebmeshWorkerProxy } from '../common/rpc-worker.ts'
 import { makeShutdownChannel } from '../common/shutdown-channel.ts'
 import { makeSharedWorkerNodeName } from '../common/webmesh-node-names.ts'
@@ -250,7 +251,7 @@ export const makeWorker = (options?: LogConfig.LoggerOptions): void => {
     WebmeshWorker.CacheService.layer({ nodeName: makeSharedWorkerNodeName({ storeId }) }),
   )
 
-  RpcServer.layer(WorkerSchema.SharedWorkerRpcs).pipe(
+  RpcServer.layer(WorkerSchema.SharedWorkerRpcs, requestScopedCauseRpcServerOptions).pipe(
     Layer.provide(WorkerSchema.SharedWorkerRpcs.toLayer(makeWorkerRunner)),
     Layer.provide(RpcServer.layerProtocolWorkerRunner),
     Layer.provide(BrowserWorkerRunner.layer),

--- a/packages/@livestore/adapter-web/vitest.config.ts
+++ b/packages/@livestore/adapter-web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    name: '@livestore/adapter-web',
+    root: import.meta.dirname,
+    include: ['src/**/*.test.ts'],
+    server: { deps: { inline: ['@effect/vitest'] } },
+  },
+})

--- a/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
+++ b/packages/@livestore/common/src/ClientSessionLeaderThreadProxy.ts
@@ -3,6 +3,7 @@ import type { Effect, Stream, Subscribable } from '@livestore/utils/effect'
 import type { StorageMode } from './adapter-types.ts'
 import type { MigrationsReport } from './defs.ts'
 import type * as Devtools from './devtools/mod.ts'
+import type { MaterializeError } from './errors.ts'
 import type { RejectedPushError } from './leader-thread/RejectedPushError.ts'
 import type { StreamEventsOptions } from './leader-thread/types.ts'
 import type * as EventSequenceNumber from './schema/EventSequenceNumber/mod.ts'
@@ -16,7 +17,7 @@ export interface ClientSessionLeaderThreadProxy {
       cursor: EventSequenceNumber.Client.Composite
     }) => Stream.Stream<{ payload: typeof PayloadUpstream.Type }>
     /** It's important that a client session doesn't call `push` concurrently. */
-    push(batch: ReadonlyArray<LiveStoreEvent.Client.Encoded>): Effect.Effect<void, RejectedPushError>
+    push(batch: ReadonlyArray<LiveStoreEvent.Client.Encoded>): Effect.Effect<void, RejectedPushError | MaterializeError>
     /** Stream events with filtering */
     stream(options: StreamEventsOptions): Stream.Stream<LiveStoreEvent.Client.Encoded>
   }

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -25,6 +25,7 @@ import {
   Subscribable,
   SubscriptionRef,
   TxQueue,
+  TxRef,
 } from '@livestore/utils/effect'
 
 import { type MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
@@ -195,6 +196,8 @@ interface Options {
   readonly testing: {
     readonly delays?: {
       readonly localPushProcessing?: Effect.Effect<void>
+      readonly beforeLocalPushCommit?: Effect.Effect<void, MaterializeError>
+      readonly afterLocalPushOffer?: Effect.Effect<void>
     }
   }
 }
@@ -254,13 +257,56 @@ export const make = Effect.fnUntraced(function* ({
     pushHeadRef.current = EventSequenceNumber.Client.max(pushHeadRef.current, eventNum)
   }
 
+  let localPushTerminalCause: Cause.Cause<never> | undefined
+  const currentLocalPushBatch = yield* TxRef.make<ReadonlyArray<LocalPushQueueItem>>([])
+
+  const toLocalPushFatalCause = <E>(cause: Cause.Cause<E>): Cause.Cause<never> =>
+    Cause.fromReasons(
+      cause.reasons.map((reason) =>
+        Cause.isFailReason(reason) === true
+          ? Cause.makeDieReason(reason.error).annotate(Cause.reasonAnnotations(reason))
+          : reason,
+      ),
+    )
+
+  const completeLocalPushesWithCause = (items: ReadonlyArray<LocalPushQueueItem>, cause: Cause.Cause<never>) =>
+    Effect.forEach(items, ([, deferred]) => Deferred.complete(deferred, Effect.failCause(cause))).pipe(
+      Effect.uninterruptible,
+    )
+
+  const terminateLocalPushes = (cause: Cause.Cause<MaterializeError>) =>
+    Effect.gen(function* () {
+      const fatalCause = toLocalPushFatalCause(cause)
+      localPushTerminalCause = fatalCause
+
+      // Closing admission and taking ownership of every buffered item is one transaction. An offer either happens
+      // before this transaction and is drained here, or is rejected afterwards and observes `localPushTerminalCause`.
+      const ownedItems = yield* Effect.tx(
+        Effect.gen(function* () {
+          const currentItems = yield* TxRef.get(currentLocalPushBatch)
+          yield* TxRef.set(currentLocalPushBatch, [])
+          const queuedItems = yield* TxQueue.clear(localPushesQueue)
+          yield* TxQueue.failCause(localPushesQueue, fatalCause)
+          return [...currentItems, ...queuedItems]
+        }),
+      )
+
+      yield* completeLocalPushesWithCause(ownedItems, fatalCause)
+    }).pipe(Effect.uninterruptible)
+
   const backgroundApplyLocalPushes = Effect.gen(function* () {
     while (true) {
       if (testing.delays?.localPushProcessing !== undefined) {
         yield* testing.delays.localPushProcessing.pipe(Effect.withSpan('localPushProcessingDelay'))
       }
 
-      const batchItems = yield* TxQueue.takeBetween(localPushesQueue, 1, localPushBatchSize)
+      const batchItems = yield* Effect.tx(
+        Effect.gen(function* () {
+          const batchItems = yield* TxQueue.takeBetween(localPushesQueue, 1, localPushBatchSize)
+          yield* TxRef.set(currentLocalPushBatch, batchItems)
+          return batchItems
+        }),
+      )
 
       // Applies a batch of local pushes, guarded by the localPushBackendPullMutex to ensure mutual exclusion with backend pulling
       yield* Effect.gen(function* () {
@@ -372,27 +418,42 @@ export const make = Effect.fnUntraced(function* ({
           }
         }
 
-        yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
+        yield* Effect.gen(function* () {
+          // This is a successful adapter commit boundary, not a cross-database atomicity guarantee. Some adapters use
+          // distinct SQLite databases and Cloudflare auto-commits eventlog writes.
+          yield* materializeEventsBatch({
+            batchItems: mergeResult.newEvents,
+            ...(testing.delays?.beforeLocalPushCommit !== undefined
+              ? { beforeCommit: testing.delays.beforeLocalPushCommit }
+              : {}),
+          })
 
-        yield* connectedClientSessionPullQueues.offer({
-          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: mergeResult.newEvents }),
-          leaderHead: mergeResult.newSyncState.localHead,
-        })
+          // Publication and acknowledgement are bounded, in-memory operations.
+          yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
 
-        yield* Effect.spanEvent(`push:advance`, {
-          batchSize: newEvents.length,
-          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-        })
+          yield* connectedClientSessionPullQueues.offer({
+            payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: mergeResult.newEvents }),
+            leaderHead: mergeResult.newSyncState.localHead,
+          })
 
-        // Don't sync client-only events
-        const globalOrUnknownEvents = mergeResult.newEvents.filter((e) => !isClientOnlyEvent(e))
+          yield* Effect.spanEvent(`push:advance`, {
+            batchSize: newEvents.length,
+            ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+          })
 
-        yield* TxQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
+          // Don't sync client-only events
+          const globalOrUnknownEvents = mergeResult.newEvents.filter((e) => !isClientOnlyEvent(e))
+          yield* TxQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
 
-        yield* materializeEventsBatch({ batchItems: mergeResult.newEvents, deferreds })
+          // Caller acknowledgement is the final publication step.
+          yield* Effect.forEach(deferreds, (deferred) => Deferred.succeed(deferred, void 0))
+          yield* TxRef.set(currentLocalPushBatch, [])
+        }).pipe(Effect.uninterruptible)
       }).pipe(localPushBackendPullMutex.withPermits(1))
+
+      yield* TxRef.set(currentLocalPushBatch, [])
     }
-  })
+  }).pipe(Effect.tapCause(terminateLocalPushes))
 
   const backgroundBackendPulling = Effect.fn('@livestore/common:LeaderSyncProcessor:backend-pulling')(function* ({
     restartBackendPushing,
@@ -520,7 +581,7 @@ export const make = Effect.fnUntraced(function* ({
 
           advancePushHead(mergeResult.newSyncState.localHead)
 
-          yield* materializeEventsBatch({ batchItems: mergeResult.newEvents, deferreds: undefined })
+          yield* materializeEventsBatch({ batchItems: mergeResult.newEvents })
 
           yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
         }).pipe(Effect.exit)
@@ -641,6 +702,8 @@ export const make = Effect.fnUntraced(function* ({
     Effect.gen(function* () {
       if (newEvents.length === 0) return
 
+      if (localPushTerminalCause !== undefined) return yield* Effect.failCause(localPushTerminalCause)
+
       // console.debug('push', newEvents)
 
       yield* validatePushBatch(newEvents, pushHeadRef.current)
@@ -653,7 +716,16 @@ export const make = Effect.fnUntraced(function* ({
 
       const items = newEvents.map((eventEncoded, i) => [eventEncoded, deferreds[i]] as LocalPushQueueItem)
 
-      yield* TxQueue.offerAll(localPushesQueue, items)
+      const rejectedItems = yield* TxQueue.offerAll(localPushesQueue, items)
+      if (rejectedItems.length > 0) {
+        // A terminal race may advance pushHeadRef before admission closes. The worker is permanently stopped, so the
+        // head must not be rolled back and every subsequent push observes the same terminal cause.
+        return yield* Effect.failCause(
+          localPushTerminalCause ?? Cause.die(new Error('Local push worker stopped before accepting queued events')),
+        )
+      }
+
+      if (testing.delays?.afterLocalPushOffer !== undefined) yield* testing.delays.afterLocalPushOffer
 
       yield* Effect.all(deferreds.map(Deferred.await))
     }).pipe(
@@ -836,43 +908,37 @@ export const layer = (options: Options) => Layer.effect(LeaderSyncProcessor, mak
 
 type MaterializeEventsBatch = (_: {
   batchItems: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
-  /**
-   * The deferreds are used by the caller to know when the mutation has been processed.
-   * Indexes are aligned with `batchItems`
-   */
-  deferreds:
-    | ReadonlyArray<Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError> | undefined>
-    | undefined
+  /** Test-only barrier for exercising acknowledgement and publication around the commit boundary. */
+  beforeCommit?: Effect.Effect<void, MaterializeError>
 }) => Effect.Effect<void, MaterializeError, LeaderThreadCtx>
 
 // TODO how to handle errors gracefully
-const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds }) =>
+const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, beforeCommit }) =>
   Effect.gen(function* () {
     const { dbState: db, dbEventlog, materializeEvent } = yield* LeaderThreadCtx
 
     // NOTE We always start a transaction to ensure consistency between db and eventlog (even for single-item batches)
-    db.execute('BEGIN TRANSACTION', undefined) // Start the transaction
-    dbEventlog.execute('BEGIN TRANSACTION', undefined) // Start the transaction
-
     yield* Effect.addFinalizer((exit) =>
       Effect.gen(function* () {
         if (Exit.isSuccess(exit) === true) return
 
-        // Rollback in case of an error
-        db.execute('ROLLBACK', undefined)
-        dbEventlog.execute('ROLLBACK', undefined)
+        // Roll back each still-open transaction independently. In a two-database partial commit, rolling back the
+        // already-committed database can itself fail and must not replace the original processing cause.
+        yield* Effect.try(() => db.execute('ROLLBACK', undefined)).pipe(Effect.ignore)
+        yield* Effect.try(() => dbEventlog.execute('ROLLBACK', undefined)).pipe(Effect.ignore)
       }),
     )
+
+    db.execute('BEGIN TRANSACTION', undefined) // Start the transaction
+    dbEventlog.execute('BEGIN TRANSACTION', undefined) // Start the transaction
 
     for (let i = 0; i < batchItems.length; i++) {
       const { sessionChangeset, hash } = yield* materializeEvent(batchItems[i]!)
       batchItems[i]!.meta.sessionChangeset = sessionChangeset
       batchItems[i]!.meta.materializerHashLeader = hash
-
-      if (deferreds?.[i] !== undefined) {
-        yield* Deferred.succeed(deferreds[i]!, void 0)
-      }
     }
+
+    if (beforeCommit !== undefined) yield* beforeCommit
 
     db.execute('COMMIT', undefined) // Commit the transaction
     dbEventlog.execute('COMMIT', undefined) // Commit the transaction

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -107,14 +107,14 @@ export interface Service {
   readonly push: (
     /** `batch` needs to follow the same rules as `batch` in `SyncBackend.push` */
     batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
-  ) => Effect.Effect<void, RejectedPushError>
+  ) => Effect.Effect<void, RejectedPushError | MaterializeError>
 
   /** Currently only used by devtools which don't provide their own event numbers */
   readonly pushPartial: (args: {
     event: LiveStoreEvent.Input.Encoded
     clientId: string
     sessionId: string
-  }) => Effect.Effect<void, UnknownEventError>
+  }) => Effect.Effect<void, UnknownEventError | MaterializeError>
 
   readonly boot: Effect.Effect<
     { initialLeaderHead: EventSequenceNumber.Client.Composite },
@@ -237,9 +237,9 @@ export const make = Effect.fnUntraced(function* ({
 
   type LocalPushQueueItem = [
     event: LiveStoreEvent.Client.EncodedWithMeta,
-    deferred: Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError>,
+    deferred: Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError | MaterializeError>,
   ]
-  const localPushesQueue = yield* TxQueue.unbounded<LocalPushQueueItem>()
+  const localPushesQueue = yield* TxQueue.unbounded<LocalPushQueueItem, MaterializeError>()
   // Ensures mutual exclusion between local push and backend pull processing.
   const localPushBackendPullMutex = yield* Semaphore.make(1)
 
@@ -257,27 +257,20 @@ export const make = Effect.fnUntraced(function* ({
     pushHeadRef.current = EventSequenceNumber.Client.max(pushHeadRef.current, eventNum)
   }
 
-  let localPushTerminalCause: Cause.Cause<never> | undefined
+  let localPushTerminalCause: Cause.Cause<MaterializeError> | undefined
   const currentLocalPushBatch = yield* TxRef.make<ReadonlyArray<LocalPushQueueItem>>([])
 
-  const toLocalPushFatalCause = <E>(cause: Cause.Cause<E>): Cause.Cause<never> =>
-    Cause.fromReasons(
-      cause.reasons.map((reason) =>
-        Cause.isFailReason(reason) === true
-          ? Cause.makeDieReason(reason.error).annotate(Cause.reasonAnnotations(reason))
-          : reason,
-      ),
-    )
-
-  const completeLocalPushesWithCause = (items: ReadonlyArray<LocalPushQueueItem>, cause: Cause.Cause<never>) =>
+  const completeLocalPushesWithCause = (
+    items: ReadonlyArray<LocalPushQueueItem>,
+    cause: Cause.Cause<MaterializeError>,
+  ) =>
     Effect.forEach(items, ([, deferred]) => Deferred.complete(deferred, Effect.failCause(cause))).pipe(
       Effect.uninterruptible,
     )
 
   const terminateLocalPushes = (cause: Cause.Cause<MaterializeError>) =>
     Effect.gen(function* () {
-      const fatalCause = toLocalPushFatalCause(cause)
-      localPushTerminalCause = fatalCause
+      localPushTerminalCause = cause
 
       // Closing admission and taking ownership of every buffered item is one transaction. An offer either happens
       // before this transaction and is drained here, or is rejected afterwards and observes `localPushTerminalCause`.
@@ -286,12 +279,12 @@ export const make = Effect.fnUntraced(function* ({
           const currentItems = yield* TxRef.get(currentLocalPushBatch)
           yield* TxRef.set(currentLocalPushBatch, [])
           const queuedItems = yield* TxQueue.clear(localPushesQueue)
-          yield* TxQueue.failCause(localPushesQueue, fatalCause)
+          yield* TxQueue.failCause(localPushesQueue, cause)
           return [...currentItems, ...queuedItems]
         }),
       )
 
-      yield* completeLocalPushesWithCause(ownedItems, fatalCause)
+      yield* completeLocalPushesWithCause(ownedItems, cause)
     }).pipe(Effect.uninterruptible)
 
   const backgroundApplyLocalPushes = Effect.gen(function* () {
@@ -1188,7 +1181,7 @@ const clearLocalDatabases = ({ dbEventlog, dbState }: { dbEventlog: SqliteDb; db
     }
   })
 
-const snapshotTxQueue = <A>(queue: TxQueue.TxQueue<A>): Effect.Effect<ReadonlyArray<A>> =>
+const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<ReadonlyArray<A>, E> =>
   Effect.tx(
     Effect.gen(function* () {
       const items = yield* TxQueue.clear(queue)
@@ -1197,10 +1190,10 @@ const snapshotTxQueue = <A>(queue: TxQueue.TxQueue<A>): Effect.Effect<ReadonlyAr
     }),
   )
 
-const takePrefixUntil = <A>(
-  queue: TxQueue.TxQueue<A>,
+const takePrefixUntil = <A, E>(
+  queue: TxQueue.TxQueue<A, E>,
   predicate: (value: A) => boolean,
-): Effect.Effect<ReadonlyArray<A>> =>
+): Effect.Effect<ReadonlyArray<A>, E> =>
   Effect.tx(
     Effect.gen(function* () {
       const items = yield* TxQueue.clear(queue)

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -18,6 +18,7 @@ import {
 import {
   type BootStatus,
   type MakeSqliteDb,
+  type MaterializeError,
   type MaterializerHashMismatchError,
   type SqliteDb,
   UnknownError,
@@ -67,6 +68,8 @@ export interface MakeLeaderThreadLayerParams {
     syncProcessor?: {
       delays?: {
         localPushProcessing?: Effect.Effect<void>
+        beforeLocalPushCommit?: Effect.Effect<void, MaterializeError>
+        afterLocalPushOffer?: Effect.Effect<void>
       }
     }
   }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -125,6 +125,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   let terminalCause: Cause.Cause<never> | undefined
   let upstreamRevision = 0
   const closingStarted = yield* Deferred.make<void>()
+  const firstRejectionHandled = yield* Deferred.make<void>()
   const pullAdmissionClosed = yield* Deferred.make<void>()
   const beforePullHandoffDelay = params.simulation?.pull?.before_pull_handoff ?? 0
   const beforePullHandoffQueue =
@@ -253,6 +254,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
                   }
                 }
                 debugInfo.rejectCount++
+                yield* Deferred.succeed(firstRejectionHandled, undefined)
                 return false
               }),
             ),
@@ -614,6 +616,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         }).pipe(Effect.runSync),
       debugInfo: () => debugInfo,
       awaitClosing: Deferred.await(closingStarted),
+      awaitRejection: Deferred.await(firstRejectionHandled),
       awaitPullAdmissionClosed: Deferred.await(pullAdmissionClosed),
       awaitBeforePullHandoff: beforePullHandoffQueue === undefined ? Effect.never : Queue.take(beforePullHandoffQueue),
     },
@@ -654,6 +657,8 @@ export interface ClientSessionSyncProcessor {
     }
     /** Diagnostic synchronization point completed by the atomic graceful-close transition. */
     awaitClosing: Effect.Effect<void>
+    /** Diagnostic synchronization point completed after the first rejected response is handled. */
+    awaitRejection: Effect.Effect<void>
     /** Diagnostic synchronization point completed when teardown stops admitting upstream payloads. */
     awaitPullAdmissionClosed: Effect.Effect<void>
     /** Diagnostic synchronization point completed immediately before each simulated pull handoff. */

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -122,6 +122,28 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       )
     }
 
+    // Register this before the pushing fiber's finalizer so scope teardown first interrupts and awaits the
+    // fiber (including an uninterruptible in-flight push), then flushes queued events without concurrent pushes.
+    // The leader belongs to the surrounding client-session scope and remains available throughout this teardown.
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        const remaining = yield* TxQueue.clear(leaderPushQueue)
+
+        for (let offset = 0; offset < remaining.length; offset += params.leaderPushBatchSize) {
+          const batch = remaining.slice(offset, offset + params.leaderPushBatchSize)
+          const wasAccepted = yield* clientSession.leaderThread.events.push(batch).pipe(
+            Effect.as(true),
+            Effect.catchIf(isRejectedPushError, () => {
+              debugInfo.rejectCount++
+              return Effect.succeed(false)
+            }),
+          )
+
+          if (wasAccepted === false) break
+        }
+      }).pipe(Effect.uninterruptible),
+    )
+
     const leaderPushingFiberHandle = yield* FiberHandle.make()
 
     const backgroundLeaderPushing = Effect.gen(function* () {
@@ -144,19 +166,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
-
-    // On store shutdown the background pushing fiber is interrupted, which can leave events queued in
-    // `leaderPushQueue` that were never handed to the leader. Flush them here so they are still durably
-    // persisted. This finalizer is registered after the pushing fiber, so it runs before it during scope
-    // teardown, while the leader is still alive to accept and persist the batch.
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        const remaining = yield* TxQueue.clear(leaderPushQueue)
-        if (remaining.length > 0) {
-          yield* clientSession.leaderThread.events.push(remaining).pipe(Effect.catchCause(() => Effect.void))
-        }
-      }).pipe(Effect.uninterruptible),
-    )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -126,11 +126,15 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     const backgroundLeaderPushing = Effect.gen(function* () {
       const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
+      // The push must run uninterruptibly so a batch that has already been taken off the queue is fully
+      // persisted by the leader before this fiber is interrupted on store shutdown. Otherwise, with a
+      // co-located leader (e.g. the single-threaded node adapter), the in-flight batch is silently lost.
       yield* clientSession.leaderThread.events.push(batch).pipe(
         Effect.catchIf(isRejectedPushError, () => {
           debugInfo.rejectCount++
           return TxQueue.clear(leaderPushQueue)
         }),
+        Effect.uninterruptible,
       )
     }).pipe(
       Effect.forever,
@@ -140,6 +144,19 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+
+    // On store shutdown the background pushing fiber is interrupted, which can leave events queued in
+    // `leaderPushQueue` that were never handed to the leader. Flush them here so they are still durably
+    // persisted. This finalizer is registered after the pushing fiber, so it runs before it during scope
+    // teardown, while the leader is still alive to accept and persist the batch.
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        const remaining = yield* TxQueue.clear(leaderPushQueue)
+        if (remaining.length > 0) {
+          yield* clientSession.leaderThread.events.push(remaining).pipe(Effect.catchCause(() => Effect.void))
+        }
+      }).pipe(Effect.uninterruptible),
+    )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -12,6 +12,7 @@ import {
   Stream,
   Subscribable,
   TxQueue,
+  TxRef,
 } from '@livestore/utils/effect'
 
 import type { ClientSession } from '../adapter-types.ts'
@@ -102,6 +103,26 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
+  const leaderPushLifecycleState = yield* TxRef.make<LeaderPushLifecycleState>({
+    _tag: 'accepting',
+    activePushCount: 0,
+  })
+
+  const takeNextLeaderPushWorkerAction: Effect.Effect<LeaderPushWorkerAction> = Effect.tx(
+    Effect.gen(function* () {
+      if ((yield* TxQueue.isEmpty(leaderPushQueue)) === false) {
+        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
+        return { _tag: 'push' as const, batch }
+      }
+
+      const lifecycleState = yield* TxRef.get(leaderPushLifecycleState)
+      if (lifecycleState._tag === 'stopping' && lifecycleState.activePushCount === 0) {
+        return { _tag: 'stop' as const }
+      }
+
+      return yield* Effect.txRetry
+    }),
+  )
 
   const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
@@ -122,50 +143,53 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       )
     }
 
-    // Register this before the pushing fiber's finalizer so scope teardown first interrupts and awaits the
-    // fiber (including an uninterruptible in-flight push), then flushes queued events without concurrent pushes.
-    // The leader belongs to the surrounding client-session scope and remains available throughout this teardown.
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        const remaining = yield* TxQueue.clear(leaderPushQueue)
+    const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
 
-        for (let offset = 0; offset < remaining.length; offset += params.leaderPushBatchSize) {
-          const batch = remaining.slice(offset, offset + params.leaderPushBatchSize)
-          const wasAccepted = yield* clientSession.leaderThread.events.push(batch).pipe(
-            Effect.as(true),
-            Effect.catchIf(isRejectedPushError, () => {
-              debugInfo.rejectCount++
-              return Effect.succeed(false)
-            }),
-          )
+    const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
+      while (true) {
+        const action = yield* takeNextLeaderPushWorkerAction
+        if (action._tag === 'stop') return
 
-          if (wasAccepted === false) break
-        }
-      }).pipe(Effect.uninterruptible),
-    )
-
-    const leaderPushingFiberHandle = yield* FiberHandle.make()
-
-    const backgroundLeaderPushing = Effect.gen(function* () {
-      const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
-      // The push must run uninterruptibly so a batch that has already been taken off the queue is fully
-      // persisted by the leader before this fiber is interrupted on store shutdown. Otherwise, with a
-      // co-located leader (e.g. the single-threaded node adapter), the in-flight batch is silently lost.
-      yield* clientSession.leaderThread.events.push(batch).pipe(
-        Effect.catchIf(isRejectedPushError, () => {
-          debugInfo.rejectCount++
-          return TxQueue.clear(leaderPushQueue)
-        }),
-        Effect.uninterruptible,
-      )
+        yield* clientSession.leaderThread.events.push(action.batch).pipe(
+          Effect.catchIf(isRejectedPushError, () => {
+            debugInfo.rejectCount++
+            return TxQueue.clear(leaderPushQueue)
+          }),
+        )
+      }
     }).pipe(
-      Effect.forever,
       Effect.interruptible,
       Effect.tapCauseLogPretty,
-      Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
+      // The worker must exit before shutdown can await it, otherwise a fatal push creates a self-deadlock.
+      Effect.catchCause((cause) =>
+        clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid),
+      ),
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+
+    // Close admission and let the sole push worker drain every admitted event before it exits. This finalizer is
+    // registered after the FiberHandle so it runs first; once the worker exits, the handle finalizer has nothing
+    // left to interrupt. The pull fiber is registered later and therefore stops before this shutdown begins.
+    yield* Effect.addFinalizer((exit) =>
+      Effect.gen(function* () {
+        yield* Effect.tx(
+          TxRef.update(
+            leaderPushLifecycleState,
+            (state): LeaderPushLifecycleState => ({
+              _tag: 'stopping',
+              activePushCount: state.activePushCount,
+            }),
+          ),
+        )
+
+        // A healthy shutdown drains durably. On failure, the leader may already be unavailable or blocked in
+        // the failing push, so waiting would deadlock teardown and cannot provide a durability guarantee.
+        yield* Exit.isSuccess(exit) === true
+          ? FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+          : FiberHandle.clear(leaderPushingFiberHandle)
+      }).pipe(Effect.uninterruptible),
+    )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>
@@ -343,30 +367,56 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
     function* (encodedEvents) {
-      const mergeResult = yield* SyncState.merge({
-        syncState: syncStateRef.current,
-        payload: { _tag: 'local-push', newEvents: encodedEvents },
-        isClientOnlyEvent,
-        isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-      }).pipe(
-        Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
-          Effect.die(new Error('Expected advance from local-push merge')),
+      const wasAdmitted = yield* Effect.tx(
+        TxRef.modify(leaderPushLifecycleState, (state): [boolean, LeaderPushLifecycleState] =>
+          state._tag === 'accepting'
+            ? [true, { _tag: 'accepting', activePushCount: state.activePushCount + 1 }]
+            : [false, state],
         ),
       )
 
-      yield* Effect.annotateCurrentSpan({
-        batchSize: encodedEvents.length,
-        mergeResultTag: mergeResult._tag,
-        eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
-          acc[event.name] = (acc[event.name] ?? 0) + 1
-          return acc
-        }, {}),
-        ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-      })
+      if (wasAdmitted === false) {
+        return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
+      }
 
-      syncStateRef.current = mergeResult.newSyncState
-      yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-      yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      yield* Effect.gen(function* () {
+        const mergeResult = yield* SyncState.merge({
+          syncState: syncStateRef.current,
+          payload: { _tag: 'local-push', newEvents: encodedEvents },
+          isClientOnlyEvent,
+          isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+        }).pipe(
+          Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
+            Effect.die(new Error('Expected advance from local-push merge')),
+          ),
+        )
+
+        yield* Effect.annotateCurrentSpan({
+          batchSize: encodedEvents.length,
+          mergeResultTag: mergeResult._tag,
+          eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
+            acc[event.name] = (acc[event.name] ?? 0) + 1
+            return acc
+          }, {}),
+          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+        })
+
+        syncStateRef.current = mergeResult.newSyncState
+        yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+        yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      }).pipe(
+        Effect.ensuring(
+          Effect.tx(
+            TxRef.update(
+              leaderPushLifecycleState,
+              (state): LeaderPushLifecycleState => ({
+                ...state,
+                activePushCount: state.activePushCount - 1,
+              }),
+            ),
+          ),
+        ),
+      )
     },
   )
 
@@ -447,3 +497,11 @@ export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
   }),
 })
 type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type
+
+type LeaderPushLifecycleState =
+  | { readonly _tag: 'accepting'; readonly activePushCount: number }
+  | { readonly _tag: 'stopping'; readonly activePushCount: number }
+
+type LeaderPushWorkerAction =
+  | { readonly _tag: 'push'; readonly batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta> }
+  | { readonly _tag: 'stop' }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -17,7 +17,7 @@ import {
 
 import type { ClientSession } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
-import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
+import { isRejectedPushError, type RejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
@@ -124,6 +124,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     }
 
     const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
+    let drainRejection: RejectedPushError | undefined
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
@@ -133,9 +134,22 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         if (batch === undefined) return
 
         yield* clientSession.leaderThread.events.push(batch).pipe(
-          Effect.catchIf(isRejectedPushError, () => {
+          Effect.catchIf(isRejectedPushError, (error) => {
             debugInfo.rejectCount++
-            return TxQueue.clear(leaderPushQueue)
+            return Effect.gen(function* () {
+              const wasOpen = yield* Effect.tx(
+                Effect.gen(function* () {
+                  const wasOpen = yield* TxQueue.isOpen(leaderPushQueue)
+                  yield* TxQueue.clear(leaderPushQueue)
+                  return wasOpen
+                }),
+              )
+
+              // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
+              // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
+              // successful durable drain after discarding pending events.
+              if (wasOpen === false) drainRejection = error
+            })
           }),
         )
       }
@@ -158,6 +172,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         ? Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)
             yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+            if (drainRejection !== undefined) return yield* Effect.die(drainRejection)
           })
         : Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -2,6 +2,7 @@
 import { LS_DEV, TRACE_VERBOSE } from '@livestore/utils'
 import {
   Cause,
+  Deferred,
   Effect,
   Exit,
   Filter,
@@ -98,6 +99,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** Only used for debugging / observability / testing, it's not relied upon for correctness of the sync processor. */
   const syncStateUpdateQueue = yield* Queue.unbounded<SyncState.SyncState>()
+  const rejectionObserved = yield* Deferred.make<void>()
   const isClientOnlyEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
@@ -126,7 +128,13 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
     let drainFailure: Cause.Cause<never> | undefined
     let rejectionRevision = 0
-    let rejectionAwaitingPull: { readonly error: Error; readonly revision: number } | undefined
+    let rejectionAwaitingPull:
+      | {
+          readonly error: Error
+          readonly rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
+          readonly revision: number
+        }
+      | undefined
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
@@ -150,8 +158,10 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
               // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
               // successful durable drain after discarding pending events.
-              if (wasOpen === true) rejectionAwaitingPull = { error, revision: ++rejectionRevision }
-              else drainFailure = Cause.die(error)
+              if (wasOpen === true) {
+                rejectionAwaitingPull = { error, rejectedEvents: batch, revision: ++rejectionRevision }
+              } else drainFailure = Cause.die(error)
+              yield* Deferred.succeed(rejectionObserved, undefined)
             })
           }),
         )
@@ -283,9 +293,14 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (mergeResult.newEvents.length === 0) {
             // If there are no new events, we need to update the sync state as well
             yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-            // An advance only resolves a cleared transport queue when it confirms every canonical pending event.
-            // Otherwise keep the marker so shutdown cannot claim a durable drain for still-stranded pending events.
-            if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+            // Clear only when this pull confirms the rejected prefix. Newer pending events may already have been
+            // admitted successfully and must not keep an obsolete rejection marker alive.
+            if (
+              rejectionAtPullStart !== undefined &&
+              isRejectedBatchRecovered(rejectionAtPullStart.rejectedEvents, mergeResult.newSyncState.pending) ===
+                true &&
+              rejectionAwaitingPull === rejectionAtPullStart
+            ) {
               rejectionAwaitingPull = undefined
             }
             return
@@ -313,7 +328,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-          if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+          if (
+            rejectionAtPullStart !== undefined &&
+            isRejectedBatchRecovered(rejectionAtPullStart.rejectedEvents, mergeResult.newSyncState.pending) === true &&
+            rejectionAwaitingPull === rejectionAtPullStart
+          ) {
             rejectionAwaitingPull = undefined
           }
         }).pipe(
@@ -432,6 +451,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       changes: Stream.fromQueue(syncStateUpdateQueue),
     }),
     debug: {
+      awaitRejection: Deferred.await(rejectionObserved),
       print: () =>
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
@@ -462,6 +482,15 @@ const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<Read
     }),
   )
 
+const isRejectedBatchRecovered = (
+  rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+  pendingEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+): boolean =>
+  rejectedEvents.every(
+    (rejectedEvent) =>
+      pendingEvents.some((pendingEvent) => LiveStoreEvent.Client.isEqualEncoded(pendingEvent, rejectedEvent)) === false,
+  )
+
 export interface ClientSessionSyncProcessor {
   boot: Effect.Effect<void, never, Scope.Scope>
   encodeEvents: (
@@ -476,6 +505,8 @@ export interface ClientSessionSyncProcessor {
    */
   syncState: Subscribable.Subscribable<SyncState.SyncState>
   debug: {
+    /** Diagnostic/test barrier completed after the first rejected leader push updates coordinator state. */
+    awaitRejection: Effect.Effect<void>
     print: () => void
     debugInfo: () => {
       rebaseCount: number

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -178,11 +178,19 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       return true
     }
 
-    const terminate = (cause: Cause.Cause<never>, exit: Parameters<ClientSession['shutdown']>[0]) =>
+    const terminate = (cause: Cause.Cause<MaterializeError>, exit: Parameters<ClientSession['shutdown']>[0]) =>
       Effect.gen(function* () {
         const targetEpoch = yield* Effect.sync(() => {
           if (terminalCause !== undefined) return undefined
-          terminalCause = cause
+          // Scope finalizers have no typed error channel. Preserve the complete cause structure while the original
+          // typed cause is sent through ClientSession.shutdown below.
+          terminalCause = Cause.fromReasons(
+            cause.reasons.map((reason) =>
+              Cause.isFailReason(reason) === true
+                ? Cause.makeDieReason(reason.error).annotate(Cause.reasonAnnotations(reason))
+                : reason,
+            ),
+          )
           admissionOpen = false
           lifecycle = 'aborting'
           return currentEpoch
@@ -278,7 +286,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         ? pullCompletion === undefined
           ? Effect.void
           : Deferred.succeed(pullCompletion, undefined).pipe(Effect.asVoid)
-        : terminate(Cause.die(Cause.squash(cause)), Exit.failCause(cause)).pipe(
+        : terminate(cause, Exit.failCause(cause)).pipe(
             pullCompletion === undefined ? Effect.asVoid : Effect.andThen(Deferred.succeed(pullCompletion, undefined)),
           )
 

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -6,11 +6,11 @@ import {
   Effect,
   Exit,
   Filter,
-  FiberHandle,
+  Fiber,
   Option,
   Queue,
   Schema,
-  type Scope,
+  Scope,
   Stream,
   Subscribable,
   TxQueue,
@@ -82,11 +82,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 }): Effect.fn.Return<ClientSessionSyncProcessor> {
   const eventSchema = LiveStoreEvent.Client.makeSchemaMemo(schema)
 
-  const simSleep = <TKey extends keyof ClientSessionSyncProcessorSimulationParams>(
-    key: TKey,
-    key2: keyof ClientSessionSyncProcessorSimulationParams[TKey],
-  ) => Effect.sleep((params.simulation?.[key]?.[key2] ?? 0) as number)
-
   const syncStateRef = {
     // The initial state is identical to the leader's initial state
     current: new SyncState.SyncState({
@@ -99,12 +94,41 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** Only used for debugging / observability / testing, it's not relied upon for correctness of the sync processor. */
   const syncStateUpdateQueue = yield* Queue.unbounded<SyncState.SyncState>()
-  const rejectionObserved = yield* Deferred.make<void>()
   const isClientOnlyEvent = (eventEncoded: LiveStoreEvent.Client.EncodedWithMeta) =>
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
-  /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
-  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>()
+  type EpochResult = 'drained' | 'fatal' | { readonly _tag: 'replaced'; readonly successor: PushEpoch }
+  type PushEpoch = {
+    readonly queue: TxQueue.TxQueue<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>
+    readonly done: Deferred.Deferred<EpochResult>
+    pullCompletion: Deferred.Deferred<void>
+    pullAdmissionOpen: boolean
+    fiber?: Fiber.Fiber<void, never>
+    status: 'accepting' | 'awaiting-rebase'
+  }
+
+  const makePushEpoch = Effect.fnUntraced(function* (): Effect.fn.Return<PushEpoch> {
+    const pullCompletion = yield* Deferred.make<void>()
+    yield* Deferred.succeed(pullCompletion, undefined)
+    return {
+      queue: yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>(),
+      done: yield* Deferred.make<EpochResult>(),
+      pullCompletion,
+      pullAdmissionOpen: true,
+      status: 'accepting',
+    }
+  })
+
+  let currentEpoch = yield* makePushEpoch()
+  let lifecycle: 'open' | 'closing' | 'drained' | 'aborting' | 'closed' = 'open'
+  let admissionOpen = true
+  let terminalCause: Cause.Cause<never> | undefined
+  let upstreamRevision = 0
+  const closingStarted = yield* Deferred.make<void>()
+  const pullAdmissionClosed = yield* Deferred.make<void>()
+  const beforePullHandoffDelay = params.simulation?.pull?.before_pull_handoff ?? 0
+  const beforePullHandoffQueue =
+    SIMULATION_ENABLED === true && beforePullHandoffDelay > 0 ? yield* Queue.unbounded<void>() : undefined
 
   const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
@@ -125,161 +149,279 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       )
     }
 
-    const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
-    let drainFailure: Cause.Cause<never> | undefined
-    let rejectionRevision = 0
-    let rejectionAwaitingPull:
-      | {
-          readonly error: Error
-          readonly rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
-          readonly revision: number
-        }
-      | undefined
+    // Pull and push workers deliberately outlive the outer scope while a successful close drains. A rejected push
+    // needs the still-live pull stream to observe the leader head, rebase the canonical pending list, and retry it.
+    const runtimeScope = yield* Scope.make()
 
-    const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
-      while (true) {
-        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize).pipe(
-          Effect.catchIf(Cause.isDone, () => Effect.succeed(undefined)),
-        )
-        if (batch === undefined) return
+    const requestShutdown = (exit: Parameters<ClientSession['shutdown']>[0]) =>
+      clientSession.shutdown(exit).pipe(Effect.forkDetach, Effect.asVoid)
 
-        yield* clientSession.leaderThread.events.push(batch).pipe(
-          Effect.catchIf(isRejectedPushError, (error) => {
-            debugInfo.rejectCount++
-            return Effect.gen(function* () {
-              const wasOpen = yield* Effect.tx(
-                Effect.gen(function* () {
-                  const wasOpen = yield* TxQueue.isOpen(leaderPushQueue)
-                  yield* TxQueue.clear(leaderPushQueue)
-                  return wasOpen
-                }),
-              )
-
-              // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
-              // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
-              // successful durable drain after discarding pending events.
-              if (wasOpen === true) {
-                rejectionAwaitingPull = { error, rejectedEvents: batch, revision: ++rejectionRevision }
-              } else drainFailure = Cause.die(error)
-              yield* Deferred.succeed(rejectionObserved, undefined)
-            })
-          }),
-        )
+    /** Atomically transfers delivery ownership; canonical pending is the only source used to seed a successor. */
+    const installEpoch = (previousEpoch: PushEpoch, successorEpoch: PushEpoch): boolean => {
+      if (
+        terminalCause !== undefined ||
+        currentEpoch !== previousEpoch ||
+        lifecycle === 'drained' ||
+        lifecycle === 'aborting' ||
+        lifecycle === 'closed'
+      ) {
+        return false
       }
-    }).pipe(
-      Effect.interruptible,
-      Effect.tapCauseLogPretty,
-      // The worker must exit before shutdown can await it, otherwise a fatal push creates a self-deadlock.
-      Effect.catchCause((cause) =>
-        Cause.hasInterruptsOnly(cause) === true
-          ? Effect.void
-          : Effect.sync(() => {
-              drainFailure = cause
-            }).pipe(
-              Effect.andThen(clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid)),
+      // Delivery ownership includes the exact pull lease active on the previous generation. This matters both for
+      // pull-driven handoff and revision-mismatch recovery installed while that pull is still before its handoff.
+      successorEpoch.pullCompletion = previousEpoch.pullCompletion
+      currentEpoch = successorEpoch
+      const rejected = Effect.runSync(TxQueue.offerAll(successorEpoch.queue, syncStateRef.current.pending))
+      if (rejected.length > 0) throw new Error('Fresh leader push epoch rejected its initial pending events')
+      if (lifecycle === 'closing') Effect.runSync(TxQueue.end(successorEpoch.queue))
+      Effect.runSync(Deferred.succeed(previousEpoch.done, { _tag: 'replaced', successor: successorEpoch }))
+      return true
+    }
+
+    const terminate = (cause: Cause.Cause<never>, exit: Parameters<ClientSession['shutdown']>[0]) =>
+      Effect.gen(function* () {
+        const targetEpoch = yield* Effect.sync(() => {
+          if (terminalCause !== undefined) return undefined
+          terminalCause = cause
+          admissionOpen = false
+          lifecycle = 'aborting'
+          return currentEpoch
+        })
+        if (targetEpoch === undefined) return
+
+        // Fork the external shutdown before waking teardown through the epoch terminal result.
+        yield* requestShutdown(exit)
+        yield* Deferred.succeed(targetEpoch.done, 'fatal')
+      }).pipe(Effect.uninterruptible)
+
+    let startEpoch: (epoch: PushEpoch) => Effect.Effect<void>
+    const runEpoch = (epoch: PushEpoch): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        while (true) {
+          const batch = yield* TxQueue.takeBetween(epoch.queue, 1, params.leaderPushBatchSize).pipe(
+            Effect.catchIf(Cause.isDone, () => Effect.succeed(undefined)),
+          )
+          if (batch === undefined) {
+            while (true) {
+              const activePull = yield* Effect.sync(() => {
+                if (currentEpoch !== epoch || terminalCause !== undefined) return undefined
+                if (lifecycle === 'closing') {
+                  // Queue exhaustion is the pull cutoff for this epoch: an already-admitted pull may still hand off
+                  // to a successor, but an endlessly productive upstream cannot keep moving the drain barrier.
+                  epoch.pullAdmissionOpen = false
+                  Effect.runSync(Deferred.succeed(pullAdmissionClosed, undefined))
+                  if (Effect.runSync(Deferred.isDone(epoch.pullCompletion)) === false) return epoch.pullCompletion
+                  lifecycle = 'drained'
+                }
+                Effect.runSync(Deferred.succeed(epoch.done, 'drained'))
+                return undefined
+              })
+              if (activePull === undefined) break
+              yield* Deferred.await(activePull)
+            }
+            return
+          }
+
+          const attemptRevision = upstreamRevision
+          const accepted = yield* clientSession.leaderThread.events.push(batch).pipe(
+            Effect.as(true),
+            Effect.catchIf(isRejectedPushError, () =>
+              Effect.gen(function* () {
+                // A response from an epoch already replaced by pull must not clear or otherwise mutate its successor.
+                if (currentEpoch === epoch && lifecycle !== 'aborting' && lifecycle !== 'closed') {
+                  if (attemptRevision === upstreamRevision) {
+                    epoch.status = 'awaiting-rebase'
+                    yield* TxQueue.clear(epoch.queue)
+                  } else {
+                    // Pull already consumed the progress that explains this rejection. Rebuild immediately from the
+                    // latest canonical pending state instead of waiting forever for another upstream payload.
+                    const successorEpoch = yield* Effect.sync(() => {
+                      if (currentEpoch !== epoch || terminalCause !== undefined) return undefined
+                      epoch.status = 'awaiting-rebase'
+                      const successor = Effect.runSync(makePushEpoch())
+                      return installEpoch(epoch, successor) === true ? successor : undefined
+                    })
+                    if (successorEpoch !== undefined) yield* startEpoch(successorEpoch)
+                  }
+                }
+                debugInfo.rejectCount++
+                return false
+              }),
             ),
-      ),
-    )
+          )
+          if (accepted === false) return
+        }
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause) === true &&
+          (currentEpoch !== epoch || lifecycle === 'aborting' || lifecycle === 'closed')
+            ? Effect.void
+            : terminate(cause, Exit.failCause(cause)),
+        ),
+      )
 
-    yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+    startEpoch = (epoch) =>
+      Effect.gen(function* () {
+        epoch.fiber = yield* runEpoch(epoch).pipe(Effect.forkIn(runtimeScope))
+      })
 
-    // Register after the FiberHandle so the push worker drains first, but before pull so LIFO scope teardown stops
-    // pull before deciding whether a rejection was left without a recovery path.
+    const awaitGracefulDrain = Effect.fnUntraced(function* (epoch: PushEpoch): Effect.fn.Return<void> {
+      const result = yield* Deferred.await(epoch.done)
+      if (terminalCause !== undefined) return yield* Effect.failCause(terminalCause)
+      if (result === 'drained') return
+      if (result === 'fatal') return yield* Effect.die('Fatal epoch result published without its terminal cause')
+      yield* awaitGracefulDrain(result.successor)
+    })
+
+    const handlePullCause = (cause: Cause.Cause<MaterializeError>, pullCompletion?: Deferred.Deferred<void>) =>
+      Cause.hasInterruptsOnly(cause) === true && (lifecycle === 'aborting' || lifecycle === 'closed')
+        ? pullCompletion === undefined
+          ? Effect.void
+          : Deferred.succeed(pullCompletion, undefined).pipe(Effect.asVoid)
+        : terminate(Cause.die(Cause.squash(cause)), Exit.failCause(cause)).pipe(
+            pullCompletion === undefined ? Effect.asVoid : Effect.andThen(Deferred.succeed(pullCompletion, undefined)),
+          )
+
+    // Register ownership before starting either child so every boot exit closes the manually managed runtime scope.
     yield* Effect.addFinalizer((exit) =>
       Exit.isSuccess(exit) === true
         ? Effect.gen(function* () {
-            yield* TxQueue.end(leaderPushQueue)
-            yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
-            if (drainFailure !== undefined) return yield* Effect.failCause(drainFailure)
-            if (rejectionAwaitingPull !== undefined) return yield* Effect.die(rejectionAwaitingPull.error)
-          })
+            yield* Effect.sync(() => {
+              admissionOpen = false
+              lifecycle = 'closing'
+              Effect.runSync(Deferred.succeed(closingStarted, undefined))
+            })
+            if (terminalCause !== undefined) return yield* Effect.failCause(terminalCause)
+            yield* TxQueue.end(currentEpoch.queue)
+            yield* awaitGracefulDrain(currentEpoch)
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                lifecycle = 'closed'
+              }).pipe(Effect.andThen(Scope.close(runtimeScope, Exit.void))),
+            ),
+          )
         : Effect.gen(function* () {
-            yield* TxQueue.end(leaderPushQueue)
-            yield* FiberHandle.clear(leaderPushingFiberHandle)
+            yield* Effect.sync(() => {
+              admissionOpen = false
+              lifecycle = 'aborting'
+            })
+            if (currentEpoch.fiber !== undefined) yield* Fiber.interrupt(currentEpoch.fiber)
+            yield* Scope.close(runtimeScope, exit)
+            lifecycle = 'closed'
           }),
     )
+
+    yield* startEpoch(currentEpoch)
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
     yield* Stream.suspend(() =>
       clientSession.leaderThread.events.pull({ cursor: syncStateRef.current.upstreamHead }),
     ).pipe(
-      Stream.tap(({ payload }) =>
-        Effect.gen(function* () {
+      Stream.tap(({ payload }) => {
+        // This variable belongs to one tap invocation; failure cleanup must complete that exact epoch lease.
+        let claimedPullCompletion: Deferred.Deferred<void> | undefined
+        return Effect.gen(function* () {
+          const pullClaim = yield* Effect.sync(() => {
+            const epoch = currentEpoch
+            if (
+              terminalCause !== undefined ||
+              epoch.pullAdmissionOpen === false ||
+              (lifecycle !== 'open' && lifecycle !== 'closing')
+            ) {
+              return undefined
+            }
+            const completion = Effect.runSync(Deferred.make<void>())
+            epoch.pullCompletion = completion
+            return { completion, epoch }
+          })
+          if (pullClaim === undefined) return
+          const pullCompletion = pullClaim.completion
+          claimedPullCompletion = pullCompletion
           // yield* Effect.logDebug('ClientSessionSyncProcessor:pull', payload)
 
           if (clientSession.devtools.enabled === true) {
             yield* clientSession.devtools.pullLatch.await
           }
 
-          const rejectionAtPullStart = rejectionAwaitingPull
+          // The ownership handoff below is synchronous; this barrier deterministically exposes its pre-state.
+          if (beforePullHandoffQueue !== undefined) {
+            yield* Queue.offer(beforePullHandoffQueue, undefined)
+            yield* Effect.sleep(beforePullHandoffDelay)
+          }
 
-          const mergeResult = yield* SyncState.merge({
-            syncState: syncStateRef.current,
-            payload,
-            isClientOnlyEvent,
-            isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-          }).pipe(
-            Effect.filterOrElse(
-              (r) => r._tag !== 'reject',
-              () => Effect.die(new Error('Unexpected reject in client-session-sync-processor')),
-            ),
-          )
+          let replacedEpoch: PushEpoch | undefined
+          let successorEpoch: PushEpoch | undefined
+          const mergeResult = yield* Effect.sync(() => {
+            // A pull claimed by a replaced epoch follows ownership to the current generation.
+            currentEpoch.pullCompletion = pullCompletion
+            upstreamRevision++
+            // `push` uses the same non-suspending admission discipline, so recomputing and publishing here forms a
+            // linearizable transition even when the preview above raced a local commit.
+            const currentMergeResult = Effect.runSync(
+              SyncState.merge({
+                syncState: syncStateRef.current,
+                payload,
+                isClientOnlyEvent,
+                isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+              }).pipe(
+                Effect.filterOrElse(
+                  (r) => r._tag !== 'reject',
+                  () => Effect.die(new Error('Unexpected reject in client-session-sync-processor')),
+                ),
+              ),
+            )
 
-          if (mergeResult._tag === 'rebase') {
-            // Publishing the rebased state, replacing the queue, and restarting its sole worker form one ownership
-            // transition. Finish that short transition before honoring teardown; leader pushes remain interruptible.
-            yield* Effect.gen(function* () {
-              syncStateRef.current = mergeResult.newSyncState
+            if (currentMergeResult._tag === 'rebase' || currentEpoch.status === 'awaiting-rebase') {
+              const previousEpoch = currentEpoch
+              const candidateEpoch = Effect.runSync(makePushEpoch())
 
-              yield* Effect.spanEvent('merge:pull:rebase', {
-                payloadTag: payload._tag,
-                ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
-                newEventsCount: mergeResult.newEvents.length,
-                rollbackCount: mergeResult.rollbackEvents.length,
-                ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
-              })
-
-              debugInfo.rebaseCount++
-
-              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
-
-              yield* FiberHandle.clear(leaderPushingFiberHandle)
-
-              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
-
-              // Reset the leader push queue since we're rebasing and will push again
-              yield* TxQueue.clear(leaderPushQueue)
-
-              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
-
-              if (LS_DEV === true) {
-                yield* Effect.logDebug(
-                  'merge:pull:rebase: rollback',
-                  mergeResult.rollbackEvents.length,
-                  ...mergeResult.rollbackEvents.slice(0, 10).map((_) => _.toJSON()),
-                )
-              }
-
-              for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
-                const event = mergeResult.rollbackEvents[i]!
-                if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
-                  rollback(event.meta.sessionChangeset.data)
-                  event.meta.sessionChangeset = { _tag: 'unset' }
+              if (currentMergeResult._tag === 'rebase') {
+                for (let i = currentMergeResult.rollbackEvents.length - 1; i >= 0; i--) {
+                  const event = currentMergeResult.rollbackEvents[i]!
+                  if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
+                    rollback(event.meta.sessionChangeset.data)
+                    event.meta.sessionChangeset = { _tag: 'unset' }
+                  }
                 }
               }
 
-              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
+              syncStateRef.current = currentMergeResult.newSyncState
+              if (installEpoch(previousEpoch, candidateEpoch) === true) {
+                successorEpoch = candidateEpoch
+                replacedEpoch = previousEpoch
+              }
+            } else {
+              syncStateRef.current = currentMergeResult.newSyncState
+            }
 
-              yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
+            return currentMergeResult
+          })
 
-              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
+          if (successorEpoch !== undefined) {
+            if (replacedEpoch?.fiber !== undefined) yield* Fiber.interrupt(replacedEpoch.fiber)
+            yield* startEpoch(successorEpoch)
+          }
 
-              rejectionAwaitingPull = undefined
-              yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
-            }).pipe(Effect.uninterruptible)
+          if (mergeResult._tag === 'rebase') {
+            yield* Effect.spanEvent('merge:pull:rebase', {
+              payloadTag: payload._tag,
+              ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
+              newEventsCount: mergeResult.newEvents.length,
+              rollbackCount: mergeResult.rollbackEvents.length,
+              ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
+            })
+
+            debugInfo.rebaseCount++
+
+            if (LS_DEV === true) {
+              yield* Effect.logDebug(
+                'merge:pull:rebase: rollback',
+                mergeResult.rollbackEvents.length,
+                ...mergeResult.rollbackEvents.slice(0, 10).map((_) => _.toJSON()),
+              )
+            }
           } else {
-            syncStateRef.current = mergeResult.newSyncState
-
             yield* Effect.spanEvent('merge:pull:advance', {
               payloadTag: payload._tag,
               ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
@@ -293,16 +435,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (mergeResult.newEvents.length === 0) {
             // If there are no new events, we need to update the sync state as well
             yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-            // Clear only when this pull confirms the rejected prefix. Newer pending events may already have been
-            // admitted successfully and must not keep an obsolete rejection marker alive.
-            if (
-              rejectionAtPullStart !== undefined &&
-              isRejectedBatchRecovered(rejectionAtPullStart.rejectedEvents, mergeResult.newSyncState.pending) ===
-                true &&
-              rejectionAwaitingPull === rejectionAtPullStart
-            ) {
-              rejectionAwaitingPull = undefined
-            }
+            yield* Deferred.succeed(pullCompletion, undefined)
             return
           }
 
@@ -328,24 +461,21 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-          if (
-            rejectionAtPullStart !== undefined &&
-            isRejectedBatchRecovered(rejectionAtPullStart.rejectedEvents, mergeResult.newSyncState.pending) === true &&
-            rejectionAwaitingPull === rejectionAtPullStart
-          ) {
-            rejectionAwaitingPull = undefined
-          }
+          yield* Deferred.succeed(pullCompletion, undefined)
         }).pipe(
           Effect.tapCauseLogPretty,
-          Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
-        ),
-      ),
+          Effect.catchCause((cause) =>
+            handlePullCause(cause, claimedPullCompletion).pipe(Effect.andThen(Effect.failCause(cause))),
+          ),
+        )
+      }),
       Stream.runDrain,
       Effect.forever, // NOTE Whenever the leader changes, we need to re-start the stream
       Effect.interruptible,
       Effect.withSpan('client-session-sync-processor:pull'),
       Effect.tapCauseLogPretty,
-      Effect.forkScoped,
+      Effect.catchCause(handlePullCause),
+      Effect.forkIn(runtimeScope),
     )
   })()
 
@@ -401,20 +531,35 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
     function* (encodedEvents) {
-      if ((yield* TxQueue.isOpen(leaderPushQueue)) === false) {
-        return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
-      }
+      const mergeResult = yield* Effect.sync(() => {
+        if (admissionOpen === false) {
+          throw new Error('Cannot push events after the client session sync processor starts shutting down')
+        }
 
-      const mergeResult = yield* SyncState.merge({
-        syncState: syncStateRef.current,
-        payload: { _tag: 'local-push', newEvents: encodedEvents },
-        isClientOnlyEvent,
-        isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-      }).pipe(
-        Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
-          Effect.die(new Error('Expected advance from local-push merge')),
-        ),
-      )
+        const currentMergeResult = Effect.runSync(
+          SyncState.merge({
+            syncState: syncStateRef.current,
+            payload: { _tag: 'local-push', newEvents: encodedEvents },
+            isClientOnlyEvent,
+            isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+          }).pipe(
+            Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
+              Effect.die(new Error('Expected advance from local-push merge')),
+            ),
+          ),
+        )
+
+        syncStateRef.current = currentMergeResult.newSyncState
+        // While rejection recovery waits for pull, canonical pending owns new commits. The replacement epoch is
+        // seeded from that complete list after rebase, so offering them to the rejected epoch would be both redundant
+        // and vulnerable to a stale worker response.
+        if (currentEpoch.status === 'accepting') {
+          const rejectedEvents = Effect.runSync(TxQueue.offerAll(currentEpoch.queue, currentMergeResult.newEvents))
+          if (rejectedEvents.length > 0) throw new Error('Leader push queue closed while accepting events')
+        }
+
+        return currentMergeResult
+      })
 
       yield* Effect.annotateCurrentSpan({
         batchSize: encodedEvents.length,
@@ -426,12 +571,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
       })
 
-      syncStateRef.current = mergeResult.newSyncState
       yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-      const rejectedEvents = yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
-      if (rejectedEvents.length > 0) {
-        return yield* Effect.die('Leader push queue closed while accepting events')
-      }
     },
   )
 
@@ -451,12 +591,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       changes: Stream.fromQueue(syncStateUpdateQueue),
     }),
     debug: {
-      awaitRejection: Deferred.await(rejectionObserved),
       print: () =>
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
           console.log('syncState', syncStateRef.current)
-          const pushQueueItems = yield* snapshotTxQueue(leaderPushQueue).pipe(
+          const pushQueueItems = yield* snapshotTxQueue(currentEpoch.queue).pipe(
             Effect.catchIf(Cause.isDone, () => Effect.succeed([])),
           )
           console.log('pushQueueSize', pushQueueItems.length)
@@ -466,6 +605,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           )
         }).pipe(Effect.runSync),
       debugInfo: () => debugInfo,
+      awaitClosing: Deferred.await(closingStarted),
+      awaitPullAdmissionClosed: Deferred.await(pullAdmissionClosed),
+      awaitBeforePullHandoff: beforePullHandoffQueue === undefined ? Effect.never : Queue.take(beforePullHandoffQueue),
     },
   } satisfies ClientSessionSyncProcessor
 })
@@ -482,15 +624,6 @@ const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<Read
     }),
   )
 
-const isRejectedBatchRecovered = (
-  rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
-  pendingEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
-): boolean =>
-  rejectedEvents.every(
-    (rejectedEvent) =>
-      pendingEvents.some((pendingEvent) => LiveStoreEvent.Client.isEqualEncoded(pendingEvent, rejectedEvent)) === false,
-  )
-
 export interface ClientSessionSyncProcessor {
   boot: Effect.Effect<void, never, Scope.Scope>
   encodeEvents: (
@@ -505,13 +638,18 @@ export interface ClientSessionSyncProcessor {
    */
   syncState: Subscribable.Subscribable<SyncState.SyncState>
   debug: {
-    /** Diagnostic/test barrier completed after the first rejected leader push updates coordinator state. */
-    awaitRejection: Effect.Effect<void>
     print: () => void
     debugInfo: () => {
       rebaseCount: number
       advanceCount: number
+      rejectCount: number
     }
+    /** Diagnostic synchronization point completed by the atomic graceful-close transition. */
+    awaitClosing: Effect.Effect<void>
+    /** Diagnostic synchronization point completed when teardown stops admitting upstream payloads. */
+    awaitPullAdmissionClosed: Effect.Effect<void>
+    /** Diagnostic synchronization point completed immediately before each simulated pull handoff. */
+    awaitBeforePullHandoff: Effect.Effect<void>
   }
 }
 
@@ -521,11 +659,7 @@ const SIMULATION_ENABLED = true
 // Warning: High values for the simulation params can lead to very long test runs since those get multiplied with the number of events
 export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
   pull: Schema.Struct({
-    '1_before_leader_push_fiber_interrupt': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '2_before_leader_push_queue_clear': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '3_before_rebase_rollback': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '4_before_leader_push_queue_offer': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '5_before_leader_push_fiber_run': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
+    before_pull_handoff: Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
   }),
 })
 type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 import { LS_DEV, TRACE_VERBOSE } from '@livestore/utils'
 import {
+  Cause,
   Effect,
   Exit,
   Filter,
@@ -12,7 +13,6 @@ import {
   Stream,
   Subscribable,
   TxQueue,
-  TxRef,
 } from '@livestore/utils/effect'
 
 import type { ClientSession } from '../adapter-types.ts'
@@ -102,27 +102,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
-  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
-  const leaderPushLifecycleState = yield* TxRef.make<LeaderPushLifecycleState>({
-    _tag: 'accepting',
-    activePushCount: 0,
-  })
-
-  const takeNextLeaderPushWorkerAction: Effect.Effect<LeaderPushWorkerAction> = Effect.tx(
-    Effect.gen(function* () {
-      if ((yield* TxQueue.isEmpty(leaderPushQueue)) === false) {
-        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
-        return { _tag: 'push' as const, batch }
-      }
-
-      const lifecycleState = yield* TxRef.get(leaderPushLifecycleState)
-      if (lifecycleState._tag === 'stopping' && lifecycleState.activePushCount === 0) {
-        return { _tag: 'stop' as const }
-      }
-
-      return yield* Effect.txRetry
-    }),
-  )
+  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>()
 
   const boot: ClientSessionSyncProcessor['boot'] = Effect.fn('client-session-sync-processor:boot')(function* () {
     if (
@@ -147,10 +127,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
-        const action = yield* takeNextLeaderPushWorkerAction
-        if (action._tag === 'stop') return
+        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize).pipe(
+          Effect.catchIf(Cause.isDone, () => Effect.succeed(undefined)),
+        )
+        if (batch === undefined) return
 
-        yield* clientSession.leaderThread.events.push(action.batch).pipe(
+        yield* clientSession.leaderThread.events.push(batch).pipe(
           Effect.catchIf(isRejectedPushError, () => {
             debugInfo.rejectCount++
             return TxQueue.clear(leaderPushQueue)
@@ -168,27 +150,19 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
 
-    // Close admission and let the sole push worker drain every admitted event before it exits. This finalizer is
-    // registered after the FiberHandle so it runs first; once the worker exits, the handle finalizer has nothing
-    // left to interrupt. The pull fiber is registered later and therefore stops before this shutdown begins.
+    // Public Store commits finish synchronously before shutdown closes the Store to new commits. Ending the queue
+    // therefore happens after its final producer and lets the sole push worker drain every buffered batch. This
+    // finalizer is registered after the FiberHandle so the handle only tears down after the graceful drain.
     yield* Effect.addFinalizer((exit) =>
-      Effect.gen(function* () {
-        yield* Effect.tx(
-          TxRef.update(
-            leaderPushLifecycleState,
-            (state): LeaderPushLifecycleState => ({
-              _tag: 'stopping',
-              activePushCount: state.activePushCount,
-            }),
-          ),
-        )
-
-        // A healthy shutdown drains durably. On failure, the leader may already be unavailable or blocked in
-        // the failing push, so waiting would deadlock teardown and cannot provide a durability guarantee.
-        yield* Exit.isSuccess(exit) === true
-          ? FiberHandle.awaitEmpty(leaderPushingFiberHandle)
-          : FiberHandle.clear(leaderPushingFiberHandle)
-      }).pipe(Effect.uninterruptible),
+      Exit.isSuccess(exit) === true
+        ? Effect.gen(function* () {
+            yield* TxQueue.end(leaderPushQueue)
+            yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+          })
+        : Effect.gen(function* () {
+            yield* TxQueue.end(leaderPushQueue)
+            yield* FiberHandle.clear(leaderPushingFiberHandle)
+          }),
     )
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
@@ -215,54 +189,60 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             ),
           )
 
-          syncStateRef.current = mergeResult.newSyncState
-
           if (mergeResult._tag === 'rebase') {
-            yield* Effect.spanEvent('merge:pull:rebase', {
-              payloadTag: payload._tag,
-              ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
-              newEventsCount: mergeResult.newEvents.length,
-              rollbackCount: mergeResult.rollbackEvents.length,
-              ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
-            })
+            // Publishing the rebased state, replacing the queue, and restarting its sole worker form one ownership
+            // transition. Finish that short transition before honoring teardown; leader pushes remain interruptible.
+            yield* Effect.gen(function* () {
+              syncStateRef.current = mergeResult.newSyncState
 
-            debugInfo.rebaseCount++
+              yield* Effect.spanEvent('merge:pull:rebase', {
+                payloadTag: payload._tag,
+                ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
+                newEventsCount: mergeResult.newEvents.length,
+                rollbackCount: mergeResult.rollbackEvents.length,
+                ...(TRACE_VERBOSE === true ? { res: jsonStringify(mergeResult) } : {}),
+              })
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
+              debugInfo.rebaseCount++
 
-            yield* FiberHandle.clear(leaderPushingFiberHandle)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
+              yield* FiberHandle.clear(leaderPushingFiberHandle)
 
-            // Reset the leader push queue since we're rebasing and will push again
-            yield* TxQueue.clear(leaderPushQueue)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
+              // Reset the leader push queue since we're rebasing and will push again
+              yield* TxQueue.clear(leaderPushQueue)
 
-            if (LS_DEV === true) {
-              yield* Effect.logDebug(
-                'merge:pull:rebase: rollback',
-                mergeResult.rollbackEvents.length,
-                ...mergeResult.rollbackEvents.slice(0, 10).map((_) => _.toJSON()),
-              )
-            }
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
 
-            for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
-              const event = mergeResult.rollbackEvents[i]!
-              if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
-                rollback(event.meta.sessionChangeset.data)
-                event.meta.sessionChangeset = { _tag: 'unset' }
+              if (LS_DEV === true) {
+                yield* Effect.logDebug(
+                  'merge:pull:rebase: rollback',
+                  mergeResult.rollbackEvents.length,
+                  ...mergeResult.rollbackEvents.slice(0, 10).map((_) => _.toJSON()),
+                )
               }
-            }
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
+              for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
+                const event = mergeResult.rollbackEvents[i]!
+                if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
+                  rollback(event.meta.sessionChangeset.data)
+                  event.meta.sessionChangeset = { _tag: 'unset' }
+                }
+              }
 
-            yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
+              yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
 
-            yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+              if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
+
+              yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+            }).pipe(Effect.uninterruptible)
           } else {
+            syncStateRef.current = mergeResult.newSyncState
+
             yield* Effect.spanEvent('merge:pull:advance', {
               payloadTag: payload._tag,
               ...(TRACE_VERBOSE === true ? { payload: jsonStringify(payload) } : {}),
@@ -367,56 +347,37 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
     function* (encodedEvents) {
-      const wasAdmitted = yield* Effect.tx(
-        TxRef.modify(leaderPushLifecycleState, (state): [boolean, LeaderPushLifecycleState] =>
-          state._tag === 'accepting'
-            ? [true, { _tag: 'accepting', activePushCount: state.activePushCount + 1 }]
-            : [false, state],
-        ),
-      )
-
-      if (wasAdmitted === false) {
+      if ((yield* TxQueue.isOpen(leaderPushQueue)) === false) {
         return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
       }
 
-      yield* Effect.gen(function* () {
-        const mergeResult = yield* SyncState.merge({
-          syncState: syncStateRef.current,
-          payload: { _tag: 'local-push', newEvents: encodedEvents },
-          isClientOnlyEvent,
-          isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-        }).pipe(
-          Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
-            Effect.die(new Error('Expected advance from local-push merge')),
-          ),
-        )
-
-        yield* Effect.annotateCurrentSpan({
-          batchSize: encodedEvents.length,
-          mergeResultTag: mergeResult._tag,
-          eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
-            acc[event.name] = (acc[event.name] ?? 0) + 1
-            return acc
-          }, {}),
-          ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-        })
-
-        syncStateRef.current = mergeResult.newSyncState
-        yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-        yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      const mergeResult = yield* SyncState.merge({
+        syncState: syncStateRef.current,
+        payload: { _tag: 'local-push', newEvents: encodedEvents },
+        isClientOnlyEvent,
+        isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
       }).pipe(
-        Effect.ensuring(
-          Effect.tx(
-            TxRef.update(
-              leaderPushLifecycleState,
-              (state): LeaderPushLifecycleState => ({
-                ...state,
-                activePushCount: state.activePushCount - 1,
-              }),
-            ),
-          ),
+        Effect.filterMapOrElse(Filter.tagged<typeof SyncState.MergeResult.Type>()('advance'), () =>
+          Effect.die(new Error('Expected advance from local-push merge')),
         ),
       )
+
+      yield* Effect.annotateCurrentSpan({
+        batchSize: encodedEvents.length,
+        mergeResultTag: mergeResult._tag,
+        eventCounts: encodedEvents.reduce<Record<string, number>>((acc, event) => {
+          acc[event.name] = (acc[event.name] ?? 0) + 1
+          return acc
+        }, {}),
+        ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+      })
+
+      syncStateRef.current = mergeResult.newSyncState
+      yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+      const rejectedEvents = yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      if (rejectedEvents.length > 0) {
+        return yield* Effect.die('Leader push queue closed while accepting events')
+      }
     },
   )
 
@@ -440,7 +401,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
           console.log('syncState', syncStateRef.current)
-          const pushQueueItems = yield* snapshotTxQueue(leaderPushQueue)
+          const pushQueueItems = yield* snapshotTxQueue(leaderPushQueue).pipe(
+            Effect.catchIf(Cause.isDone, () => Effect.succeed([])),
+          )
           console.log('pushQueueSize', pushQueueItems.length)
           console.log(
             'pushQueueItems',
@@ -452,9 +415,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   } satisfies ClientSessionSyncProcessor
 })
 
-const snapshotTxQueue = <A>(queue: TxQueue.TxQueue<A>): Effect.Effect<ReadonlyArray<A>> =>
+const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<ReadonlyArray<A>, E> =>
   Effect.tx(
     Effect.gen(function* () {
+      // Re-offering a snapshot to a closing queue would reject and lose the cleared items.
+      if ((yield* TxQueue.isOpen(queue)) === false) return []
+
       const items = yield* TxQueue.clear(queue)
       yield* TxQueue.offerAll(queue, items)
       return items
@@ -497,11 +463,3 @@ export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
   }),
 })
 type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type
-
-type LeaderPushLifecycleState =
-  | { readonly _tag: 'accepting'; readonly activePushCount: number }
-  | { readonly _tag: 'stopping'; readonly activePushCount: number }
-
-type LeaderPushWorkerAction =
-  | { readonly _tag: 'push'; readonly batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta> }
-  | { readonly _tag: 'stop' }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -17,7 +17,7 @@ import {
 
 import type { ClientSession } from '../adapter-types.ts'
 import type { MaterializeError } from '../errors.ts'
-import { isRejectedPushError, type RejectedPushError } from '../leader-thread/RejectedPushError.ts'
+import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
@@ -124,7 +124,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     }
 
     const leaderPushingFiberHandle = yield* FiberHandle.make<void, never>()
-    let drainRejection: RejectedPushError | undefined
+    let drainFailure: Cause.Cause<never> | undefined
+    let rejectionRevision = 0
+    let rejectionAwaitingPull: { readonly error: Error; readonly revision: number } | undefined
 
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
@@ -148,7 +150,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               // Normal rejection recovery relies on pull rebasing and repopulating the open queue. Pull has already
               // stopped once graceful scope teardown closes the queue, so that path must fail rather than report a
               // successful durable drain after discarding pending events.
-              if (wasOpen === false) drainRejection = error
+              if (wasOpen === true) rejectionAwaitingPull = { error, revision: ++rejectionRevision }
+              else drainFailure = Cause.die(error)
             })
           }),
         )
@@ -158,21 +161,27 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.tapCauseLogPretty,
       // The worker must exit before shutdown can await it, otherwise a fatal push creates a self-deadlock.
       Effect.catchCause((cause) =>
-        clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid),
+        Cause.hasInterruptsOnly(cause) === true
+          ? Effect.void
+          : Effect.sync(() => {
+              drainFailure = cause
+            }).pipe(
+              Effect.andThen(clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid)),
+            ),
       ),
     )
 
     yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
 
-    // Public Store commits finish synchronously before shutdown closes the Store to new commits. Ending the queue
-    // therefore happens after its final producer and lets the sole push worker drain every buffered batch. This
-    // finalizer is registered after the FiberHandle so the handle only tears down after the graceful drain.
+    // Register after the FiberHandle so the push worker drains first, but before pull so LIFO scope teardown stops
+    // pull before deciding whether a rejection was left without a recovery path.
     yield* Effect.addFinalizer((exit) =>
       Exit.isSuccess(exit) === true
         ? Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)
             yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
-            if (drainRejection !== undefined) return yield* Effect.die(drainRejection)
+            if (drainFailure !== undefined) return yield* Effect.failCause(drainFailure)
+            if (rejectionAwaitingPull !== undefined) return yield* Effect.die(rejectionAwaitingPull.error)
           })
         : Effect.gen(function* () {
             yield* TxQueue.end(leaderPushQueue)
@@ -191,6 +200,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (clientSession.devtools.enabled === true) {
             yield* clientSession.devtools.pullLatch.await
           }
+
+          const rejectionAtPullStart = rejectionAwaitingPull
 
           const mergeResult = yield* SyncState.merge({
             syncState: syncStateRef.current,
@@ -253,6 +264,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
               if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
 
+              rejectionAwaitingPull = undefined
               yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
             }).pipe(Effect.uninterruptible)
           } else {
@@ -271,6 +283,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           if (mergeResult.newEvents.length === 0) {
             // If there are no new events, we need to update the sync state as well
             yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+            // An advance only resolves a cleared transport queue when it confirms every canonical pending event.
+            // Otherwise keep the marker so shutdown cannot claim a durable drain for still-stranded pending events.
+            if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+              rejectionAwaitingPull = undefined
+            }
             return
           }
 
@@ -296,6 +313,9 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
+          if (mergeResult.newSyncState.pending.length === 0 && rejectionAwaitingPull === rejectionAtPullStart) {
+            rejectionAwaitingPull = undefined
+          }
         }).pipe(
           Effect.tapCauseLogPretty,
           Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -27,17 +27,17 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -170,17 +170,17 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -313,17 +313,17 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -456,17 +456,17 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -599,17 +599,17 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -742,24 +742,24 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
           "_name": "client-session-sync-processor:pull",
           "attributes": {
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
           },
         },
       ],
@@ -958,17 +958,17 @@ exports[`otel > otel 3`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -1263,17 +1263,17 @@ exports[`otel > with thunks 7`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],
@@ -1402,17 +1402,17 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
-          "_name": "client-session-sync-processor:pull",
-          "attributes": {
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
-          },
-        },
-        {
           "_name": "@livestore/common:LeaderSyncProcessor:push",
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
+          },
+        },
+        {
+          "_name": "client-session-sync-processor:pull",
+          "attributes": {
+            "span.label": "⚠︎ Interrupted",
+            "status.interrupted": true,
           },
         },
       ],

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -38,8 +38,6 @@ exports[`otel > QueryBuilder subscription - async iterator 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -183,8 +181,6 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 1
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -328,8 +324,6 @@ exports[`otel > QueryBuilder subscription - basic functionality 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -473,8 +467,6 @@ exports[`otel > QueryBuilder subscription - direct table subscription 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -618,8 +610,6 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -763,8 +753,13 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 1`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
           },
         },
       ],
@@ -974,8 +969,6 @@ exports[`otel > otel 3`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -1281,8 +1274,6 @@ exports[`otel > with thunks 7`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],
@@ -1422,8 +1413,6 @@ exports[`otel > with thunks with query builder and without labels 3`] = `
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
           },
         },
       ],

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -333,7 +333,10 @@ export const createStore = <
         exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
       ) =>
         Effect.gen(function* () {
-          yield* Scope.close(lifetimeScope, exit).pipe(
+          // Time out waiting for teardown, not teardown itself. Interrupting Scope.close can leave its sequential
+          // finalizer chain half-run while the scope is already marked closed and cannot be resumed.
+          const closeFiber = yield* Scope.close(lifetimeScope, exit).pipe(Effect.forkDetach)
+          yield* Fiber.join(closeFiber).pipe(
             Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),
             Effect.timeout(1000),
             Effect.catchTag('TimeoutError', () =>

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -328,27 +328,58 @@ export const createStore = <
         })
 
       const services = yield* Effect.context<Scope.Scope>()
+      const cleanupStarted = yield* Deferred.make<void>()
+      const cleanupFiberDeferred = yield* Deferred.make<Fiber.Fiber<void, never>>()
 
       const shutdown = (
         exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
       ) =>
         Effect.gen(function* () {
-          // Time out waiting for teardown, not teardown itself. Interrupting Scope.close can leave its sequential
-          // finalizer chain half-run while the scope is already marked closed and cannot be resumed.
-          const closeFiber = yield* Scope.close(lifetimeScope, exit).pipe(Effect.forkDetach)
-          yield* Fiber.join(closeFiber).pipe(
-            Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),
-            Effect.timeout(1000),
-            Effect.catchTag('TimeoutError', () =>
-              Effect.logError('@livestore/livestore:shutdown: Timed out after 1 second'),
-            ),
-          )
+          const didInitiateCleanup = yield* Deferred.succeed(cleanupStarted, undefined)
 
-          if (shutdownDeferred !== undefined) {
-            yield* Deferred.done(shutdownDeferred, exit)
+          if (didInitiateCleanup === true) {
+            // Time out waiting for teardown, not teardown itself. Interrupting Scope.close can leave its sequential
+            // finalizer chain half-run while the scope is already marked closed and cannot be resumed.
+            const cleanupFiber = yield* Scope.close(lifetimeScope, exit).pipe(
+              Effect.onExit((cleanupExit) =>
+                Exit.isSuccess(cleanupExit) === true
+                  ? Effect.logDebug('LiveStore shutdown cleanup completed successfully')
+                  : Effect.logError('LiveStore shutdown cleanup failed', cleanupExit.cause),
+              ),
+              Effect.withSpan('@livestore/livestore:shutdown:cleanup', {
+                attributes: {
+                  'livestore.shutdown.trigger': Exit.isSuccess(exit) === true ? 'intentional' : 'failure',
+                },
+              }),
+              Effect.forkDetach,
+            )
+            yield* Deferred.succeed(cleanupFiberDeferred, cleanupFiber)
           }
 
-          yield* Effect.logDebug('LiveStore shutdown complete')
+          const cleanupFiber = yield* Deferred.await(cleanupFiberDeferred)
+          if (didInitiateCleanup === true) {
+            yield* Fiber.join(cleanupFiber).pipe(
+              Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),
+              Effect.timeout(1000),
+              Effect.catchTag('TimeoutError', () =>
+                Effect.gen(function* () {
+                  yield* Effect.spanEvent('cleanup:continuing-after-timeout', { timeoutMs: 1000 })
+                  yield* Effect.logError(
+                    '@livestore/livestore:shutdown: Timed out after 1 second; cleanup is continuing in the background',
+                  )
+                }),
+              ),
+              // The shutdown signal records the elected exit after this caller's wait has either settled or exhausted
+              // its budget. Cleanup defects must not leave adapter shutdown observers waiting forever.
+              Effect.ensuring(shutdownDeferred === undefined ? Effect.void : Deferred.done(shutdownDeferred, exit)),
+            )
+          } else {
+            // Concurrent callers join the same finalizer chain without duplicating lifecycle diagnostics.
+            yield* Fiber.join(cleanupFiber).pipe(
+              Effect.timeout(1000),
+              Effect.catchTag('TimeoutError', () => Effect.void),
+            )
+          }
         }).pipe(
           Effect.withSpan('@livestore/livestore:shutdown'),
           Effect.provide(services),

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -27,24 +27,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
           "_name": "client-session-sync-processor:pull",
           "attributes": {
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
           },
         },
       ],
@@ -306,24 +306,24 @@ exports[`useClientDocument > otel > should update the data based on component ke
       "_name": "client-session-sync-processor:boot",
       "children": [
         {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
+          },
+        },
+        {
           "_name": "client-session-sync-processor:pull",
           "attributes": {
             "span.label": "⚠︎ Interrupted",
             "status.interrupted": true,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
-          },
-        },
-        {
-          "_name": "@livestore/common:LeaderSyncProcessor:push",
-          "attributes": {
-            "batch": "undefined",
-            "batchSize": 1,
           },
         },
       ],

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -38,8 +38,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
           },
         },
       ],
@@ -312,8 +317,13 @@ exports[`useClientDocument > otel > should update the data based on component ke
           "attributes": {
             "batch": "undefined",
             "batchSize": 1,
-            "span.label": "⚠︎ Interrupted",
-            "status.interrupted": true,
+          },
+        },
+        {
+          "_name": "@livestore/common:LeaderSyncProcessor:push",
+          "attributes": {
+            "batch": "undefined",
+            "batchSize": 1,
           },
         },
       ],

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -8,7 +8,7 @@ import {
   LeaderAheadError,
   makeMockSyncBackend,
   SyncState,
-  type UnknownError,
+  UnknownError,
 } from '@livestore/common'
 import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
@@ -33,6 +33,7 @@ import {
   Fiber,
   Hash,
   Layer,
+  Logger,
   Option,
   Queue,
   References,
@@ -768,8 +769,10 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect('store shutdown timeout stops waiting without cancelling teardown', (test) =>
-    Effect.gen(function* () {
+  Vitest.it.effect('store shutdown timeout stops waiting without cancelling teardown', (test) => {
+    const logMessages: string[] = []
+
+    return Effect.gen(function* () {
       const { makeStore } = yield* TestContext
       const pushStarted = yield* Deferred.make<void>()
       const releasePush = yield* Deferred.make<void>()
@@ -800,15 +803,137 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       store.commit(events.todoCreated({ id: 'blocked', text: 'blocked', completed: false }))
       yield* Deferred.await(pushStarted)
 
-      const shutdownFiber = yield* store.shutdown().pipe(Effect.forkChild)
+      const shutdownReturned = yield* Deferred.make<void>()
+      const concurrentShutdownReturned = yield* Deferred.make<void>()
+      const shutdownFiber = yield* store
+        .shutdown()
+        .pipe(Effect.ensuring(Deferred.succeed(shutdownReturned, undefined)), Effect.forkChild)
+      const concurrentShutdownFiber = yield* store
+        .shutdown()
+        .pipe(Effect.ensuring(Deferred.succeed(concurrentShutdownReturned, undefined)), Effect.forkChild)
+      yield* TestClock.adjust(0)
+
+      expect(yield* Deferred.isDone(shutdownReturned)).toBe(false)
+      expect(yield* Deferred.isDone(concurrentShutdownReturned)).toBe(false)
+      expect(logMessages.some((message) => message.includes('shutdown cleanup completed successfully'))).toBe(false)
+
       yield* TestClock.adjust(1000)
       yield* Fiber.join(shutdownFiber)
+      yield* Fiber.join(concurrentShutdownFiber)
 
       expect(yield* Deferred.isDone(pushCompleted)).toBe(false)
       expect(yield* Deferred.isDone(pushInterrupted)).toBe(false)
+      expect(logMessages.filter((message) => message.includes('cleanup is continuing in the background'))).toHaveLength(
+        1,
+      )
+      expect(logMessages.some((message) => message.includes('shutdown cleanup completed successfully'))).toBe(false)
 
       yield* Deferred.succeed(releasePush, undefined)
       yield* Deferred.await(pushCompleted)
+      // A later caller joins the same cleanup fiber and gives the detached finalizer chain a deterministic
+      // completion boundary for the completion-log assertion.
+      yield* store.shutdown()
+
+      expect(logMessages.filter((message) => message.includes('shutdown cleanup completed successfully'))).toHaveLength(
+        1,
+      )
+    }).pipe(
+      Effect.provide(
+        Logger.layer([
+          Logger.make(({ message }) => {
+            const messages = Array.isArray(message) === true ? message : [message]
+            logMessages.push(messages.map(String).join(' '))
+          }),
+        ]),
+      ),
+      withTestCtx(test),
+    )
+  })
+
+  Vitest.it.effect('signals the elected successful exit when rejected drain cleanup fails', (test) => {
+    const logMessages: string[] = []
+
+    return Effect.gen(function* () {
+      const { makeStore, shutdownDeferred } = yield* TestContext
+      const pushStarted = yield* Deferred.make<void>()
+      const rejectPush = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+
+      const store = yield* makeStore({
+        testing: {
+          overrides: {
+            clientSession: {
+              leaderThreadProxy: (leader) => ({
+                ...leader,
+                events: {
+                  ...leader.events,
+                  push: () =>
+                    Deferred.succeed(pushStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(rejectPush)),
+                      Effect.andThen(Effect.fail(rejection)),
+                    ),
+                },
+              }),
+            },
+          },
+        },
+      })
+
+      store.commit(events.todoCreated({ id: 'rejected', text: 'rejected', completed: false }))
+      yield* Deferred.await(pushStarted)
+
+      const electedShutdownFiber = yield* store.shutdown().pipe(Effect.exit, Effect.forkChild)
+      yield* TestClock.adjust(0)
+
+      const laterFailure = new UnknownError({ cause: new Error('later shutdown failure') })
+      const concurrentShutdownFiber = yield* store
+        .shutdown(Cause.fail(laterFailure))
+        .pipe(Effect.exit, Effect.forkChild)
+      yield* TestClock.adjust(0)
+      yield* Deferred.succeed(rejectPush, undefined)
+
+      const electedShutdownExit = yield* Fiber.join(electedShutdownFiber)
+      const concurrentShutdownExit = yield* Fiber.join(concurrentShutdownFiber)
+      expect(Exit.isFailure(electedShutdownExit)).toBe(true)
+      expect(Exit.isFailure(concurrentShutdownExit)).toBe(true)
+
+      // Cleanup failure is reported to callers, while the shutdown signal still records the first elected trigger.
+      const notifiedExit = yield* Effect.exit(Deferred.await(shutdownDeferred))
+      expect(Exit.isSuccess(notifiedExit)).toBe(true)
+      expect(logMessages.filter((message) => message.includes('shutdown cleanup failed'))).toHaveLength(1)
+      expect(logMessages.some((message) => message.includes('cleanup completed successfully'))).toBe(false)
+    }).pipe(
+      Effect.provide(
+        Logger.layer([
+          Logger.make(({ message }) => {
+            const messages = Array.isArray(message) === true ? message : [message]
+            logMessages.push(messages.map(String).join(' '))
+          }),
+        ]),
+      ),
+      withTestCtx(test),
+    )
+  })
+
+  Vitest.it.effect('records a failed exit when failed shutdown wins election', (test) =>
+    Effect.gen(function* () {
+      const { makeStore, shutdownDeferred } = yield* TestContext
+      const store = yield* makeStore()
+      const electedFailure = new UnknownError({ cause: new Error('elected shutdown failure') })
+
+      const electedShutdownFiber = yield* store.shutdown(Cause.fail(electedFailure)).pipe(Effect.forkChild)
+      yield* TestClock.adjust(0)
+      const concurrentShutdownFiber = yield* store.shutdown().pipe(Effect.forkChild)
+
+      yield* Fiber.join(electedShutdownFiber)
+      yield* Fiber.join(concurrentShutdownFiber)
+
+      const notifiedError = yield* Deferred.await(shutdownDeferred).pipe(Effect.flip)
+      expect(notifiedError).toBe(electedFailure)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -524,6 +524,131 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     { fastCheck: { numRuns: 50 } },
   )
 
+  Vitest.asProp(
+    Vitest.live,
+    'preserves pending FIFO across repeated completed rebase replacements',
+    [
+      FastCheck.integer({ min: 1, max: 5 }),
+      FastCheck.array(FastCheck.array(FastCheck.integer({ min: 1, max: 4 }), { minLength: 1, maxLength: 4 }), {
+        minLength: 1,
+        maxLength: 3,
+      }),
+    ] as const,
+    ([leaderPushBatchSize, epochPushGroups], test) =>
+      Effect.gen(function* () {
+        type Attempt = {
+          readonly batch: ReadonlyArray<LiveStoreEvent.Client.Encoded>
+          readonly release: Deferred.Deferred<void>
+          readonly settled: Deferred.Deferred<Exit.Exit<void>>
+        }
+
+        const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+        const attempts = yield* Queue.unbounded<Attempt>()
+        let activePushCount = 0
+        let maxActivePushCount = 0
+
+        const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+          leaderPushBatchSize,
+          pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+          push: (batch) =>
+            Effect.gen(function* () {
+              const release = yield* Deferred.make<void>()
+              const settled = yield* Deferred.make<Exit.Exit<void>>()
+              activePushCount++
+              maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
+              yield* Queue.offer(attempts, { batch, release, settled })
+
+              yield* Deferred.await(release).pipe(
+                Effect.onExit((exit) =>
+                  Effect.sync(() => {
+                    activePushCount--
+                  }).pipe(Effect.andThen(Deferred.succeed(settled, exit))),
+                ),
+              )
+            }),
+        })
+        let scopeClosed = false
+        yield* Effect.addFinalizer(() =>
+          scopeClosed === true ? Effect.void : Scope.close(scope, Exit.fail(new Error('property run cleanup'))),
+        )
+
+        const expectedIds: string[] = []
+        const offerGroups = Effect.fnUntraced(function* (pushGroupSizes: ReadonlyArray<number>) {
+          for (const groupSize of pushGroupSizes) {
+            const groupIds = Array.from({ length: groupSize }, (_, index) => `event-${expectedIds.length + index}`)
+            expectedIds.push(...groupIds)
+            yield* pushIds(groupIds)
+          }
+        })
+
+        yield* offerGroups(epochPushGroups[0]!)
+        let currentAttempt = yield* Queue.take(attempts)
+
+        for (const [epochIndex, pushGroupSizes] of epochPushGroups.entries()) {
+          if (epochIndex > 0) yield* offerGroups(pushGroupSizes)
+
+          // Taking the attempt is the explicit happens-before edge proving that the old epoch owns a batch.
+          // The upstream advance then forces rebase to interrupt that owner and reconstruct its queue from pending.
+          const global = epochIndex + 1
+          const [remoteBase] = yield* processor.encodeEvents([
+            events.todoCreated({ id: `remote-${global}`, text: `remote-${global}`, completed: false }),
+          ])
+          yield* Queue.offer(
+            pullQueue,
+            SyncState.PayloadUpstreamAdvance.make({
+              newEvents: [
+                LiveStoreEvent.Client.EncodedWithMeta.make({
+                  ...remoteBase!,
+                  seqNum: EventSequenceNumber.Client.Composite.make({ global, client: 0 }),
+                  parentSeqNum:
+                    global === 1
+                      ? EventSequenceNumber.Client.ROOT
+                      : EventSequenceNumber.Client.Composite.make({ global: global - 1, client: 0 }),
+                  clientId: 'remote-client',
+                  sessionId: 'remote-session',
+                }),
+              ],
+            }),
+          )
+
+          const replacedExit = yield* Deferred.await(currentAttempt.settled)
+          expect(Exit.isFailure(replacedExit)).toBe(true)
+          assert(Exit.isFailure(replacedExit))
+          expect(Cause.hasInterruptsOnly(replacedExit.cause)).toBe(true)
+
+          // The successor can only call the fake leader after pending has been projected and its worker published.
+          // Carry that attempt into the next command instead of depending on scheduler progress between commands.
+          currentAttempt = yield* Queue.take(attempts)
+          const stateAfterReplacement = yield* processor.syncState.get
+          expect(stateAfterReplacement.pending.map((event) => event.args.id)).toEqual(expectedIds)
+        }
+
+        const acceptedIds: string[] = []
+        let nextAttempt: Attempt | undefined = currentAttempt
+        while (acceptedIds.length < expectedIds.length) {
+          const attempt = nextAttempt ?? (yield* Queue.take(attempts))
+          nextAttempt = undefined
+          const attemptIds = attempt.batch.map((event) => event.args.id as string)
+          expect(attemptIds).toEqual(expectedIds.slice(acceptedIds.length, acceptedIds.length + attemptIds.length))
+          expect(attemptIds.length).toBeGreaterThan(0)
+          expect(attemptIds.length).toBeLessThanOrEqual(leaderPushBatchSize)
+
+          acceptedIds.push(...attemptIds)
+          yield* Deferred.succeed(attempt.release, undefined)
+          const attemptExit = yield* Deferred.await(attempt.settled)
+          expect(Exit.isSuccess(attemptExit)).toBe(true)
+        }
+
+        yield* Scope.close(scope, Exit.void)
+        scopeClosed = true
+
+        expect(acceptedIds).toEqual(expectedIds)
+        expect(new Set(acceptedIds).size).toBe(expectedIds.length)
+        expect(maxActivePushCount).toBe(1)
+      }).pipe(withTestCtx(test)),
+    { fastCheck: { numRuns: 50 } },
+  )
+
   Vitest.it.effect('finishes closing while upstream continuously produces empty payloads', (test) =>
     Effect.gen(function* () {
       const pullQueue = yield* Queue.bounded<typeof SyncState.PayloadUpstream.Type>(1)

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -72,6 +72,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   push,
   pull = () => Stream.empty,
   rollback = () => undefined,
+  materializeEvent,
   shutdown = () => Effect.void,
   leaderPushBatchSize = 1,
   simulation,
@@ -79,6 +80,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   push: LeaderEvents['push']
   pull?: LeaderEvents['pull']
   rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
+  materializeEvent?: ClientProcessorParams['materializeEvent']
   shutdown?: ClientSession['shutdown']
   leaderPushBatchSize?: number
   simulation?: ClientProcessorParams['params']['simulation']
@@ -118,12 +120,14 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   const processor = yield* makeClientSessionSyncProcessor({
     schema: schema as LiveStoreSchema,
     clientSession,
-    materializeEvent: () =>
-      Effect.succeed({
-        writeTables: new Set<string>(),
-        sessionChangeset: { _tag: 'no-op' as const },
-        materializerHash: Option.none<number>(),
-      }),
+    materializeEvent:
+      materializeEvent ??
+      (() =>
+        Effect.succeed({
+          writeTables: new Set<string>(),
+          sessionChangeset: { _tag: 'no-op' as const },
+          materializerHash: Option.none<number>(),
+        })),
     rollback,
     refreshTables: () => undefined,
     params: { leaderPushBatchSize, simulation },
@@ -446,7 +450,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       let activePushCount = 0
       let maxActivePushCount = 0
 
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
         push: (batch) =>
           Effect.gen(function* () {
             activePushCount++
@@ -468,10 +472,9 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['second'])
       yield* pushIds(['third'])
 
-      // Drive the close fiber until it is waiting for the sleeping leader push, then release that push. This gives
-      // the test an explicit virtual-time happens-before edge without depending on scheduler yields or wall time.
+      // Close election happens before advancing the virtual clock that releases the in-flight push.
       const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
-      yield* TestClock.adjust(0)
+      yield* processor.debug.awaitClosing
       yield* TestClock.adjust('1 millis')
       yield* Fiber.join(closeFiber)
 
@@ -521,76 +524,253 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     { fastCheck: { numRuns: 50 } },
   )
 
-  for (const shutdownPoint of [
-    '1_before_leader_push_fiber_interrupt',
-    '3_before_rebase_rollback',
-    '5_before_leader_push_fiber_run',
-  ] as const) {
-    Vitest.it.effect(`does not lose rebased pending events when shutdown reaches ${shutdownPoint}`, (test) =>
-      Effect.gen(function* () {
-        const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
-        const firstPushStarted = yield* Deferred.make<void>()
-        const persistedIds: string[] = []
-        let pushCallCount = 0
+  Vitest.it.effect('finishes closing while upstream continuously produces empty payloads', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.bounded<typeof SyncState.PayloadUpstream.Type>(1)
+      const backToBackPayloadsObserved = yield* Deferred.make<void>()
+      const emptyPayload = SyncState.PayloadUpstreamAdvance.make({ newEvents: [] })
+      let pullCount = 0
 
-        const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
-          pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
-          push: (batch) => {
-            pushCallCount++
-            return pushCallCount === 1
-              ? Deferred.succeed(firstPushStarted, undefined).pipe(Effect.andThen(Effect.never))
-              : Effect.sync(() => persistedIds.push(...batch.map((event) => event.args.id as string)))
-          },
-          simulation: {
-            pull: {
-              '1_before_leader_push_fiber_interrupt': shutdownPoint === '1_before_leader_push_fiber_interrupt' ? 1 : 0,
-              '2_before_leader_push_queue_clear': 0,
-              '3_before_rebase_rollback': shutdownPoint === '3_before_rebase_rollback' ? 1 : 0,
-              '4_before_leader_push_queue_offer': 0,
-              '5_before_leader_push_fiber_run': shutdownPoint === '5_before_leader_push_fiber_run' ? 1 : 0,
-            },
-          },
-        })
+      const { processor, scope } = yield* makeClientProcessorHarness({
+        push: () => Effect.void,
+        pull: () =>
+          Stream.fromQueue(pullQueue).pipe(
+            Stream.map((payload) => {
+              pullCount++
+              if (pullCount === 2) Effect.runSync(Deferred.succeed(backToBackPayloadsObserved, undefined))
+              return { payload }
+            }),
+          ),
+      })
 
-        const [localEvent] = yield* pushIds(['local'])
-        localEvent!.meta.sessionChangeset = {
-          _tag: 'sessionChangeset',
-          data: new Uint8Array([1]),
-          debug: {},
-        }
-        yield* Deferred.await(firstPushStarted)
+      const producer = yield* Queue.offer(pullQueue, emptyPayload).pipe(Effect.forever, Effect.forkChild)
+      yield* Deferred.await(backToBackPayloadsObserved)
 
-        const [remoteBase] = yield* processor.encodeEvents([
-          events.todoCreated({ id: 'remote', text: 'remote', completed: false }),
-        ])
-        const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
-          ...remoteBase!,
-          seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
-          parentSeqNum: EventSequenceNumber.Client.ROOT,
-          clientId: 'remote-client',
-          sessionId: 'remote-session',
-        })
-        yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+      yield* processor.debug.awaitClosing
+      yield* processor.debug.awaitPullAdmissionClosed
+      yield* Fiber.join(closeFiber)
+      yield* Fiber.interrupt(producer)
 
-        // Let rebase reach the selected virtual-time barrier, start shutdown there, then finish the handoff.
-        yield* TestClock.adjust(0)
-        const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
-        yield* TestClock.adjust(0)
-        yield* TestClock.adjust('1 millis')
-        yield* Fiber.join(closeFiber)
+      expect(pullCount).toBeGreaterThanOrEqual(2)
+    }).pipe(withTestCtx(test)),
+  )
 
-        expect(processor.debug.debugInfo().rebaseCount).toBe(1)
-        expect(persistedIds).toEqual(['local'])
-      }).pipe(withTestCtx(test)),
-    )
-  }
+  Vitest.it.effect('admits recovery pull for a successor after the previous epoch pull cutoff', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushCompleted = yield* Deferred.make<void>()
+      const secondRejectionObserved = yield* Deferred.make<void>()
+      const thirdPushCompleted = yield* Deferred.make<void>()
+      const closeCompleted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          if (pushCount === 1) return Deferred.succeed(firstPushCompleted, undefined)
+          if (pushCount === 2) {
+            return Effect.fail(rejection).pipe(
+              Effect.onError(() => Deferred.succeed(secondRejectionObserved, undefined)),
+            )
+          }
+          return Deferred.succeed(thirdPushCompleted, undefined)
+        },
+        simulation: { pull: { before_pull_handoff: 1 } },
+      })
+
+      yield* pushIds(['two-generation-recovery'])
+      yield* Deferred.await(firstPushCompleted)
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-two-generation', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* processor.debug.awaitBeforePullHandoff
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(
+        Effect.ensuring(Deferred.succeed(closeCompleted, undefined)),
+        Effect.forkChild,
+      )
+      yield* processor.debug.awaitClosing
+      yield* processor.debug.awaitPullAdmissionClosed
+      expect(yield* Deferred.isDone(closeCompleted)).toBe(false)
+
+      // Complete P: it installs ended successor B after epoch A's cutoff; B's rejection then requires pull Q.
+      yield* TestClock.adjust('1 millis')
+      yield* Deferred.await(secondRejectionObserved)
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
+      yield* processor.debug.awaitBeforePullHandoff
+      yield* TestClock.adjust('1 millis')
+      yield* Deferred.await(thirdPushCompleted)
+      yield* Fiber.join(closeFiber)
+
+      expect(pushCount).toBe(3)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('transfers a paused pull lease through revision-mismatch recovery', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const releaseRejection = yield* Deferred.make<void>()
+      const successorPushCompleted = yield* Deferred.make<void>()
+      const materializationStarted = yield* Deferred.make<void>()
+      const releaseMaterialization = yield* Deferred.make<void>()
+      const closeCompleted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseRejection)),
+                Effect.andThen(Effect.fail(rejection)),
+              )
+            : Deferred.succeed(successorPushCompleted, undefined)
+        },
+        materializeEvent: () =>
+          Deferred.succeed(materializationStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseMaterialization)),
+            Effect.as({
+              writeTables: new Set<string>(),
+              sessionChangeset: { _tag: 'no-op' as const },
+              materializerHash: Option.none<number>(),
+            }),
+          ),
+        simulation: { pull: { before_pull_handoff: 1 } },
+      })
+
+      yield* pushIds(['revision-mismatch-lease'])
+      yield* Deferred.await(firstPushStarted)
+      // X advances the revision after the first push attempt captured it.
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
+      yield* processor.debug.awaitBeforePullHandoff
+      yield* TestClock.adjust('1 millis')
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-paused-lease', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* processor.debug.awaitBeforePullHandoff
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(
+        Effect.ensuring(Deferred.succeed(closeCompleted, undefined)),
+        Effect.forkChild,
+      )
+      yield* processor.debug.awaitClosing
+      yield* Deferred.succeed(releaseRejection, undefined)
+      yield* Deferred.await(successorPushCompleted)
+      yield* processor.debug.awaitPullAdmissionClosed
+      expect(yield* Deferred.isDone(closeCompleted)).toBe(false)
+
+      yield* TestClock.adjust('1 millis')
+      yield* Deferred.await(materializationStarted)
+      expect(yield* Deferred.isDone(closeCompleted)).toBe(false)
+      yield* Deferred.succeed(releaseMaterialization, undefined)
+      yield* Fiber.join(closeFiber)
+
+      expect(pushCount).toBeGreaterThanOrEqual(2)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('admits a local push during rebase without losing it from the successor epoch', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const rebaseMaterializationStarted = yield* Deferred.make<void>()
+      const releaseRebaseMaterialization = yield* Deferred.make<void>()
+      const shutdownRequested = yield* Deferred.make<void>()
+      const persistedIds: string[] = []
+      let isFirstMaterialization = true
+
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => {
+          return Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload })))
+        },
+        push: (batch) =>
+          Effect.sync(() => {
+            persistedIds.push(...batch.map((event) => event.args.id as string))
+          }),
+        materializeEvent: () =>
+          Effect.gen(function* () {
+            if (isFirstMaterialization === true) {
+              isFirstMaterialization = false
+              yield* Deferred.succeed(rebaseMaterializationStarted, undefined)
+              yield* Deferred.await(releaseRebaseMaterialization)
+            }
+            return {
+              writeTables: new Set<string>(),
+              sessionChangeset: { _tag: 'no-op' as const },
+              materializerHash: Option.none<number>(),
+            }
+          }),
+        shutdown: () => Deferred.succeed(shutdownRequested, undefined),
+      })
+
+      yield* pushIds(['before-rebase'])
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-rebase-base', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+
+      // The published rebase handoff happens-before materialization, so this push targets its successor epoch while
+      // the pull fiber is still processing the rebase.
+      yield* Deferred.await(rebaseMaterializationStarted)
+      yield* pushIds(['during-rebase'])
+      const pendingDuringRebase = yield* processor.syncState.get
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+      yield* Deferred.succeed(releaseRebaseMaterialization, undefined)
+      yield* Fiber.join(closeFiber)
+
+      expect(persistedIds).toEqual(['before-rebase', 'before-rebase', 'during-rebase'])
+      expect(pendingDuringRebase.pending.map((event) => event.args.id)).toEqual(['before-rebase', 'during-rebase'])
+      expect(yield* Deferred.isDone(shutdownRequested)).toBe(false)
+    }).pipe(withTestCtx(test)),
+  )
 
   Vitest.it.effect('interrupts a hung leader push during failed shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
       const firstPushInterrupted = yield* Deferred.make<void>()
+      const admissionAtInterrupt = yield* Deferred.make<Exit.Exit<void, unknown>>()
       let shutdownCalls = 0
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      let captureAdmissionAtInterrupt: Effect.Effect<void> = Effect.die('processor not initialized')
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
         shutdown: () =>
           Effect.sync(() => {
             shutdownCalls++
@@ -598,9 +778,15 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         push: () =>
           Deferred.succeed(firstPushStarted, undefined).pipe(
             Effect.andThen(Effect.never),
-            Effect.onInterrupt(() => Deferred.succeed(firstPushInterrupted, undefined)),
+            Effect.onInterrupt(() =>
+              captureAdmissionAtInterrupt.pipe(Effect.andThen(Deferred.succeed(firstPushInterrupted, undefined))),
+            ),
           ),
       })
+      captureAdmissionAtInterrupt = processor.push([]).pipe(
+        Effect.exit,
+        Effect.flatMap((exit) => Deferred.succeed(admissionAtInterrupt, exit)),
+      )
 
       yield* pushIds(['blocked'])
       yield* Deferred.await(firstPushStarted)
@@ -608,105 +794,162 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+      expect(Exit.isFailure(yield* Deferred.await(admissionAtInterrupt))).toBe(true)
       expect(shutdownCalls).toBe(0)
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect('does not report a successful drain when the leader rejects during shutdown', (test) =>
-    Effect.gen(function* () {
-      const pushStarted = yield* Deferred.make<void>()
-      const rejectPush = yield* Deferred.make<void>()
-      const rejection = new LeaderAheadError({
-        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
-        providedNum: EventSequenceNumber.Client.ROOT,
-        sessionId: 'session-test',
-      })
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
-        push: () =>
-          Deferred.succeed(pushStarted, undefined).pipe(
-            Effect.andThen(Deferred.await(rejectPush)),
-            Effect.andThen(Effect.fail(rejection)),
-          ),
-      })
-
-      yield* pushIds(['rejected'])
-      yield* Deferred.await(pushStarted)
-
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
-      // Drive close until it ends queue admission and waits for the in-flight leader response.
-      yield* TestClock.adjust(0)
-      yield* Deferred.succeed(rejectPush, undefined)
-      const closeExit = yield* Fiber.join(closeFiber)
-
-      expect(Exit.isFailure(closeExit)).toBe(true)
-    }).pipe(withTestCtx(test)),
-  )
-
-  Vitest.it.effect('fails the drain when pull stops before a leader rejection can recover', (test) =>
-    Effect.gen(function* () {
-      const pullStopped = yield* Deferred.make<void>()
-      const pushStarted = yield* Deferred.make<void>()
-      const rejectPush = yield* Deferred.make<void>()
-      const rejection = new LeaderAheadError({
-        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
-        providedNum: EventSequenceNumber.Client.ROOT,
-        sessionId: 'session-test',
-      })
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
-        pull: () => Stream.never.pipe(Stream.ensuring(Deferred.succeed(pullStopped, undefined))),
-        push: () =>
-          Deferred.succeed(pushStarted, undefined).pipe(
-            Effect.andThen(Deferred.await(rejectPush)),
-            Effect.andThen(Effect.fail(rejection)),
-          ),
-      })
-
-      yield* pushIds(['rejected-after-pull'])
-      yield* Deferred.await(pushStarted)
-
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
-      yield* Deferred.await(pullStopped)
-      yield* Deferred.succeed(rejectPush, undefined)
-      const closeExit = yield* Fiber.join(closeFiber)
-
-      expect(Exit.isFailure(closeExit)).toBe(true)
-    }).pipe(withTestCtx(test)),
-  )
-
-  Vitest.it.effect('does not treat an unrelated pull advance as recovery from a rejected push', (test) =>
+  Vitest.it.effect('fails a graceful drain when its in-flight leader push dies', (test) =>
     Effect.gen(function* () {
       const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
-      const pushReturned = yield* Deferred.make<void>()
-      const rejection = new LeaderAheadError({
-        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
-        providedNum: EventSequenceNumber.Client.ROOT,
-        sessionId: 'session-test',
-      })
+      const pushStarted = yield* Deferred.make<void>()
+      const releaseFailure = yield* Deferred.make<void>()
+      const failure = new Error('leader push defect during close')
       const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseFailure)),
+            Effect.andThen(Effect.die(failure)),
+          ),
         pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
-        push: () => Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(pushReturned, undefined))),
+        simulation: { pull: { before_pull_handoff: 1 } },
       })
 
-      yield* pushIds(['still-pending'])
-      // Drain the local-push notification so the next observed change belongs to the explicit upstream payload.
-      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
-      yield* Deferred.await(pushReturned)
-      yield* TestClock.adjust(0)
-
-      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
-      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
-
-      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+      yield* pushIds(['fatal'])
+      yield* Deferred.await(pushStarted)
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-worker-fatal', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* processor.debug.awaitBeforePullHandoff
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      yield* Deferred.succeed(releaseFailure, undefined)
+      yield* TestClock.adjust('1 millis')
+      const closeExit = yield* Fiber.join(closeFiber)
 
       expect(Exit.isFailure(closeExit)).toBe(true)
-      expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['still-pending'])
+      assert(Exit.isFailure(closeExit))
+      expect(Cause.findDefect(closeExit.cause)).toEqual(Result.succeed(failure))
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect('clears a recovered rejection while newer admitted events remain pending', (test) =>
+  Vitest.it.effect('fails a graceful drain when rebase materialization dies after installing a successor', (test) =>
     Effect.gen(function* () {
       const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
-      const secondPushAccepted = yield* Deferred.make<void>()
+      const materializationStarted = yield* Deferred.make<void>()
+      const failMaterialization = yield* Deferred.make<void>()
+      const failure = new Error('pull defect during close')
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () => Effect.void,
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        materializeEvent: () =>
+          Deferred.succeed(materializationStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(failMaterialization)),
+            Effect.andThen(Effect.die(failure)),
+          ),
+      })
+
+      yield* pushIds(['pending-before-pull-fatal'])
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-pull-fatal', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      // Queue a completed payload immediately before the fatal materializing payload to exercise latch replacement.
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* Deferred.await(materializationStarted)
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      yield* Deferred.succeed(failMaterialization, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('stops processing buffered pull payloads after a fatal materialization', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstMaterializationStarted = yield* Deferred.make<void>()
+      const failFirstMaterialization = yield* Deferred.make<void>()
+      const secondMaterializationStarted = yield* Deferred.make<void>()
+      const pullIterationEnded = yield* Deferred.make<void>()
+      let materializationCount = 0
+
+      const { processor, scope } = yield* makeClientProcessorHarness({
+        push: () => Effect.void,
+        pull: () =>
+          Stream.fromQueue(pullQueue).pipe(
+            Stream.take(2),
+            Stream.map((payload) => ({ payload })),
+            Stream.ensuring(Deferred.succeed(pullIterationEnded, undefined)),
+          ),
+        materializeEvent: () => {
+          materializationCount++
+          return materializationCount === 1
+            ? Deferred.succeed(firstMaterializationStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(failFirstMaterialization)),
+                Effect.andThen(Effect.die(new Error('first pull materialization failed'))),
+              )
+            : Deferred.succeed(secondMaterializationStarted, undefined).pipe(
+                Effect.as({
+                  writeTables: new Set<string>(),
+                  sessionChangeset: { _tag: 'no-op' as const },
+                  materializerHash: Option.none<number>(),
+                }),
+              )
+        },
+      })
+
+      const [firstBase, secondBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-fatal-first', text: 'first', completed: false }),
+        events.todoCreated({ id: 'remote-fatal-second', text: 'second', completed: false }),
+      ])
+      const firstEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...firstBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      const secondEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...secondBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 2, client: 0 }),
+        parentSeqNum: firstEvent.seqNum,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [firstEvent] }))
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [secondEvent] }))
+      yield* Deferred.await(firstMaterializationStarted)
+      yield* Deferred.succeed(failFirstMaterialization, undefined)
+      yield* Deferred.await(pullIterationEnded)
+
+      expect(yield* Deferred.isDone(secondMaterializationStarted)).toBe(false)
+      yield* Scope.close(scope, Exit.fail(new Error('test cleanup')))
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('keeps pull alive to rebase and retry a rejected shutdown drain', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const pushStarted = yield* Deferred.make<void>()
+      const rejectPush = yield* Deferred.make<void>()
+      const rejectionObserved = yield* Deferred.make<void>()
+      const retryCompleted = yield* Deferred.make<void>()
       const rejection = new LeaderAheadError({
         minimumExpectedNum: EventSequenceNumber.Client.ROOT,
         providedNum: EventSequenceNumber.Client.ROOT,
@@ -718,54 +961,319 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         push: () => {
           pushCount++
           return pushCount === 1
-            ? Effect.fail(rejection)
-            : Deferred.succeed(secondPushAccepted, undefined).pipe(Effect.asVoid)
+            ? Deferred.succeed(pushStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(rejectPush)),
+                Effect.andThen(Effect.fail(rejection)),
+                Effect.onError(() => Deferred.succeed(rejectionObserved, undefined)),
+              )
+            : Deferred.succeed(retryCompleted, undefined)
+        },
+      })
+
+      yield* pushIds(['rejected'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+      yield* Deferred.succeed(rejectPush, undefined)
+      // Rejection completion happens-before publishing the leader advance that enables recovery.
+      yield* Deferred.await(rejectionObserved)
+
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-rejection-base', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* Deferred.await(retryCompleted)
+      yield* Fiber.join(closeFiber)
+
+      expect(pushCount).toBe(2)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('does not finish a recovered drain before recovery pull materialization', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const releaseRejection = yield* Deferred.make<void>()
+      const retryCompleted = yield* Deferred.make<void>()
+      const materializationStarted = yield* Deferred.make<void>()
+      const failMaterialization = yield* Deferred.make<void>()
+      const closeCompleted = yield* Deferred.make<void>()
+      const closeAdmissionObserved = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      let assertCloseAdmission: Effect.Effect<void> = Effect.die('processor not initialized')
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(
+                Effect.andThen(Effect.suspend(() => assertCloseAdmission)),
+                Effect.andThen(Deferred.succeed(closeAdmissionObserved, undefined)),
+                Effect.andThen(Deferred.await(releaseRejection)),
+                Effect.andThen(Effect.fail(rejection)),
+              )
+            : Deferred.succeed(retryCompleted, undefined)
+        },
+        materializeEvent: () =>
+          Deferred.succeed(materializationStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(failMaterialization)),
+            Effect.andThen(Effect.die(new Error('recovery materialization failed'))),
+          ),
+      })
+      assertCloseAdmission = Effect.gen(function* () {
+        yield* processor.debug.awaitClosing
+        expect(Exit.isFailure(yield* processor.push([]).pipe(Effect.exit))).toBe(true)
+      })
+
+      yield* pushIds(['recovery-fatal'])
+      yield* Deferred.await(firstPushStarted)
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(
+        Effect.exit,
+        Effect.ensuring(Deferred.succeed(closeCompleted, undefined)),
+        Effect.forkChild,
+      )
+      yield* Deferred.await(closeAdmissionObserved)
+      yield* Deferred.succeed(releaseRejection, undefined)
+
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-recovery-fatal', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* Deferred.await(retryCompleted)
+      yield* Deferred.await(materializationStarted)
+      expect(yield* Deferred.isDone(closeCompleted)).toBe(false)
+
+      yield* Deferred.succeed(failMaterialization, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+      expect(Exit.isFailure(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('retains pushes admitted while an open epoch awaits rebase recovery', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const releaseRejection = yield* Deferred.make<void>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const rejectionObserved = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const retryIds: string[] = []
+      let pushCount = 0
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: (batch) => {
+          pushCount++
+          return pushCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseRejection)),
+                Effect.andThen(Effect.fail(rejection)),
+                Effect.onError(() => Deferred.succeed(rejectionObserved, undefined)),
+              )
+            : Effect.sync(() => retryIds.push(...batch.map((event) => event.args.id as string)))
+        },
+      })
+
+      yield* pushIds(['rejected-open'])
+      yield* Deferred.await(firstPushStarted)
+      yield* Deferred.succeed(releaseRejection, undefined)
+      yield* Deferred.await(rejectionObserved)
+      while (processor.debug.debugInfo().rejectCount === 0) {
+        yield* Effect.sync(() => processor.debug.debugInfo().rejectCount)
+      }
+      expect(processor.debug.debugInfo().rejectCount).toBe(1)
+      yield* pushIds(['admitted-awaiting'])
+
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-awaiting-base', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* Scope.close(scope, Exit.void)
+
+      expect(retryIds).toEqual(['rejected-open', 'admitted-awaiting'])
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('clears a confirmed rejected prefix while newer admitted events remain pending', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const rejectionReturned = yield* Deferred.make<void>()
+      const retryAccepted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(rejectionReturned, undefined)))
+            : Deferred.succeed(retryAccepted, undefined).pipe(Effect.asVoid)
         },
       })
 
       const [rejectedEvent] = yield* pushIds(['rejected-prefix'])
-      yield* processor.debug.awaitRejection
+      yield* Deferred.await(rejectionReturned)
       yield* pushIds(['newer-admitted'])
-      yield* Deferred.await(secondPushAccepted)
-      // Drain both local notifications so the next one proves the upstream confirmation was processed.
-      yield* processor.syncState.changes.pipe(Stream.take(2), Stream.runDrain)
 
       yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedEvent!] }))
-      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Deferred.await(retryAccepted)
+      yield* Scope.close(scope, Exit.void)
 
-      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
-
-      expect(Exit.isSuccess(closeExit)).toBe(true)
+      expect(pushCount).toBe(2)
       expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['newer-admitted'])
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect('propagates a fatal leader push from the graceful drain', (test) =>
+  Vitest.it.effect('rebuilds from pull progress admitted after close but before rejection', (test) =>
     Effect.gen(function* () {
-      const pushStarted = yield* Deferred.make<void>()
-      const failPush = yield* Deferred.make<void>()
-      const failure = new Error('leader push crashed')
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
-        push: () =>
-          Deferred.succeed(pushStarted, undefined).pipe(
-            Effect.andThen(Deferred.await(failPush)),
-            Effect.andThen(Effect.die(failure)),
-          ),
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const closeAdmissionObserved = yield* Deferred.make<void>()
+      const releaseRejection = yield* Deferred.make<void>()
+      const retryCompleted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      let assertCloseAdmission: Effect.Effect<void> = Effect.die('processor not initialized')
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(
+                Effect.andThen(Effect.suspend(() => assertCloseAdmission)),
+                Effect.andThen(Deferred.succeed(closeAdmissionObserved, undefined)),
+                Effect.andThen(Deferred.await(releaseRejection)),
+                Effect.andThen(Effect.fail(rejection)),
+              )
+            : Deferred.succeed(retryCompleted, undefined)
+        },
+      })
+      assertCloseAdmission = Effect.gen(function* () {
+        yield* processor.debug.awaitClosing
+        expect(Exit.isFailure(yield* processor.push([]).pipe(Effect.exit))).toBe(true)
       })
 
-      yield* pushIds(['fatal'])
-      yield* Deferred.await(pushStarted)
+      yield* pushIds(['revision-race'])
+      yield* Deferred.await(firstPushStarted)
+      // Drain the local-push notification so the next observed update is causally tied to the upstream payload.
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+      yield* Deferred.await(closeAdmissionObserved)
 
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
-      yield* TestClock.adjust(0)
-      yield* Deferred.succeed(failPush, undefined)
-      const closeExit = yield* Fiber.join(closeFiber)
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
+      // The notification proves the close-time payload was consumed before the delayed rejection was released.
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Deferred.succeed(releaseRejection, undefined)
+      yield* Deferred.await(retryCompleted)
+      yield* Fiber.join(closeFiber)
 
-      expect(Exit.isFailure(closeExit)).toBe(true)
-      Exit.match(closeExit, {
-        onFailure: (cause) => expect(Cause.squash(cause)).toBe(failure),
-        onSuccess: () => assert.fail('expected graceful drain to fail'),
+      expect(pushCount).toBe(2)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('ignores a delayed rejection from an epoch already replaced by rebase', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const enterUninterruptibleResponse = yield* Deferred.make<void>()
+      const uninterruptibleResponseEntered = yield* Deferred.make<void>()
+      const releaseStaleRejection = yield* Deferred.make<void>()
+      const retryCompleted = yield* Deferred.make<void>()
+      const shutdownRequested = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
       })
+      let pushCount = 0
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(enterUninterruptibleResponse)),
+                Effect.andThen(
+                  Deferred.succeed(uninterruptibleResponseEntered, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseStaleRejection)),
+                    Effect.andThen(Effect.fail(rejection)),
+                    Effect.uninterruptible,
+                  ),
+                ),
+              )
+            : Deferred.succeed(retryCompleted, undefined)
+        },
+        shutdown: () => Deferred.succeed(shutdownRequested, undefined),
+        simulation: { pull: { before_pull_handoff: 1 } },
+      })
+
+      const [localEvent] = yield* pushIds(['stale-attempt'])
+      localEvent!.meta.sessionChangeset = {
+        _tag: 'sessionChangeset',
+        data: new Uint8Array([1]),
+        debug: {},
+      }
+      yield* Deferred.await(firstPushStarted)
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Deferred.succeed(enterUninterruptibleResponse, undefined)
+      yield* Deferred.await(uninterruptibleResponseEntered)
+
+      const [remoteBase] = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'remote-stale-base', text: 'remote', completed: false }),
+      ])
+      const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...remoteBase!,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+        clientId: 'remote-client',
+        sessionId: 'remote-session',
+      })
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* TestClock.adjust('1 millis')
+      const stateAfterHandoff = yield* processor.syncState.get
+      expect(EventSequenceNumber.Client.isEqual(stateAfterHandoff.upstreamHead, remoteEvent.seqNum)).toBe(true)
+      yield* Deferred.succeed(releaseStaleRejection, undefined)
+      yield* Deferred.await(retryCompleted)
+      yield* Scope.close(scope, Exit.void)
+
+      expect(pushCount).toBe(2)
+      expect(yield* Deferred.isDone(shutdownRequested)).toBe(false)
     }).pipe(withTestCtx(test)),
   )
 
@@ -811,13 +1319,14 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const concurrentShutdownFiber = yield* store
         .shutdown()
         .pipe(Effect.ensuring(Deferred.succeed(concurrentShutdownReturned, undefined)), Effect.forkChild)
-      yield* TestClock.adjust(0)
 
+      // Half of the declared timeout is an observable boundary: both callers must still be joining one cleanup.
+      yield* TestClock.adjust(500)
       expect(yield* Deferred.isDone(shutdownReturned)).toBe(false)
       expect(yield* Deferred.isDone(concurrentShutdownReturned)).toBe(false)
       expect(logMessages.some((message) => message.includes('shutdown cleanup completed successfully'))).toBe(false)
 
-      yield* TestClock.adjust(1000)
+      yield* TestClock.adjust(500)
       yield* Fiber.join(shutdownFiber)
       yield* Fiber.join(concurrentShutdownFiber)
 
@@ -830,8 +1339,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       yield* Deferred.succeed(releasePush, undefined)
       yield* Deferred.await(pushCompleted)
-      // A later caller joins the same cleanup fiber and gives the detached finalizer chain a deterministic
-      // completion boundary for the completion-log assertion.
       yield* store.shutdown()
 
       expect(logMessages.filter((message) => message.includes('shutdown cleanup completed successfully'))).toHaveLength(
@@ -850,20 +1357,18 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     )
   })
 
-  Vitest.it.effect('signals the elected successful exit when rejected drain cleanup fails', (test) => {
+  Vitest.it.effect('signals the elected successful exit when cleanup dies', (test) => {
     const logMessages: string[] = []
 
     return Effect.gen(function* () {
-      const { makeStore, shutdownDeferred } = yield* TestContext
+      const { makeStore } = yield* TestContext
+      const shutdownDeferred = yield* makeShutdownDeferred
       const pushStarted = yield* Deferred.make<void>()
-      const rejectPush = yield* Deferred.make<void>()
-      const rejection = new LeaderAheadError({
-        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
-        providedNum: EventSequenceNumber.Client.ROOT,
-        sessionId: 'session-test',
-      })
+      const failPush = yield* Deferred.make<void>()
+      const failure = new Error('shutdown cleanup defect')
 
       const store = yield* makeStore({
+        shutdownDeferred,
         testing: {
           overrides: {
             clientSession: {
@@ -873,8 +1378,8 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
                   ...leader.events,
                   push: () =>
                     Deferred.succeed(pushStarted, undefined).pipe(
-                      Effect.andThen(Deferred.await(rejectPush)),
-                      Effect.andThen(Effect.fail(rejection)),
+                      Effect.andThen(Deferred.await(failPush)),
+                      Effect.andThen(Effect.die(failure)),
                     ),
                 },
               }),
@@ -883,27 +1388,21 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         },
       })
 
-      store.commit(events.todoCreated({ id: 'rejected', text: 'rejected', completed: false }))
+      store.commit(events.todoCreated({ id: 'fatal', text: 'fatal', completed: false }))
       yield* Deferred.await(pushStarted)
 
       const electedShutdownFiber = yield* store.shutdown().pipe(Effect.exit, Effect.forkChild)
-      yield* TestClock.adjust(0)
-
+      // Crossing a declared fraction of the timeout establishes that the first caller has won and is awaiting cleanup.
+      yield* TestClock.adjust(500)
       const laterFailure = new UnknownError({ cause: new Error('later shutdown failure') })
       const concurrentShutdownFiber = yield* store
         .shutdown(Cause.fail(laterFailure))
         .pipe(Effect.exit, Effect.forkChild)
-      yield* TestClock.adjust(0)
-      yield* Deferred.succeed(rejectPush, undefined)
+      yield* Deferred.succeed(failPush, undefined)
 
-      const electedShutdownExit = yield* Fiber.join(electedShutdownFiber)
-      const concurrentShutdownExit = yield* Fiber.join(concurrentShutdownFiber)
-      expect(Exit.isFailure(electedShutdownExit)).toBe(true)
-      expect(Exit.isFailure(concurrentShutdownExit)).toBe(true)
-
-      // Cleanup failure is reported to callers, while the shutdown signal still records the first elected trigger.
-      const notifiedExit = yield* Effect.exit(Deferred.await(shutdownDeferred))
-      expect(Exit.isSuccess(notifiedExit)).toBe(true)
+      expect(Exit.isFailure(yield* Fiber.join(electedShutdownFiber))).toBe(true)
+      expect(Exit.isFailure(yield* Fiber.join(concurrentShutdownFiber))).toBe(true)
+      expect(Exit.isSuccess(yield* Effect.exit(Deferred.await(shutdownDeferred)))).toBe(true)
       expect(logMessages.filter((message) => message.includes('shutdown cleanup failed'))).toHaveLength(1)
       expect(logMessages.some((message) => message.includes('cleanup completed successfully'))).toBe(false)
     }).pipe(
@@ -925,12 +1424,8 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const store = yield* makeStore()
       const electedFailure = new UnknownError({ cause: new Error('elected shutdown failure') })
 
-      const electedShutdownFiber = yield* store.shutdown(Cause.fail(electedFailure)).pipe(Effect.forkChild)
-      yield* TestClock.adjust(0)
-      const concurrentShutdownFiber = yield* store.shutdown().pipe(Effect.forkChild)
-
-      yield* Fiber.join(electedShutdownFiber)
-      yield* Fiber.join(concurrentShutdownFiber)
+      yield* store.shutdown(Cause.fail(electedFailure))
+      yield* store.shutdown()
 
       const notifiedError = yield* Deferred.await(shutdownDeferred).pipe(Effect.flip)
       expect(notifiedError).toBe(electedFailure)
@@ -1250,6 +1745,7 @@ class TestContext extends Context.Service<
   {
     makeStore: (args?: {
       boot?: (store: Store) => void
+      shutdownDeferred?: ShutdownDeferred
       testing?: {
         overrides?: {
           clientSession?: {
@@ -1280,7 +1776,7 @@ const TestContextLive = Layer.effect(
         schema: schema as LiveStoreSchema,
         adapter,
         storeId: nanoid(),
-        shutdownDeferred,
+        shutdownDeferred: args?.shutdownDeferred ?? shutdownDeferred,
         ...omitUndefineds({ boot: args?.boot }),
       })
     }

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -702,6 +702,43 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
+  Vitest.it.effect('clears a recovered rejection while newer admitted events remain pending', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const secondPushAccepted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Effect.fail(rejection)
+            : Deferred.succeed(secondPushAccepted, undefined).pipe(Effect.asVoid)
+        },
+      })
+
+      const [rejectedEvent] = yield* pushIds(['rejected-prefix'])
+      yield* processor.debug.awaitRejection
+      yield* pushIds(['newer-admitted'])
+      yield* Deferred.await(secondPushAccepted)
+      // Drain both local notifications so the next one proves the upstream confirmation was processed.
+      yield* processor.syncState.changes.pipe(Stream.take(2), Stream.runDrain)
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedEvent!] }))
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+
+      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+
+      expect(Exit.isSuccess(closeExit)).toBe(true)
+      expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['newer-admitted'])
+    }).pipe(withTestCtx(test)),
+  )
+
   Vitest.it.effect('propagates a fatal leader push from the graceful drain', (test) =>
     Effect.gen(function* () {
       const pushStarted = yield* Deferred.make<void>()

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -1224,9 +1224,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Deferred.await(firstPushStarted)
       yield* Deferred.succeed(releaseRejection, undefined)
       yield* Deferred.await(rejectionObserved)
-      while (processor.debug.debugInfo().rejectCount === 0) {
-        yield* Effect.sync(() => processor.debug.debugInfo().rejectCount)
-      }
+      yield* processor.debug.awaitRejection
       expect(processor.debug.debugInfo().rejectCount).toBe(1)
       yield* pushIds(['admitted-awaiting'])
 
@@ -1270,6 +1268,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       const [rejectedEvent] = yield* pushIds(['rejected-prefix'])
       yield* Deferred.await(rejectionReturned)
+      yield* processor.debug.awaitRejection
       yield* pushIds(['newer-admitted'])
 
       yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedEvent!] }))
@@ -1390,6 +1389,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         sessionId: 'remote-session',
       })
       yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+      yield* processor.debug.awaitBeforePullHandoff
       yield* TestClock.adjust('1 millis')
       const stateAfterHandoff = yield* processor.syncState.get
       expect(EventSequenceNumber.Client.isEqual(stateAfterHandoff.upstreamHead, remoteEvent.seqNum)).toBe(true)

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -36,7 +36,7 @@ import {
   References,
   Result,
   Schema,
-  type Scope,
+  Scope,
   Stream,
   Subscribable,
   SubscriptionRef,
@@ -351,6 +351,112 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       expect(res).toMatchObject([
         { id: 'client_0', text: 't1', completed: false, deletedAt: null },
         { id: 'backend_0', text: 't2', completed: false, deletedAt: null },
+      ])
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('flushes in-flight and queued leader pushes serially before shutdown', (test) =>
+    Effect.gen(function* () {
+      const firstPushStarted = yield* Deferred.make<void>()
+      const releaseFirstPush = yield* Deferred.make<void>()
+      const shutdownStarted = yield* Deferred.make<void>()
+      const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
+      let isFirstPush = true
+      let activePushCount = 0
+      let maxActivePushCount = 0
+
+      const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
+      const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
+        events: {
+          pull: () => Stream.empty,
+          push: (batch) =>
+            Effect.gen(function* () {
+              activePushCount++
+              maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
+
+              if (isFirstPush === true) {
+                isFirstPush = false
+                yield* Deferred.succeed(firstPushStarted, undefined)
+                yield* Deferred.await(releaseFirstPush)
+              }
+
+              persistedBatches.push(batch)
+              activePushCount--
+            }),
+          stream: () => Stream.empty,
+        },
+        initialState: {
+          leaderHead: EventSequenceNumber.Client.ROOT,
+          migrationsReport: { migrations: [] },
+          storageMode: 'persisted',
+        },
+        export: Effect.die(new Error('not implemented')),
+        getEventlogData: Effect.die(new Error('not implemented')),
+        syncState: Subscribable.make({
+          get: Effect.die(new Error('not implemented')),
+          changes: Stream.empty,
+        }),
+        sendDevtoolsMessage: () => Effect.void,
+        networkStatus: Subscribable.make({
+          get: Effect.die(new Error('not implemented')),
+          changes: Stream.empty,
+        }),
+      }
+
+      const clientSession: ClientSession = {
+        sqliteDb: {} as ClientSession['sqliteDb'],
+        devtools: { enabled: false },
+        clientId: 'client-test',
+        sessionId: 'session-test',
+        lockStatus,
+        shutdown: () => Effect.void,
+        leaderThread,
+        debugInstanceId: 'test-instance',
+      }
+
+      const syncProcessor = yield* makeClientSessionSyncProcessor({
+        schema: schema as LiveStoreSchema,
+        clientSession,
+        materializeEvent: () => Effect.die(new Error('not used')),
+        rollback: () => undefined,
+        refreshTables: () => undefined,
+        params: { leaderPushBatchSize: 1 },
+        confirmUnsavedChanges: false,
+      })
+
+      const processorScope = yield* Scope.make()
+      yield* syncProcessor.boot.pipe(Scope.provide(processorScope))
+
+      const [firstEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'first', text: 'first', completed: false }),
+      ])
+      yield* syncProcessor.push([firstEvent!])
+      yield* Deferred.await(firstPushStarted)
+
+      const [secondEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'second', text: 'second', completed: false }),
+      ])
+      yield* syncProcessor.push([secondEvent!])
+      const [thirdEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'third', text: 'third', completed: false }),
+      ])
+      yield* syncProcessor.push([thirdEvent!])
+
+      // This marker runs first during teardown and lets the test release the blocked leader push only after
+      // scope closure has begun. The shutdown path must finish that push before flushing the queued batch.
+      yield* Effect.addFinalizer(() => Deferred.succeed(shutdownStarted, undefined)).pipe(Scope.provide(processorScope))
+      const closeFiber = yield* Scope.close(processorScope, Exit.void).pipe(Effect.forkChild)
+      yield* Deferred.await(shutdownStarted)
+      yield* Effect.yieldNow
+      yield* Effect.yieldNow
+      yield* Deferred.succeed(releaseFirstPush, undefined)
+      yield* Fiber.join(closeFiber)
+
+      expect(maxActivePushCount).toBe(1)
+      expect(persistedBatches).toMatchObject([
+        [{ args: { id: 'first' } }],
+        [{ args: { id: 'second' } }],
+        [{ args: { id: 'third' } }],
       ])
     }).pipe(withTestCtx(test)),
   )

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -355,7 +355,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.live('flushes in-flight and queued leader pushes serially before shutdown', (test) =>
+  Vitest.live('drains admitted leader pushes serially and closes admission on shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
       const releaseFirstPush = yield* Deferred.make<void>()
@@ -441,16 +441,19 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         events.todoCreated({ id: 'third', text: 'third', completed: false }),
       ])
       yield* syncProcessor.push([thirdEvent!])
+      const [postShutdownEvent] = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'post-shutdown', text: 'post-shutdown', completed: false }),
+      ])
 
-      // This marker runs first during teardown and lets the test release the blocked leader push only after
-      // scope closure has begun. The shutdown path must finish that push before flushing the queued batch.
+      // Release the blocked worker only after scope closure begins. Graceful shutdown must let that same worker
+      // finish its owned batch, drain the queued batches, and exit without admitting any later pushes.
       yield* Effect.addFinalizer(() => Deferred.succeed(shutdownStarted, undefined)).pipe(Scope.provide(processorScope))
       const closeFiber = yield* Scope.close(processorScope, Exit.void).pipe(Effect.forkChild)
       yield* Deferred.await(shutdownStarted)
-      yield* Effect.yieldNow
-      yield* Effect.yieldNow
       yield* Deferred.succeed(releaseFirstPush, undefined)
       yield* Fiber.join(closeFiber)
+
+      const postShutdownPushExit = yield* Effect.exit(syncProcessor.push([postShutdownEvent!]))
 
       expect(maxActivePushCount).toBe(1)
       expect(persistedBatches).toMatchObject([
@@ -458,6 +461,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         [{ args: { id: 'second' } }],
         [{ args: { id: 'third' } }],
       ])
+      expect(Exit.isFailure(postShutdownPushExit)).toBe(true)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -27,6 +27,7 @@ import {
   Effect,
   Equal,
   Exit,
+  FastCheck,
   FetchHttpClient,
   Fiber,
   Hash,
@@ -40,6 +41,7 @@ import {
   Stream,
   Subscribable,
   SubscriptionRef,
+  TestClock,
 } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 import { PlatformNode } from '@livestore/utils/node'
@@ -59,6 +61,83 @@ const withTestCtx = Vitest.makeWithTestCtx({
       FetchHttpClient.layer,
       Layer.succeed(References.MinimumLogLevel, 'Debug'),
     ),
+})
+
+type LeaderEvents = ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy['events']
+type ClientProcessorParams = Parameters<typeof makeClientSessionSyncProcessor>[0]
+
+const makeClientProcessorHarness = Effect.fn(function* ({
+  push,
+  pull = () => Stream.empty,
+  rollback = () => undefined,
+  leaderPushBatchSize = 1,
+  simulation,
+}: {
+  push: LeaderEvents['push']
+  pull?: LeaderEvents['pull']
+  rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
+  leaderPushBatchSize?: number
+  simulation?: ClientProcessorParams['params']['simulation']
+}) {
+  const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
+  const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
+    events: { pull, push, stream: () => Stream.empty },
+    initialState: {
+      leaderHead: EventSequenceNumber.Client.ROOT,
+      migrationsReport: { migrations: [] },
+      storageMode: 'persisted',
+    },
+    export: Effect.die(new Error('not implemented')),
+    getEventlogData: Effect.die(new Error('not implemented')),
+    syncState: Subscribable.make({
+      get: Effect.die(new Error('not implemented')),
+      changes: Stream.empty,
+    }),
+    sendDevtoolsMessage: () => Effect.void,
+    networkStatus: Subscribable.make({
+      get: Effect.die(new Error('not implemented')),
+      changes: Stream.empty,
+    }),
+  }
+
+  const clientSession: ClientSession = {
+    sqliteDb: {} as ClientSession['sqliteDb'],
+    devtools: { enabled: false },
+    clientId: 'client-test',
+    sessionId: 'session-test',
+    lockStatus,
+    shutdown: () => Effect.void,
+    leaderThread,
+    debugInstanceId: 'test-instance',
+  }
+
+  const processor = yield* makeClientSessionSyncProcessor({
+    schema: schema as LiveStoreSchema,
+    clientSession,
+    materializeEvent: () =>
+      Effect.succeed({
+        writeTables: new Set<string>(),
+        sessionChangeset: { _tag: 'no-op' as const },
+        materializerHash: Option.none<number>(),
+      }),
+    rollback,
+    refreshTables: () => undefined,
+    params: { leaderPushBatchSize, simulation },
+    confirmUnsavedChanges: false,
+  })
+
+  const scope = yield* Scope.make()
+  yield* processor.boot.pipe(Scope.provide(scope))
+
+  const pushIds = Effect.fn(function* (ids: ReadonlyArray<string>) {
+    const encoded = yield* processor.encodeEvents(
+      ids.map((id) => events.todoCreated({ id, text: id, completed: false })),
+    )
+    yield* processor.push(encoded)
+    return encoded
+  })
+
+  return { processor, pushIds, scope }
 })
 
 // TODO use property tests for simulation params
@@ -355,113 +434,215 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.live('drains admitted leader pushes serially and closes admission on shutdown', (test) =>
+  Vitest.it.effect('drains in-flight and queued leader pushes serially on shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
-      const releaseFirstPush = yield* Deferred.make<void>()
-      const shutdownStarted = yield* Deferred.make<void>()
       const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
       let isFirstPush = true
       let activePushCount = 0
       let maxActivePushCount = 0
 
-      const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
-      const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
-        events: {
-          pull: () => Stream.empty,
-          push: (batch) =>
-            Effect.gen(function* () {
-              activePushCount++
-              maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: (batch) =>
+          Effect.gen(function* () {
+            activePushCount++
+            maxActivePushCount = Math.max(maxActivePushCount, activePushCount)
 
-              if (isFirstPush === true) {
-                isFirstPush = false
-                yield* Deferred.succeed(firstPushStarted, undefined)
-                yield* Deferred.await(releaseFirstPush)
-              }
+            if (isFirstPush === true) {
+              isFirstPush = false
+              yield* Deferred.succeed(firstPushStarted, undefined)
+              yield* Effect.sleep('1 millis')
+            }
 
-              persistedBatches.push(batch)
-              activePushCount--
-            }),
-          stream: () => Stream.empty,
-        },
-        initialState: {
-          leaderHead: EventSequenceNumber.Client.ROOT,
-          migrationsReport: { migrations: [] },
-          storageMode: 'persisted',
-        },
-        export: Effect.die(new Error('not implemented')),
-        getEventlogData: Effect.die(new Error('not implemented')),
-        syncState: Subscribable.make({
-          get: Effect.die(new Error('not implemented')),
-          changes: Stream.empty,
-        }),
-        sendDevtoolsMessage: () => Effect.void,
-        networkStatus: Subscribable.make({
-          get: Effect.die(new Error('not implemented')),
-          changes: Stream.empty,
-        }),
-      }
-
-      const clientSession: ClientSession = {
-        sqliteDb: {} as ClientSession['sqliteDb'],
-        devtools: { enabled: false },
-        clientId: 'client-test',
-        sessionId: 'session-test',
-        lockStatus,
-        shutdown: () => Effect.void,
-        leaderThread,
-        debugInstanceId: 'test-instance',
-      }
-
-      const syncProcessor = yield* makeClientSessionSyncProcessor({
-        schema: schema as LiveStoreSchema,
-        clientSession,
-        materializeEvent: () => Effect.die(new Error('not used')),
-        rollback: () => undefined,
-        refreshTables: () => undefined,
-        params: { leaderPushBatchSize: 1 },
-        confirmUnsavedChanges: false,
+            persistedBatches.push(batch)
+            activePushCount--
+          }),
       })
 
-      const processorScope = yield* Scope.make()
-      yield* syncProcessor.boot.pipe(Scope.provide(processorScope))
-
-      const [firstEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'first', text: 'first', completed: false }),
-      ])
-      yield* syncProcessor.push([firstEvent!])
+      yield* pushIds(['first'])
       yield* Deferred.await(firstPushStarted)
+      yield* pushIds(['second'])
+      yield* pushIds(['third'])
 
-      const [secondEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'second', text: 'second', completed: false }),
-      ])
-      yield* syncProcessor.push([secondEvent!])
-      const [thirdEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'third', text: 'third', completed: false }),
-      ])
-      yield* syncProcessor.push([thirdEvent!])
-      const [postShutdownEvent] = yield* syncProcessor.encodeEvents([
-        events.todoCreated({ id: 'post-shutdown', text: 'post-shutdown', completed: false }),
-      ])
-
-      // Release the blocked worker only after scope closure begins. Graceful shutdown must let that same worker
-      // finish its owned batch, drain the queued batches, and exit without admitting any later pushes.
-      yield* Effect.addFinalizer(() => Deferred.succeed(shutdownStarted, undefined)).pipe(Scope.provide(processorScope))
-      const closeFiber = yield* Scope.close(processorScope, Exit.void).pipe(Effect.forkChild)
-      yield* Deferred.await(shutdownStarted)
-      yield* Deferred.succeed(releaseFirstPush, undefined)
+      // Drive the close fiber until it is waiting for the sleeping leader push, then release that push. This gives
+      // the test an explicit virtual-time happens-before edge without depending on scheduler yields or wall time.
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+      yield* TestClock.adjust(0)
+      yield* TestClock.adjust('1 millis')
       yield* Fiber.join(closeFiber)
 
-      const postShutdownPushExit = yield* Effect.exit(syncProcessor.push([postShutdownEvent!]))
+      const postShutdownPushExit = yield* Effect.exit(pushIds(['post-shutdown']))
 
       expect(maxActivePushCount).toBe(1)
-      expect(persistedBatches).toMatchObject([
-        [{ args: { id: 'first' } }],
-        [{ args: { id: 'second' } }],
-        [{ args: { id: 'third' } }],
+      expect(persistedBatches.map((batch) => batch.map((event) => event.args.id))).toEqual([
+        ['first'],
+        ['second'],
+        ['third'],
       ])
       expect(Exit.isFailure(postShutdownPushExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.asProp(
+    Vitest.live,
+    'preserves event order and batch bounds through graceful shutdown',
+    [
+      FastCheck.integer({ min: 1, max: 5 }),
+      FastCheck.array(FastCheck.integer({ min: 1, max: 4 }), { minLength: 0, maxLength: 6 }),
+    ] as const,
+    ([leaderPushBatchSize, pushGroupSizes], test) =>
+      Effect.gen(function* () {
+        const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
+
+        const { pushIds, scope } = yield* makeClientProcessorHarness({
+          leaderPushBatchSize,
+          push: (batch) =>
+            Effect.sync(() => {
+              persistedBatches.push(batch)
+            }),
+        })
+
+        const expectedIds: string[] = []
+        for (const groupSize of pushGroupSizes) {
+          const groupIds = Array.from({ length: groupSize }, (_, index) => `event-${expectedIds.length + index}`)
+          expectedIds.push(...groupIds)
+          yield* pushIds(groupIds)
+        }
+
+        yield* Scope.close(scope, Exit.void)
+
+        expect(persistedBatches.flatMap((batch) => batch.map((event) => event.args.id))).toEqual(expectedIds)
+        expect(persistedBatches.every((batch) => batch.length > 0 && batch.length <= leaderPushBatchSize)).toBe(true)
+      }).pipe(withTestCtx(test)),
+    { fastCheck: { numRuns: 50 } },
+  )
+
+  for (const shutdownPoint of [
+    '1_before_leader_push_fiber_interrupt',
+    '3_before_rebase_rollback',
+    '5_before_leader_push_fiber_run',
+  ] as const) {
+    Vitest.it.effect(`does not lose rebased pending events when shutdown reaches ${shutdownPoint}`, (test) =>
+      Effect.gen(function* () {
+        const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+        const firstPushStarted = yield* Deferred.make<void>()
+        const persistedIds: string[] = []
+        let pushCallCount = 0
+
+        const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+          pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+          push: (batch) => {
+            pushCallCount++
+            return pushCallCount === 1
+              ? Deferred.succeed(firstPushStarted, undefined).pipe(Effect.andThen(Effect.never))
+              : Effect.sync(() => persistedIds.push(...batch.map((event) => event.args.id as string)))
+          },
+          simulation: {
+            pull: {
+              '1_before_leader_push_fiber_interrupt': shutdownPoint === '1_before_leader_push_fiber_interrupt' ? 1 : 0,
+              '2_before_leader_push_queue_clear': 0,
+              '3_before_rebase_rollback': shutdownPoint === '3_before_rebase_rollback' ? 1 : 0,
+              '4_before_leader_push_queue_offer': 0,
+              '5_before_leader_push_fiber_run': shutdownPoint === '5_before_leader_push_fiber_run' ? 1 : 0,
+            },
+          },
+        })
+
+        const [localEvent] = yield* pushIds(['local'])
+        localEvent!.meta.sessionChangeset = {
+          _tag: 'sessionChangeset',
+          data: new Uint8Array([1]),
+          debug: {},
+        }
+        yield* Deferred.await(firstPushStarted)
+
+        const [remoteBase] = yield* processor.encodeEvents([
+          events.todoCreated({ id: 'remote', text: 'remote', completed: false }),
+        ])
+        const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+          ...remoteBase!,
+          seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+          parentSeqNum: EventSequenceNumber.Client.ROOT,
+          clientId: 'remote-client',
+          sessionId: 'remote-session',
+        })
+        yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+
+        // Let rebase reach the selected virtual-time barrier, start shutdown there, then finish the handoff.
+        yield* TestClock.adjust(0)
+        const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
+        yield* TestClock.adjust(0)
+        yield* TestClock.adjust('1 millis')
+        yield* Fiber.join(closeFiber)
+
+        expect(processor.debug.debugInfo().rebaseCount).toBe(1)
+        expect(persistedIds).toEqual(['local'])
+      }).pipe(withTestCtx(test)),
+    )
+  }
+
+  Vitest.it.effect('interrupts a hung leader push during failed shutdown', (test) =>
+    Effect.gen(function* () {
+      const firstPushStarted = yield* Deferred.make<void>()
+      const firstPushInterrupted = yield* Deferred.make<void>()
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(firstPushStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Deferred.succeed(firstPushInterrupted, undefined)),
+          ),
+      })
+
+      yield* pushIds(['blocked'])
+      yield* Deferred.await(firstPushStarted)
+
+      yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
+
+      expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('store shutdown timeout stops waiting without cancelling teardown', (test) =>
+    Effect.gen(function* () {
+      const { makeStore } = yield* TestContext
+      const pushStarted = yield* Deferred.make<void>()
+      const releasePush = yield* Deferred.make<void>()
+      const pushCompleted = yield* Deferred.make<void>()
+      const pushInterrupted = yield* Deferred.make<void>()
+
+      const store = yield* makeStore({
+        testing: {
+          overrides: {
+            clientSession: {
+              leaderThreadProxy: (leader) => ({
+                ...leader,
+                events: {
+                  ...leader.events,
+                  push: () =>
+                    Deferred.succeed(pushStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releasePush)),
+                      Effect.andThen(Deferred.succeed(pushCompleted, undefined)),
+                      Effect.onInterrupt(() => Deferred.succeed(pushInterrupted, undefined)),
+                    ),
+                },
+              }),
+            },
+          },
+        },
+      })
+
+      store.commit(events.todoCreated({ id: 'blocked', text: 'blocked', completed: false }))
+      yield* Deferred.await(pushStarted)
+
+      const shutdownFiber = yield* store.shutdown().pipe(Effect.forkChild)
+      yield* TestClock.adjust(1000)
+      yield* Fiber.join(shutdownFiber)
+
+      expect(yield* Deferred.isDone(pushCompleted)).toBe(false)
+      expect(yield* Deferred.isDone(pushInterrupted)).toBe(false)
+
+      yield* Deferred.succeed(releasePush, undefined)
+      yield* Deferred.await(pushCompleted)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -5,6 +5,7 @@ import {
   type BootStatus,
   type ClientSession,
   type ClientSessionLeaderThreadProxy,
+  LeaderAheadError,
   makeMockSyncBackend,
   SyncState,
   type UnknownError,
@@ -599,6 +600,36 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('does not report a successful drain when the leader rejects during shutdown', (test) =>
+    Effect.gen(function* () {
+      const pushStarted = yield* Deferred.make<void>()
+      const rejectPush = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(rejectPush)),
+            Effect.andThen(Effect.fail(rejection)),
+          ),
+      })
+
+      yield* pushIds(['rejected'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      // Drive close until it ends queue admission and waits for the in-flight leader response.
+      yield* TestClock.adjust(0)
+      yield* Deferred.succeed(rejectPush, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -71,12 +71,14 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   push,
   pull = () => Stream.empty,
   rollback = () => undefined,
+  shutdown = () => Effect.void,
   leaderPushBatchSize = 1,
   simulation,
 }: {
   push: LeaderEvents['push']
   pull?: LeaderEvents['pull']
   rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
+  shutdown?: ClientSession['shutdown']
   leaderPushBatchSize?: number
   simulation?: ClientProcessorParams['params']['simulation']
 }) {
@@ -107,7 +109,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
     clientId: 'client-test',
     sessionId: 'session-test',
     lockStatus,
-    shutdown: () => Effect.void,
+    shutdown,
     leaderThread,
     debugInstanceId: 'test-instance',
   }
@@ -586,7 +588,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
       const firstPushInterrupted = yield* Deferred.make<void>()
+      let shutdownCalls = 0
       const { pushIds, scope } = yield* makeClientProcessorHarness({
+        shutdown: () =>
+          Effect.sync(() => {
+            shutdownCalls++
+          }),
         push: () =>
           Deferred.succeed(firstPushStarted, undefined).pipe(
             Effect.andThen(Effect.never),
@@ -600,6 +607,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
+      expect(shutdownCalls).toBe(0)
     }).pipe(withTestCtx(test)),
   )
 
@@ -630,6 +638,96 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       const closeExit = yield* Fiber.join(closeFiber)
 
       expect(Exit.isFailure(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('fails the drain when pull stops before a leader rejection can recover', (test) =>
+    Effect.gen(function* () {
+      const pullStopped = yield* Deferred.make<void>()
+      const pushStarted = yield* Deferred.make<void>()
+      const rejectPush = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.never.pipe(Stream.ensuring(Deferred.succeed(pullStopped, undefined))),
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(rejectPush)),
+            Effect.andThen(Effect.fail(rejection)),
+          ),
+      })
+
+      yield* pushIds(['rejected-after-pull'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      yield* Deferred.await(pullStopped)
+      yield* Deferred.succeed(rejectPush, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('does not treat an unrelated pull advance as recovery from a rejected push', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const pushReturned = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(pushReturned, undefined))),
+      })
+
+      yield* pushIds(['still-pending'])
+      // Drain the local-push notification so the next observed change belongs to the explicit upstream payload.
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Deferred.await(pushReturned)
+      yield* TestClock.adjust(0)
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
+      yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+
+      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+      expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['still-pending'])
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('propagates a fatal leader push from the graceful drain', (test) =>
+    Effect.gen(function* () {
+      const pushStarted = yield* Deferred.make<void>()
+      const failPush = yield* Deferred.make<void>()
+      const failure = new Error('leader push crashed')
+      const { pushIds, scope } = yield* makeClientProcessorHarness({
+        push: () =>
+          Deferred.succeed(pushStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(failPush)),
+            Effect.andThen(Effect.die(failure)),
+          ),
+      })
+
+      yield* pushIds(['fatal'])
+      yield* Deferred.await(pushStarted)
+
+      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      yield* TestClock.adjust(0)
+      yield* Deferred.succeed(failPush, undefined)
+      const closeExit = yield* Fiber.join(closeFiber)
+
+      expect(Exit.isFailure(closeExit)).toBe(true)
+      Exit.match(closeExit, {
+        onFailure: (cause) => expect(Cause.squash(cause)).toBe(failure),
+        onSuccess: () => assert.fail('expected graceful drain to fail'),
+      })
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -6,8 +6,10 @@ import {
   type MockSyncBackend,
   type MockSyncBackendOptions,
   makeMockSyncBackend,
+  MaterializeError,
   type RejectedPushError,
   ServerAheadError,
+  SqliteError,
   StaleRebaseGenerationError,
   type SyncBackend,
   type SyncOptions,
@@ -23,11 +25,14 @@ import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
 import { omitUndefineds } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
 import {
+  Cause,
   Context,
   Deferred,
   Duration,
   Effect,
+  Exit,
   FetchHttpClient,
+  Fiber,
   Layer,
   Queue,
   References,
@@ -114,6 +119,142 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(2), Stream.runDrain)
     }).pipe(withTestCtx()(test)),
   )
+
+  Vitest.live('publishes and acknowledges a local push only after its commit boundary', (test) => {
+    let commitReached!: Deferred.Deferred<void>
+    let commitAllowed!: Deferred.Deferred<void>
+
+    const beforeLocalPushCommit = Effect.gen(function* () {
+      yield* Deferred.succeed(commitReached, void 0)
+      yield* Deferred.await(commitAllowed)
+    })
+
+    return Effect.gen(function* () {
+      commitReached = yield* Deferred.make<void>()
+      commitAllowed = yield* Deferred.make<void>()
+
+      const leaderThreadCtx = yield* LeaderThreadCtx
+      const testContext = yield* TestContext
+      const pushFiber = yield* testContext
+        .pushEncoded(
+          testContext.eventFactory.todoCreated.next({ id: '1', text: 't1', completed: false }),
+          testContext.eventFactory.todoCreated.next({ id: '2', text: 't2', completed: false }),
+        )
+        .pipe(Effect.forkChild)
+
+      yield* Deferred.await(commitReached)
+
+      const pushBeforeCommit = pushFiber.pollUnsafe()
+      const syncStateBeforeCommit = yield* leaderThreadCtx.syncProcessor.syncState.get
+      const pullBeforeCommit = yield* Queue.poll(testContext.pullQueue)
+      expect(pushBeforeCommit).toBeUndefined()
+      expect(syncStateBeforeCommit.localHead).toEqual(EventSequenceNumber.Client.ROOT)
+      expect(pullBeforeCommit._tag).toBe('None')
+
+      yield* Deferred.succeed(commitAllowed, void 0)
+      yield* Fiber.join(pushFiber)
+
+      expect(leaderThreadCtx.dbState.select<{ id: string }>(tables.todos.asSql().query)).toEqual([
+        { id: '1', text: 't1', completed: 0, deletedAt: null },
+        { id: '2', text: 't2', completed: 0, deletedAt: null },
+      ])
+      expect(leaderThreadCtx.dbEventlog.select<{ count: number }>('SELECT COUNT(*) AS count FROM eventlog')).toEqual([
+        { count: 2 },
+      ])
+      const syncStateAfterCommit = yield* leaderThreadCtx.syncProcessor.syncState.get
+      const pullAfterCommit = yield* Queue.poll(testContext.pullQueue)
+      expect(syncStateAfterCommit.localHead.global).toBe(2)
+      expect(pullAfterCommit._tag).toBe('Some')
+    }).pipe(
+      Effect.ensuring(Effect.suspend(() => Deferred.succeed(commitAllowed, void 0))),
+      withTestCtx({ testing: { syncProcessor: { delays: { beforeLocalPushCommit } } } })(test),
+    )
+  })
+
+  Vitest.live('terminates local push waiters without publication when materialization fails', (test) => {
+    let commitReached!: Deferred.Deferred<void>
+    let commitAllowed!: Deferred.Deferred<void>
+    let secondPushOffered!: Deferred.Deferred<void>
+    let offerCount = 0
+    const materializeFailure = MaterializeError.make({
+      cause: SqliteError.make({ cause: new Error('injected local push materialization failure') }),
+    })
+    const companionDefect = new Error('injected companion defect')
+
+    const expectTerminalCauses = (exit: Exit.Exit<void, RejectedPushError>) => {
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit) === false) return
+      const defects = exit.cause.reasons.flatMap((reason) =>
+        Cause.isDieReason(reason) === true ? [reason.defect] : [],
+      )
+      expect(defects).toEqual(expect.arrayContaining([materializeFailure, companionDefect]))
+    }
+
+    const beforeLocalPushCommit = Effect.gen(function* () {
+      yield* Deferred.succeed(commitReached, void 0)
+      yield* Deferred.await(commitAllowed)
+      return yield* Effect.failCause(
+        Cause.fromReasons([Cause.makeFailReason(materializeFailure), Cause.makeDieReason(companionDefect)]),
+      )
+    })
+
+    const afterLocalPushOffer = Effect.gen(function* () {
+      offerCount++
+      if (offerCount === 2) yield* Deferred.succeed(secondPushOffered, void 0)
+    })
+
+    return Effect.gen(function* () {
+      commitReached = yield* Deferred.make<void>()
+      commitAllowed = yield* Deferred.make<void>()
+      secondPushOffered = yield* Deferred.make<void>()
+
+      const leaderThreadCtx = yield* LeaderThreadCtx
+      const testContext = yield* TestContext
+      const pushFiber = yield* testContext
+        .pushEncoded(testContext.eventFactory.todoCreated.next({ id: '1', text: 't1', completed: false }))
+        .pipe(Effect.forkChild)
+
+      yield* Deferred.await(commitReached)
+      const queuedPushFiber = yield* testContext
+        .pushEncoded(testContext.eventFactory.todoCreated.next({ id: '2', text: 't2', completed: false }))
+        .pipe(Effect.forkChild)
+      yield* Deferred.await(secondPushOffered)
+
+      const pushBeforeCommit = pushFiber.pollUnsafe()
+      const queuedPushBeforeCommit = queuedPushFiber.pollUnsafe()
+      const syncStateBeforeCommit = yield* leaderThreadCtx.syncProcessor.syncState.get
+      const pullBeforeCommit = yield* Queue.poll(testContext.pullQueue)
+      expect(pushBeforeCommit).toBeUndefined()
+      expect(queuedPushBeforeCommit).toBeUndefined()
+      expect(syncStateBeforeCommit.localHead).toEqual(EventSequenceNumber.Client.ROOT)
+      expect(pullBeforeCommit._tag).toBe('None')
+
+      yield* Deferred.succeed(commitAllowed, void 0)
+      const pushExit = yield* Fiber.await(pushFiber)
+      const queuedPushExit = yield* Fiber.await(queuedPushFiber)
+
+      expectTerminalCauses(pushExit)
+      expectTerminalCauses(queuedPushExit)
+      expect(leaderThreadCtx.dbState.select<{ id: string }>(tables.todos.asSql().query)).toEqual([])
+      expect(leaderThreadCtx.dbEventlog.select<{ count: number }>('SELECT COUNT(*) AS count FROM eventlog')).toEqual([
+        { count: 0 },
+      ])
+      const syncStateAfterFailure = yield* leaderThreadCtx.syncProcessor.syncState.get
+      const pullAfterFailure = yield* Queue.poll(testContext.pullQueue)
+      expect(syncStateAfterFailure.localHead).toEqual(EventSequenceNumber.Client.ROOT)
+      expect(pullAfterFailure._tag).toBe('None')
+
+      const futurePushExit = yield* testContext
+        .pushEncoded(testContext.eventFactory.todoCreated.next({ id: '3', text: 't3', completed: false }))
+        .pipe(Effect.exit)
+      expectTerminalCauses(futurePushExit)
+    }).pipe(
+      Effect.ensuring(Effect.suspend(() => Deferred.succeed(commitAllowed, void 0))),
+      withTestCtx({
+        testing: { syncProcessor: { delays: { beforeLocalPushCommit, afterLocalPushOffer } } },
+      })(test),
+    )
+  })
 
   Vitest.live('non-live paginated pull does not stall local pushes', (test) =>
     Effect.gen(function* () {
@@ -818,7 +959,7 @@ class TestContext extends Context.Service<
 >()('TestContext') {}
 
 const LeaderThreadCtxLive = ({
-  syncProcessor,
+  testing,
   params,
   syncOptions,
   captureShutdown,
@@ -826,7 +967,7 @@ const LeaderThreadCtxLive = ({
   seedMockBackend,
   mockBackendOverride,
 }: {
-  syncProcessor?: NonNullable<MakeLeaderThreadLayerParams['testing']>['syncProcessor']
+  testing?: MakeLeaderThreadLayerParams['testing']
   params?: MakeLeaderThreadLayerParams['params']
   /** Optional overrides for sync options (e.g. custom backend, livePull flag) */
   syncOptions?: Partial<SyncOptions>
@@ -872,10 +1013,7 @@ const LeaderThreadCtxLive = ({
       dbEventlog: yield* makeSqliteDb({ _tag: 'in-memory' }),
       devtoolsOptions: { enabled: false },
       shutdownChannel: shutdownProxy?.webChannel ?? (yield* WebChannel.noopChannel<any, any>()),
-      testing: {
-        ...omitUndefineds({ syncProcessor }),
-      },
-      ...omitUndefineds({ params }),
+      ...omitUndefineds({ params, testing }),
     }).pipe(Layer.provide(FetchHttpClient.layer))
 
     const testContextLayer = Effect.gen(function* () {

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -181,13 +181,15 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     })
     const companionDefect = new Error('injected companion defect')
 
-    const expectTerminalCauses = (exit: Exit.Exit<void, RejectedPushError>) => {
+    const expectTerminalCauses = (exit: Exit.Exit<void, RejectedPushError | MaterializeError>) => {
       expect(Exit.isFailure(exit)).toBe(true)
       if (Exit.isFailure(exit) === false) return
+      const errors = exit.cause.reasons.flatMap((reason) => (Cause.isFailReason(reason) === true ? [reason.error] : []))
       const defects = exit.cause.reasons.flatMap((reason) =>
         Cause.isDieReason(reason) === true ? [reason.defect] : [],
       )
-      expect(defects).toEqual(expect.arrayContaining([materializeFailure, companionDefect]))
+      expect(errors).toEqual([materializeFailure])
+      expect(defects).toEqual([companionDefect])
     }
 
     const beforeLocalPushCommit = Effect.gen(function* () {
@@ -954,7 +956,7 @@ class TestContext extends Context.Service<
     /** Equivalent to the ClientSessionSyncProcessor calling `.push` on the LeaderThreadCtx */
     pushEncoded: (
       ...events: ReadonlyArray<LiveStoreEvent.Global.Encoded>
-    ) => Effect.Effect<void, RejectedPushError, Scope.Scope | LeaderThreadCtx>
+    ) => Effect.Effect<void, RejectedPushError | MaterializeError, Scope.Scope | LeaderThreadCtx>
   }
 >()('TestContext') {}
 


### PR DESCRIPTION
## Problem

Stacked on #1405. That PR prevents orderly shutdown from abandoning an already-dequeued leader push, but its queue drain is still only one part of the durability boundary:

- a client can observe leader-push success before the leader transaction commits;
- rebase transfers queue, push-worker, and pull-worker ownership through implicit scheduler ordering;
- stale rejection recovery can mutate a replacement epoch;
- typed materialization failures can become defects, and a mixed failure/defect can terminate unrelated worker RPC requests;
- concurrent shutdown calls can start independent cleanup attempts or mistake a caller timeout for completed cleanup.

These gaps matter because client-session events are not restart-replayable until the leader eventlog accepts them. A successful lifecycle outcome must mean committed by the leader, not merely dequeued or sent.

## Solution

- Acknowledge leader pushes only after transaction commit/publication. The leader processor atomically owns its current batch, queued batches, and terminal `Cause` so current, queued, and future waiters see the same outcome.
- Model client submission recovery as explicit push epochs. Epoch installation is the sole ownership-transfer point for queues, push workers, pull leases, rejection recovery, and the per-epoch pull-admission cutoff.
- Replace scheduler guesses in lifecycle tests with diagnostic `Deferred`/`Queue` handshakes. The processor test file contains no `yieldNow` or zero-duration clock nudges.
- Preserve typed materialization causes through the leader service, both worker RPC hops, and client shutdown. Worker RPC defects are request-scoped at this trusted same-origin boundary, so a failed push cannot poison unrelated requests.
- Make Store cleanup single-flight: concurrent shutdown callers join one cleanup fiber, while each timeout only stops that caller from waiting.
- Add a generated repeated-rebase model covering randomized epoch counts, event-group sizes, batching bounds, FIFO delivery, duplicate absence, and the single-active-push invariant.

### Trade-offs and scope

The client processor grows substantially because lifecycle state that was previously distributed across fibers is now explicit and atomically updated in the domain coordinator. Multiple architecture/minimality passes did not find a smaller generic abstraction that retained the ownership invariants; extracting a callback-driven generic coordinator would expose domain internals and increase total production code.

The generated property deliberately models repeated successful rebases rather than every command transition. Rejection, fatal, close, abort, and ownership races have deterministic handshake-driven regressions. A full arbitrary command/state-machine generator and richer low-cardinality lifecycle telemetry remain tracked in #1425.

Request-scoped defects are appropriate for the trusted worker protocol: application defects remain visible in the request `Cause`, while protocol/decode failures still fail the protocol itself.

## Validation

Red-before/green-after proofs:

- #1405 tests fail before `19b939d7d` for incomplete drain and fatal push, then pass with the fix.
- The recovered-prefix regression fails with the old `pending.length === 0` marker and passes at #1405 head.
- The pre-commit acknowledgement behavior fails the existing side-effecting `MaterializeError` regression; the typed post-commit cause path makes it green.
- With Effect RPC's default `disableFatalDefects: false`, a mixed typed/defect push loses its typed failure and poisons an unrelated request. Both one-hop and forwarded two-hop tests pass with request-scoped failures.

Green checks on this stack:

- `vitest run tests/package-common/src/sync/ClientSessionSyncProcessor.test.ts` — 32 passed
- `vitest run tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts` — 19 passed, 1 skipped
- adapter-web worker RPC tests — 3 passed, including one-hop, two-hop forwarding, and JSON `Exit` codec coverage
- `vitest run tests/package-common` — 87 passed, 1 skipped
- `mono ts`
- `dt ts:check`
- `dt lint:full:fix`
- `mono test unit` — all projects passed on the pre-RPC-test run; the final parallel run had one 5s timeout in the existing package-common stream property, which then passed alone and as part of the complete package-common suite

Independent lifecycle, test-model, error-contract, architecture, and regression reviews approve the final tree.

### Data-flow view

```text
Store commit -> epoch-owned client queue -> one active leader push
                                          -> worker RPC hop(s)
                                          -> leader transaction commit
                                          -> acknowledgement

rebase -> install replacement epoch -> transfer pull lease -> retire stale epoch
close  -> stop admission -> drain epoch -> join single cleanup outcome
```

## Related issues

- Tracks #1425
- Stacked on #1405
- Related: #1301, #1338
