### PR TITLE
Fix client event loss during orderly shutdown

### DIFF
--- a/.changeset/fix-client-session-shutdown-drain.md
+++ b/.changeset/fix-client-session-shutdown-drain.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Prevent orderly `store.shutdown()` from losing client events when a leader push is in flight or queued. Shutdown now stops new admission, stops the pull worker, and drains admitted events to the leader before closing the store lifetime scope.

--- a/.changeset/fix-client-session-shutdown-drain.md
+++ b/.changeset/fix-client-session-shutdown-drain.md
@@ -1,5 +1,8 @@
 ---
-"@livestore/common": patch
+'@livestore/common': patch
+'@livestore/livestore': patch
 ---
 
 Prevent orderly `store.shutdown()` from losing client events when a leader push is in flight or queued. Shutdown now stops new admission, stops the pull worker, and drains admitted events to the leader before closing the store lifetime scope.
+
+The drain is implemented without regressing normal operation: `store.commit()` stays fully synchronous (the `push` path never blocks on a lock), and `push` is serialized against an in-progress rebase by a non-blocking atomic queue reconciliation that re-reads the live pending state — so a commit landing during a rebase can no longer throw `AsyncFiberError` or be silently torn away. Shutdown cleanup runs detached under a hard timeout that force-closes the lifetime scope, so an unresponsive leader can no longer leak it. Durability contract: an orderly shutdown flushes every admitted client commit to the leader; a hard crash may still lose un-acked client commits (persist-before-admit is tracked separately).

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -3,7 +3,7 @@
 Role: `02-processors/` owns the two drivers of the merge core: the
 `LeaderSyncProcessor` (leader⇄backend plus applying session pushes) and the
 `ClientSessionSyncProcessor` (session⇄leader). Queueing, batching, retry,
-precedence, and cursor semantics live here; *where* the processors run is
+precedence, and cursor semantics live here; _where_ the processors run is
 `../../04-runtime/`'s concern (LS.SYS.SYNC.SS-R04).
 
 ## Context
