### PR TITLE
test(sync-cf): guard sync-DO hibernation over Durable Object RPC

### DIFF
--- a/.changeset/do-rpc-hibernation-guard.md
+++ b/.changeset/do-rpc-hibernation-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Adds a regression test that the Cloudflare sync backend Durable Object still hibernates when its only client is an idle live pull over Durable Object RPC (not a WebSocket) (#1328): reintroducing a timer that pins the DO resident turns the test red. Stacked on #1427, reusing its non-persisted `instanceId` probe; runs in the `cf-do-rpc-do` matrix cell but does not gate a merge (those cells swallow failures, #1430). Guards non-hibernation only — it deliberately does not assert that the live pull survives hibernation, which over DO RPC is a separate, currently-failing property (the rebuilt DO drops its in-memory subscribers).

--- a/tests/sync-provider/src/do-rpc-hibernation.test.ts
+++ b/tests/sync-provider/src/do-rpc-hibernation.test.ts
@@ -1,0 +1,133 @@
+import { expect } from 'vitest'
+
+import { EventFactory } from '@livestore/common/testing'
+import { nanoid } from '@livestore/livestore'
+import { events } from '@livestore/livestore/internal/testing-utils'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import {
+  type Context,
+  Data,
+  type Duration,
+  Effect,
+  FetchHttpClient,
+  type HttpClient,
+  KeyValueStore,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Schedule,
+  Stream,
+} from '@livestore/utils/effect'
+
+import * as CloudflareDoRpcProvider from './providers/cloudflare-do-rpc.ts'
+import { SyncProviderImpl } from './types.ts'
+
+const idleWindow: Duration.Input = '20 seconds' // workerd evicts somewhere between 9s and 11s idle
+
+type RuntimeServices = SyncProviderImpl | HttpClient.HttpClient | KeyValueStore.KeyValueStore
+
+// CI cells select by title (see scripts/src/commands/test-commands.ts); renaming this stops it running anywhere.
+Vitest.describe(`${CloudflareDoRpcProvider.doSqlite.name} sync provider — DO hibernation`, () => {
+  let runtime: ManagedRuntime.ManagedRuntime<RuntimeServices, never>
+  let runtimeContext: Context.Context<RuntimeServices>
+
+  Vitest.beforeAll(async () => {
+    runtime = ManagedRuntime.make(
+      CloudflareDoRpcProvider.doSqlite.layer.pipe(
+        Layer.provideMerge(FetchHttpClient.layer),
+        Layer.provideMerge(KeyValueStore.layerMemory),
+        Layer.orDie,
+      ),
+    )
+    runtimeContext = await runtime.context()
+  })
+
+  Vitest.afterAll(async () => await runtime.dispose())
+
+  Vitest.live('an idle DO-RPC live pull still lets the sync DO hibernate, and a warm DO stays resident', () =>
+    Effect.gen(function* () {
+      const observed = yield* Effect.all(
+        { livePull: hibernatesWhileIdleOverDoRpc, warmControl: staysResidentWhileWarm },
+        { concurrency: 'unbounded' },
+      )
+
+      expect(observed).toEqual({ livePull: true, warmControl: false })
+    }).pipe(Effect.provide(runtimeContext)),
+  )
+})
+
+class HibernationProbeError extends Data.TaggedError('HibernationProbeError')<{ message: string }> {}
+
+const syncProvider = Effect.gen(function* () {
+  const { makeProvider, providerSpecific } = yield* SyncProviderImpl
+  const { port } = providerSpecific
+  if (port === undefined) {
+    return yield* Effect.die('sync provider did not expose a dev server port')
+  }
+  return { makeProvider, port }
+})
+
+const eventClient = EventFactory.clientIdentity('do-rpc-hibernation-client', 'do-rpc-hibernation-session')
+const makeFactory = EventFactory.makeFactory(events)
+
+const probeSyncDo = ({ port, storeId }: { port: number; storeId: string }) =>
+  Effect.promise(() =>
+    fetch(`http://localhost:${port}/instance/sync?storeId=${storeId}`).then((res) => res.json()),
+  ).pipe(Effect.map((json) => json as { instanceId: string; webSocketCount: number }))
+
+const awaitDelivery = ({ received, id }: { received: ReadonlyArray<string>; id: string }) =>
+  Effect.sync(() => received.includes(id)).pipe(
+    Effect.flatMap((delivered) =>
+      delivered === true ? Effect.void : Effect.fail(new HibernationProbeError({ message: `never delivered: ${id}` })),
+    ),
+    Effect.retry(Schedule.spaced('300 millis')),
+    Effect.timeout('10 seconds'),
+  )
+
+const hibernatesWhileIdleOverDoRpc = Effect.gen(function* () {
+  const { makeProvider, port } = yield* syncProvider
+  const storeId = `do-rpc-hibernation-${nanoid()}`
+  const syncBackend = yield* makeProvider({ storeId, clientId: eventClient.clientId, payload: undefined })
+  const factory = makeFactory({ client: eventClient, startSeq: 1, initialParent: 'root' })
+  const received: string[] = []
+
+  yield* syncBackend.connect
+  yield* syncBackend.pull(Option.none(), { live: true }).pipe(
+    Stream.runForEach((res) =>
+      Effect.sync(() => {
+        for (const item of res.batch) {
+          received.push(item.eventEncoded.args.id)
+        }
+      }),
+    ),
+    Effect.tapCauseLogPretty,
+    Effect.forkScoped,
+  )
+
+  // DO RPC keeps no socket, so this delivery is the only proof the live pull is really parked before we idle.
+  yield* Effect.sleep('1 second')
+  yield* syncBackend.push([factory.todoCreated.next({ id: 'before-idle', text: 'before', completed: false })])
+  yield* awaitDelivery({ received, id: 'before-idle' })
+
+  const before = yield* probeSyncDo({ port, storeId })
+  yield* Effect.sleep(idleWindow)
+  const after = yield* probeSyncDo({ port, storeId })
+
+  return before.instanceId !== after.instanceId
+})
+
+const staysResidentWhileWarm = Effect.gen(function* () {
+  const { port } = yield* syncProvider
+  const storeId = `do-rpc-hibernation-warm-${nanoid()}`
+
+  const before = yield* probeSyncDo({ port, storeId })
+  yield* probeSyncDo({ port, storeId }).pipe(
+    Effect.delay('3 seconds'),
+    Effect.forever,
+    Effect.timeout(idleWindow),
+    Effect.ignore,
+  )
+  const after = yield* probeSyncDo({ port, storeId })
+
+  return before.instanceId !== after.instanceId
+})

--- a/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
+++ b/tests/sync-provider/src/providers/cloudflare-do-rpc.ts
@@ -44,7 +44,7 @@ const makeLayer = (config?: { wranglerConfigPath?: string; label: string }): Syn
           })(args),
         turnBackendOffline: Effect.log('TODO implement turnBackendOffline'),
         turnBackendOnline: Effect.log('TODO implement turnBackendOnline'),
