### PR TITLE
Automate verified DevTools manifest updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,9 @@
 # Release-sensitive repository policy and release automation.
 /.github/ @schickling
 /release/ @schickling
+# This generated pointer is guarded by official-release provenance, monotonic
+# transition checks, and the normal required status checks.
+/release/devtools-artifact.json
 /scripts/src/commands/changesets.ts @schickling
 /scripts/src/commands/devtools-artifact.ts @schickling
 /scripts/src/commands/release.ts @schickling
-

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -57,6 +57,7 @@ env:
   ARTIFACT_CHROME_ZIP_SHA256: ${{ github.event.client_payload.chromeZipSha256 || inputs.chrome_zip_sha256 }}
   DEVTOOLS_BUILD_ID: ${{ github.event.client_payload.devtoolsBuildId || inputs.devtools_build_id }}
   BASE_BRANCH: ${{ github.event.repository.default_branch }}
+  PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
 jobs:
   source-policy:
@@ -576,6 +577,17 @@ jobs:
       - name: Write artifact manifest
         run: |
           set -euo pipefail
+          previous_manifest="$RUNNER_TEMP/devtools-artifact.previous.json"
+          if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+            git show "$PR_BASE_SHA:release/devtools-artifact.json" > "$previous_manifest"
+            if ! cmp -s "$previous_manifest" release/devtools-artifact.json; then
+              echo "LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST=$previous_manifest" >> "$GITHUB_ENV"
+            fi
+          else
+            cp release/devtools-artifact.json "$previous_manifest"
+            echo "LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST=$previous_manifest" >> "$GITHUB_ENV"
+          fi
+
           if [ -z "${ARTIFACT_METADATA_URL:-}" ] && [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
             ARTIFACT_METADATA_URL="$(jq -r '.artifact.metadataUrl' release/devtools-artifact.json)"
             ARTIFACT_TARBALL_URL="$(jq -r '.artifact.tarballUrl' release/devtools-artifact.json)"
@@ -654,3 +666,7 @@ jobs:
           else
             gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE_BRANCH" --head "$branch" --title "$title" --body "$body"
           fi
+
+          # Auto-merge still waits for every branch-rule check. This workflow has no
+          # ruleset bypass and cannot merge changes outside the manifest-only boundary.
+          gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto --merge

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -579,6 +579,9 @@ jobs:
           set -euo pipefail
           previous_manifest="$RUNNER_TEMP/devtools-artifact.previous.json"
           if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+            # actions/checkout uses a shallow PR merge checkout, so the declared base
+            # commit is not guaranteed to exist locally.
+            git fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
             git show "$PR_BASE_SHA:release/devtools-artifact.json" > "$previous_manifest"
             if ! cmp -s "$previous_manifest" release/devtools-artifact.json; then
               echo "LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST=$previous_manifest" >> "$GITHUB_ENV"

--- a/.github/workflows/devtools-artifact.yml.genie.ts
+++ b/.github/workflows/devtools-artifact.yml.genie.ts
@@ -90,6 +90,9 @@ export default githubWorkflow({
           run: `set -euo pipefail
 previous_manifest="$RUNNER_TEMP/devtools-artifact.previous.json"
 if [ "\${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+  # actions/checkout uses a shallow PR merge checkout, so the declared base
+  # commit is not guaranteed to exist locally.
+  git fetch --no-tags --depth=1 origin "$PR_BASE_SHA"
   git show "$PR_BASE_SHA:release/devtools-artifact.json" > "$previous_manifest"
   if ! cmp -s "$previous_manifest" release/devtools-artifact.json; then
     echo "LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST=$previous_manifest" >> "$GITHUB_ENV"

--- a/.github/workflows/devtools-artifact.yml.genie.ts
+++ b/.github/workflows/devtools-artifact.yml.genie.ts
@@ -75,6 +75,7 @@ export default githubWorkflow({
     ARTIFACT_CHROME_ZIP_SHA256: '${{ github.event.client_payload.chromeZipSha256 || inputs.chrome_zip_sha256 }}',
     DEVTOOLS_BUILD_ID: '${{ github.event.client_payload.devtoolsBuildId || inputs.devtools_build_id }}',
     BASE_BRANCH: '${{ github.event.repository.default_branch }}',
+    PR_BASE_SHA: '${{ github.event.pull_request.base.sha }}',
   },
 
   jobs: {
@@ -87,6 +88,17 @@ export default githubWorkflow({
         {
           name: 'Write artifact manifest',
           run: `set -euo pipefail
+previous_manifest="$RUNNER_TEMP/devtools-artifact.previous.json"
+if [ "\${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+  git show "$PR_BASE_SHA:release/devtools-artifact.json" > "$previous_manifest"
+  if ! cmp -s "$previous_manifest" release/devtools-artifact.json; then
+    echo "LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST=$previous_manifest" >> "$GITHUB_ENV"
+  fi
+else
+  cp release/devtools-artifact.json "$previous_manifest"
+  echo "LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST=$previous_manifest" >> "$GITHUB_ENV"
+fi
+
 if [ -z "\${ARTIFACT_METADATA_URL:-}" ] && [ "\${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
   ARTIFACT_METADATA_URL="$(jq -r '.artifact.metadataUrl' release/devtools-artifact.json)"
   ARTIFACT_TARBALL_URL="$(jq -r '.artifact.tarballUrl' release/devtools-artifact.json)"
@@ -168,7 +180,11 @@ if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
   gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body" --base "$BASE_BRANCH"
 else
   gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE_BRANCH" --head "$branch" --title "$title" --body "$body"
-fi`,
+fi
+
+# Auto-merge still waits for every branch-rule check. This workflow has no
+# ruleset bypass and cannot merge changes outside the manifest-only boundary.
+gh pr merge "$branch" --repo "$GITHUB_REPOSITORY" --auto --merge`,
         },
       ],
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- DevTools artifact manifest updates now verify canonical release provenance and forward-only transitions before entering the normal required-check auto-merge path (#1444).
+
 > NOTE: LiveStore is still in beta and releases can include breaking changes.
 > See
 > [state of the project](https://docs.livestore.dev/misc/state-of-the-project/)

--- a/devenv.nix
+++ b/devenv.nix
@@ -81,7 +81,7 @@ let
     cd "$DEVENV_ROOT"
 
     : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
-    artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
+    artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}" --require-official-release)
     if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" || -n "''${LIVESTORE_DEVTOOLS_CHROME_ZIP:-}" ]]; then
       echo "release:devtools-artifact repack requires LIVESTORE_DEVTOOLS_MANIFEST so release-candidate certification can bind to the selected artifact." >&2
       echo "Use release:devtools-artifact:verify for direct metadata/tarball integrity checks." >&2
@@ -456,7 +456,8 @@ in
       set -euo pipefail
       cd "$DEVENV_ROOT"
 
-      artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}")
+      artifact_command=verify
+      artifact_args=(--manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}" --require-official-release)
       if [[ -n "''${LIVESTORE_DEVTOOLS_METADATA:-}" || -n "''${LIVESTORE_DEVTOOLS_TARBALL:-}" || -n "''${LIVESTORE_DEVTOOLS_CHROME_ZIP:-}" ]]; then
         : "''${LIVESTORE_DEVTOOLS_METADATA:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
         : "''${LIVESTORE_DEVTOOLS_TARBALL:?Set both LIVESTORE_DEVTOOLS_METADATA and LIVESTORE_DEVTOOLS_TARBALL, or neither to use the checked-in manifest}"
@@ -464,9 +465,12 @@ in
         if [[ -n "''${LIVESTORE_DEVTOOLS_CHROME_ZIP:-}" ]]; then
           artifact_args+=(--chrome-zip "$LIVESTORE_DEVTOOLS_CHROME_ZIP")
         fi
+      elif [[ -n "''${LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST:-}" ]]; then
+        artifact_command=verify-transition
+        artifact_args+=(--previous-manifest "$LIVESTORE_DEVTOOLS_PREVIOUS_MANIFEST")
       fi
 
-      bun scripts/src/commands/devtools-artifact.ts verify "''${artifact_args[@]}"
+      bun scripts/src/commands/devtools-artifact.ts "$artifact_command" "''${artifact_args[@]}"
     '';
     after = [ "pnpm:install" ];
   };

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -4,6 +4,8 @@ import {
   type ArtifactManifest,
   type ArtifactMetadata,
   assertCertifiedDevtoolsArtifactForLivestore,
+  assertMonotonicArtifactTransition,
+  assertOfficialArtifactRelease,
   assertUncertifiedRepackMode,
   containsForbiddenPattern,
   type DevtoolsArtifactCertification,
@@ -33,6 +35,37 @@ const manifest = () =>
       tarballUrl: 'livestore-devtools-vite.tgz',
     },
   }) satisfies ArtifactManifest
