### PR TITLE
chore(devenv): drop redundant guard lib.lowPrio (effect-utils #924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > for more info. LiveStore is following a semver-like release strategy where
 > breaking changes are released in minor versions before the 1.0 release.
 
+## Unreleased
+
+### Changed
+
+- Removed redundant devenv package entries now owned by the task guard modules.
+
 ## 0.4.0 - 2026-06-02
 
 > **Installing v0.4.0:** Make sure all LiveStore packages use the same version:

--- a/devenv.nix
+++ b/devenv.nix
@@ -406,8 +406,6 @@ in
   ];
 
   packages = [
-    (lib.lowPrio pnpmPkg)
-    (lib.lowPrio effectTsgo)
     pkgs.bun
     pkgs.nodejs_24
     oxlintWithPlugins


### PR DESCRIPTION
## Why

The removed devenv profile entries are redundant with the current task guard contract: passing `tsBinPkg` to `taskModules.ts` and `pnpmPkg` to `taskModules.pnpm` makes the guard own the command shims and execute the real binaries from the closure.

## What

Removes the extra low-priority `pnpmPkg` and `effectTsgo` package entries from `devenv.nix`. This is intended as a no-functional-change cleanup.

## Validation

- Confirmed `taskModules.ts` still receives `tsBinPkg = effectTsgo`.
- Confirmed `taskModules.pnpm` still receives `pnpmPkg`.
- Confirmed no real `pnpx` or bare `effect-tsgo` PATH call sites.
- `CI=1 devenv tasks run --show-output ts:check`
- `CI=1 devenv tasks run --show-output pnpm:install`

Full `check:all` was intentionally skipped for runtime/disk scope: this change only drops redundant profile entries, and CI remains the authority for the broader suite.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🏜️ co1-dune |
| `agent_session_id` | b0b5cfa8-142f-4be4-901f-92065ded6b49 |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-18-tsgo-924-adopt |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->