### PR TITLE
chore(devenv): tsgo Expand — drop pkgs.typescript, advisory Effect gate

### DIFF
--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -162,7 +162,6 @@ export default githubWorkflow({
     }),
 
     'type-check': standardCIJob({
-      // TODO(oep-1n3.9): Switch back to patched tsc once Effect diagnostics backlog is addressed.
       steps: [...livestoreSetupSteps, { name: 'Run type-check', run: runDevenvTasksBefore('ts:build') }],
     }),
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -14,7 +14,9 @@ let
     else
       inputs.effect-utils;
   effectUtilsPackages = effectUtils.packages.${pkgs.system};
+  effectTsgo = effectUtilsPackages.effect-tsgo;
   taskModules = effectUtils.devenvModules.tasks;
+  pnpmPkg = effectUtils.lib.mkPnpm { inherit pkgs; };
   ci = builtins.getEnv "CI" != "";
 
   # Custom oxlint with NAPI bindings + @overeng/oxc-config JS plugin
@@ -323,7 +325,11 @@ in
     # Shared task modules from effect-utils
     taskModules.genie
     (taskModules.megarepo { syncAll = !ci; })
-    (taskModules.ts { tsconfigFile = "tsconfig.dev.json"; })
+    (taskModules.ts {
+      tsconfigFile = "tsconfig.dev.json";
+      tsBinPkg = effectTsgo;
+      tscBin = "$DEVENV_ROOT/node_modules/.bin/tsc";
+    })
     (taskModules.check {
       hasTests = false;
       hasNixCheck = false;
@@ -364,7 +370,10 @@ in
       genieCoverageExcludes = [ "packages/@livestore/wa-sqlite/" ];
       tsconfig = "tsconfig.dev.json";
     })
-    (taskModules.pnpm { packages = pnpmPackages; })
+    (taskModules.pnpm {
+      packages = pnpmPackages;
+      inherit pnpmPkg;
+    })
     # PR-preview reporting: provides workflow-report:{collect-bundle,
     # render-comment-body,publish}, invoked by the generated report-pr-preview
     # CI job. Replaces the former `nix run <effect-utils>#workflow-report` flake
@@ -396,45 +405,15 @@ in
     ":(glob)genie/**/*.ts"
   ];
 
-  # Keep Nix-provided `tsc` aligned with the workspace TypeScript catalog override so
-  # devenv tasks validate against the same compiler as package-local tooling. Remove
-  # this once the inherited nixpkgs `pkgs.typescript` provides TypeScript 6.0.3 or newer.
-  overlays = [
-    (_final: prev: {
-      typescript = prev.typescript.overrideAttrs (
-        _finalAttrs: _oldAttrs:
-        let
-          typescriptSrc = prev.fetchFromGitHub {
-            owner = "microsoft";
-            repo = "TypeScript";
-            rev = "v6.0.3";
-            hash = "sha256-RvM+fGO94ItdQxgXUcCdkpX039pytnMri100wGjNhhc=";
-          };
-        in
-        {
-          version = "6.0.3";
-          src = typescriptSrc;
-          npmDeps = prev.fetchNpmDeps {
-            name = "typescript-6.0.3-npm-deps";
-            src = typescriptSrc;
-            hash = "sha256-nnBXImViLpuPPNYwBxe3T+hpoiuA/7qpIMVcXJmjklg=";
-          };
-          npmDepsHash = "sha256-nnBXImViLpuPPNYwBxe3T+hpoiuA/7qpIMVcXJmjklg=";
-        }
-      );
-    })
-  ];
-
   packages = [
-    (effectUtils.lib.mkPnpm { inherit pkgs; })
+    (lib.lowPrio pnpmPkg)
+    (lib.lowPrio effectTsgo)
     pkgs.bun
     pkgs.nodejs_24
-    pkgs.typescript
     oxlintWithPlugins
     pkgs.oxfmt
     # CLIs from effect-utils (Nix-built packages)
   ]
