### PR TITLE
Preserve DevTools package contract in release and PR snapshots

### DIFF
--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -95,9 +95,9 @@ const parsePackage = (tarball) => {
 const readTopology = async (topologyPath) => {
   const bytes = await readFile(topologyPath)
   const topology = JSON.parse(bytes.toString('utf8'))
-  const names = topology.publishablePackageNames
+  const names = topology.snapshotPackageNames
   if (Array.isArray(names) === false || names.length === 0 || names.some((name) => typeof name !== 'string') === true) {
-    fail('Trusted release topology has no valid publishablePackageNames')
+    fail('Trusted release topology has no valid snapshotPackageNames')
   }
   if (new Set(names).size !== names.length) fail('Trusted release topology contains duplicate package names')
   return { packageNames: [...names].toSorted((a, b) => a.localeCompare(b)), topologyDigest: sha256(bytes) }
@@ -211,6 +211,27 @@ const validatePackageManifest = ({ packageJson, expectedName, expectedVersion, p
         fail(`${expectedName} has non-exact ${field} entry ${name}@${spec}`)
       }
     }
+  }
+
+  if (expectedName === '@livestore/devtools-vite') {
+    validateDevtoolsPackageManifest({ packageJson, expectedVersion })
+  }
+}
+
+const validateDevtoolsPackageManifest = ({ packageJson, expectedVersion }) => {
+  const peerDependencies = packageJson.peerDependencies ?? {}
+  for (const peerName of ['@livestore/adapter-web', '@livestore/utils']) {
+    if (peerDependencies[peerName] !== expectedVersion) {
+      fail(`DevTools snapshot requires exact peer ${peerName}@${expectedVersion}`)
+    }
+  }
+  if (typeof peerDependencies.vite !== 'string' || peerDependencies.vite.length === 0) {
+    fail('DevTools snapshot requires a non-empty Vite peer dependency range')
+  }
+
+  const dependencies = packageJson.dependencies ?? {}
+  if (Object.keys(dependencies).length !== 1 || typeof dependencies['@parcel/watcher'] !== 'string') {
+    fail('DevTools snapshot runtime dependencies must contain only @parcel/watcher')
   }
 }
 

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -83,23 +83,39 @@ const tar = (entries) => {
   return gzipSync(Buffer.concat(chunks))
 }
 
-const fixture = async () => {
+const fixture = async ({ includeDevtools = false } = {}) => {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'livestore-pr-snapshot-'))
   const artifactDir = path.join(dir, 'artifact')
   await mkdir(artifactDir)
   const topologyPath = path.join(dir, 'topology.json')
   const headSha = 'a'.repeat(40)
   const version = `0.0.0-snapshot-pr.42.${headSha}`
