### PR TITLE
Fix browser bundling by isolating Effect test helpers

### DIFF
--- a/.changeset/browser-safe-effect-facade.md
+++ b/.changeset/browser-safe-effect-facade.md
@@ -1,0 +1,7 @@
+---
+'@livestore/utils': minor
+---
+
+Fix browser bundling of `@livestore/utils/effect` by keeping Effect's Node-only schema test assertions out of the runtime facade.
+
+`TestSchema` is no longer exported from `@livestore/utils/effect`; tests should import it from `effect/testing`.

--- a/genie/external.ts
+++ b/genie/external.ts
@@ -194,6 +194,7 @@ export const livestoreOnlyCatalog = {
   '@types/node': '25.3.3',
   '@types/react': '19.2.7',
   '@vitejs/plugin-react': '5.1.2',
+  esbuild: '0.28.0',
   react: '19.2.3',
   'react-dom': '19.2.3',
   vite: '7.3.1',

--- a/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts
@@ -1,6 +1,7 @@
+import { TestSchema } from 'effect/testing'
 import { assert, describe, expect, it } from 'vitest'
 
-import { Schema, SchemaAST, Struct, TestSchema } from '@livestore/utils/effect'
+import { Schema, SchemaAST, Struct } from '@livestore/utils/effect'
 
 import * as State from '../mod.ts'
 import { withAutoIncrement, withColumnType, withDefault, withPrimaryKey, withUnique } from './column-annotations.ts'

--- a/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts
@@ -1,6 +1,7 @@
+import { TestSchema } from 'effect/testing'
 import { describe, expect, it } from 'vitest'
 
-import { Schema, SchemaTransformation, TestSchema } from '@livestore/utils/effect'
+import { Schema, SchemaTransformation } from '@livestore/utils/effect'
 
 import { State } from '../../../mod.ts'
 import { getResultSchema } from './impl.ts'

--- a/packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts
@@ -1,6 +1,7 @@
+import { TestSchema } from 'effect/testing'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
-import { Schema, SchemaAST, SchemaTransformation, TestSchema } from '@livestore/utils/effect'
+import { Schema, SchemaAST, SchemaTransformation } from '@livestore/utils/effect'
 
 import { State } from '../../mod.ts'
 

--- a/packages/@livestore/utils/package.json
+++ b/packages/@livestore/utils/package.json
@@ -95,6 +95,7 @@
     "@types/node": "25.3.3",
     "@types/web": "0.0.264",
     "effect": "4.0.0-beta.97",
+    "esbuild": "0.28.0",
     "jsdom": "26.1.0",
     "vitest": "4.1.9"
   },

--- a/packages/@livestore/utils/package.json.genie.ts
+++ b/packages/@livestore/utils/package.json.genie.ts
@@ -25,6 +25,7 @@ const runtimeDeps = catalog.compose({
       '@types/jsdom',
       '@types/node',
       '@types/web',
+      'esbuild',
       'jsdom',
       'vitest',
     ),

--- a/packages/@livestore/utils/src/effect/mod.browser-build.test.ts
+++ b/packages/@livestore/utils/src/effect/mod.browser-build.test.ts
@@ -1,0 +1,19 @@
+import { build } from 'esbuild'
+import { expect, it } from 'vitest'
+
+it('bundles the Effect facade for browsers without Node builtins', async () => {
+  const result = await build({
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    stdin: {
+      contents: `import { Schema } from './mod.ts'; export const BrowserSchema = Schema.Struct({ value: Schema.String })`,
+      loader: 'ts',
+      resolveDir: import.meta.dirname,
+      sourcefile: 'browser-build-fixture.ts',
+    },
+    write: false,
+  })
+
+  expect(result.outputFiles).toHaveLength(1)
+})

--- a/packages/@livestore/utils/src/effect/mod.ts
+++ b/packages/@livestore/utils/src/effect/mod.ts
@@ -110,7 +110,9 @@ export {
   TxRef,
   Types,
 } from 'effect'
-export { FastCheck, TestClock, TestConsole, TestSchema } from 'effect/testing'
+export * as FastCheck from 'effect/testing/FastCheck'
+export * as TestClock from 'effect/testing/TestClock'
+export * as TestConsole from 'effect/testing/TestConsole'
 export * as Debug from './Debug.ts'
 export * as Effect from './Effect.ts'
 export * from './Error.ts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1537,6 +1537,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.97
         version: 4.0.0-beta.97
+      esbuild:
+        specifier: 0.28.0
+        version: 0.28.0
       jsdom:
         specifier: 26.1.0
         version: 26.1.0


### PR DESCRIPTION
## Problem

`@livestore/utils/effect` statically re-exported `TestSchema` through the `effect/testing` barrel. Effect 4's `TestSchema` implementation imports `node:assert`, so esbuild/Vite dependency traversal of the runtime facade failed in browser builds even when an application imported only runtime APIs such as `Schema`.

This blocks the LiveStore contrib Effect 4 migration tracked in https://github.com/livestorejs/livestore-contrib/issues/12.

## Solution

- Remove the Node-only `TestSchema` API from the runtime facade and import it directly from `effect/testing` in schema tests.
- Preserve the existing `FastCheck`, `TestClock`, and `TestConsole` facade APIs through their browser-safe Effect submodules rather than the aggregate testing barrel.
- Add an esbuild browser-bundle characterization for the public runtime facade.

The narrow compatibility impact is that snapshot consumers importing `TestSchema` from `@livestore/utils/effect` must use `effect/testing`. The other existing testing exports remain available.

## Validation

- Characterization against the old export: fails with `Could not resolve "node:assert"` at `effect/dist/testing/TestSchema.js:12`.
- `pnpm exec vitest run packages/@livestore/utils/src/effect/mod.browser-build.test.ts --config packages/@livestore/utils/vitest.config.ts` (1 passed)
- `pnpm exec vitest run packages/@livestore/common/src/schema/state/sqlite/column-def.test.ts packages/@livestore/common/src/schema/state/sqlite/table-def.test.ts packages/@livestore/common/src/schema/state/sqlite/query-builder/impl.test.ts --config packages/@livestore/common/vitest.config.ts` (113 passed)
- `pnpm exec vitest run packages/@livestore/livestore/src/store/StoreRegistry.test.ts --config packages/@livestore/livestore/vitest.config.ts` (21 passed, 1 existing skip)
- `pnpm exec vitest run packages/@livestore/utils-dev/src/node-vitest/Vitest.test.ts --config packages/@livestore/utils-dev/vitest.config.ts` (2 passed, 1 expected failure)
- `devenv tasks run ts:check`
- `devenv tasks run lint:check:format lint:check:oxlint genie:check`

### Demo

Before:

```text
ERROR: Could not resolve "node:assert"
effect/dist/testing/TestSchema.js:12:24
```

After: the same browser bundle emits successfully without a Node builtin edge.

## Related issues

- https://github.com/livestorejs/livestore-contrib/issues/12

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-browser-safe-effect-facade/schickling/fix/browser-safe-effect-facade |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->