### PR TITLE
Fix query timing with OpenTelemetry no-op spans

### DIFF
--- a/.changeset/fix-noop-span-timing.md
+++ b/.changeset/fix-noop-span-timing.md
@@ -1,0 +1,7 @@
+---
+"@livestore/common": patch
+"@livestore/livestore": patch
+"@livestore/utils": patch
+---
+
+Prevent SQLite and live-query timing instrumentation from crashing when applications use an OpenTelemetry tracer without SDK-private span timing fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,8 @@ See the [S2 sync provider docs](https://dev.docs.livestore.dev/reference/syncing
 
 #### Core Runtime & Storage
 
+- **OpenTelemetry no-op tracing:** SQLite initialization and live queries now measure debug timing independently of tracer internals, preventing crashes when no OpenTelemetry SDK provider is registered ([#1448](https://github.com/livestorejs/livestore/issues/1448)).
+
 - **Event log lookup optimization:** Improved event log lookup performance for large unsynced logs, speeding startup time ([#1012](https://github.com/livestorejs/livestore/pull/1012)).
 
 - **DevTools protocol versioning:** The app and DevTools now exchange an explicit protocol version during handshake, decoupling DevTools runtime compatibility from package versions. Newer or older DevTools builds connect cleanly to any LiveStore runtime that speaks the same protocol ([#1232](https://github.com/livestorejs/livestore/pull/1232)).

--- a/packages/@livestore/common/src/otel.ts
+++ b/packages/@livestore/common/src/otel.ts
@@ -28,11 +28,3 @@ export const provideOtel =
       Effect.provide(TracingLive),
     )
   }
-
-export const getDurationMsFromSpan = (span: otel.Span): number => {
-  const durationHr: [seconds: number, nanos: number] = (span as any)._duration
-  return durationHr[0] * 1000 + durationHr[1] / 1_000_000
-}
-
-export const getStartTimeHighResFromSpan = (span: otel.Span): DOMHighResTimeStamp =>
-  (span as any)._performanceStartTime as DOMHighResTimeStamp

--- a/packages/@livestore/livestore/src/SqliteDbWrapper.test.ts
+++ b/packages/@livestore/livestore/src/SqliteDbWrapper.test.ts
@@ -1,3 +1,4 @@
+import * as otel from '@opentelemetry/api'
 import { expect } from 'vitest'
 
 import { Vitest } from '@livestore/utils-dev/node-vitest'
@@ -7,6 +8,27 @@ import { StoreInternalsSymbol } from './store/store-types.ts'
 import { makeTodoMvc } from './utils/tests/fixture.ts'
 
 Vitest.describe('SqliteDbWrapper', () => {
+  Vitest.live('works with the OpenTelemetry API no-op tracer', (_test) =>
+    Effect.gen(function* () {
+      const otelTracer = otel.trace.getTracer('sqlite-wrapper-noop-test')
+      const probeSpan = otelTracer.startSpan('verify-noop-tracer')
+      expect(probeSpan.isRecording()).toBe(false)
+      probeSpan.end()
+
+      // Store creation exercises the configureSQLite execute path.
+      const store = yield* makeTodoMvc({ otelTracer })
+      const sqliteDbWrapper = store[StoreInternalsSymbol].sqliteDbWrapper
+      const { durationMs } = sqliteDbWrapper.cachedExecute('CREATE TABLE noop_timing_test (id INTEGER)', undefined, {
+        hasNoEffects: true,
+      })
+
+      expect(sqliteDbWrapper.select('SELECT 1 AS value')).toEqual([{ value: 1 }])
+      expect(sqliteDbWrapper.debugInfo.queryFrameCount).toBeGreaterThan(0)
+      expect(sqliteDbWrapper.debugInfo.queryFrameDuration).toBeGreaterThanOrEqual(0)
+      expect(durationMs).toBeGreaterThanOrEqual(0)
+    }),
+  )
+
   Vitest.describe('getTablesUsed', () => {
     const getTablesUsed = (query: string) =>
       Effect.gen(function* () {

--- a/packages/@livestore/livestore/src/SqliteDbWrapper.ts
+++ b/packages/@livestore/livestore/src/SqliteDbWrapper.ts
@@ -4,8 +4,6 @@ import {
   BoundArray,
   BoundMap,
   type DebugInfo,
-  getDurationMsFromSpan,
-  getStartTimeHighResFromSpan,
   type MutableDebugInfo,
   type PreparedBindValues,
   type PreparedStatement,
@@ -179,6 +177,8 @@ export class SqliteDbWrapper implements SqliteDb {
       { attributes: { 'sql.query': queryStr } },
       options?.otelContext ?? this.otelRootSpanContext,
       (span) => {
+        const startTimePerfNow = performance.now()
+
         try {
           let stmt = this.cachedStmts.get(queryStr)
           if (stmt === undefined) {
@@ -196,7 +196,7 @@ export class SqliteDbWrapper implements SqliteDb {
 
           span.end()
 
-          const durationMs = getDurationMsFromSpan(span)
+          const durationMs = performance.now() - startTimePerfNow
 
           this.debugInfo.queryFrameDuration += durationMs
           this.debugInfo.queryFrameCount++
@@ -208,7 +208,7 @@ export class SqliteDbWrapper implements SqliteDb {
               durationMs,
               rowsCount: undefined,
               queriedTables: new Set(),
-              startTimePerfNow: getStartTimeHighResFromSpan(span),
+              startTimePerfNow,
             })
           }
 
@@ -248,6 +248,8 @@ export class SqliteDbWrapper implements SqliteDb {
       {},
       otelContext ?? this.otelRootSpanContext,
       (span) => {
+        const startTimePerfNow = performance.now()
+
         try {
           span.setAttribute('sql.query', queryStr)
 
@@ -276,7 +278,7 @@ export class SqliteDbWrapper implements SqliteDb {
 
           span.end()
 
-          const durationMs = getDurationMsFromSpan(span)
+          const durationMs = performance.now() - startTimePerfNow
 
           this.debugInfo.queryFrameDuration += durationMs
           this.debugInfo.queryFrameCount++
@@ -289,7 +291,7 @@ export class SqliteDbWrapper implements SqliteDb {
               durationMs,
               rowsCount: result.length,
               queriedTables: queriedTables_,
-              startTimePerfNow: getStartTimeHighResFromSpan(span),
+              startTimePerfNow,
             })
           }
 

--- a/packages/@livestore/livestore/src/live-queries/computed.ts
+++ b/packages/@livestore/livestore/src/live-queries/computed.ts
@@ -1,6 +1,5 @@
 import * as otel from '@opentelemetry/api'
 
-import { getDurationMsFromSpan } from '@livestore/common'
 import { Equal, Hash } from '@livestore/utils/effect'
 
 import type { Thunk } from '../reactive.ts'
@@ -137,12 +136,13 @@ export class LiveStoreComputedQuery<TResult> extends LiveStoreQueryBase<TResult>
     this.results$ = this.reactivityGraph.makeThunk(
       (get, setDebugInfo, ctx, otelContext) =>
         ctx.otelTracer.startActiveSpan(`js:${label}`, {}, otelContext ?? ctx.rootOtelContext, (span) => {
+          const startTimePerfNow = performance.now()
           const otelContext = otel.trace.setSpan(otel.context.active(), span)
           const res = fn(makeGetAtomResult(get, ctx, otelContext, this.dependencyQueriesRef))
 
           span.end()
 
-          const durationMs = getDurationMsFromSpan(span)
+          const durationMs = performance.now() - startTimePerfNow
 
           this.executionTimes.push(durationMs)
 

--- a/packages/@livestore/livestore/src/live-queries/db-query.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.ts
@@ -2,7 +2,6 @@ import * as otel from '@opentelemetry/api'
 
 import type { Bindable, QueryBuilder } from '@livestore/common'
 import {
-  getDurationMsFromSpan,
   getResultSchema,
   isQueryBuilder,
   prepareBindValues,
@@ -359,6 +358,7 @@ export class LiveStoreDbQuery<TResultSchema, TResult = TResultSchema> extends Li
           },
           otelContext ?? queryContext.rootOtelContext,
           (span) => {
+            const startTimePerfNow = performance.now()
             const otelContext = otel.trace.setSpan(otel.context.active(), span)
             const { store } = queryContext
 
@@ -434,7 +434,7 @@ Result:`,
 
             span.end()
 
-            const durationMs = getDurationMsFromSpan(span)
+            const durationMs = performance.now() - startTimePerfNow
 
             this.executionTimes.push(durationMs)
 

--- a/packages/@livestore/utils/src/NoopTracer.ts
+++ b/packages/@livestore/utils/src/NoopTracer.ts
@@ -3,10 +3,7 @@ import type * as otel from '@opentelemetry/api'
 import { cuid } from '@livestore/utils/cuid'
 
 export const makeNoopSpan = () => {
-  const performanceStartTime = performance.now()
-
   const spanImpl = {
-    _performanceStartTime: performanceStartTime,
     setAttribute: () => null,
     setAttributes: () => null,
     addEvent: () => null,
@@ -14,20 +11,13 @@ export const makeNoopSpan = () => {
     setStatus: () => null,
     updateName: () => null,
     recordException: () => null,
-    end: () => {
-      const endTime = performance.now()
-      const duration = endTime - performanceStartTime
-      const durationSecs = duration / 1000
-      const durationRestNs = (duration % 1000) * 1_000_000
-      spanImpl._duration = [durationSecs, durationRestNs] as [number, number]
-    },
+    end: () => null,
     spanContext: () => {
       return {
         traceId: `livestore-noop-trace-id${cuid()}`,
         spanId: `livestore-noop-span-id${cuid()}`,
       }
     },
-    _duration: [0, 0] as [number, number],
   }
 
   // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- noop otel.Span implementation; only implements the subset needed by LiveStore


### PR DESCRIPTION
## Problem

`SqliteDbWrapper` and live-query timing read the private OpenTelemetry span fields `_duration` and `_performanceStartTime`. The API no-op span does not provide those SDK implementation details, so successful SQLite work can be converted into a `SqliteError` while collecting debug timing.

## Goal

Keep query timing and slow-query diagnostics while making runtime behavior independent of the concrete OpenTelemetry tracer implementation.

## Decisions

- Measure elapsed time locally with the monotonic `performance.now()` clock at each operation owner.
- Remove the shared private-field helpers from `@livestore/common` and their now-unused compatibility state from LiveStore’s custom no-op span.
- Cover the real OpenTelemetry API no-op tracer. The test verifies a non-recording span, store construction through `configureSQLite`, direct `cachedExecute`, and select.

A fallback inside the span helper was rejected because it would preserve reliance on non-standard fields and produce inconsistent timing semantics across tracers.

## Verification

- `devenv shell -- vitest run packages/@livestore/livestore/src/SqliteDbWrapper.test.ts --config packages/@livestore/livestore/vitest.config.ts --reporter verbose`
  - 1 file passed, 4 tests passed.
- `devenv tasks run ts:check --mode before`
  - Passed.
- `devenv tasks run lint:full --mode before`
  - Passed.
- Commit hook `check-quick` passed.

## Complexity

No new abstraction or dependency. Timing moves to the code that consumes it, and the custom no-op span becomes smaller.

## Concerns

`performance.now()` measures the same callback interval for every tracer. It includes the small cost of ending the span, whereas SDK `_duration` ended immediately before the read. The difference is negligible for debug timing and avoids tracer-dependent behavior. The existing 5 ms slow-query threshold and monotonic start timestamp semantics are preserved.

## Friction & bottlenecks

The downstream Effect RPC defect decoder omitted the originating worker stack, so the transported `SqliteError` initially appeared to originate in schema decoding. No persistent build or test bottleneck was encountered.

## Follow-ups

None.

## References

Closes #1448.

Related: #1447. This PR is independent and should merge first; the Effect beta.99 cohort should then rebase onto it before downstream contrib E2E verification.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/fix-noop-span-timing |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->