### PR TITLE
fix(events): preserve Date wire encoding on Effect 4

### DIFF
--- a/.changeset/empty-effect4-date-wire-examples.md
+++ b/.changeset/empty-effect4-date-wire-examples.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Corrects Effect 4 date wire schemas in examples, documentation, and test fixtures, with regression coverage only.

--- a/docs/src/content/_assets/code/data-modeling/todo-workspaces/workspace.schema.ts
+++ b/docs/src/content/_assets/code/data-modeling/todo-workspaces/workspace.schema.ts
@@ -25,7 +25,10 @@ const todoCompleted = Events.synced({
 // Emitted when a todo item is deleted (soft delete)
 const todoDeleted = Events.synced({
   name: 'v1.TodoDeleted',
-  schema: Schema.Struct({ todoId: Schema.String, deletedAt: Schema.Date }),
+  schema: Schema.Struct({
+    todoId: Schema.String,
+    deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+  }),
 })
 
 // Emitted when a new user joins this workspace

--- a/docs/src/content/_assets/code/getting-started/expo/livestore/schema.ts
+++ b/docs/src/content/_assets/code/getting-started/expo/livestore/schema.ts
@@ -32,11 +32,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/docs/src/content/_assets/code/getting-started/react-web/livestore/schema.ts
+++ b/docs/src/content/_assets/code/getting-started/react-web/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/docs/src/content/_assets/code/getting-started/vue/livestore/schema.ts
+++ b/docs/src/content/_assets/code/getting-started/vue/livestore/schema.ts
@@ -32,11 +32,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/docs/src/content/_assets/code/reference/custom-elements/livestore/schema.ts
+++ b/docs/src/content/_assets/code/reference/custom-elements/livestore/schema.ts
@@ -32,7 +32,10 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/docs/src/content/_assets/code/reference/framework-integrations/react/schema.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/react/schema.ts
@@ -23,7 +23,11 @@ export const tables = {
 export const events = {
   todoCreated: Events.synced({
     name: 'v1.TodoCreated',
-    schema: Schema.Struct({ id: Schema.String, text: Schema.String, createdAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      text: Schema.String,
+      createdAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
 } as const
 

--- a/docs/src/content/_assets/code/reference/framework-integrations/solid/livestore/schema.ts
+++ b/docs/src/content/_assets/code/reference/framework-integrations/solid/livestore/schema.ts
@@ -32,11 +32,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/docs/src/content/_assets/code/reference/mcp/schema.ts
+++ b/docs/src/content/_assets/code/reference/mcp/schema.ts
@@ -6,7 +6,7 @@ const events = {
     schema: Schema.Struct({
       id: Schema.String,
       title: Schema.String,
-      createdAt: Schema.DateFromString,
+      createdAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 }

--- a/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/schema.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/schema.ts
@@ -27,11 +27,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
 }
 

--- a/docs/src/content/_assets/code/reference/state/sqlite-schema/schema.ts
+++ b/docs/src/content/_assets/code/reference/state/sqlite-schema/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/docs/src/content/_assets/code/reference/syncing/cloudflare/schema.ts
+++ b/docs/src/content/_assets/code/reference/syncing/cloudflare/schema.ts
@@ -27,11 +27,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
 }
 

--- a/docs/src/content/docs/patterns/storybook.mdx
+++ b/docs/src/content/docs/patterns/storybook.mdx
@@ -172,11 +172,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   // Auto-generated client document event
   uiStateSet: tables.uiState.set,
@@ -225,5 +228,4 @@ Create a decorator that wraps stories with a fresh LiveStore instance and use th
 <Code code={CODE.schema} lang="ts" title="src/schema.ts" />
 </TabItem>
 </Tabs>
-
 

--- a/examples/cloudflare-todomvc/src/livestore/schema.ts
+++ b/examples/cloudflare-todomvc/src/livestore/schema.ts
@@ -29,11 +29,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
 }
 

--- a/examples/web-email-client/src/stores/mailbox/schema.ts
+++ b/examples/web-email-client/src/stores/mailbox/schema.ts
@@ -65,7 +65,7 @@ export const mailboxEvents = {
       type: Schema.Literals(['system', 'user']),
       color: Schema.String.pipe(Schema.NullOr),
       displayOrder: Schema.Number,
-      createdAt: Schema.Date,
+      createdAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 
@@ -76,7 +76,7 @@ export const mailboxEvents = {
       id: Schema.String,
       subject: Schema.String,
       participants: Schema.Array(Schema.String), // Array of email addresses
-      createdAt: Schema.Date,
+      createdAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 
@@ -86,7 +86,7 @@ export const mailboxEvents = {
     schema: Schema.Struct({
       threadId: Schema.String,
       labelId: Schema.String,
-      appliedAt: Schema.Date,
+      appliedAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 
@@ -96,7 +96,7 @@ export const mailboxEvents = {
     schema: Schema.Struct({
       threadId: Schema.String,
       labelId: Schema.String,
-      removedAt: Schema.Date,
+      removedAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 

--- a/examples/web-email-client/src/stores/thread/schema.ts
+++ b/examples/web-email-client/src/stores/thread/schema.ts
@@ -44,7 +44,7 @@ export const threadEvents = {
       id: Schema.String,
       subject: Schema.String,
       participants: Schema.Array(Schema.String), // Array of email addresses
-      createdAt: Schema.Date,
+      createdAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 
@@ -56,7 +56,7 @@ export const threadEvents = {
       content: Schema.String,
       sender: Schema.String,
       senderName: Schema.String.pipe(Schema.NullOr),
-      timestamp: Schema.Date,
+      timestamp: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 
@@ -66,7 +66,7 @@ export const threadEvents = {
     schema: Schema.Struct({
       threadId: Schema.String,
       labelId: Schema.String,
-      appliedAt: Schema.Date,
+      appliedAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 
@@ -76,7 +76,7 @@ export const threadEvents = {
     schema: Schema.Struct({
       threadId: Schema.String,
       labelId: Schema.String,
-      removedAt: Schema.Date,
+      removedAt: Schema.DateFromString.check(Schema.isDateValid()),
     }),
   }),
 }

--- a/examples/web-todomvc-react-router/src/livestore/schema.ts
+++ b/examples/web-todomvc-react-router/src/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/examples/web-todomvc-redwood/src/app/todomvc/livestore/schema.ts
+++ b/examples/web-todomvc-redwood/src/app/todomvc/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/examples/web-todomvc-script/src/livestore/schema.ts
+++ b/examples/web-todomvc-script/src/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/examples/web-todomvc-sync-cf/src/livestore/schema.ts
+++ b/examples/web-todomvc-sync-cf/src/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/examples/web-todomvc/src/livestore/schema.ts
+++ b/examples/web-todomvc/src/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }

--- a/packages/@livestore/common/src/schema/EventDef/define.test.ts
+++ b/packages/@livestore/common/src/schema/EventDef/define.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest'
+
+import { Schema } from '@livestore/utils/effect'
+
+import { synced } from './define.ts'
+
+describe('synced event wire schema', () => {
+  const occurredAt = new Date('2026-07-17T10:15:30.000Z')
+  const event = synced({
+    name: 'v1.Occurred',
+    schema: Schema.Struct({
+      occurredAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
+  })
+  const jsonSchema = Schema.fromJsonString(event.schema)
+
+  test('roundtrips a valid date through JSON', () => {
+    const encoded = Schema.encodeSync(jsonSchema)({ occurredAt })
+
+    expect(encoded).toBe('{"occurredAt":"2026-07-17T10:15:30.000Z"}')
+    expect(Schema.decodeSync(jsonSchema)(encoded)).toEqual({ occurredAt })
+  })
+
+  test('rejects invalid dates on encode and decode', () => {
+    expect(() => Schema.encodeSync(jsonSchema)({ occurredAt: new Date(Number.NaN) })).toThrow()
+    expect(() => Schema.decodeSync(jsonSchema)('{"occurredAt":"not-a-date"}')).toThrow()
+  })
+})

--- a/tests/integration/src/tests/playwright/fixtures/devtools/todomvc/livestore/events.ts
+++ b/tests/integration/src/tests/playwright/fixtures/devtools/todomvc/livestore/events.ts
@@ -26,10 +26,13 @@ export const todoUncompleted = Events.synced({
 
 export const todoDeleted = Events.synced({
   name: 'v1.TodoDeleted',
-  schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+  schema: Schema.Struct({
+    id: Schema.String,
+    deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+  }),
 })
 
 export const todoClearedCompleted = Events.synced({
   name: 'v1.TodoClearedCompleted',
-  schema: Schema.Struct({ deletedAt: Schema.Date }),
+  schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
 })

--- a/tests/perf-eventlog/test-app/src/livestore/schema.ts
+++ b/tests/perf-eventlog/test-app/src/livestore/schema.ts
@@ -35,11 +35,14 @@ export const events = {
   }),
   todoDeleted: Events.synced({
     name: 'v1.TodoDeleted',
-    schema: Schema.Struct({ id: Schema.String, deletedAt: Schema.Date }),
+    schema: Schema.Struct({
+      id: Schema.String,
+      deletedAt: Schema.DateFromString.check(Schema.isDateValid()),
+    }),
   }),
   todoClearedCompleted: Events.synced({
     name: 'v1.TodoClearedCompleted',
-    schema: Schema.Struct({ deletedAt: Schema.Date }),
+    schema: Schema.Struct({ deletedAt: Schema.DateFromString.check(Schema.isDateValid()) }),
   }),
   uiStateSet: tables.uiState.set,
 }


### PR DESCRIPTION
## Problem

Effect 4 changed `Schema.Date` from Effect 3's ISO-string-to-`Date` transform into a `Date` instance schema. LiveStore's migrated synced-event examples still type-checked, but their encoded contract no longer matched the JSON event format used for storage and sync. `Schema.DateFromString` alone also accepts invalid dates.

## Goal

Preserve the Effect 3 synced-event wire contract on Effect 4: valid JavaScript `Date` values encode to ISO strings, decode back from JSON, and invalid dates are rejected.

## Decisions

- Use `Schema.DateFromString.check(Schema.isDateValid())`, the strict Effect 4 equivalent of Effect 3 `Schema.Date`, for synced-event fields.
- Update executable examples, test fixtures, and their documentation mirrors together so copied schemas retain the same wire contract.
- Leave `Schema.DateFromMillis` SQLite columns and intentional Effect 4 `Schema.Date` SQLite/client-document/query schemas unchanged because those boundaries have different encoded representations.

## Verification

- `pnpm --filter @livestore/common test --run`: 18 files passed, 265 tests passed.
- `devenv tasks run lint:check`: passed.
- `devenv tasks run ts:check:strict`: passed.
- `devenv tasks run check:all`: passed, including source policy, lock alignment, generated-file checks, lint, and TypeScript.
- The focused regression test verifies JSON ISO-string encode/decode roundtripping and invalid-date rejection on both encode and decode.

## Complexity

No new abstraction or dependency. This is a boundary-specific schema correction plus regression coverage.

## Concerns

None. Event names and their intended wire representation remain unchanged.

## Friction & bottlenecks

The Effect 4 migration guide documented `DateFromSelf` -> `Date`, but not the semantic reassignment of Effect 3's `Date` identifier. The upstream issue tracks that documentation gap. No execution bottleneck was encountered.

## Follow-ups

None in LiveStore. Upstream migration-guide clarification is tracked in Effect.

## References

- https://github.com/Effect-TS/effect/issues/6481
- https://github.com/schickling-repros/2026-07-effect-v4-schema-date-migration

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-date-wire-effect4/schickling/fix/effect4-date-wire |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->