-  ++ [ effectUtilsPackages.effect-tsgo ]
   ++ [
     effectUtilsPackages.genie
     effectUtils.packages.${pkgs.system}.megarepo

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -89,8 +89,7 @@ export type {
 export const domLib = effectUtilsDomLib.filter((lib) => lib !== 'DOM.Iterable' && lib !== 'DOM.AsyncIterable')
 
 // Strip inherited options that now match defaults so generated
-// tsconfigs only carry LiveStore-specific intent. `plugins` is pulled out
-// separately so we can override the Effect-LSP exit-code gate below.
+// tsconfigs only carry LiveStore-specific intent.
 const {
   allowJs: _allowJs,
   esModuleInterop: _esModuleInterop,
@@ -98,34 +97,22 @@ const {
   forceConsistentCasingInFileNames: _forceConsistentCasingInFileNames,
   moduleResolution: _moduleResolution,
   strict: _strict,
-  plugins: inheritedTsconfigPlugins,
-  ...baseTsconfigCompilerOptionsWithoutPlugins
+  ...baseTsconfigCompilerOptionsWithoutDefaults
 } = effectUtilsBaseTsconfigCompilerOptions
 
-/**
- * #811 Effect-LSP gate — deferred warning/suggestion burndown.
- *
- * effect-utils sets `effectDiagnosticsGate = { warnings: true, suggestions: true }`,
- * so its `@effect/language-service` plugin config fails `tsgo --build` on every
- * Effect *warning* and *suggestion*, not just errors. Adopting this effect-utils
- * revision surfaced ~406 pre-existing advisory diagnostics (duplicatePackage,
- * schemaNumber, preferSchemaOverJson, …) across the LiveStore tree.
- *
- * For this effect-utils bump we restore LiveStore's pre-bump gating — ERRORS only —
- * by flipping just the two exit-code flags. Warnings/suggestions stay VISIBLE in
- * build output (advisory) but no longer fail the build; real Effect errors (e.g.
- * the `missingReturnYieldStar` bugs fixed in this PR) still gate hard via the
- * inherited `ignoreEffectErrorsInTscExitCode: false`. The full warning/suggestion
- * burndown to the #811 Effect-LSP bar is deferred to a dedicated follow-up PR.
- * This mirrors effect-utils' own `effectDiagnosticsGate` phased-adoption design.
- */
 const baseTsconfigCompilerOptions = {
-  ...baseTsconfigCompilerOptionsWithoutPlugins,
-  plugins: inheritedTsconfigPlugins.map((plugin) =>
-    plugin.name === '@effect/language-service'
-      ? { ...plugin, ignoreEffectWarningsInTscExitCode: true, ignoreEffectSuggestionsInTscExitCode: true }
-      : plugin,
-  ),
+  ...baseTsconfigCompilerOptionsWithoutDefaults,
+  // LIVE-MIGRATION BRIDGE tsgo-strict-gate — DELETE at contraction — see live-migrations registry
+  // Advisory gate: Effect warnings and suggestions remain visible without failing the exit code.
+  plugins: [
+    {
+      ...effectUtilsBaseTsconfigCompilerOptions.plugins[0],
+      ignoreEffectWarningsInTscExitCode: true,
+      ignoreEffectSuggestionsInTscExitCode: true,
+      ignoreEffectErrorsInTscExitCode: false,
+    },
+  ],
+  // LIVE-MIGRATION END tsgo-strict-gate
 } as const
 
 /**


### PR DESCRIPTION
## Problem

LiveStore's merged tooling-contract bump makes the current effect-utils hub available, but compiler ownership is still split: Nix supplies a custom TypeScript 6 overlay, effect-tsgo is an unguarded PATH package, and pnpm-local TypeScript is not the explicit emit compiler. That leaves the repository outside the fleet's deterministic tsgo task contract.

## Goal

Adopt the standard tsgo Expand phase while keeping existing Effect diagnostics advisory: tsgo owns type-check/build through the shared guard, root TypeScript 6.0.3 owns JS compiler/emit work, and the later Contract phase can delete one marked bridge to enable the strict Effect gate.

## Decisions

- Keep the already-current effect-utils pin (`348be5df`) and existing direct root TypeScript 6.0.3 dependency; no dependency re-lock is needed.
- Guard-own both `tsgo` and `pnpm`, with their real packages at low priority, to avoid PATH collisions.
- Remove both `pkgs.typescript` and LiveStore's TypeScript 6.0.3 `overrideAttrs` overlay; `tscBin` now resolves explicitly through the root pnpm install.
- Replace the bump PR's broad advisory override with the standard single additive `LIVE-MIGRATION BRIDGE` block. Deleting that block restores the inherited strict plugin unchanged.
- Remove the now-stale CI comment about switching back to patched tsc.

## Verification

- `CI=1 DEVENV_TASK_PASSTHROUGH=1 devenv tasks --refresh-task-cache run check:quick --no-tui` — pass; the same check also passed in the pre-commit hook.
- Forced tsgo build — exit 0 with 0 errors while visibly reporting 229 warnings and 184 suggestions.
- Throwaway `Schema.Number` probe — reported suggestion `TS377098` while the compiler retained exit 0; probe reverted.
- `ts:emit` — pass through root TypeScript 6.0.3.
- Fresh isolated install with empty `node_modules`, `.devenv`, `PNPM_HOME`, and `PNPM_STORE_DIR` — pass; lock stayed unchanged with 144 `hasBin` records and first-install shims for TypeScript, Vitest, Astro, Playwright, Vite, sync-provider, and wa-sqlite runners.
- Exact local CI lanes passing: `ts:build`, `lint:full:with-megarepo-check`, `test:unit`, all seven sync-provider matrix members, wa-sqlite build + test, source policy, and both changeset checks.
- Playwright proof boundary: `misc` passes locally once the existing pnpm-GVS native-module closure is exposed; the published devtools package otherwise cannot resolve `@parcel/watcher`'s platform binary locally. `todomvc` then reaches the browser test but hits a baseline page-console failure; `devtools` completes under its CI soft-failure semantics. The parent tooling-contract PR's authoritative CI run passed all three Playwright suites, and this PR's CI remains the authoritative validation for that baseline-sensitive surface.

## Complexity

No new abstraction or dependency. The change removes a custom Nix overlay and 35 net lines while adopting existing shared task contracts.

## Concerns

- The repository still has 413 advisory Effect diagnostics by design. The follow-up Contract phase must burn those down and delete the bridge.
- The repository ruleset requires `@schickling` review before merge.

## Friction & bottlenecks

- Local pnpm GVS materialization exposes `@parcel/watcher` but the bundled published devtools package cannot see its platform optional dependency without an explicit module-search path. This is baseline package-closure behavior, not tsgo fallout; it is documented here rather than folded into the bounded Expand.
- The cold wa-sqlite Nix build fetched a large toolchain closure, but completed without a hash mismatch.

## Follow-ups

- Run the separate tsgo Contract phase after this Expand merges: burn down Effect diagnostics, delete the bridge, and prove strict failure behavior.
- Track the published devtools / pnpm-GVS native-module closure issue in the tooling/infra workstream.

## References

- Follows #1397.
- Fleet epic: https://github.com/schickling/megarepo-all/issues/106
- Worked Expand pattern: https://github.com/overengineeringstudio/diffstream/pull/67

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ⚫ co3-onyx |
| `agent_session_id` | 7b8e53d0-1f04-47cd-8048-6f695582f1da |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/qq3avrif77r90ypqbdv3hgd3gvwj5s32-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/pjlb3cwf453ghzmc8jj4v8h29sw6p4dg-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-17-2026-07-17-tsgo-expand |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4b8e1c5 |
</details>
<!-- agent-footer:end -->