### PR TITLE
Expose reusable Effects for docs and snapshot workflows

### DIFF
--- a/scripts/src/commands/command-effects.test.ts
+++ b/scripts/src/commands/command-effects.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { Effect } from '@livestore/utils/effect'
+
+import { exportMarkdown } from './docs-export.ts'
+import { releaseSnapshot } from './release.ts'
+
+describe('command Effect operations', () => {
+  it('exposes markdown export as a lazy Effect with plain-value options', () => {
+    const operation = exportMarkdown({
+      out: '/tmp/livestore-docs',
+      includeLlms: true,
+      workspaceRoot: '/tmp/livestore',
+    })
+
+    expect(Effect.isEffect(operation)).toBe(true)
+  })
+
+  it('exposes snapshot release as a lazy Effect with plain-value options', () => {
+    const operation = releaseSnapshot({
+      cwd: '/tmp/livestore',
+      gitSha: 'abc123',
+      version: '0.0.0-snapshot-abc123',
+      dryRun: true,
+      yes: true,
+      tscBin: 'tsc',
+    })
+
+    expect(Effect.isEffect(operation)).toBe(true)
+  })
+})

--- a/scripts/src/commands/docs-export.ts
+++ b/scripts/src/commands/docs-export.ts
@@ -6,6 +6,77 @@ import { Cli } from '@livestore/utils/node'
 import { transformMultiCodeDocument } from '@local/docs/multi-code-markdown'
 import { docsSidebar, type TSidebarItem } from '@local/docs/sidebar'
 