+
+const officialMetadata = (overrides: Partial<ArtifactMetadata> = {}): ArtifactMetadata => ({
+  ...metadata,
+  devtoolsBuildId: 'dt-20260718-51c22feb',
+  builtAt: '2026-07-18T09:00:00.000Z',
+  sourceRevision: 'bf243c179c801511e2c0f9c9987d107b57484417',
+  files: {
+    tarball: {
+      name: 'livestore-devtools-vite.tgz',
+      sha256: 'a'.repeat(64),
+      integrity: 'sha512-tarball',
+    },
+    chromeZip: {
+      name: 'livestore-devtools-chrome.zip',
+      sha256: 'b'.repeat(64),
+      integrity: 'sha512-chrome',
+    },
+  },
+  ...overrides,
+})
+
+const officialManifest = (buildId = 'dt-20260718-51c22feb'): ArtifactManifest => ({
+  schemaVersion: 2,
+  artifact: {
+    metadataUrl: `https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-${buildId}/release-metadata.json`,
+    tarballUrl: `https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-${buildId}/livestore-devtools-vite.tgz`,
+    sha256: 'a'.repeat(64),
+    chromeZipUrl: `https://github.com/livestorejs/livestore-devtools-artifacts/releases/download/devtools-artifact-${buildId}/livestore-devtools-chrome.zip`,
+    chromeZipSha256: 'b'.repeat(64),
+  },
+})
 
 const certification = (overrides: Partial<DevtoolsArtifactCertification> = {}) => ({
   livestoreVersion: '0.4.0-dev.25',
@@ -213,5 +246,103 @@ describe('artifact forbidden text patterns', () => {
     expect(containsForbiddenText('HOME: "/home/web_user"')).toBe(false)
     expect(containsForbiddenText('source: "/home/alice/project/src/file.ts"')).toBe(true)
     expect(containsForbiddenText('source: "/Users/alice/project/src/file.ts"')).toBe(true)
+  })
+})
+
+describe('official artifact release policy', () => {
+  it('accepts canonical official release assets with matching metadata', () => {
+    expect(() =>
+      assertOfficialArtifactRelease({ manifest: officialManifest(), metadata: officialMetadata() }),
+    ).not.toThrow()
+  })
+
+  it.each([
+    [
+      'foreign repository',
+      /livestorejs\/livestore-devtools-artifacts/,
+      'livestorejs/other-artifacts',
+      /must come from livestorejs\/livestore-devtools-artifacts release assets/,
+    ],
+    [
+      'mixed release tag',
+      /devtools-artifact-dt-20260718-51c22feb/,
+      'devtools-artifact-dt-20260718-deadbeef',
+      /does not match/,
+    ],
+    ['non-canonical filename', /livestore-devtools-vite\.tgz$/, 'devtools.tgz', /does not match/],
+  ])('rejects a %s', (_case, pattern, replacement, expected) => {
+    const canonical = officialManifest()
+    const manifestWithReplacement: ArtifactManifest = {
+      ...canonical,
+      artifact: {
+        ...canonical.artifact,
+        tarballUrl: canonical.artifact.tarballUrl.replace(pattern, replacement),
+      },
+    }
+    expect(() =>
+      assertOfficialArtifactRelease({ manifest: manifestWithReplacement, metadata: officialMetadata() }),
+    ).toThrow(expected)
+  })
+
+  it('rejects malformed, mismatched, or incomplete digests', () => {
+    const canonical = officialManifest()
+    const { chromeZipUrl: _chromeZipUrl, ...withoutChromeUrl } = canonical.artifact
+    expect(() =>
+      assertOfficialArtifactRelease({
+        manifest: { ...canonical, artifact: { ...canonical.artifact, sha256: 'A'.repeat(64) } },
+        metadata: officialMetadata(),
+      }),
+    ).toThrow(/lowercase SHA-256/)
+    expect(() =>
+      assertOfficialArtifactRelease({
+        manifest: { ...canonical, artifact: { ...canonical.artifact, sha256: 'c'.repeat(64) } },
+        metadata: officialMetadata(),
+      }),
+    ).toThrow(/does not match release metadata/)
+    expect(() =>
+      assertOfficialArtifactRelease({
+        manifest: { ...canonical, artifact: withoutChromeUrl },
+        metadata: officialMetadata(),
+      }),
+    ).toThrow(/requires matching Chrome ZIP/)
+  })
+
+  it.each([
+    [{ devtoolsBuildId: 'latest' }, /build id/],
+    [{ sourceRevision: 'bf243c1' }, /full source revision/],
+    [{ builtAt: 'not-a-date' }, /valid builtAt/],
+  ])('rejects invalid identity metadata %#', (overrides, expected) => {
+    expect(() =>
+      assertOfficialArtifactRelease({ manifest: officialManifest(), metadata: officialMetadata(overrides) }),
+    ).toThrow(expected)
+  })
+})
+
+describe('artifact transition policy', () => {
+  it('accepts a newer, distinct artifact build', () => {
+    expect(() =>
+      assertMonotonicArtifactTransition({
+        previous: officialMetadata(),
+        next: officialMetadata({ devtoolsBuildId: 'dt-20260719-deadbeef', builtAt: '2026-07-19T09:00:00.000Z' }),
+      }),
+    ).not.toThrow()
+  })
+
+  it.each([
+    [
+      'older timestamp',
+      { devtoolsBuildId: 'dt-20260717-deadbeef', builtAt: '2026-07-17T09:00:00.000Z' },
+      /move forward/,
+    ],
+    [
+      'equal timestamp',
+      { devtoolsBuildId: 'dt-20260719-deadbeef', builtAt: '2026-07-18T09:00:00.000Z' },
+      /move forward/,
+    ],
+    ['same build', { devtoolsBuildId: 'dt-20260718-51c22feb', builtAt: '2026-07-19T09:00:00.000Z' }, /new build/],
+  ])('rejects a %s', (_case, overrides, expected) => {
+    expect(() =>
+      assertMonotonicArtifactTransition({ previous: officialMetadata(), next: officialMetadata(overrides) }),
+    ).toThrow(expected)
   })
 })

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -97,7 +97,8 @@ type ArtifactManifestV2 = {
 export type ArtifactManifest = ArtifactManifestV1 | ArtifactManifestV2
 
 const usage = `Usage:
-  bun scripts/src/commands/devtools-artifact.ts verify (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>)
+  bun scripts/src/commands/devtools-artifact.ts verify (--manifest <file> | --metadata <url-or-file> --tarball <url-or-file>) [--require-official-release]
+  bun scripts/src/commands/devtools-artifact.ts verify-transition --previous-manifest <file> --manifest <file>
   bun scripts/src/commands/devtools-artifact.ts certify --manifest <file> --version <version> --out <file> [--evidence <text>]
   bun scripts/src/commands/devtools-artifact.ts repack --manifest <file> --version <version> [--certification <file>|--allow-uncertified] [--dry-run|--publish]
 
@@ -112,6 +113,7 @@ Options:
   --out <file>              Certification output path for the certify command
   --dry-run                 Run npm publish dry-run for the repacked package
   --publish                 Publish the repacked package to npm
+  --require-official-release Require canonical assets from the official artifact release repository
 `
 
 const parseArgs = (argv: ReadonlyArray<string>) => {
@@ -144,6 +146,130 @@ const readFlag = (flags: Map<string, string | true>, name: string): string | und
 }
 
 const hasFlag = (flags: Map<string, string | true>, name: string): boolean => flags.get(name) === true
+
+const officialArtifactRepository = 'livestorejs/livestore-devtools-artifacts'
+const canonicalArtifactFiles = {
+  metadata: 'release-metadata.json',
+  tarball: 'livestore-devtools-vite.tgz',
+  chromeZip: 'livestore-devtools-chrome.zip',
+} as const
+const sha256Pattern = /^[a-f0-9]{64}$/
+const buildIdPattern = /^dt-[0-9]{8}-[a-f0-9]{8}$/
+
+const parseOfficialReleaseAssetUrl = (source: string) => {
+  let url: URL
+  try {
+    url = new URL(source)
+  } catch {
+    throw new Error(`Official artifact source must be an HTTPS URL: ${source}`)
+  }
+
+  if (
+    url.protocol !== 'https:' ||
+    url.hostname !== 'github.com' ||
+    url.port !== '' ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.search !== '' ||
+    url.hash !== ''
+  ) {
+    throw new Error(`Artifact source must use the canonical GitHub release URL: ${source}`)
+  }
+
+  const parts = url.pathname.split('/').filter((part) => part.length > 0)
+  const [owner, repo, releases, download, tag, file, ...extra] = parts
+  if (
+    `${owner}/${repo}` !== officialArtifactRepository ||
+    releases !== 'releases' ||
+    download !== 'download' ||
+    tag === undefined ||
+    file === undefined ||
+    extra.length > 0
+  ) {
+    throw new Error(`Artifact source must come from ${officialArtifactRepository} release assets: ${source}`)
+  }
+
+  return { tag, file }
+}
+
+export const assertOfficialArtifactRelease = ({
+  manifest,
+  metadata,
+}: {
+  readonly manifest: ArtifactManifest
+  readonly metadata: ArtifactMetadata
+}) => {
+  if (buildIdPattern.test(metadata.devtoolsBuildId) === false) {
+    throw new Error(`Invalid DevTools artifact build id: ${metadata.devtoolsBuildId}`)
+  }
+  if (metadata.sourceRevision === undefined || /^[a-f0-9]{40}$/.test(metadata.sourceRevision) === false) {
+    throw new Error('Official DevTools artifact metadata requires a full source revision')
+  }
+  if (metadata.builtAt === undefined || Number.isFinite(Date.parse(metadata.builtAt)) === false) {
+    throw new Error('Official DevTools artifact metadata requires a valid builtAt timestamp')
+  }
+
+  const expectedTag = `devtools-artifact-${metadata.devtoolsBuildId}`
+  const sources = [
+    [manifest.artifact.metadataUrl, canonicalArtifactFiles.metadata],
+    [manifest.artifact.tarballUrl, canonicalArtifactFiles.tarball],
+    ...(manifest.artifact.chromeZipUrl === undefined
+      ? []
+      : ([[manifest.artifact.chromeZipUrl, canonicalArtifactFiles.chromeZip]] as const)),
+  ] as const
+
+  for (const [source, expectedFile] of sources) {
+    const { tag, file } = parseOfficialReleaseAssetUrl(source)
+    if (tag !== expectedTag) throw new Error(`Artifact source tag ${tag} does not match ${expectedTag}`)
+    if (file !== expectedFile) throw new Error(`Artifact source file ${file} does not match ${expectedFile}`)
+  }
+
+  if (metadata.files.tarball.name !== canonicalArtifactFiles.tarball) {
+    throw new Error(`Unexpected metadata tarball filename: ${metadata.files.tarball.name}`)
+  }
+  if (manifest.artifact.sha256 === undefined || sha256Pattern.test(manifest.artifact.sha256) === false) {
+    throw new Error('Official artifact manifest requires a lowercase SHA-256 tarball digest')
+  }
+  if (manifest.artifact.sha256 !== metadata.files.tarball.sha256) {
+    throw new Error('Manifest tarball SHA-256 does not match release metadata')
+  }
+
+  const metadataChrome = metadata.files.chromeZip
+  const manifestChromeUrl = manifest.artifact.chromeZipUrl
+  const manifestChromeSha = manifest.artifact.chromeZipSha256
+  if (metadataChrome === undefined || manifestChromeUrl === undefined || manifestChromeSha === undefined) {
+    throw new Error('Official artifact release requires matching Chrome ZIP metadata, URL, and digest')
+  }
+  if (metadataChrome.name !== canonicalArtifactFiles.chromeZip) {
+    throw new Error(`Unexpected metadata Chrome ZIP filename: ${metadataChrome.name}`)
+  }
+  if (sha256Pattern.test(manifestChromeSha) === false) {
+    throw new Error('Official artifact manifest requires a lowercase SHA-256 Chrome ZIP digest')
+  }
+  if (manifestChromeSha !== metadataChrome.sha256) {
+    throw new Error('Manifest Chrome ZIP SHA-256 does not match release metadata')
+  }
+}
+
+export const assertMonotonicArtifactTransition = ({
+  previous,
+  next,
+}: {
+  readonly previous: ArtifactMetadata
+  readonly next: ArtifactMetadata
+}) => {
+  const previousBuiltAt = previous.builtAt === undefined ? Number.NaN : Date.parse(previous.builtAt)
+  const nextBuiltAt = next.builtAt === undefined ? Number.NaN : Date.parse(next.builtAt)
+  if (Number.isFinite(previousBuiltAt) === false || Number.isFinite(nextBuiltAt) === false) {
+    throw new Error('Artifact transition requires valid builtAt timestamps')
+  }
+  if (nextBuiltAt <= previousBuiltAt) {
+    throw new Error(`Artifact transition must move forward from ${previous.builtAt} to a newer build`)
+  }
+  if (next.devtoolsBuildId === previous.devtoolsBuildId) {
+    throw new Error(`Artifact transition must select a new build, not ${next.devtoolsBuildId}`)
+  }
+}
 
 const run = (command: ReadonlyArray<string>, options: { readonly cwd?: string } = {}) => {
   const result = spawnSync(command[0]!, command.slice(1), {
@@ -542,6 +668,10 @@ const assertNoForbiddenZipText = async (chromeZipPath: string) => {
 const verifyArtifact = async (flags: Map<string, string | true>) => {
   const { metadata, tarballPath, chromeZipPath, workDir, manifest } = await prepareInputs(flags)
   assertMetadata(metadata, tarballPath, chromeZipPath)
+  if (hasFlag(flags, 'require-official-release') === true) {
+    if (manifest === undefined) throw new Error('--require-official-release requires --manifest')
+    assertOfficialArtifactRelease({ manifest, metadata })
+  }
   assertTarballEntries(tarballPath)
   await assertNoForbiddenText(tarballPath)
   if (chromeZipPath !== undefined) {
@@ -549,6 +679,30 @@ const verifyArtifact = async (flags: Map<string, string | true>) => {
     await assertNoForbiddenZipText(chromeZipPath)
   }
   return { metadata, tarballPath, chromeZipPath, workDir, manifest }
+}
+
+const verifyArtifactTransition = async (flags: Map<string, string | true>) => {
+  const previousManifestSource = readFlag(flags, 'previous-manifest')
+  if (previousManifestSource === undefined) throw new Error('--previous-manifest is required')
+
+  const next = await verifyArtifact(new Map([...flags, ['require-official-release', true]]))
+  const previousManifest = JSON.parse(readFileSync(path.resolve(previousManifestSource), 'utf8')) as ArtifactManifest
+  if (previousManifest.schemaVersion !== 1 && previousManifest.schemaVersion !== 2) {
+    throw new Error('Unsupported previous artifact manifest schemaVersion')
+  }
+
+  const previousWorkDir = mkdtempSync(path.join(tmpdir(), 'livestore-devtools-previous-'))
+  try {
+    const previousMetadataPath = path.join(previousWorkDir, canonicalArtifactFiles.metadata)
+    await fetchToFile(previousManifest.artifact.metadataUrl, previousMetadataPath)
+    const previousMetadata = JSON.parse(readFileSync(previousMetadataPath, 'utf8')) as ArtifactMetadata
+    assertOfficialArtifactRelease({ manifest: previousManifest, metadata: previousMetadata })
+    assertMonotonicArtifactTransition({ previous: previousMetadata, next: next.metadata })
+  } finally {
+    rmSync(previousWorkDir, { recursive: true, force: true })
+  }
+
+  return next
 }
 
 const readCertification = (flags: Map<string, string | true>) => {
@@ -768,6 +922,17 @@ const main = async () => {
   if (command === 'verify') {
     const result = await verifyArtifact(flags)
     console.log(JSON.stringify({ devtoolsBuildId: result.metadata.devtoolsBuildId, workDir: result.workDir }, null, 2))
+    return
+  }
+  if (command === 'verify-transition') {
+    const result = await verifyArtifactTransition(flags)
+    console.log(
+      JSON.stringify(
+        { devtoolsBuildId: result.metadata.devtoolsBuildId, workDir: result.workDir, transition: 'valid' },
+        null,
+        2,
+      ),
+    )
     return
   }
   if (command === 'certify') {


### PR DESCRIPTION
## Problem

Every sanitized DevTools artifact publication opens a manifest-only PR, but `/release/` CODEOWNERS currently forces a manual approval even though the artifact has already passed the dedicated verification workflow.

## Goal

Allow future manifest-only updates to merge automatically after the normal branch rules and required checks prove an official, forward-only artifact transition.

## Decisions

- Exempt only `/release/devtools-artifact.json` from the broader `/release/` CODEOWNERS rule. Workflow definitions, release code, and every other release file remain owned.
- Validate exact HTTPS assets from `livestorejs/livestore-devtools-artifacts`, canonical tag and filenames, full source revision, build identity, and matching lowercase SHA-256 digests.
- Compare `builtAt` and build ID against the PR base manifest to reject rollback, replay, and same-build transitions.
- Use normal `gh pr merge --auto --merge`; do not grant GitHub Actions a ruleset bypass.

Rejected alternatives: a broad Actions bypass could skip required checks; a machine-user token or custom GitHub App would add credential and lifecycle complexity without improving this narrow trust boundary.

## Verification

- `pnpm exec vitest run scripts/src/commands/devtools-artifact.test.ts`: 23/23 passed.
- `devenv tasks run lint:check ts:check --no-tui`: lint passed; TypeScript passed after fixing the only new exact-optional diagnostic. Existing Effect advisory diagnostics remain non-fatal.
- `devenv tasks run release:devtools-artifact:verify --no-tui`: passed against the checked-in public release.
- `devenv --refresh-task-cache tasks run genie:run --no-tui`: generated workflow is current.
- Commit hook `check-quick`: passed.
- Repository settings confirm auto-merge and merge commits are enabled.

## Complexity

The additional validator is kept in the existing artifact command and task. The complexity is required because removing the human approval gate must replace judgment with an explicit, testable provenance and transition policy.

## Concerns

The official artifact repository remains the publication trust root. A compromised publisher there could publish a malicious newer artifact, but cannot bypass this repository's byte-integrity checks, public-content audit, or normal required checks.

## Friction & bottlenecks

The previous manifest PR's pull-request verification failed independently of PR event delivery; this change keeps that verification mandatory and makes the previous-manifest input explicit from the base SHA.

## Follow-ups

After this one-time CODEOWNERS governance approval, validate the next real artifact dispatch as the end-to-end proof of unattended auto-merge.

## References

Closes #1444
Related: #1443

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-18-devtools-auto-merge |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->