-  const packageNames = ['@livestore/a', '@livestore/b']
-  await writeFile(topologyPath, JSON.stringify({ publishablePackageNames: packageNames }))
+  const packageNames = [
+    '@livestore/a',
+    '@livestore/b',
+    ...(includeDevtools === true ? ['@livestore/devtools-vite'] : []),
+  ]
+  await writeFile(topologyPath, JSON.stringify({ snapshotPackageNames: packageNames }))
   for (const name of packageNames) {
     const file = `${name.slice('@livestore/'.length)}.tgz`
-    const packageJson = {
-      name,
-      version,
-      dependencies: name.endsWith('/b') === true ? { '@livestore/a': version } : {},
-      scripts: { test: 'node --test' },
-    }
+    const packageJson =
+      name === '@livestore/devtools-vite'
+        ? {
+            name,
+            version,
+            dependencies: { '@parcel/watcher': '^2.5.0' },
+            peerDependencies: {
+              '@livestore/adapter-web': version,
+              '@livestore/utils': version,
+              vite: '^7.3.1 || ^8.0.16',
+            },
+          }
+        : {
+            name,
+            version,
+            dependencies: name.endsWith('/b') === true ? { '@livestore/a': version } : {},
+            scripts: { test: 'node --test' },
+          }
     await writeFile(
       path.join(artifactDir, file),
       tar([
@@ -138,6 +154,56 @@ test('creates and validates an exact-run package cohort', async () => {
   assert.equal(result.packageCount, 2)
   assert.match(result.manifestDigest, /^[0-9a-f]{64}$/)
   assert.equal(await readFile(publishListPath, 'utf8'), '@livestore/a\ta.tgz\n@livestore/b\tb.tgz\n')
+})
+
+test('requires the repacked DevTools dependency boundary', async () => {
+  const { dir, topologyPath, headSha, version } = await fixture({ includeDevtools: true })
+  const devtoolsPath = path.join(dir, 'devtools-vite.tgz')
+
+  const writeDevtools = async (packageJson) =>
+    writeFile(devtoolsPath, tar([['package/package.json', JSON.stringify(packageJson)]]))
+
+  await writeDevtools({
+    name: '@livestore/devtools-vite',
+    version,
+    dependencies: { '@parcel/watcher': '^2.5.0' },
+    peerDependencies: { '@livestore/adapter-web': version, vite: '^7.3.1 || ^8.0.16' },
+  })
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /requires exact peer @livestore\/utils/,
+  )
+
+  await writeDevtools({
+    name: '@livestore/devtools-vite',
+    version,
+    dependencies: { '@livestore/adapter-web': version, '@parcel/watcher': '^2.5.0', vite: '*' },
+    peerDependencies: {
+      '@livestore/adapter-web': version,
+      '@livestore/utils': version,
+      vite: '^7.3.1 || ^8.0.16',
+    },
+  })
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /runtime dependencies must contain only @parcel\/watcher/,
+  )
 })
 
 test('requires an approval for the unchanged head', () => {
@@ -214,6 +280,7 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(dispatch, /assess-registry.*--verified-receipt="\$verified_receipt"/s)
   assert.match(dispatch, /cohort_failed=true.*scan_failed=true.*continue/s)
   assert.match(dispatch, /if \[ "\$scan_failed" = true \]; then\s+exit 1/s)
+  assert.match(dispatch, /\.snapshotPackageNames\[\]/)
 
   const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
   const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
@@ -270,6 +337,18 @@ test('generated promotion workflow is anchored to trusted main', async () => {
     workflow.slice(validateStart, attestStart),
     /name: 'pr-snapshot-\$\{\{ steps\.identity\.outputs\.head-sha \}\}-\$\{\{ steps\.identity\.outputs\.run-attempt \}\}'/,
   )
+})
+
+test('generated snapshot topology includes externally repacked DevTools', async () => {
+  const topology = JSON.parse(
+    await readFile(new URL('../../scripts/src/generated/release-topology.json', import.meta.url), 'utf8'),
+  )
+
+  assert.equal(topology.publishablePackageNames.includes('@livestore/devtools-vite'), false)
+  assert.equal(topology.snapshotPackageNames.includes('@livestore/devtools-vite'), true)
+  assert.deepEqual(topology.externalSnapshotPackages, [
+    { name: '@livestore/devtools-vite', manifest: 'release/devtools-artifact.json' },
+  ])
 })
 
 test('derives a deterministic publish-time tag for each PR head cohort', () => {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,7 +527,7 @@ jobs:
               remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
               jq --arg name "$package_name" --arg version "$remote_version" --arg tag "$remote_tag"       '. + [{name: $name, version: $version, tag: $tag}]' "$registry_state_file" > "$registry_state_file.next"
               mv "$registry_state_file.next" "$registry_state_file"
-            done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
+            done < <(jq -r '.snapshotPackageNames[]' scripts/src/generated/release-topology.json)
 
             assessment=$(node .github/scripts/pr-snapshot-artifact.mjs assess-registry     --state-file="$registry_state_file"     --version="$version"     --verified-receipt="$verified_receipt")
             action=$(jq -r .action <<<"$assessment")

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -230,7 +230,7 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
     jq --arg name "$package_name" --arg version "$remote_version" --arg tag "$remote_tag" \
       '. + [{name: $name, version: $version, tag: $tag}]' "$registry_state_file" > "$registry_state_file.next"
     mv "$registry_state_file.next" "$registry_state_file"
-  done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
+  done < <(jq -r '.snapshotPackageNames[]' scripts/src/generated/release-topology.json)
 
   assessment=$(node .github/scripts/pr-snapshot-artifact.mjs assess-registry \
     --state-file="$registry_state_file" \

--- a/genie/release-topology.ts
+++ b/genie/release-topology.ts
@@ -18,4 +18,11 @@ const ignoredLivestorePackages = rootWorkspacePackages
 
 export const publishableLivestorePackageDescriptors = publishableLivestorePackages
 export const publishableLivestorePackageJsonNames = publishableLivestorePackages.map((pkg) => pkg.name)
+export const externalSnapshotPackageDescriptors = [
+  { name: '@livestore/devtools-vite', manifest: 'release/devtools-artifact.json' },
+] as const
+export const snapshotLivestorePackageJsonNames = [
+  ...publishableLivestorePackageJsonNames,
+  ...externalSnapshotPackageDescriptors.map(({ name }) => name),
+].toSorted()
 export const changesetsIgnoredPackageJsonNames = ignoredLivestorePackages

--- a/scripts/src/commands/devtools-artifact.test.ts
+++ b/scripts/src/commands/devtools-artifact.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest'
 import {
   type ArtifactManifest,
   type ArtifactMetadata,
+  assertRepackedDevtoolsPackageJson,
   assertCertifiedDevtoolsArtifactForLivestore,
   assertUncertifiedRepackMode,
   containsForbiddenPattern,
   type DevtoolsArtifactCertification,
   forbiddenPatterns,
+  repackDevtoolsPackageJson,
 } from './devtools-artifact.ts'
 
 const metadata: ArtifactMetadata = {
@@ -213,5 +215,61 @@ describe('artifact forbidden text patterns', () => {
     expect(containsForbiddenText('HOME: "/home/web_user"')).toBe(false)
     expect(containsForbiddenText('source: "/home/alice/project/src/file.ts"')).toBe(true)
     expect(containsForbiddenText('source: "/Users/alice/project/src/file.ts"')).toBe(true)
+  })
+})
+
+describe('repackDevtoolsPackageJson', () => {
+  const artifactPackage = {
+    name: '@livestore/devtools-vite',
+    version: '0.4.0-dev.24',
+    dependencies: {
+      '@livestore/adapter-web': '0.4.0-dev.24',
+      '@livestore/utils': '0.4.0-dev.24',
+      '@parcel/watcher': '^2.5.0',
+      vite: '*',
+    },
+    peerDependencies: {
+      '@livestore/adapter-web': '0.4.0-dev.24',
+      '@livestore/utils': '0.4.0-dev.24',
+      vite: '^7.3.1 || ^8.0.16',
+    },
+  }
+
+  it.each(['0.0.0-snapshot-abc123', '0.4.0-dev.25'])('preserves peer ranges for target %s', (version) => {
+    const repackedPackage = repackDevtoolsPackageJson({ artifactPackage, version })
+
+    expect(repackedPackage.peerDependencies).toEqual({
+      '@livestore/adapter-web': version,
+      '@livestore/utils': version,
+      vite: '^7.3.1 || ^8.0.16',
+    })
+    expect(repackedPackage.dependencies).toEqual({ '@parcel/watcher': '^2.5.0' })
+  })
+
+  it('rejects repacked manifests whose core peers are not exact', () => {
+    expect(() =>
+      assertRepackedDevtoolsPackageJson({
+        artifactPackage,
+        repackedPackage: {
+          ...artifactPackage,
+          dependencies: { '@parcel/watcher': '^2.5.0' },
+          peerDependencies: {
+            ...artifactPackage.peerDependencies,
+            '@livestore/adapter-web': '^0.4.0',
+            '@livestore/utils': '0.4.0-dev.25',
+          },
+        },
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/requires exact peer @livestore\/adapter-web@0\.4\.0-dev\.25/)
+  })
+
+  it('rejects artifacts without the externalized watcher runtime dependency', () => {
+    expect(() =>
+      repackDevtoolsPackageJson({
+        artifactPackage: { ...artifactPackage, dependencies: {} },
+        version: '0.4.0-dev.25',
+      }),
+    ).toThrow(/missing required runtime dependency @parcel\/watcher/)
   })
 })

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -56,6 +56,89 @@ type ArtifactSource = {
   readonly chromeZipSha256?: string
 }
 
+export type DevtoolsArtifactPackageJson = {
+  readonly [key: string]: unknown
+  readonly version?: string
+  readonly dependencies?: Readonly<Record<string, string>>
+  readonly peerDependencies?: Readonly<Record<string, string>>
+  readonly homepage?: string
+  readonly repository?: string | { readonly type?: string; readonly url?: string; readonly directory?: string }
+  readonly bugs?: { readonly url?: string }
+}
+
+const livestoreCorePeerDependencies = ['@livestore/adapter-web', '@livestore/utils'] as const
+
+export const repackDevtoolsPackageJson = ({
+  artifactPackage,
+  version,
+}: {
+  readonly artifactPackage: DevtoolsArtifactPackageJson
+  readonly version: string
+}): DevtoolsArtifactPackageJson => {
+  const watcherVersion = artifactPackage.dependencies?.['@parcel/watcher']
+  if (watcherVersion === undefined) {
+    throw new Error('DevTools artifact is missing required runtime dependency @parcel/watcher')
+  }
+
+  const repackedPackage = {
+    ...artifactPackage,
+    version,
+    repository: {
+      type: 'git',
+      url: 'https://github.com/livestorejs/livestore',
+      directory: 'packages/@livestore/devtools-vite',
+    },
+    homepage: 'https://github.com/livestorejs/livestore/tree/main/packages/@livestore/devtools-vite',
+    bugs: { url: 'https://github.com/livestorejs/livestore/issues' },
+    dependencies: { '@parcel/watcher': watcherVersion },
+    peerDependencies: {
+      ...artifactPackage.peerDependencies,
+      '@livestore/adapter-web': version,
+      '@livestore/utils': version,
+    },
+  } satisfies DevtoolsArtifactPackageJson
+
+  assertRepackedDevtoolsPackageJson({ artifactPackage, repackedPackage, version })
+  return repackedPackage
+}
+
+export const assertRepackedDevtoolsPackageJson = ({
+  artifactPackage,
+  repackedPackage,
+  version,
+}: {
+  readonly artifactPackage: DevtoolsArtifactPackageJson
+  readonly repackedPackage: DevtoolsArtifactPackageJson
+  readonly version: string
+}) => {
+  const repackedPeerDependencies = repackedPackage.peerDependencies ?? {}
+  for (const peerName of livestoreCorePeerDependencies) {
+    if (repackedPeerDependencies[peerName] !== version) {
+      throw new Error(`DevTools repack requires exact peer ${peerName}@${version}`)
+    }
+  }
+
+  for (const [peerName, artifactRange] of Object.entries(artifactPackage.peerDependencies ?? {})) {
+    const expectedRange =
+      livestoreCorePeerDependencies.includes(peerName as (typeof livestoreCorePeerDependencies)[number]) === true
+        ? version
+        : artifactRange
+    if (repackedPeerDependencies[peerName] !== expectedRange) {
+      throw new Error(`DevTools repack changed peer dependency ${peerName}; expected ${expectedRange}`)
+    }
+  }
+
+  const artifactWatcherVersion = artifactPackage.dependencies?.['@parcel/watcher']
+  const repackedDependencies = repackedPackage.dependencies ?? {}
+  if (
+    artifactWatcherVersion === undefined ||
+    Object.keys(repackedDependencies).length !== 1 ||
+    repackedDependencies['@parcel/watcher'] !== artifactWatcherVersion
+  ) {
+    throw new Error('DevTools repack runtime dependencies must contain only the artifact @parcel/watcher version')
+  }
+}
+
 export type DevtoolsArtifactCertification = {
   readonly livestoreVersion: string
   readonly devtoolsBuildId: string
@@ -670,27 +753,8 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
 
   const packageDir = path.join(unpackDir, 'package')
   const packageJsonPath = path.join(packageDir, 'package.json')
-  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-    version?: string
-    dependencies?: Record<string, string>
-    homepage?: string
-    repository?: string | { readonly type?: string; readonly url?: string; readonly directory?: string }
-    bugs?: { readonly url?: string }
-  }
-  pkg.version = version
-  pkg.repository = {
-    type: 'git',
-    url: 'https://github.com/livestorejs/livestore',
-    directory: 'packages/@livestore/devtools-vite',
-  }
-  pkg.homepage = 'https://github.com/livestorejs/livestore/tree/main/packages/@livestore/devtools-vite'
-  pkg.bugs = { url: 'https://github.com/livestorejs/livestore/issues' }
-  pkg.dependencies = {
-    ...pkg.dependencies,
-    '@livestore/adapter-web': version,
-    '@livestore/utils': version,
-    vite: '*',
-  }
+  const artifactPackage = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as DevtoolsArtifactPackageJson
+  const pkg = repackDevtoolsPackageJson({ artifactPackage, version })
   writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`)
 
   writeFileSync(

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -723,6 +723,23 @@ const publishChromeZipReleaseAsset = (version: string, assetPath: string) => {
   run(['gh', 'release', 'upload', tag, assetPath, '--repo', repo, '--clobber'])
 }
 
+export const repackDevtoolsSnapshotArtifact = ({
+  manifest,
+  outDir,
+  version,
+}: {
+  readonly manifest: string
+  readonly outDir: string
+  readonly version: string
+}) =>
+  repackArtifact(
+    new Map([
+      ['manifest', manifest],
+      ['out-dir', outDir],
+      ['version', version],
+    ]),
+  )
+
 const repackArtifact = async (flags: Map<string, string | true>) => {
   const version = readFlag(flags, 'version')
   if (version === undefined) throw new Error('--version is required')
@@ -820,7 +837,9 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
     }
   }
 
-  console.log(JSON.stringify({ repackedPath, sha256: sha256(repackedPath), chromeZipPath }, null, 2))
+  const result = { repackedPath, sha256: sha256(repackedPath), chromeZipPath }
+  console.log(JSON.stringify(result, null, 2))
+  return result
 }
 
 const main = async () => {

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -9,6 +9,7 @@ import { Effect, FileSystem, Result, Schedule, Schema } from '@livestore/utils/e
 import { Cli } from '@livestore/utils/node'
 
 import { appendGithubSummaryMarkdown, formatMarkdownTable } from '../shared/misc.ts'
+import { repackDevtoolsSnapshotArtifact } from './devtools-artifact.ts'
 
 export type ReleaseSnapshotOptions = {
   readonly cwd: string
@@ -54,7 +55,22 @@ type TReleasePlan = (typeof ReleasePlan)['Type']
 
 type TReleaseTopology = {
   publishablePackages: readonly { name: string; dir: string }[]
+  externalSnapshotPackages: readonly { name: string; manifest: string }[]
 }
+
+const readReleaseTopology = (cwd: string) =>
+  Effect.gen(function* () {
+    const fsEffect = yield* FileSystem.FileSystem
+    const content = yield* fsEffect.readFileString(`${cwd}/scripts/src/generated/release-topology.json`)
+    return yield* Effect.try({
+      try: () => jsonParse(content) as TReleaseTopology,
+      catch: (cause) =>
+        new PackageJsonParseError({
+          message: 'Failed to parse scripts/src/generated/release-topology.json',
+          cause,
+        }),
+    })
+  })
 
 const toErrorMessage = (cause: unknown) => (cause instanceof Error ? cause.message : String(cause))
 
@@ -302,18 +318,7 @@ export const rewriteSnapshotInternalDependencyRanges = ({
 const listSnapshotPackages = (cwd: string) =>
   Effect.gen(function* () {
     const fsEffect = yield* FileSystem.FileSystem
-    const topology = yield* fsEffect.readFileString(`${cwd}/scripts/src/generated/release-topology.json`).pipe(
-      Effect.flatMap((content) =>
-        Effect.try({
-          try: () => jsonParse(content) as TReleaseTopology,
-          catch: (cause) =>
-            new PackageJsonParseError({
-              message: 'Failed to parse scripts/src/generated/release-topology.json',
-              cause,
-            }),
-        }),
-      ),
-    )
+    const topology = yield* readReleaseTopology(cwd)
     const packages: string[] = []
 
     for (const { dir, name: expectedName } of topology.publishablePackages) {
@@ -435,6 +440,38 @@ const packPackageForPublish = ({ cwd, pkg, version }: { cwd: string; pkg: string
     }
 
     return `${packDir}/${tarballs[0]}`
+  })
+
+const packExternalSnapshotPackage = ({
+  cwd,
+  descriptor,
+  version,
+}: {
+  cwd: string
+  descriptor: TReleaseTopology['externalSnapshotPackages'][number]
+  version: string
+}) =>
+  Effect.gen(function* () {
+    if (descriptor.name !== '@livestore/devtools-vite') {
+      return yield* new ReleaseError({ message: `Unsupported external snapshot package: ${descriptor.name}` })
+    }
+
+    const fsEffect = yield* FileSystem.FileSystem
+    const workDir = `${cwd}/tmp/release-pack/${version}/livestore-devtools-vite-artifact`
+    yield* fsEffect.remove(workDir, { recursive: true }).pipe(Effect.catch(() => Effect.void))
+    yield* fsEffect.makeDirectory(workDir, { recursive: true })
+
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        repackDevtoolsSnapshotArtifact({
+          manifest: `${cwd}/${descriptor.manifest}`,
+          outDir: workDir,
+          version,
+        }),
+      catch: (cause) =>
+        new ReleaseError({ message: `Failed to repack external snapshot package ${descriptor.name}`, cause }),
+    })
+    return result.repackedPath
   })
 
 const publishReleasePackages = ({
@@ -698,6 +735,7 @@ export const packSnapshot = Effect.fn(function* ({
 
   const version = `0.0.0-snapshot-pr.${prNumber}.${gitSha}`
   const packages = yield* listSnapshotPackages(cwd)
+  const topology = yield* readReleaseTopology(cwd)
 
   if (packages.length === 0) {
     return yield* new ReleaseError({ message: 'Snapshot package topology is empty' })
@@ -711,7 +749,7 @@ export const packSnapshot = Effect.fn(function* ({
     catch: (cause) => new ReleaseError({ message: `Failed to prepare snapshot artifact directory ${outDir}`, cause }),
   })
 
-  const tarballs = yield* Effect.gen(function* () {
+  const coreTarballs = yield* Effect.gen(function* () {
     yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 LIVESTORE_RELEASE_VERSION=${version} genie --writeable`, {
       shell: true,
     }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
@@ -724,6 +762,13 @@ export const packSnapshot = Effect.fn(function* ({
       concurrency: 1,
     })
   }).pipe(Effect.ensuring(restoreGeneratedReleaseFiles(cwd)))
+
+  const externalTarballs = yield* Effect.forEach(
+    topology.externalSnapshotPackages,
+    (descriptor) => packExternalSnapshotPackage({ cwd, descriptor, version }),
+    { concurrency: 1 },
+  )
+  const tarballs = [...coreTarballs, ...externalTarballs]
 
   yield* Effect.tryPromise({
     try: async () => {

--- a/scripts/src/generated/release-topology.json
+++ b/scripts/src/generated/release-topology.json
@@ -73,5 +73,28 @@
     "@livestore/wa-sqlite",
     "@livestore/webmesh"
   ],
+  "externalSnapshotPackages": [
+    {
+      "name": "@livestore/devtools-vite",
+      "manifest": "release/devtools-artifact.json"
+    }
+  ],
+  "snapshotPackageNames": [
+    "@livestore/adapter-cloudflare",
+    "@livestore/adapter-web",
+    "@livestore/common",
+    "@livestore/common-cf",
+    "@livestore/devtools-vite",
+    "@livestore/framework-toolkit",
+    "@livestore/livestore",
+    "@livestore/peer-deps",
+    "@livestore/react",
+    "@livestore/sqlite-wasm",
+    "@livestore/sync-cf",
+    "@livestore/utils",
+    "@livestore/utils-dev",
+    "@livestore/wa-sqlite",
+    "@livestore/webmesh"
+  ],
   "changesetsIgnoredPackageNames": ["@livestore/effect-playwright"]
 }

--- a/scripts/src/generated/release-topology.json.genie.ts
+++ b/scripts/src/generated/release-topology.json.genie.ts
@@ -2,14 +2,18 @@ import { jsonArtifact } from '#mr/effect-utils/packages/@overeng/genie/src/runti
 
 import {
   changesetsIgnoredPackageJsonNames,
+  externalSnapshotPackageDescriptors,
   publishableLivestorePackageDescriptors,
   publishableLivestorePackageJsonNames,
+  snapshotLivestorePackageJsonNames,
 } from '../../../genie/release-topology.ts'
 
 export default jsonArtifact({
   data: {
     publishablePackages: publishableLivestorePackageDescriptors,
     publishablePackageNames: publishableLivestorePackageJsonNames,
+    externalSnapshotPackages: externalSnapshotPackageDescriptors,
+    snapshotPackageNames: snapshotLivestorePackageJsonNames,
     changesetsIgnoredPackageNames: changesetsIgnoredPackageJsonNames,
   },
 })


### PR DESCRIPTION
## Problem

The DevTools artifact repacker discarded the verified artifact's peer contract: it moved Vite and LiveStore core packages into runtime dependencies and widened Vite to `*`. Separately, trusted PR snapshots packed only the 14 workspace-owned packages, so `@livestore/devtools-vite` could not be installed at the exact snapshot version used by downstream integration tests.

## Goal

Preserve the artifact-owned host compatibility contract, exact-pin its LiveStore peers, and publish DevTools as part of the same immutable 15-package trusted PR snapshot cohort.

## Decisions

- Preserve every artifact peer range except `@livestore/adapter-web` and `@livestore/utils`; bind those two peers to the exact target version.
- Retain only the externalized native `@parcel/watcher` package as a runtime dependency and fail closed if it is absent.
- Keep workspace release discovery unchanged at 14 packages. Model DevTools explicitly as an externally repacked snapshot package, and derive a separate 15-package `snapshotPackageNames` topology.
- Expose a typed snapshot-only repack entry point. It cannot select publish or uncertified modes.
- Make trusted-main validation require DevTools' exact core peers, non-empty Vite peer range, and watcher-only runtime dependencies before attestation or publication.

## Verification

- `node --test .github/scripts/pr-snapshot-artifact.test.mjs`: 13/13 passed, including negative DevTools peer/runtime-boundary cases and generated workflow/topology checks.
- `vitest run scripts/src/commands/devtools-artifact.test.ts`: 15/15 passed for snapshot and release manifest rewrites.
- `devenv tasks run check:quick --no-tui --show-output`: passed after merging current `main`, including TypeScript, formatting, oxlint, Genie, lockfile, source-policy, and megarepo checks.
- Real `release:snapshot:pack:git-sha` proof: packed 15 packages as `0.0.0-snapshot-pr.1447.1d789fbcaaef68b2fef50936410a578e18d164b2`; trusted manifest creation accepted all 15.
- Repacked DevTools tarball SHA-256: `f9ced6987ddbbec23b4c194ce72f80073ea8f9fcd7665e06f34f98885b79b04b`.
- Its manifest contained only `@parcel/watcher@^2.5.0` in runtime dependencies, exact snapshot peers for adapter-web/utils, and the artifact's unchanged `vite@^8.0.16` peer range. Embedded release metadata bound it to build `dt-20260718-51c22feb` with `ci-snapshot` certification.

No package was published during local verification.

## Complexity

The release topology now distinguishes workspace-published packages from externally repacked snapshot packages. The distinction is necessary because DevTools is built in a separate artifact pipeline but must participate in the same immutable npm cohort.

## Concerns

The checked-in artifact currently declares Vite 8 only. This PR deliberately preserves that source contract; a refreshed artifact must widen the source peer range before Vite 7 consumers can install the cohort.

The trusted topology change must merge before any PR head expecting a 15-package candidate can be promoted. Older 14-package candidates remain valid only against the older trusted topology digest.

## Friction & bottlenecks

The real snapshot proof takes about two minutes because it rebuilds and packs the complete release group. No persistent product bottleneck was introduced.

## Follow-ups

- Refresh the checked-in DevTools artifact after its source peer range includes the supported Vite versions.
- Re-run the exact 15-package trusted snapshot proof against that artifact before consuming it downstream.

## References

Closes #1454.

Related: #1458.

No changeset or changelog entry: this changes repository-local release tooling and does not itself publish or alter a package version.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-devtools-artifact-peer-deps/schickling-assistant/fix/devtools-artifact-peer-deps |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->