+export type ExportMarkdownOptions = {
+  readonly out?: string | undefined
+  readonly includeLlms?: boolean
+  readonly workspaceRoot?: string | undefined
+}
+
+export const exportMarkdown = Effect.fn(function* ({
+  out,
+  includeLlms = false,
+  workspaceRoot: workspaceRootOption,
+}: ExportMarkdownOptions) {
+  const workspaceRoot =
+    workspaceRootOption ??
+    process.env.WORKSPACE_ROOT ??
+    shouldNeverHappen(`WORKSPACE_ROOT is not set. Make sure to run 'direnv allow'`)
+  const docsRoot = path.join(workspaceRoot, 'docs')
+  const contentRoot = path.join(docsRoot, 'src', 'content', 'docs')
+  const outputDir =
+    out === undefined ? path.join(workspaceRoot, 'packages', '@livestore', 'livestore', 'docs') : path.resolve(out)
+
+  yield* assertSnippetManifest(docsRoot)
+
+  const docs = yield* loadDocs(contentRoot)
+
+  const llmsDocs: ReadonlyArray<TLlmsDoc> = docs
+    .filter((doc) => !doc.slug.startsWith('api/'))
+    .map((doc) => ({
+      title: doc.title,
+      description: doc.description,
+      slug: doc.slug,
+      sidebarOrder: doc.sidebarOrder,
+    }))
+
+  for (const doc of docs) {
+    const transformed = yield* Effect.promise(() =>
+      transformMultiCodeDocument({
+        id: doc.id,
+        collection: 'docs',
+        body: doc.body,
+        docsRoot,
+      }),
+    )
+
+    const cleaned = stripLeadingImports(transformed).trim()
+    const markdown = replaceLlmsShortPlaceholders({
+      markdown: cleaned,
+      docs: llmsDocs,
+      site: null,
+    })
+    const final = `# ${doc.title}\n\n${markdown}\n`
+    yield* writeDoc(outputDir, doc, final)
+  }
+
+  if (includeLlms === true) {
+    const fs = yield* FileSystem.FileSystem
+    const llmsList = renderLlmsListHierarchical({ docs: llmsDocs, site: null })
+    const llmsBody = `# LiveStore Documentation for LLMs
+
+> LiveStore is a client-centric local-first data layer for high-performance apps based on SQLite and event-sourcing.
+
+## Notes
+
+- Most LiveStore APIs are synchronous and don't need \`await\`
+
+${llmsList}`
+    yield* fs.writeFileString(path.join(outputDir, 'llms.txt'), `${llmsBody.trimEnd()}\n`)
+  }
+
+  yield* Effect.log(`Exported ${docs.length} docs to ${outputDir}`)
+})
+
 export const exportMarkdownCommand = Cli.Command.make(
   'export-markdown',
   {
@@ -22,73 +93,12 @@ export const exportMarkdownCommand = Cli.Command.make(
       Cli.Flag.withDescription('Also emit llms.txt alongside index.md'),
     ),
   },
-  Effect.fn(function* ({ out, includeLlms, workspaceRoot: workspaceRootOption }) {
-    const workspaceRoot =
-      workspaceRootOption._tag === 'Some'
-        ? workspaceRootOption.value
-        : (process.env.WORKSPACE_ROOT ??
-          shouldNeverHappen(`WORKSPACE_ROOT is not set. Make sure to run 'direnv allow'`))
-    const docsRoot = path.join(workspaceRoot, 'docs')
-    const contentRoot = path.join(docsRoot, 'src', 'content', 'docs')
-    const outputDir =
-      out._tag === 'Some'
-        ? path.resolve(out.value)
-        : path.join(workspaceRoot, 'packages', '@livestore', 'livestore', 'docs')
-
-    yield* assertSnippetManifest(docsRoot)
-
-    const docs = yield* loadDocs(contentRoot)
-
-    const llmsDocs: ReadonlyArray<TLlmsDoc> = docs
-      .filter((doc) => !doc.slug.startsWith('api/'))
-      .map((doc) => ({
-        title: doc.title,
-        description: doc.description,
-        slug: doc.slug,
-        sidebarOrder: doc.sidebarOrder,
-      }))
-
-    const exportEffect = Effect.gen(function* () {
-      for (const doc of docs) {
-        const transformed = yield* Effect.promise(() =>
-          transformMultiCodeDocument({
-            id: doc.id,
-            collection: 'docs',
-            body: doc.body,
-            docsRoot,
-          }),
-        )
-
-        const cleaned = stripLeadingImports(transformed).trim()
-        const markdown = replaceLlmsShortPlaceholders({
-          markdown: cleaned,
-          docs: llmsDocs,
-          site: null,
-        })
-        const final = `# ${doc.title}\n\n${markdown}\n`
-        yield* writeDoc(outputDir, doc, final)
-      }
-
-      if (includeLlms === true) {
-        const fs = yield* FileSystem.FileSystem
-        const llmsList = renderLlmsListHierarchical({ docs: llmsDocs, site: null })
-        const llmsBody = `# LiveStore Documentation for LLMs
-
-> LiveStore is a client-centric local-first data layer for high-performance apps based on SQLite and event-sourcing.
-
-## Notes
-
-- Most LiveStore APIs are synchronous and don't need \`await\`
-
-${llmsList}`
-        yield* fs.writeFileString(path.join(outputDir, 'llms.txt'), `${llmsBody.trimEnd()}\n`)
-      }
-
-      yield* Effect.log(`Exported ${docs.length} docs to ${outputDir}`)
-    })
-
-    yield* exportEffect
-  }),
+  ({ out, includeLlms, workspaceRoot }) =>
+    exportMarkdown({
+      out: out._tag === 'Some' ? out.value : undefined,
+      includeLlms,
+      workspaceRoot: workspaceRoot._tag === 'Some' ? workspaceRoot.value : undefined,
+    }),
 )
 
 export class SnippetManifestMissing extends Schema.TaggedErrorClass<SnippetManifestMissing>()(

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -7,6 +7,15 @@ import { Cli } from '@livestore/utils/node'
 
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../shared/misc.ts'
 
+export type ReleaseSnapshotOptions = {
+  readonly cwd: string
+  readonly gitSha?: string | undefined
+  readonly version?: string | undefined
+  readonly dryRun?: boolean
+  readonly yes?: boolean
+  readonly tscBin?: string | undefined
+}
+
 class PackageJsonParseError extends Schema.TaggedErrorClass<PackageJsonParseError>()('PackageJsonParseError', {
   message: Schema.String,
   cause: Schema.Defect(),
@@ -594,6 +603,57 @@ export const releaseStableCommand = Cli.Command.make(
   }),
 )
 
+export const releaseSnapshot = Effect.fn(function* ({
+  gitSha: gitShaOption,
+  dryRun = false,
+  yes = false,
+  cwd,
+  version: versionOption,
+  tscBin = 'tsc',
+}: ReleaseSnapshotOptions) {
+  const gitSha =
+    gitShaOption ??
+    (yield* cmdText('git rev-parse HEAD').pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))).trim()
+
+  const snapshotVersion = versionOption ?? `0.0.0-snapshot-${gitSha}`
+  const snapshotPackages = yield* listSnapshotPackages(cwd)
+
+  /** Confirm before proceeding unless --yes is passed or CI is detected. */
+  const isCI = process.env.CI === 'true' || process.env.CI === '1'
+  const skipConfirmation = yes || isCI
+  if (skipConfirmation === false) {
+    yield* Effect.log(
+      `About to publish ${snapshotPackages.length} package(s) as ${snapshotVersion}${dryRun === true ? ' (dry-run)' : ''}`,
+    )
+    const confirmed = yield* Cli.Prompt.confirm({ message: 'Proceed with snapshot release?' })
+    if (confirmed === false) {
+      yield* Effect.log('Snapshot release aborted by user')
+      return
+    }
+  }
+
+  yield* publishReleasePackages({
+    cwd,
+    version: snapshotVersion,
+    npmTag: 'snapshot',
+    packages: snapshotPackages,
+    dryRun,
+    allowExisting: true,
+    tscBin,
+  })
+
+  yield* appendGithubSummaryMarkdown({
+    markdown: formatReleaseSummaryMarkdown({
+      packages: snapshotPackages,
+      version: snapshotVersion,
+      npmTag: 'snapshot',
+      dryRun,
+      title: 'Snapshot release',
+    }),
+    context: 'snapshot release',
+  })
+})
+
 export const releaseSnapshotCommand = Cli.Command.make(
   'snapshot',
   {
@@ -611,51 +671,15 @@ export const releaseSnapshotCommand = Cli.Command.make(
     versionOption: Cli.Flag.string('version').pipe(Cli.Flag.optional),
     tscBin: Cli.Flag.string('tsc-bin').pipe(Cli.Flag.optional),
   },
-  Effect.fn(function* ({ gitShaOption, dryRun, yes, cwd, versionOption, tscBin: tscBinOption }) {
-    const gitSha =
-      gitShaOption._tag === 'Some'
-        ? gitShaOption.value
-        : (yield* cmdText('git rev-parse HEAD').pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))).trim()
-
-    const snapshotVersion = versionOption._tag === 'Some' ? versionOption.value : `0.0.0-snapshot-${gitSha}`
-    const snapshotPackages = yield* listSnapshotPackages(cwd)
-
-    /** Confirm before proceeding unless --yes is passed or CI is detected. */
-    const isCI = process.env.CI === 'true' || process.env.CI === '1'
-    const skipConfirmation = yes || isCI
-    if (skipConfirmation === false) {
-      yield* Effect.log(
-        `About to publish ${snapshotPackages.length} package(s) as ${snapshotVersion}${dryRun === true ? ' (dry-run)' : ''}`,
-      )
-      const confirmed = yield* Cli.Prompt.confirm({ message: 'Proceed with snapshot release?' })
-      if (confirmed === false) {
-        yield* Effect.log('Snapshot release aborted by user')
-        return
-      }
-    }
-
-    const tsc = tscBinOption._tag === 'Some' ? tscBinOption.value : 'tsc'
-    yield* publishReleasePackages({
-      cwd,
-      version: snapshotVersion,
-      npmTag: 'snapshot',
-      packages: snapshotPackages,
+  ({ gitShaOption, dryRun, yes, cwd, versionOption, tscBin }) =>
+    releaseSnapshot({
+      gitSha: gitShaOption._tag === 'Some' ? gitShaOption.value : undefined,
       dryRun,
-      allowExisting: true,
-      tscBin: tsc,
-    })
-
-    yield* appendGithubSummaryMarkdown({
-      markdown: formatReleaseSummaryMarkdown({
-        packages: snapshotPackages,
-        version: snapshotVersion,
-        npmTag: 'snapshot',
-        dryRun,
-        title: 'Snapshot release',
-      }),
-      context: 'snapshot release',
-    })
-  }),
+      yes,
+      cwd,
+      version: versionOption._tag === 'Some' ? versionOption.value : undefined,
+      tscBin: tscBin._tag === 'Some' ? tscBin.value : undefined,
+    }),
 )
 
 export const releaseNotesExtractCommand = Cli.Command.make(


### PR DESCRIPTION
## Problem

Effect 4 CLI commands no longer expose a `.handler` surface. Downstream release orchestration therefore cannot safely compose the existing docs export and snapshot release behavior without duplicating it or invoking the CLI as a subprocess.

## Goal

Expose both workflows as ordinary Effect operations while retaining the existing CLI flags and behavior.

## Decisions

- Export plain-value option types rather than leaking Effect CLI `Option` values into programmatic callers.
- Keep CLI commands as adapters that translate parsed flags and delegate to the exported operations.
- Preserve defaults, confirmation behavior, package selection, publishing, and summary generation unchanged.

## Verification

- `vitest run --root scripts --config vitest.config.ts src/commands/command-effects.test.ts src/commands/release.test.ts`: 2 files passed, 9 tests passed.
- `tsc -p scripts/tsconfig.json --noEmit`: passed.
- `oxlint scripts/src/commands/docs-export.ts scripts/src/commands/release.ts scripts/src/commands/command-effects.test.ts`: 0 warnings, 0 errors.
- `git diff --check`: passed.

## Complexity

No new dependencies or abstractions. Existing command bodies become named Effect operations, and the commands become thin adapters.

## Concerns

None. The operation tests intentionally prove lazy composability without executing filesystem export or npm publishing side effects.

## Friction & bottlenecks

The isolated worktree reused the current core dependency projection for targeted validation; the root Vitest project fan-out required selecting the scripts project explicitly. No persistent bottleneck observed.

## Follow-ups

None in core. Downstream orchestration can migrate from removed `.handler` access to these exported operations.

## References

- Related migration: https://github.com/livestorejs/livestore-contrib/pull/10

No changeset or CHANGELOG entry: this only changes repository-local scripts and does not alter a published package.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-cli-effect-exports/schickling/fix/cli-effect-exports |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->