### PR TITLE
Fix record-form schema property tests by normalizing arbitraries

### DIFF
--- a/.changeset/fix-effect4-record-arbitraries.md
+++ b/.changeset/fix-effect4-record-arbitraries.md
@@ -1,0 +1,5 @@
+---
+'@livestore/utils-dev': patch
+---
+
+Normalize Effect 4 record-form schemas before generating Vitest arbitraries.

--- a/packages/@livestore/utils-dev/src/node-vitest/Vitest.test.ts
+++ b/packages/@livestore/utils-dev/src/node-vitest/Vitest.test.ts
@@ -38,6 +38,25 @@ Vitest.describe('Vitest.asProp', () => {
     { fastCheck: { numRuns: 4 } },
   )
 
+  Vitest.asProp(
+    Vitest.live,
+    'converts record-form schemas to arbitraries',
+    {
+      count: Schema.Int,
+      payload: Schema.Struct({
+        label: Schema.String,
+        note: Schema.optional(Schema.String),
+      }),
+    },
+    ({ count, payload }) =>
+      Effect.sync(() => {
+        Vitest.expect(Number.isInteger(count)).toBe(true)
+        Vitest.expect(typeof payload.label).toBe('string')
+        Vitest.expect(payload.note === undefined || typeof payload.note === 'string').toBe(true)
+      }),
+    { fastCheck: { numRuns: 10 } },
+  )
+
   // Failing test - should show initial + shrinking phases
   let alreadyFailed = false
   Vitest.asProp(

--- a/packages/@livestore/utils-dev/src/node-vitest/Vitest.ts
+++ b/packages/@livestore/utils-dev/src/node-vitest/Vitest.ts
@@ -12,7 +12,7 @@ import {
   Layer,
   type OtelTracer,
   Predicate,
-  type Schema,
+  Schema,
   type Scope,
 } from '@livestore/utils/effect'
 import { OtelLiveDummy } from '@livestore/utils/node'
@@ -189,6 +189,7 @@ export const asProp = <Arbs extends Vitest.Vitest.Arbitraries, A, E, R>(
   propOptions: number | PropOptions<Arbs>,
 ) => {
   const normalizedPropOptions = normalizePropOptions(propOptions)
+  const normalizedArbitraries = normalizeArbitraries(arbitraries)
   const numRuns = normalizedPropOptions.fastCheck?.numRuns ?? 100
   let runIndex = 0
   let shrinkAttempts = 0
@@ -196,7 +197,7 @@ export const asProp = <Arbs extends Vitest.Vitest.Arbitraries, A, E, R>(
 
   return api.prop(
     name,
-    arbitraries,
+    normalizedArbitraries,
     (properties, ctx) => {
       if (ctx.signal.aborted === true) {
         return ctx.skip('Test aborted')
@@ -229,4 +230,23 @@ export const asProp = <Arbs extends Vitest.Vitest.Arbitraries, A, E, R>(
     },
     normalizedPropOptions,
   )
+}
+
+/**
+ * Work around Effect-TS/effect#6413 until `@effect/vitest` converts schemas in
+ * record-form property definitions instead of passing them to FastCheck unchanged.
+ */
+const normalizeArbitraries = <Arbs extends Vitest.Vitest.Arbitraries>(arbitraries: Arbs): Arbs => {
+  if (Array.isArray(arbitraries) === true) return arbitraries
+
+  const normalized = Object.fromEntries(
+    Object.entries(arbitraries).map(([key, arbitrary]) => [
+      key,
+      Schema.isSchema(arbitrary) === true ? Schema.toArbitrary(arbitrary) : arbitrary,
+    ]),
+  )
+
+  // Normalization preserves record keys and value output types while replacing
+  // schema values with their equivalent FastCheck arbitraries.
+  return normalized as unknown as Arbs
 }


### PR DESCRIPTION
## Problem

`@effect/vitest@4.0.0-beta.98` accepts schemas in property-test definitions, but its record-form normalization converts each schema to a FastCheck arbitrary and then overwrites the result with the original schema. `Vitest.asProp` therefore fails during collection for record inputs such as `{ count: Schema.Int }`, preventing LiveStore's node-sync property suite from executing.

Upstream defect and minimal reproduction: Effect-TS/effect#6413

## Solution

Normalize schema-valued records at LiveStore's existing `Vitest.asProp` boundary before calling `@effect/vitest`. Array-form inputs remain untouched because upstream already handles them correctly.

The workaround is deliberately narrow and linked to its removal condition. Once Effect #6413 is released, this normalization can be removed instead of retaining two conversion layers.

## Validation

- Added record-form characterization coverage with a primitive schema and a struct containing an optional field.
- `pnpm --dir packages/@livestore/utils-dev exec vitest run src/node-vitest/Vitest.test.ts --config vitest.config.ts`: pass.
- `pnpm exec tsc -b packages/@livestore/utils-dev/tsconfig.json`: pass.
- Targeted `oxlint --deny-warnings`, `oxfmt`, and `git diff --check`: pass.

## Related issues

- Effect-TS/effect#6413
- livestorejs/livestore-contrib#12

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-effect-vitest-record-arbs/schickling/fix/effect-vitest-record-arbs |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->