@@ -26,6 +26,12 @@ Builds on [../requirements.md](../requirements.md) and
   precedence when both contend (spec: [Leader Sync
   Processor](./spec.md#leader-sync-processor)). Adopted 2026-07-16
   (interview). `refines: LS.SYS.SYNC-R01`
+- **LS.SYS.SYNC.PROC-R03 Orderly session drain:** Successful orderly Store
+  shutdown closes client-session admission and sends every admitted event to
+  the leader in FIFO order within configured batch bounds. A rejected or fatal
+  leader push fails the drain instead of claiming durability. Failed shutdown
+  may interrupt blocked processor work. Adopted 2026-07-18 (#1437).
+  `refines: LS.SYS.STORE-R07`
 
 Further processor requirements (e.g. the crash-atomicity contract of batch
 materialization) remain open pending `LS.SYS.STATE-DQ2`;

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -30,7 +30,13 @@ Builds on [../requirements.md](../requirements.md) and
   shutdown closes client-session admission and sends every admitted event to
   the leader in FIFO order within configured batch bounds. A rejected or fatal
   leader push fails the drain instead of claiming durability. Failed shutdown
-  may interrupt blocked processor work. Adopted 2026-07-18 (#1437).
+  may interrupt blocked processor work. The drain must **not** block the
+  synchronous commit path: `push` serializes against rebase by non-blocking
+  atomic reconciliation, never a permit (preserves LS.SYS.STORE-R09). Cleanup
+  runs detached under a hard bound so an unresponsive leader cannot leak the
+  lifetime scope. Adopted 2026-07-18 (#1437); non-blocking design + hard bound
+  2026-07-19 (#1465, store
+  [`.decisions/0001`](../../05-store/.decisions/0001-client-session-shutdown-drain.md)).
   `refines: LS.SYS.STORE-R07`
 
 Further processor requirements (e.g. the crash-atomicity contract of batch

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -80,8 +80,8 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 `sync/ClientSessionSyncProcessor.ts`. One unbounded STM `leaderPushQueue`
 (`:104`) decouples `push()` (synchronous commit path) from leader I/O:
 
-- **Push** (`:341-343`): merge into local sync state, enqueue the merge's
-  `newEvents`; a background fiber drains
+- **Push** (`:341-343`): synchronously merge into local sync state and enqueue
+  the merge's `newEvents` without waiting for pull/rebase ownership; a background fiber drains
   `takeBetween(1, leaderPushBatchSize)` and pushes to the leader (`:128-129`).
   Coalescing is opportunistic (whatever accumulated while the previous
   push was in flight); there is no time-based debounce. A rejected push

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -98,8 +98,15 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   (`meta.sessionChangeset`, then mark `unset`) → re-offer rebased pending
   → restart the push fiber. Sequencing is what the built-in simulation
   harness perturbs (`simSleep` hooks at 5 labeled points, `:83-86,
-  414-422`; `SIMULATION_ENABLED` is hardcoded `true` with a build-macro
+414-422`; `SIMULATION_ENABLED` is hardcoded `true` with a build-macro
   TODO, `:410-411`).
+- **Shutdown drain:** orderly shutdown closes new `push()` admission, stops
+  pull processing while holding the same state-ownership permit, ends the push
+  queue, and awaits its sole worker. Success therefore means all admitted
+  events reached the leader; an unresolved rejection or fatal push fails the
+  drain. Failed shutdown interrupts the pull and push workers. Store-level
+  timeout stops waiting without cancelling this cleanup
+  (LS.SYS.SYNC.PROC-R03).
 - **Observability** (`:98-99, 358-361`): sync-state updates surface via a
   separate queue explicitly not relied on for correctness; a devtools
   latch can pause upstream application (`:152-153`).

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -93,20 +93,31 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   re-materialize into the session DB with changesets and session-side
   materializer hashes written back, then `refreshTables` runs once per
   merge (`:232-250`).
-- **Rebase critical section** (`:170-214`): interrupt the push fiber →
-  clear the queue → roll back session changesets in reverse order
-  (`meta.sessionChangeset`, then mark `unset`) → re-offer rebased pending
-  → restart the push fiber. Sequencing is what the built-in simulation
-  harness perturbs (`simSleep` hooks at 5 labeled points, `:83-86,
-414-422`; `SIMULATION_ENABLED` is hardcoded `true` with a build-macro
-  TODO, `:410-411`).
+- **Rebase critical section** (`:209-272`): interrupt the push fiber → roll
+  back session changesets in reverse order (`meta.sessionChangeset`, then mark
+  `unset`) → **atomically reconcile** the push queue (clear + re-offer the
+  _live_ `syncStateRef.current.pending` inside one `Effect.tx`, with no async
+  park between the read, clear, and offer) → restart the push fiber. Re-reading
+  the live pending (rather than the stale merge-time snapshot) is what
+  serializes `push` against rebase **without blocking it**: `push` runs via
+  `Effect.runSyncWith` as an indivisible unit that can only interleave in the
+  pull fiber's async gaps, so a synchronous commit admitted during a rebase
+  park is folded into the reconciliation instead of being torn away by the
+  clear. This replaces the earlier blocking `rebaseOwnership` permit on `push`,
+  which violated the synchronous-commit invariant (LS.SYS.STORE-R09) by
+  suspending the commit path (see `.decisions/`, #1465). Deterministic
+  `rebaseBarriers` hooks at 3 labeled points let tests inject a concurrent
+  push/shutdown into this window (the F1 no-loss oracle).
 - **Shutdown drain:** orderly shutdown closes new `push()` admission, stops
-  pull processing while holding the same state-ownership permit, ends the push
-  queue, and awaits its sole worker. Success therefore means all admitted
+  pull processing while holding the state-ownership permit (which still
+  serializes shutdown↔rebase — only `push` was taken off that permit), ends the
+  push queue, and awaits its sole worker. Success therefore means all admitted
   events reached the leader; an unresolved rejection or fatal push fails the
-  drain. Failed shutdown interrupts the pull and push workers. Store-level
-  timeout stops waiting without cancelling this cleanup
-  (LS.SYS.SYNC.PROC-R03).
+  drain. Failed shutdown interrupts the pull and push workers. The Store runs
+  this cleanup detached under a **hard bound**: the caller stops waiting after
+  1s, and the detached drain is itself force-closed after
+  `SHUTDOWN_DRAIN_HARD_TIMEOUT_MS` so an unresponsive leader cannot leak the
+  lifetime scope (LS.SYS.SYNC.PROC-R03, LS.SYS.STORE-R07).
 - **Observability** (`:98-99, 358-361`): sync-state updates surface via a
   separate queue explicitly not relied on for correctness; a devtools
   latch can pause upstream application (`:152-153`).

--- a/context/02-system/05-store/.decisions/0001-client-session-shutdown-drain.md
+++ b/context/02-system/05-store/.decisions/0001-client-session-shutdown-drain.md
@@ -1,0 +1,91 @@
+# 0001 — Client-session shutdown drain: non-blocking serialization, flush-on-shutdown durability
+
+Status: accepted (2026-07-19, maintainer-approved design resolution of the
+#1465 review of #1451; supersedes the blocking-permit implementation on that
+branch)
+
+## Context
+
+`Store.shutdown()` could report success after silently dropping client-session
+events that were admitted to the caller but not yet accepted by the leader
+(#1437): client commits become restart-replayable only once the leader writes
+them to the eventlog, so tearing down the lifetime scope with events still
+queued / a push in flight loses them. #1451 added an explicit processor drain
+before lifetime-scope teardown — the right fix — but implemented the
+push↔rebase serialization it needed with a **blocking** `rebaseOwnership`
+`Semaphore` permit sitting on the `push` path.
+
+The store's commit pipeline is spec'd **fully synchronous**, run via
+`Effect.runSyncWith` (`store.ts:945`, LS.SYS.STORE-R09). A blocking permit on
+`push` means a `store.commit()` landing while the pull fiber is parked mid-rebase
+(holding the permit) suspends the commit effect → `runSyncWith` throws
+`AsyncFiberError` out of `store.commit()`. The #1465 review verified this and
+three further gaps (unbounded detached teardown; an untested no-loss invariant;
+cross-fiber mutable `let`s). Standalone repro of the mechanism:
+`schickling-repros/2026-07-effect-runsync-contended-semaphore`.
+
+Three questions had to be settled before choosing an implementation.
+
+## Options
+
+- **Q1 — Must `store.commit()` stay fully synchronous?**
+  - A. Yes, invariant (chosen). Forbids any blocking/suspension on the push
+    path; constrains every future redesign.
+  - B. Relax to allow an async commit. Rejected: breaks the React-suspense /
+    `runSyncWith` contract and every synchronous caller.
+- **Q2 — What is the durability contract?**
+  - A. Flush-on-shutdown (chosen): a successful orderly `shutdown()` flushes
+    every admitted client commit to the leader; a hard crash may still lose
+    un-acked client commits. #1451 (so fixed) is therefore _done_, not a
+    stopgap.
+  - B. Persist-before-admit for client sessions (crash-durable client commits).
+    The real disease-cure, but a separate, larger effort — deferred to
+    LS.SYS.STORE-DQ1 / #1425, gated by the command/intent root LS-DQ1.
+- **Q3 — How to serialize push↔rebase now?**
+  - A. Minimal non-blocking fix (chosen): drop the blocking permit from `push`;
+    have the rebase re-read/re-validate the live `syncStateRef.current.pending`
+    and reconcile the push queue atomically after the async parks, so a push
+    admitted during a park is folded in rather than torn away.
+  - B. Structural actor/mailbox rewrite (single serialized owner-fiber
+    consuming `LocalPush | PullChunk | Shutdown`; ordering intrinsic). The
+    stronger long-term shape, matching the code's own "unify the processors"
+    note — but larger and deferred.
+
+## Decision
+
+Q1 = A, Q2 = A, Q3 = A. The `push` path never blocks (invariant); orderly
+shutdown flushes admitted client commits (documented contract), with
+persist-before-admit as the separate future target; push↔rebase is serialized
+by a **non-blocking atomic reconcile** rather than a permit. The actor rewrite
+(Q3-B) is not built now.
+
+Evidence: maintainer-approved resolution captured in the #1465 review thread
+(design questions 1–4) and this branch's implementation + deterministic F1
+oracle.
+
+## Consequences
+
+- `ClientSessionSyncProcessor.push` holds no permit. The rebase critical
+  section rolls back, then in one `Effect.tx` clears the `leaderPushQueue` and
+  re-offers the **live** `syncStateRef.current.pending` (not the stale
+  merge-time snapshot) with no async park between read/clear/offer — atomic
+  w.r.t. the synchronous `push`, which can only interleave in the pull fiber's
+  async gaps. The permit is retained only on the pull tap ↔ `runShutdown` to
+  serialize shutdown against rebase.
+- The detached shutdown cleanup is hard-bounded
+  (`SHUTDOWN_DRAIN_HARD_TIMEOUT_MS`, `create-store.ts`): after the bound the
+  lifetime scope is force-closed, so an unresponsive leader cannot leak it
+  (restores the intent of LS.SYS.STORE-R07). The 1s caller-side wait is
+  unchanged.
+- The no-loss invariant is now covered by a deterministic barrier test
+  (`rebaseBarriers` hooks; replaces the flaky virtual-time `simSleep`
+  harness): a push admitted at the rebase discard window survives, and the test
+  fails if the reconcile reverts to the stale snapshot.
+- Spec updates: LS.SYS.STORE-R09 commit-synchronicity restated as an explicit
+  invariant; the store durability contract states flush-on-shutdown;
+  LS.SYS.STORE-DQ1 annotated with persist-before-admit as the future target;
+  LS.SYS.SYNC.PROC-R03 aligned with the non-blocking design.
+- Not addressed (tracked as follow-ups): the actor/mailbox rewrite (Q3-B);
+  persist-before-admit (Q2-B, #1425); the cross-fiber mutable `let`s
+  (`shutdownStarted`, `terminalPushCause`, `unresolvedRejection`) noted in
+  #1465 remain raw `let`s.

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -74,9 +74,11 @@ per-commit root span with links.
 ## Lifecycle
 
 - Every public operation guards on `isShutdown` (`checkShutdown`).
-- `shutdown` closes the store's `lifetimeScope` with a 1s timeout + warning
-  (`create-store.ts:336-342`); intentional shutdown is distinguished from
-  failure via the Exit cause (LS.SYS.STORE-R07).
+- `shutdown` first drains admitted client-session events to the leader, then
+  closes the store's `lifetimeScope`. Its 1s timeout limits how long the caller
+  waits without cancelling cleanup; intentional shutdown is distinguished
+  from failure via the Exit cause (LS.SYS.STORE-R07,
+  LS.SYS.SYNC.PROC-R03).
 - During boot, `batchUpdates` is the identity function and is swapped to the
   adapter-provided implementation after boot (`create-store.ts:399,430`) —
   events committed during boot are unbatched.

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -51,7 +51,15 @@ simulation}`, `debug.instanceId`, `shutdownDeferred`, `signal`
 ## Commit Path
 
 The pipeline is fully synchronous, run via `Effect.runSyncWith`
-(`store.ts:945`):
+(`store.ts:945`). **This synchronicity is an invariant** (Q1, see
+[`.decisions/0001-client-session-shutdown-drain.md`](./.decisions/0001-client-session-shutdown-drain.md)):
+no step on the commit path — including the `ClientSessionSyncProcessor.push`
+enqueue (step 3) — may block or suspend on a lock/permit, because a suspension
+turns the commit effect async and makes `runSyncWith` throw `AsyncFiberError`
+out of `store.commit`. This is why `push` serializes against rebase by
+non-blocking reconciliation rather than a permit
+([`../03-sync/02-processors/spec.md`](../03-sync/02-processors/spec.md), #1465).
+The steps:
 
 1. Validate and encode events against their definitions; assign client
    sequence numbers.
@@ -75,10 +83,16 @@ per-commit root span with links.
 
 - Every public operation guards on `isShutdown` (`checkShutdown`).
 - `shutdown` first drains admitted client-session events to the leader, then
-  closes the store's `lifetimeScope`. Its 1s timeout limits how long the caller
-  waits without cancelling cleanup; intentional shutdown is distinguished
-  from failure via the Exit cause (LS.SYS.STORE-R07,
-  LS.SYS.SYNC.PROC-R03).
+  closes the store's `lifetimeScope`. **Durability contract (Q2, see
+  [`.decisions/0001-client-session-shutdown-drain.md`](./.decisions/0001-client-session-shutdown-drain.md)):
+  a successful orderly `shutdown()` flushes every admitted client commit to the
+  leader; a hard crash may still lose un-acked client commits** — the client
+  session is the only tier without persist-before-admit (LS.SYS.STORE-DQ1). The
+  caller's 1s timeout limits how long `shutdown()` blocks; the detached cleanup
+  is itself hard-bounded (`SHUTDOWN_DRAIN_HARD_TIMEOUT_MS`, `create-store.ts`),
+  after which the lifetime scope is force-closed so an unresponsive leader
+  cannot leak it. Intentional shutdown is distinguished from failure via the
+  Exit cause (LS.SYS.STORE-R07, LS.SYS.SYNC.PROC-R03).
 - During boot, `batchUpdates` is the identity function and is swapped to the
   adapter-provided implementation after boot (`create-store.ts:399,430`) —
   events committed during boot are unbatched.
@@ -116,4 +130,9 @@ RFC 0001, the implementation is the contract:
   confirmation surface cannot be specified independently. A concrete design, if
   pursued, belongs in an RFC (per
   [decision 0004](../../.decisions/0004-rfc-vrs-boundary.md)). `../03-sync/`
-  LS.SYS.SYNC-DQ1 cross-references this.
+  LS.SYS.SYNC-DQ1 cross-references this. **Persist-before-admit for client
+  sessions** — making client commits crash-durable, not merely flushed on
+  orderly shutdown — is the separate future target that would subsume the
+  shutdown drain (LS.SYS.SYNC.PROC-R03); it is gated by LS-DQ1 and tracked as
+  #1425. Until then, the orderly-shutdown flush is the accepted durability
+  contract (Q2), not a stopgap for a specific release.

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -180,13 +180,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     const backgroundPulling = Stream.suspend(() =>
       clientSession.leaderThread.events.pull({ cursor: syncStateRef.current.upstreamHead }),
     ).pipe(
+      Stream.tap(() =>
+        clientSession.devtools.enabled === true ? clientSession.devtools.pullLatch.await : Effect.void,
+      ),
       Stream.tap(({ payload }) =>
         Effect.gen(function* () {
           // yield* Effect.logDebug('ClientSessionSyncProcessor:pull', payload)
-
-          if (clientSession.devtools.enabled === true) {
-            yield* clientSession.devtools.pullLatch.await
-          }
 
           const rejectionAtPullStart = unresolvedRejection
           const mergeResult = yield* SyncState.merge({
@@ -395,8 +394,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     return { writeTables }
   })
 
-  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')((encodedEvents) =>
-    Effect.gen(function* () {
+  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
+    function* (encodedEvents) {
       if (shutdownStarted === true) {
         return yield* Effect.die(
           new Error('Cannot push events after the client session sync processor starts shutting down'),
@@ -430,7 +429,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       if (rejectedEvents.length > 0) {
         return yield* Effect.die(new Error('Leader push queue closed while accepting events'))
       }
-    }).pipe(rebaseOwnership.withPermits(1)),
+    },
   )
 
   const debugInfo = {

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -147,7 +147,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
       while (true) {
         const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize).pipe(
-          Effect.catchIf(Cause.isDone, () => Effect.succeed(undefined)),
+          Effect.catchIf(Cause.isDone, () => Effect.void),
         )
         if (batch === undefined) return
 
@@ -314,8 +314,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     exit: Exit.Exit<unknown, unknown>,
   ) {
     if (Exit.isFailure(exit) === true) {
-      yield* TxQueue.end(leaderPushQueue)
       if (pullingFiberHandle !== undefined) yield* FiberHandle.clear(pullingFiberHandle)
+      yield* rebaseOwnership.withPermits(1)(TxQueue.end(leaderPushQueue))
       if (leaderPushingFiberHandle !== undefined) yield* FiberHandle.clear(leaderPushingFiberHandle)
       return
     }
@@ -395,10 +395,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     return { writeTables }
   })
 
-  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
-    function* (encodedEvents) {
+  const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')((encodedEvents) =>
+    Effect.gen(function* () {
       if (shutdownStarted === true) {
-        return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
+        return yield* Effect.die(
+          new Error('Cannot push events after the client session sync processor starts shutting down'),
+        )
       }
 
       const mergeResult = yield* SyncState.merge({
@@ -422,13 +424,13 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
       })
 
-      const rejectedEvents = yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
-      if (rejectedEvents.length > 0) {
-        return yield* Effect.die('Leader push queue closed while accepting events')
-      }
       syncStateRef.current = mergeResult.newSyncState
       yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-    },
+      const rejectedEvents = yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      if (rejectedEvents.length > 0) {
+        return yield* Effect.die(new Error('Leader push queue closed while accepting events'))
+      }
+    }).pipe(rebaseOwnership.withPermits(1)),
   )
 
   const debugInfo = {

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -1,6 +1,8 @@
 /// <reference lib="dom" />
 import { LS_DEV, TRACE_VERBOSE } from '@livestore/utils'
 import {
+  Cause,
+  Deferred,
   Effect,
   Exit,
   Filter,
@@ -8,6 +10,7 @@ import {
   Option,
   Queue,
   Schema,
+  Semaphore,
   type Scope,
   Stream,
   Subscribable,
@@ -101,7 +104,21 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
     schema.eventsDefsMap.get(eventEncoded.name)?.options.clientOnly ?? false
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
-  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
+  const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>()
+  const rebaseOwnership = yield* Semaphore.make(1)
+  const shutdownDone = yield* Deferred.make<void>()
+  const drainStartedSignal = yield* Deferred.make<void>()
+  const rejectionObserved = yield* Deferred.make<void>()
+  let shutdownStarted = false
+  let terminalPushCause: Cause.Cause<never> | undefined
+  let unresolvedRejection:
+    | {
+        readonly error: Error
+        readonly events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
+      }
+    | undefined
+  let leaderPushingFiberHandle: FiberHandle.FiberHandle<void, never> | undefined
+  let pullingFiberHandle: FiberHandle.FiberHandle<void, never> | undefined
 
   const boot: ClientSessionSyncProcessor['boot'] = Effect.gen(function* () {
     if (
@@ -122,27 +139,45 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       )
     }
 
-    const leaderPushingFiberHandle = yield* FiberHandle.make()
+    const leaderPushingHandle = yield* FiberHandle.make<void, never>()
+    const pullingHandle = yield* FiberHandle.make<void, never>()
+    leaderPushingFiberHandle = leaderPushingHandle
+    pullingFiberHandle = pullingHandle
 
-    const backgroundLeaderPushing = Effect.gen(function* () {
-      const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize)
-      yield* clientSession.leaderThread.events.push(batch).pipe(
-        Effect.catchIf(isRejectedPushError, () => {
-          debugInfo.rejectCount++
-          return TxQueue.clear(leaderPushQueue)
-        }),
-      )
+    const backgroundLeaderPushing: Effect.Effect<void> = Effect.gen(function* () {
+      while (true) {
+        const batch = yield* TxQueue.takeBetween(leaderPushQueue, 1, params.leaderPushBatchSize).pipe(
+          Effect.catchIf(Cause.isDone, () => Effect.succeed(undefined)),
+        )
+        if (batch === undefined) return
+
+        yield* clientSession.leaderThread.events.push(batch).pipe(
+          Effect.catchIf(isRejectedPushError, (error) => {
+            debugInfo.rejectCount++
+            if (shutdownStarted === true) return Effect.die(error)
+
+            unresolvedRejection = { error, events: batch }
+            return TxQueue.clear(leaderPushQueue).pipe(Effect.andThen(Deferred.succeed(rejectionObserved, undefined)))
+          }),
+        )
+      }
     }).pipe(
-      Effect.forever,
       Effect.interruptible,
       Effect.tapCauseLogPretty,
-      Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause) === true) return Effect.void
+
+        terminalPushCause ??= cause
+        return shutdownStarted === true
+          ? Effect.void
+          : clientSession.shutdown(Exit.failCause(cause)).pipe(Effect.forkDetach, Effect.asVoid)
+      }),
     )
 
-    yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+    yield* FiberHandle.run(leaderPushingHandle, backgroundLeaderPushing)
 
     // NOTE We need to lazily call `.pull` as we want the cursor to be updated
-    yield* Stream.suspend(() =>
+    const backgroundPulling = Stream.suspend(() =>
       clientSession.leaderThread.events.pull({ cursor: syncStateRef.current.upstreamHead }),
     ).pipe(
       Stream.tap(({ payload }) =>
@@ -153,6 +188,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             yield* clientSession.devtools.pullLatch.await
           }
 
+          const rejectionAtPullStart = unresolvedRejection
           const mergeResult = yield* SyncState.merge({
             syncState: syncStateRef.current,
             payload,
@@ -180,7 +216,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
             if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
 
-            yield* FiberHandle.clear(leaderPushingFiberHandle)
+            yield* FiberHandle.clear(leaderPushingHandle)
 
             if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
 
@@ -211,7 +247,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
             if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
 
-            yield* FiberHandle.run(leaderPushingFiberHandle, backgroundLeaderPushing)
+            yield* FiberHandle.run(leaderPushingHandle, backgroundLeaderPushing)
           } else {
             yield* Effect.spanEvent('merge:pull:advance', {
               payloadTag: payload._tag,
@@ -221,6 +257,14 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             })
 
             debugInfo.advanceCount++
+          }
+
+          if (
+            rejectionAtPullStart !== undefined &&
+            unresolvedRejection === rejectionAtPullStart &&
+            isRejectedBatchRecovered(rejectionAtPullStart.events, mergeResult.newSyncState.pending) === true
+          ) {
+            unresolvedRejection = undefined
           }
 
           if (mergeResult.newEvents.length === 0) {
@@ -252,6 +296,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
         }).pipe(
+          rebaseOwnership.withPermits(1),
           Effect.tapCauseLogPretty,
           Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
         ),
@@ -261,9 +306,43 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       Effect.interruptible,
       Effect.withSpan('client-session-sync-processor:pull'),
       Effect.tapCauseLogPretty,
-      Effect.forkScoped,
     )
+    yield* FiberHandle.run(pullingHandle, backgroundPulling)
   }).pipe(Effect.withSpan('client-session-sync-processor:boot'))
+
+  const runShutdown = Effect.fn('client-session-sync-processor:shutdown')(function* (
+    exit: Exit.Exit<unknown, unknown>,
+  ) {
+    if (Exit.isFailure(exit) === true) {
+      yield* TxQueue.end(leaderPushQueue)
+      if (pullingFiberHandle !== undefined) yield* FiberHandle.clear(pullingFiberHandle)
+      if (leaderPushingFiberHandle !== undefined) yield* FiberHandle.clear(leaderPushingFiberHandle)
+      return
+    }
+
+    yield* rebaseOwnership.withPermits(1)(
+      Effect.gen(function* () {
+        if (pullingFiberHandle !== undefined) yield* FiberHandle.clear(pullingFiberHandle)
+        yield* TxQueue.end(leaderPushQueue)
+        yield* Deferred.succeed(drainStartedSignal, undefined)
+      }),
+    )
+    if (leaderPushingFiberHandle !== undefined) yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+    if (terminalPushCause !== undefined) return yield* Effect.failCause(terminalPushCause)
+    if (unresolvedRejection !== undefined) return yield* Effect.die(unresolvedRejection.error)
+  })
+
+  const shutdown: ClientSessionSyncProcessor['shutdown'] = (exit) =>
+    Effect.suspend(() => {
+      if (shutdownStarted === true) return Deferred.await(shutdownDone)
+      shutdownStarted = true
+      return runShutdown(exit).pipe(
+        Effect.exit,
+        Effect.tap((shutdownExit) => Deferred.done(shutdownDone, shutdownExit)),
+        Effect.forkDetach,
+        Effect.andThen(Deferred.await(shutdownDone)),
+      )
+    })
 
   const encodeEvents: ClientSessionSyncProcessor['encodeEvents'] = Effect.fn(
     'client-session-sync-processor:encode-events',
@@ -318,6 +397,10 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   const push: ClientSessionSyncProcessor['push'] = Effect.fn('client-session-sync-processor:push')(
     function* (encodedEvents) {
+      if (shutdownStarted === true) {
+        return yield* Effect.die('Cannot push events after the client session sync processor starts shutting down')
+      }
+
       const mergeResult = yield* SyncState.merge({
         syncState: syncStateRef.current,
         payload: { _tag: 'local-push', newEvents: encodedEvents },
@@ -339,9 +422,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
       })
 
+      const rejectedEvents = yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
+      if (rejectedEvents.length > 0) {
+        return yield* Effect.die('Leader push queue closed while accepting events')
+      }
       syncStateRef.current = mergeResult.newSyncState
       yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
-      yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newEvents)
     },
   )
 
@@ -353,6 +439,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   return {
     boot,
+    shutdown,
     encodeEvents,
     materializeEvents,
     push,
@@ -361,6 +448,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
       changes: Stream.fromQueue(syncStateUpdateQueue),
     }),
     debug: {
+      awaitDrainStarted: Deferred.await(drainStartedSignal),
+      awaitRejection: Deferred.await(rejectionObserved),
       print: () =>
         Effect.gen(function* () {
           console.log('debugInfo', debugInfo)
@@ -377,17 +466,29 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   } satisfies ClientSessionSyncProcessor
 })
 
-const snapshotTxQueue = <A>(queue: TxQueue.TxQueue<A>): Effect.Effect<ReadonlyArray<A>> =>
+const snapshotTxQueue = <A, E>(queue: TxQueue.TxQueue<A, E>): Effect.Effect<ReadonlyArray<A>, E> =>
   Effect.tx(
     Effect.gen(function* () {
+      if ((yield* TxQueue.isOpen(queue)) === false) return []
+
       const items = yield* TxQueue.clear(queue)
       yield* TxQueue.offerAll(queue, items)
       return items
     }),
   )
 
+const isRejectedBatchRecovered = (
+  rejectedEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+  pendingEvents: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
+): boolean =>
+  rejectedEvents.every(
+    (rejectedEvent) =>
+      pendingEvents.some((pendingEvent) => LiveStoreEvent.Client.isEqualEncoded(pendingEvent, rejectedEvent)) === false,
+  )
+
 export interface ClientSessionSyncProcessor {
   boot: Effect.Effect<void, never, Scope.Scope>
+  shutdown: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>
   encodeEvents: (
     events: ReadonlyArray<LiveStoreEvent.Input.Decoded>,
   ) => Effect.Effect<ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>>
@@ -400,6 +501,8 @@ export interface ClientSessionSyncProcessor {
    */
   syncState: Subscribable.Subscribable<SyncState.SyncState>
   debug: {
+    awaitDrainStarted: Effect.Effect<void>
+    awaitRejection: Effect.Effect<void>
     print: () => void
     debugInfo: () => {
       rebaseCount: number

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -73,7 +73,13 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   refreshTables: (tables: Set<string>) => void
   params: {
     leaderPushBatchSize: number
-    simulation?: ClientSessionSyncProcessorSimulationParams
+    /**
+     * Test-only deterministic barriers, awaited at fixed points of the rebase critical section.
+     * A test can park the pull fiber at a chosen point, inject a concurrent operation
+     * (a synchronous `push` or a `shutdown`), then release the barrier — without relying on
+     * virtual-time scheduling. Unset in production, where each lookup resolves to `Effect.void`.
+     */
+    rebaseBarriers?: Partial<Record<RebaseBarrierPoint, Effect.Effect<void>>>
   }
   /**
    * Currently only used in the web adapter:
@@ -83,10 +89,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 }): Effect.fn.Return<ClientSessionSyncProcessor> {
   const eventSchema = LiveStoreEvent.Client.makeSchemaMemo(schema)
 
-  const simSleep = <TKey extends keyof ClientSessionSyncProcessorSimulationParams>(
-    key: TKey,
-    key2: keyof ClientSessionSyncProcessorSimulationParams[TKey],
-  ) => Effect.sleep((params.simulation?.[key]?.[key2] ?? 0) as number)
+  const rebaseBarrier = (point: RebaseBarrierPoint): Effect.Effect<void> =>
+    params.rebaseBarriers?.[point] ?? Effect.void
 
   const syncStateRef = {
     // The initial state is identical to the leader's initial state
@@ -213,16 +217,10 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
             debugInfo.rebaseCount++
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '1_before_leader_push_fiber_interrupt')
+            // Barrier: before we interrupt the in-flight leader-push worker.
+            yield* rebaseBarrier('before_leader_push_fiber_interrupt')
 
             yield* FiberHandle.clear(leaderPushingHandle)
-
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '2_before_leader_push_queue_clear')
-
-            // Reset the leader push queue since we're rebasing and will push again
-            yield* TxQueue.clear(leaderPushQueue)
-
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '3_before_rebase_rollback')
 
             if (LS_DEV === true) {
               yield* Effect.logDebug(
@@ -232,6 +230,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               )
             }
 
+            // Roll back the optimistic session changesets for the events this rebase discards.
+            // (Independent of the push queue below; order relative to the queue reconcile is irrelevant.)
             for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
               const event = mergeResult.rollbackEvents[i]!
               if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
@@ -240,11 +240,34 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               }
             }
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '4_before_leader_push_queue_offer')
+            // Barrier: before the atomic queue reconciliation (the "discard + re-offer" step).
+            // A `push` admitted here appends its event to `syncStateRef.current.pending` AND to
+            // `leaderPushQueue`; the reconciliation below re-reads the LIVE pending, so that event
+            // is preserved rather than torn away by the clear.
+            yield* rebaseBarrier('before_queue_reconcile')
 
-            yield* TxQueue.offerAll(leaderPushQueue, mergeResult.newSyncState.pending)
+            // Atomic queue reconciliation. `push` runs via `Effect.runSyncWith` (a synchronous run,
+            // per the store's fully-synchronous commit contract), so it executes as an indivisible
+            // unit that can only interleave in THIS fiber's async gaps — never inside a synchronous
+            // stretch. By reading the live pending, clearing, and re-offering with no async park
+            // between them, this block is atomic w.r.t. `push`. This replaces the blocking
+            // `rebaseOwnership` permit that previously forced `push` to wait: push↔rebase is now
+            // serialized WITHOUT ever suspending the synchronous commit path.
+            //
+            // We re-read `syncStateRef.current.pending` (the LIVE pending) instead of the stale
+            // `mergeResult.newSyncState.pending` snapshot captured at merge time, so any event a
+            // concurrent push appended during the async steps above (fiber interrupt / rollback /
+            // barriers) is included. `Effect.tx` commits the clear+offer as one transaction.
+            const livePending = syncStateRef.current.pending
+            yield* Effect.tx(
+              Effect.gen(function* () {
+                yield* TxQueue.clear(leaderPushQueue)
+                yield* TxQueue.offerAll(leaderPushQueue, livePending)
+              }),
+            )
 
-            if (SIMULATION_ENABLED === true) yield* simSleep('pull', '5_before_leader_push_fiber_run')
+            // Barrier: before restarting the leader-push worker.
+            yield* rebaseBarrier('before_leader_push_fiber_run')
 
             yield* FiberHandle.run(leaderPushingHandle, backgroundLeaderPushing)
           } else {
@@ -512,17 +535,11 @@ export interface ClientSessionSyncProcessor {
   }
 }
 
-// TODO turn this into a build-time "macro" so all simulation snippets are removed for production builds
-const SIMULATION_ENABLED = true
-
-// Warning: High values for the simulation params can lead to very long test runs since those get multiplied with the number of events
-export const ClientSessionSyncProcessorSimulationParams = Schema.Struct({
-  pull: Schema.Struct({
-    '1_before_leader_push_fiber_interrupt': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '2_before_leader_push_queue_clear': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '3_before_rebase_rollback': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '4_before_leader_push_queue_offer': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-    '5_before_leader_push_fiber_run': Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 15 })),
-  }),
-})
-type ClientSessionSyncProcessorSimulationParams = typeof ClientSessionSyncProcessorSimulationParams.Type
+/**
+ * Injection points inside the rebase critical section where a test-only barrier may be awaited.
+ * Named for the step they precede so the deterministic no-loss tests can target the exact window.
+ */
+export type RebaseBarrierPoint =
+  | 'before_leader_push_fiber_interrupt'
+  | 'before_queue_reconcile'
+  | 'before_leader_push_fiber_run'

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -328,12 +328,17 @@ export const createStore = <
         })
 
       const services = yield* Effect.context<Scope.Scope>()
+      let shutdownSyncProcessor: ((exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>) | undefined
 
       const shutdown = (
         exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
       ) =>
         Effect.gen(function* () {
-          yield* Scope.close(lifetimeScope, exit).pipe(
+          const closeFiber = yield* (shutdownSyncProcessor?.(exit) ?? Effect.void).pipe(
+            Effect.ensuring(Scope.close(lifetimeScope, exit)),
+            Effect.forkDetach,
+          )
+          yield* Fiber.join(closeFiber).pipe(
             Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),
             Effect.timeout(1000),
             Effect.catchTag('TimeoutError', () =>
@@ -404,6 +409,7 @@ export const createStore = <
           ...omitUndefineds({ simulation: params?.simulation }),
         },
       })
+      shutdownSyncProcessor = store[StoreInternalsSymbol].syncProcessor.shutdown
 
       // Starts background fibers (syncing, event processing, etc) for store
       yield* store[StoreInternalsSymbol].boot

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -6,7 +6,6 @@ import {
   type BootStatus,
   type ClientSession,
   type ClientSessionDevtoolsChannel,
-  type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
   type MaterializeError,
   type MigrationsReport,
@@ -42,6 +41,14 @@ import type {
 } from './store-types.ts'
 import { StoreInternalsSymbol } from './store-types.ts'
 import { STORE_DEFAULT_PARAMS, Store } from './store.ts'
+
+/**
+ * Hard upper bound (ms) for the detached shutdown drain. A dead/unresponsive leader must not keep
+ * the drain (and therefore the lifetime scope) alive forever; after this bound the scope is
+ * force-closed. Kept comfortably above the 1s caller-side soft wait so that a still-progressing
+ * in-flight leader push is allowed to finish rather than being interrupted.
+ */
+const SHUTDOWN_DRAIN_HARD_TIMEOUT_MS = 30_000
 
 declare global {
   /** Store instances for console debugging */
@@ -213,9 +220,6 @@ export interface CreateStoreOptions<
     leaderPushBatchSize?: number
     /** Chunk size used when the stream replays confirmed events. */
     eventQueryBatchSize?: number
-    simulation?: {
-      clientSessionSyncProcessor: typeof ClientSessionSyncProcessorSimulationParams.Type
-    }
   }
   debug?: {
     instanceId?: string
@@ -334,10 +338,25 @@ export const createStore = <
         exit: Exit.Exit<IntentionalShutdownCause, UnknownError | MaterializeError | BackendIdMismatchError>,
       ) =>
         Effect.gen(function* () {
+          // Hard outer bound on the DETACHED teardown: the processor drain `awaitEmpty`s the
+          // leader-push worker, which never completes if the leader is dead/unresponsive. Without a
+          // bound the drain would block forever, so `Scope.close(lifetimeScope)` (in `ensuring`)
+          // would never run and the lifetime scope + its resources would leak indefinitely (a later
+          // `createStore`/registry dispose on the same `storeId` would observe a never-closed store).
+          // Drain up to the bound, then force-close the scope regardless. The bound exceeds the
+          // caller-side wait below so an in-flight (but progressing) push is not cut short.
           const closeFiber = yield* (shutdownSyncProcessor?.(exit) ?? Effect.void).pipe(
+            Effect.timeout(SHUTDOWN_DRAIN_HARD_TIMEOUT_MS),
+            Effect.catchTag('TimeoutError', () =>
+              Effect.logError(
+                `@livestore/livestore:shutdown: drain exceeded hard bound of ${SHUTDOWN_DRAIN_HARD_TIMEOUT_MS}ms; forcing scope close`,
+              ),
+            ),
             Effect.ensuring(Scope.close(lifetimeScope, exit)),
             Effect.forkDetach,
           )
+          // Caller-side soft wait: stop blocking the shutdown() caller after 1s without cancelling
+          // the detached teardown above (which remains bounded by SHUTDOWN_DRAIN_HARD_TIMEOUT_MS).
           yield* Fiber.join(closeFiber).pipe(
             Effect.logWarnIfTakesLongerThan({ label: '@livestore/livestore:shutdown', duration: 500 }),
             Effect.timeout(1000),
@@ -406,7 +425,6 @@ export const createStore = <
         params: {
           leaderPushBatchSize: params?.leaderPushBatchSize ?? STORE_DEFAULT_PARAMS.leaderPushBatchSize,
           eventQueryBatchSize: params?.eventQueryBatchSize ?? STORE_DEFAULT_PARAMS.eventQueryBatchSize,
-          ...omitUndefineds({ simulation: params?.simulation }),
         },
       })
       shutdownSyncProcessor = store[StoreInternalsSymbol].syncProcessor.shutdown

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -4,7 +4,6 @@ import {
   type BackendIdMismatchError,
   type ClientSession,
   type ClientSessionSyncProcessor,
-  type ClientSessionSyncProcessorSimulationParams,
   type IntentionalShutdownCause,
   isQueryBuilder,
   type MaterializeError,
@@ -196,9 +195,6 @@ export type StoreConstructorParams<TSchema extends LiveStoreSchema = LiveStoreSc
   params: {
     leaderPushBatchSize: number
     eventQueryBatchSize?: number
-    simulation?: {
-      clientSessionSyncProcessor: typeof ClientSessionSyncProcessorSimulationParams.Type
-    }
   }
   __runningInDevtools: boolean
 }

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -316,9 +316,6 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         ...omitUndefineds({
           leaderPushBatchSize: params.leaderPushBatchSize,
         }),
-        ...(params.simulation?.clientSessionSyncProcessor !== undefined
-          ? { simulation: params.simulation.clientSessionSyncProcessor }
-          : {}),
       },
       confirmUnsavedChanges,
     }).pipe(Effect.runSyncWith(effectContext.services))

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -13,7 +13,11 @@ import {
 import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
-import { makeClientSessionSyncProcessor, type SyncBackend } from '@livestore/common/sync'
+import {
+  type ClientSessionSyncProcessor,
+  makeClientSessionSyncProcessor,
+  type SyncBackend,
+} from '@livestore/common/sync'
 import { EventFactory } from '@livestore/common/testing'
 import type { ShutdownDeferred, Store } from '@livestore/livestore'
 import { createStore, makeShutdownDeferred, StoreInternalsSymbol } from '@livestore/livestore'
@@ -486,6 +490,34 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         ['third'],
       ])
       expect(Exit.isFailure(postShutdownPushExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('publishes local pending state before the leader worker observes the batch', (test) =>
+    Effect.gen(function* () {
+      const observedPendingState = yield* Deferred.make<boolean>()
+      let processorRef: ClientSessionSyncProcessor | undefined
+
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
+        push: (batch) =>
+          Effect.gen(function* () {
+            const activeProcessor = processorRef
+            if (activeProcessor === undefined) return yield* Effect.die(new Error('Processor not initialized'))
+            const syncState = yield* activeProcessor.syncState.get
+            yield* Deferred.succeed(
+              observedPendingState,
+              batch.every((event) =>
+                syncState.pending.some((pending) => LiveStoreEvent.Client.isEqualEncoded(pending, event)),
+              ),
+            )
+          }),
+      })
+      processorRef = processor
+
+      yield* pushIds(['local'])
+
+      expect(yield* Deferred.await(observedPendingState)).toBe(true)
+      yield* close()
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -140,7 +140,10 @@ const makeClientProcessorHarness = Effect.fn(function* ({
     return encoded
   })
 
-  return { processor, pushIds, scope }
+  const close = (exit: Exit.Exit<unknown, unknown> = Exit.void) =>
+    processor.shutdown(exit).pipe(Effect.ensuring(Scope.close(scope, exit)))
+
+  return { processor, pushIds, close, scope }
 })
 
 // TODO use property tests for simulation params
@@ -438,17 +441,16 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  // TODO(https://github.com/livestorejs/livestore/issues/1437): Re-enable these stricter shutdown specifications
-  // incrementally as the replacement implementation satisfies each invariant.
-  Vitest.it.effect.skip('drains in-flight and queued leader pushes serially on shutdown', (test) =>
+  Vitest.it.effect('drains in-flight and queued leader pushes serially on shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
+      const releaseFirstPush = yield* Deferred.make<void>()
       const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
       let isFirstPush = true
       let activePushCount = 0
       let maxActivePushCount = 0
 
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
         push: (batch) =>
           Effect.gen(function* () {
             activePushCount++
@@ -457,7 +459,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
             if (isFirstPush === true) {
               isFirstPush = false
               yield* Deferred.succeed(firstPushStarted, undefined)
-              yield* Effect.sleep('1 millis')
+              yield* Deferred.await(releaseFirstPush)
             }
 
             persistedBatches.push(batch)
@@ -470,11 +472,9 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['second'])
       yield* pushIds(['third'])
 
-      // Drive the close fiber until it is waiting for the sleeping leader push, then release that push. This gives
-      // the test an explicit virtual-time happens-before edge without depending on scheduler yields or wall time.
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
-      yield* TestClock.adjust(0)
-      yield* TestClock.adjust('1 millis')
+      const closeFiber = yield* close().pipe(Effect.forkChild)
+      yield* processor.debug.awaitDrainStarted
+      yield* Deferred.succeed(releaseFirstPush, undefined)
       yield* Fiber.join(closeFiber)
 
       const postShutdownPushExit = yield* Effect.exit(pushIds(['post-shutdown']))
@@ -500,7 +500,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       Effect.gen(function* () {
         const persistedBatches: ReadonlyArray<LiveStoreEvent.Client.Encoded>[] = []
 
-        const { pushIds, scope } = yield* makeClientProcessorHarness({
+        const { pushIds, close } = yield* makeClientProcessorHarness({
           leaderPushBatchSize,
           push: (batch) =>
             Effect.sync(() => {
@@ -515,12 +515,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
           yield* pushIds(groupIds)
         }
 
-        yield* Scope.close(scope, Exit.void)
+        yield* close()
 
         expect(persistedBatches.flatMap((batch) => batch.map((event) => event.args.id))).toEqual(expectedIds)
         expect(persistedBatches.every((batch) => batch.length > 0 && batch.length <= leaderPushBatchSize)).toBe(true)
       }).pipe(withTestCtx(test)),
-    { skip: true, fastCheck: { numRuns: 50 } },
+    { fastCheck: { numRuns: 50 } },
   )
 
   for (const shutdownPoint of [
@@ -587,12 +587,12 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     )
   }
 
-  Vitest.it.effect.skip('interrupts a hung leader push during failed shutdown', (test) =>
+  Vitest.it.effect('interrupts a hung leader push during failed shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()
       const firstPushInterrupted = yield* Deferred.make<void>()
       let shutdownCalls = 0
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
         shutdown: () =>
           Effect.sync(() => {
             shutdownCalls++
@@ -607,15 +607,15 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['blocked'])
       yield* Deferred.await(firstPushStarted)
 
-      // @effect-diagnostics-next-line globalErrorInEffectFailure:off -- test-only synthetic shutdown failure fed to Scope.close; a tagged error adds no value for this throwaway test signal
-      yield* Scope.close(scope, Exit.fail(new Error('test shutdown failure')))
+      // @effect-diagnostics-next-line globalErrorInEffectFailure:off -- test-only synthetic shutdown failure fed to close; a tagged error adds no value for this throwaway test signal
+      yield* close(Exit.fail(new Error('test shutdown failure')))
 
       expect(yield* Deferred.isDone(firstPushInterrupted)).toBe(true)
       expect(shutdownCalls).toBe(0)
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect.skip('does not report a successful drain when the leader rejects during shutdown', (test) =>
+  Vitest.it.effect('does not report a successful drain when the leader rejects during shutdown', (test) =>
     Effect.gen(function* () {
       const pushStarted = yield* Deferred.make<void>()
       const rejectPush = yield* Deferred.make<void>()
@@ -624,7 +624,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         providedNum: EventSequenceNumber.Client.ROOT,
         sessionId: 'session-test',
       })
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
         push: () =>
           Deferred.succeed(pushStarted, undefined).pipe(
             Effect.andThen(Deferred.await(rejectPush)),
@@ -635,9 +635,8 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['rejected'])
       yield* Deferred.await(pushStarted)
 
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
-      // Drive close until it ends queue admission and waits for the in-flight leader response.
-      yield* TestClock.adjust(0)
+      const closeFiber = yield* close().pipe(Effect.exit, Effect.forkChild)
+      yield* processor.debug.awaitDrainStarted
       yield* Deferred.succeed(rejectPush, undefined)
       const closeExit = yield* Fiber.join(closeFiber)
 
@@ -645,7 +644,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect.skip('fails the drain when pull stops before a leader rejection can recover', (test) =>
+  Vitest.it.effect('fails the drain when pull stops before a leader rejection can recover', (test) =>
     Effect.gen(function* () {
       const pullStopped = yield* Deferred.make<void>()
       const pushStarted = yield* Deferred.make<void>()
@@ -655,7 +654,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         providedNum: EventSequenceNumber.Client.ROOT,
         sessionId: 'session-test',
       })
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      const { pushIds, close } = yield* makeClientProcessorHarness({
         pull: () => Stream.never.pipe(Stream.ensuring(Deferred.succeed(pullStopped, undefined))),
         push: () =>
           Deferred.succeed(pushStarted, undefined).pipe(
@@ -667,7 +666,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['rejected-after-pull'])
       yield* Deferred.await(pushStarted)
 
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
+      const closeFiber = yield* close().pipe(Effect.exit, Effect.forkChild)
       yield* Deferred.await(pullStopped)
       yield* Deferred.succeed(rejectPush, undefined)
       const closeExit = yield* Fiber.join(closeFiber)
@@ -676,7 +675,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect.skip('does not treat an unrelated pull advance as recovery from a rejected push', (test) =>
+  Vitest.it.effect('does not treat an unrelated pull advance as recovery from a rejected push', (test) =>
     Effect.gen(function* () {
       const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
       const pushReturned = yield* Deferred.make<void>()
@@ -685,7 +684,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         providedNum: EventSequenceNumber.Client.ROOT,
         sessionId: 'session-test',
       })
-      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
         pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
         push: () => Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(pushReturned, undefined))),
       })
@@ -694,19 +693,19 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       // Drain the local-push notification so the next observed change belongs to the explicit upstream payload.
       yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
       yield* Deferred.await(pushReturned)
-      yield* TestClock.adjust(0)
+      yield* processor.debug.awaitRejection
 
       yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }))
       yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
 
-      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+      const closeExit = yield* close().pipe(Effect.exit)
 
       expect(Exit.isFailure(closeExit)).toBe(true)
       expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['still-pending'])
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect.skip('clears a recovered rejection while newer admitted events remain pending', (test) =>
+  Vitest.it.effect('clears a recovered rejection while newer admitted events remain pending', (test) =>
     Effect.gen(function* () {
       const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
       const secondPushAccepted = yield* Deferred.make<void>()
@@ -717,7 +716,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         sessionId: 'session-test',
       })
       let pushCount = 0
-      const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
         pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
         push: () => {
           pushCount++
@@ -729,6 +728,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       const [rejectedEvent] = yield* pushIds(['rejected-prefix'])
       yield* Deferred.await(firstPushRejected)
+      yield* processor.debug.awaitRejection
       yield* pushIds(['newer-admitted'])
       yield* Deferred.await(secondPushAccepted)
       // Drain both local notifications so the next one proves the upstream confirmation was processed.
@@ -737,19 +737,19 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedEvent!] }))
       yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
 
-      const closeExit = yield* Scope.close(scope, Exit.void).pipe(Effect.exit)
+      const closeExit = yield* close().pipe(Effect.exit)
 
       expect(Exit.isSuccess(closeExit)).toBe(true)
       expect((yield* processor.syncState.get).pending.map((event) => event.args.id)).toEqual(['newer-admitted'])
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect.skip('propagates a fatal leader push from the graceful drain', (test) =>
+  Vitest.it.effect('propagates a fatal leader push from the graceful drain', (test) =>
     Effect.gen(function* () {
       const pushStarted = yield* Deferred.make<void>()
       const failPush = yield* Deferred.make<void>()
       const failure = new Error('leader push crashed')
-      const { pushIds, scope } = yield* makeClientProcessorHarness({
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
         push: () =>
           Deferred.succeed(pushStarted, undefined).pipe(
             Effect.andThen(Deferred.await(failPush)),
@@ -760,8 +760,8 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* pushIds(['fatal'])
       yield* Deferred.await(pushStarted)
 
-      const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.exit, Effect.forkChild)
-      yield* TestClock.adjust(0)
+      const closeFiber = yield* close().pipe(Effect.exit, Effect.forkChild)
+      yield* processor.debug.awaitDrainStarted
       yield* Deferred.succeed(failPush, undefined)
       const closeExit = yield* Fiber.join(closeFiber)
 
@@ -773,7 +773,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect.skip('store shutdown timeout stops waiting without cancelling teardown', (test) =>
+  Vitest.it.effect('store shutdown timeout stops waiting without cancelling teardown', (test) =>
     Effect.gen(function* () {
       const { makeStore } = yield* TestContext
       const pushStarted = yield* Deferred.make<void>()

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -36,6 +36,7 @@ import {
   FetchHttpClient,
   Fiber,
   Hash,
+  Latch,
   Layer,
   Option,
   Queue,
@@ -76,6 +77,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   pull = () => Stream.empty,
   rollback = () => undefined,
   shutdown = () => Effect.void,
+  devtools = { enabled: false },
   leaderPushBatchSize = 1,
   simulation,
 }: {
@@ -83,6 +85,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   pull?: LeaderEvents['pull']
   rollback?: (changeset: Uint8Array<ArrayBuffer>) => void
   shutdown?: ClientSession['shutdown']
+  devtools?: ClientSession['devtools']
   leaderPushBatchSize?: number
   simulation?: ClientProcessorParams['params']['simulation']
 }) {
@@ -109,7 +112,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
 
   const clientSession: ClientSession = {
     sqliteDb: {} as ClientSession['sqliteDb'],
-    devtools: { enabled: false },
+    devtools,
     clientId: 'client-test',
     sessionId: 'session-test',
     lockStatus,
@@ -490,6 +493,35 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         ['third'],
       ])
       expect(Exit.isFailure(postShutdownPushExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('admits synchronous pushes while pull waits on the devtools latch', (test) =>
+    Effect.gen(function* () {
+      const pullLatch = yield* Latch.make(false)
+      const pushLatch = yield* Latch.make(true)
+      const pullStarted = yield* Deferred.make<void>()
+
+      const { processor, close } = yield* makeClientProcessorHarness({
+        devtools: { enabled: true, pullLatch, pushLatch },
+        pull: () =>
+          Stream.fromEffect(
+            Deferred.succeed(pullStarted, undefined).pipe(
+              Effect.as({ payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: [] }) }),
+            ),
+          ),
+        push: () => Effect.void,
+      })
+      yield* Deferred.await(pullStarted)
+      yield* Effect.yieldNow
+
+      const localEvents = yield* processor.encodeEvents([
+        events.todoCreated({ id: 'local', text: 'local', completed: false }),
+      ])
+      const pushExit = yield* Effect.sync(() => Effect.runSyncExit(processor.push(localEvents)))
+
+      expect(Exit.isSuccess(pushExit)).toBe(true)
+      yield* close()
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -79,7 +79,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   shutdown = () => Effect.void,
   devtools = { enabled: false },
   leaderPushBatchSize = 1,
-  simulation,
+  rebaseBarriers,
 }: {
   push: LeaderEvents['push']
   pull?: LeaderEvents['pull']
@@ -87,7 +87,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
   shutdown?: ClientSession['shutdown']
   devtools?: ClientSession['devtools']
   leaderPushBatchSize?: number
-  simulation?: ClientProcessorParams['params']['simulation']
+  rebaseBarriers?: ClientProcessorParams['params']['rebaseBarriers']
 }) {
   const lockStatus = yield* SubscriptionRef.make<LockStatus>('has-lock')
   const leaderThread: ClientSessionLeaderThreadProxy.ClientSessionLeaderThreadProxy = {
@@ -132,7 +132,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
       }),
     rollback,
     refreshTables: () => undefined,
-    params: { leaderPushBatchSize, simulation },
+    params: { leaderPushBatchSize, rebaseBarriers },
     confirmUnsavedChanges: false,
   })
 
@@ -587,19 +587,105 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     { fastCheck: { numRuns: 50 } },
   )
 
-  for (const shutdownPoint of [
-    '1_before_leader_push_fiber_interrupt',
-    '3_before_rebase_rollback',
-    '5_before_leader_push_fiber_run',
+  // Deterministic barrier: the returned `effect` (handed to the processor via `rebaseBarriers`)
+  // signals `reached` when the rebase parks at the point, then blocks until `release` is called.
+  // This replaces the previous virtual-time `simSleep` injection, which was flaky and — as filed in
+  // #1465 — misaligned with the source's simulation points (it never covered the discard step).
+  const makeRebaseBarrier = Effect.fn(function* () {
+    const reached = yield* Deferred.make<void>()
+    const release = yield* Deferred.make<void>()
+    return {
+      effect: Deferred.succeed(reached, undefined).pipe(Effect.andThen(Deferred.await(release))),
+      awaitReached: Deferred.await(reached),
+      release: Deferred.succeed(release, undefined).pipe(Effect.asVoid),
+    }
+  })
+
+  // Builds a leader payload that conflicts with the local pending event, forcing a rebase.
+  const makeConflictingUpstream = Effect.fn(function* (processor: ClientSessionSyncProcessor) {
+    const [remoteBase] = yield* processor.encodeEvents([
+      events.todoCreated({ id: 'remote', text: 'remote', completed: false }),
+    ])
+    const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
+      ...remoteBase!,
+      seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
+      parentSeqNum: EventSequenceNumber.Client.ROOT,
+      clientId: 'remote-client',
+      sessionId: 'remote-session',
+    })
+    return SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] })
+  })
+
+  // F1 no-loss oracle (Fix for #1465 §3 torn-`syncStateRef` race): a `push` admitted while the pull
+  // fiber is parked mid-rebase — right before the queue reconcile ("discard" step) — must NOT be lost.
+  // The guard is the atomic reconcile re-reading the LIVE `syncStateRef.current.pending`. Reverting the
+  // reconcile to the stale `mergeResult.newSyncState.pending` snapshot makes this test fail (the
+  // concurrently-admitted event is cleared from the queue and never re-offered → never pushed).
+  Vitest.it.effect('does not lose a push admitted during the rebase discard window', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const persistedIds: string[] = []
+      let pushCallCount = 0
+
+      const reconcileBarrier = yield* makeRebaseBarrier()
+
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        // First push (the initial 'local' admission) blocks so 'local' stays pending until the
+        // conflicting upstream forces a rebase; the rebase interrupts it. Later pushes record.
+        push: (batch) => {
+          pushCallCount++
+          return pushCallCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(Effect.andThen(Effect.never))
+            : Effect.sync(() => persistedIds.push(...batch.map((event) => event.args.id as string)))
+        },
+        rebaseBarriers: { before_queue_reconcile: reconcileBarrier.effect },
+      })
+
+      yield* pushIds(['local'])
+      yield* Deferred.await(firstPushStarted)
+
+      // Force the rebase and let it park right before the atomic queue reconcile.
+      yield* Queue.offer(pullQueue, yield* makeConflictingUpstream(processor))
+      yield* reconcileBarrier.awaitReached
+
+      // Concurrently admit a new push while the rebase is parked (models a `store.commit()` landing
+      // during a rebase). It appends to `syncStateRef.current.pending` and to the leader push queue.
+      yield* pushIds(['concurrent'])
+
+      // Resume the rebase: the reconcile must re-read the LIVE pending and preserve 'concurrent'.
+      yield* reconcileBarrier.release
+
+      // Draining via orderly shutdown flushes every queued event to the leader.
+      yield* close()
+
+      expect(processor.debug.debugInfo().rebaseCount).toBe(1)
+      expect(persistedIds).toContain('concurrent')
+      expect(persistedIds).toContain('local')
+    }).pipe(withTestCtx(test)),
+  )
+
+  // F1 no-loss oracle for shutdown↔rebase (guarded by the `rebaseOwnership` permit shared by the
+  // pull tap and `runShutdown`): an orderly shutdown that interleaves a rebase at any point of the
+  // discard→re-offer window must still flush the rebased pending event. Removing the permit from
+  // `runShutdown` makes the pre-reconcile cases (points 1/2) fail — the queue is ended and the pull
+  // fiber interrupted before the rebased event is re-offered.
+  for (const barrierPoint of [
+    'before_leader_push_fiber_interrupt',
+    'before_queue_reconcile',
+    'before_leader_push_fiber_run',
   ] as const) {
-    Vitest.it.effect.skip(`does not lose rebased pending events when shutdown reaches ${shutdownPoint}`, (test) =>
+    Vitest.it.effect(`does not lose the rebased pending event when shutdown interleaves at ${barrierPoint}`, (test) =>
       Effect.gen(function* () {
         const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
         const firstPushStarted = yield* Deferred.make<void>()
         const persistedIds: string[] = []
         let pushCallCount = 0
 
-        const { processor, pushIds, scope } = yield* makeClientProcessorHarness({
+        const barrier = yield* makeRebaseBarrier()
+
+        const { processor, pushIds, close } = yield* makeClientProcessorHarness({
           pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
           push: (batch) => {
             pushCallCount++
@@ -607,42 +693,20 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
               ? Deferred.succeed(firstPushStarted, undefined).pipe(Effect.andThen(Effect.never))
               : Effect.sync(() => persistedIds.push(...batch.map((event) => event.args.id as string)))
           },
-          simulation: {
-            pull: {
-              '1_before_leader_push_fiber_interrupt': shutdownPoint === '1_before_leader_push_fiber_interrupt' ? 1 : 0,
-              '2_before_leader_push_queue_clear': 0,
-              '3_before_rebase_rollback': shutdownPoint === '3_before_rebase_rollback' ? 1 : 0,
-              '4_before_leader_push_queue_offer': 0,
-              '5_before_leader_push_fiber_run': shutdownPoint === '5_before_leader_push_fiber_run' ? 1 : 0,
-            },
-          },
+          rebaseBarriers: { [barrierPoint]: barrier.effect },
         })
 
-        const [localEvent] = yield* pushIds(['local'])
-        localEvent!.meta.sessionChangeset = {
-          _tag: 'sessionChangeset',
-          data: new Uint8Array([1]),
-          debug: {},
-        }
+        yield* pushIds(['local'])
         yield* Deferred.await(firstPushStarted)
 
-        const [remoteBase] = yield* processor.encodeEvents([
-          events.todoCreated({ id: 'remote', text: 'remote', completed: false }),
-        ])
-        const remoteEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
-          ...remoteBase!,
-          seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0 }),
-          parentSeqNum: EventSequenceNumber.Client.ROOT,
-          clientId: 'remote-client',
-          sessionId: 'remote-session',
-        })
-        yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [remoteEvent] }))
+        yield* Queue.offer(pullQueue, yield* makeConflictingUpstream(processor))
+        yield* barrier.awaitReached
 
-        // Let rebase reach the selected virtual-time barrier, start shutdown there, then finish the handoff.
-        yield* TestClock.adjust(0)
-        const closeFiber = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild)
-        yield* TestClock.adjust(0)
-        yield* TestClock.adjust('1 millis')
+        // Start an orderly shutdown while the rebase is parked. The success path takes the
+        // `rebaseOwnership` permit still held by the parked pull fiber, so it cannot end the queue
+        // until the rebase releases the permit (i.e. after re-offering the rebased pending event).
+        const closeFiber = yield* close().pipe(Effect.forkChild)
+        yield* barrier.release
         yield* Fiber.join(closeFiber)
 
         expect(processor.debug.debugInfo().rebaseCount).toBe(1)
@@ -650,7 +714,6 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       }).pipe(withTestCtx(test)),
     )
   }
-
   Vitest.it.effect('interrupts a hung leader push during failed shutdown', (test) =>
     Effect.gen(function* () {
       const firstPushStarted = yield* Deferred.make<void>()


### PR DESCRIPTION
## Problem

`Store.shutdown()` closes the lifetime scope while `ClientSessionSyncProcessor` may still have a leader push in flight or additional admitted events in its queue. Those events are not restart-replayable until the leader accepts them, so orderly shutdown can report completion after losing local commits.

Effect 4 beta.99's corrected `Fiber.interruptAll` behavior exposed this existing lifecycle bug consistently in the contrib multi-user chat scenario.

## Goal

Make successful orderly shutdown mean that every event admitted by the client-session processor reached the leader, while failed shutdown interrupts blocked work and caller timeouts do not cancel cleanup.

## Decisions

- Add an explicit processor `shutdown` operation before lifetime-scope teardown.
- Close admission first, serialize shutdown against pull processing, stop pull ownership, end the transactional push queue, and await its sole worker.
- Keep `push()` synchronous even when pull/rebase ownership is paused by the DevTools latch; move the latch wait before pull takes ownership.
- Preserve ordinary open-session rejection recovery, but fail shutdown when a rejection or fatal push remains unresolved.
- Run cleanup in a detached fiber so the existing one-second Store timeout limits waiting without cancelling teardown.
- Keep the broader provider-dispose lifecycle boundary out of this PR.

## Verification

- `vitest run tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts --reporter=dot`: 23 passed, 3 skipped.
- Re-enabled deterministic proofs for serial in-flight and queued drain, FIFO and batch bounds (50 property runs), pending-state publication before leader-worker observation, post-close admission rejection, failed-shutdown interruption, rejection/fatal propagation, pull-stop ordering, rejection recovery identity, and non-cancelling Store timeout.
- `devenv tasks run test:unit --no-tui --show-output`: all directly affected suites passed. The aggregate rerun reported unrelated existing property failures in `stream-events.test.ts` (5-second timeout) and `webmesh/src/node.test.ts` (ping observed before application message); an earlier run passed the complete graph.
- `devenv tasks run ts:check --no-tui`: passed.
- `devenv tasks run lint:check --no-tui`: passed.
- `devenv tasks run lint:full:fix --no-tui --show-output`: passed, including dependency-cycle validation.
- `vitest run tests/package-common/src/intent-layer --reporter=dot`: 8 passed.

## Complexity

The lifecycle state is local to `ClientSessionSyncProcessor`: one shutdown owner, one pull/push ownership semaphore, terminal push state, and the two existing background workers under explicit handles. Pull processing is serialized as a unit instead of rewriting the rebase state machine.

The production processor diff is 152 changed lines versus 204 in the reverted implementation from #1405.

## Concerns

- Three simulation-driven rebase interruption specifications remain skipped. They still depend on virtual-time scheduling and should be converted to explicit barriers before being used as proof.
- The contrib cf-chat beta.99 composition against the code commit `7f51d876a09ff6cd04fdd0a6fa8dfd3acc409608` is pending. Keep this PR draft until that lost-local-commit scenario is green.
- This PR does not claim to fix provider disposal after a store has already shut down.

## Friction & bottlenecks

The repository commit hook points to a missing `.pre-commit-config.yaml`; the commit used `PREK_ALLOW_NO_CONFIG=1` after the repository's lint, type, focused, and unit tasks passed.

## Follow-ups

- Convert the three retained rebase simulation cases to explicit lifecycle barriers.
- Resolve the provider-dispose boundary independently from client commit draining.

## References

Closes #1437

Related: #1405, #1439, Effect-TS/effect#6438

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-pr1451-shutdown |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->