-        providerSpecific: {},
+        providerSpecific: { port: server.port },
       }
     }),
   ).pipe(


### PR DESCRIPTION
> Stacked on #1427 — it reuses the non-persisted `instanceId` probe added there, so review/merge #1427 first. Base is `bohdan/test/do-hibernation-guard`; the diff here is only the DO-RPC additions.

## Problem

The sync backend Durable Object never hibernated (#1328): under Effect v3 a parked live pull kept a `setInterval` registered, which disqualifies hibernation. #1427 guards this over the **WebSocket** transport. The sync DO also serves clients over **Durable Object RPC** (the `@livestore/adapter-cf` path), which #1427 does not cover — a timer reintroduced anywhere in the DO would silently pin it resident on that path too, with no failing test.

## Solution

The test drives the production DO-RPC proxy client through the real chain — `vitest → WS → TestClientDO → DO RPC → real SyncBackendDO` — holds an idle live pull, idles past workerd's eviction window, and checks the sync DO's id changed. A `warmControl` arm — a DO kept warm by a probe every 3s — must report an **unchanged** id, catching a broken probe that would otherwise make any run look hibernated.

One difference from the WS case drives the design: over DO RPC the sync DO holds **no WebSocket** (it's reached by native RPC), so there's no socket to count as a liveness signal. The before-idle delivery is therefore the proof that the live pull is genuinely parked before we idle. A one-line change exposes the dev-server port on the DO-RPC provider, mirroring #1427.

Scope is **non-hibernation only**. It deliberately does not assert that the live pull *survives* hibernation: over DO RPC the rebuilt DO drops its in-memory subscribers (`push.ts` reads a non-persisted `Map`), so that property fails on `main` today and is tracked separately with the reap-on-client-verdict fix. Empty changeset; test-only.

## Validation

Mutation-verified (see Demo): the guard goes red only when the sync DO stops hibernating, and the mutation was reverted (`git diff` on `packages/@livestore/sync-cf` is empty). `lint:full`, `ts:check`, and the test all pass, and `vitest list` confirms the `cf-do-rpc-do` cell selects it while `cf-do-rpc-d1` does not.

Same gating caveat as #1427: `cf-do-rpc-do` `exit 0`s on failure (#1430), so this runs on every PR but cannot block a merge.

### Demo

Forcing non-hibernation in the real DO turns the guard red — `warmControl` holds, so the failure is genuine non-hibernation, not a broken probe:

| Mutation applied to production code | Result |
| --- | --- |
| `setInterval(2**31-1)` in the real `makeDurableObject` constructor (reproduces #1328) | fails: `{ livePull: false, warmControl: false }` |

## Related issues

- #1328 — the bug this guards against, on the DO-RPC transport.
- #1427 — the WS-transport guard this stacks on and reuses the probe from.
- #1430 — `cf-*` cells swallow failures, so this runs but cannot gate.
