### PR TITLE
Automate trusted PR snapshot candidates

### DIFF
--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -118,8 +118,8 @@ export const snapshotVersion = ({ prNumber, headSha }) => {
 export const successfulProducerAttempt = ({ jobs, jobName }) => {
   if (Array.isArray(jobs) === false) fail('Workflow jobs response is not an array')
   const matches = jobs.filter((job) => job?.name === jobName && job?.conclusion === 'success')
-  if (matches.length !== 1) fail(`Expected exactly one successful ${jobName} job, found ${matches.length}`)
-  return positiveInteger(matches[0].run_attempt, `${jobName} run attempt`)
+  if (matches.length === 0) fail(`Expected at least one successful ${jobName} job`)
+  return Math.max(...matches.map((job) => positiveInteger(job.run_attempt, `${jobName} run attempt`)))
 }
 
 export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => {

--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -1,0 +1,367 @@
+import { createHash } from 'node:crypto'
+import { lstat, readFile, readdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { gunzipSync } from 'node:zlib'
+
+const shaPattern = /^[0-9a-f]{40}$/
+const digestPattern = /^[0-9a-f]{64}$/
+const lifecycleScripts = new Set([
+  'preinstall',
+  'install',
+  'postinstall',
+  'prepack',
+  'prepare',
+  'postpack',
+  'prepublish',
+  'publish',
+  'postpublish',
+])
+const dependencyFields = ['dependencies', 'optionalDependencies', 'peerDependencies']
+const maxArtifactBytes = 500 * 1024 * 1024
+const maxTarballBytes = 100 * 1024 * 1024
+const maxTarEntries = 100_000
+const maxTarUncompressedBytes = 256 * 1024 * 1024
+
+const fail = (message) => {
+  throw new Error(message)
+}
+
+const sha256 = (bytes) => createHash('sha256').update(bytes).digest('hex')
+
+const parseOctal = (bytes, label) => {
+  const value = Buffer.from(bytes).toString('ascii').replaceAll('\0', '').trim()
+  if (/^[0-7]+$/.test(value) === false) fail(`Invalid tar ${label}: ${JSON.stringify(value)}`)
+  return Number.parseInt(value, 8)
+}
+
+const tarEntries = (tarball) => {
+  const archive = gunzipSync(tarball, { maxOutputLength: maxTarUncompressedBytes })
+  const entries = []
+
+  for (let offset = 0; offset + 512 <= archive.length; ) {
+    const header = archive.subarray(offset, offset + 512)
+    if (header.every((byte) => byte === 0) === true) break
+
+    const storedChecksum = parseOctal(header.subarray(148, 156), 'checksum')
+    const checksumHeader = Buffer.from(header)
+    checksumHeader.fill(0x20, 148, 156)
+    const actualChecksum = checksumHeader.reduce((sum, byte) => sum + byte, 0)
+    if (storedChecksum !== actualChecksum) fail('Tar header checksum mismatch')
+
+    const readString = (start, end) => {
+      const decoded = Buffer.from(header.subarray(start, end)).toString('utf8')
+      const nullIndex = decoded.indexOf(String.fromCharCode(0))
+      return nullIndex === -1 ? decoded : decoded.slice(0, nullIndex)
+    }
+    const name = readString(0, 100)
+    const prefix = readString(345, 500)
+    const rawEntryPath = prefix === '' ? name : `${prefix}/${name}`
+    const size = parseOctal(header.subarray(124, 136), 'size')
+    const type = header[156] === 0 ? '0' : String.fromCharCode(header[156])
+    const bodyStart = offset + 512
+    const bodyEnd = bodyStart + size
+    if (bodyEnd > archive.length) fail(`Truncated tar entry: ${rawEntryPath}`)
+
+    const entryPath = type === '5' ? rawEntryPath.replace(/\/$/, '') : rawEntryPath
+    if (entryPath.startsWith('package/') === false || path.posix.isAbsolute(entryPath) === true) {
+      fail(`Tar entry is outside package/: ${entryPath}`)
+    }
+    if (entryPath.split('/').some((segment) => segment === '..' || segment === '') === true) {
+      fail(`Unsafe tar entry path: ${entryPath}`)
+    }
+    if (entryPath === 'package/.npmrc') fail('Package tarball must not contain .npmrc')
+    if (type !== '0' && type !== '5') fail(`Unsupported tar entry type ${JSON.stringify(type)}: ${entryPath}`)
+
+    entries.push({ path: entryPath, type, body: archive.subarray(bodyStart, bodyEnd) })
+    if (entries.length > maxTarEntries) fail(`Tarball exceeds ${maxTarEntries} entries`)
+    offset = bodyStart + Math.ceil(size / 512) * 512
+  }
+
+  return entries
+}
+
+const parsePackage = (tarball) => {
+  const manifests = tarEntries(tarball).filter((entry) => entry.path === 'package/package.json' && entry.type === '0')
+  if (manifests.length !== 1) fail(`Expected exactly one package/package.json, found ${manifests.length}`)
+
+  try {
+    return JSON.parse(manifests[0].body.toString('utf8'))
+  } catch (cause) {
+    throw new Error('Invalid package/package.json', { cause })
+  }
+}
+
+const readTopology = async (topologyPath) => {
+  const bytes = await readFile(topologyPath)
+  const topology = JSON.parse(bytes.toString('utf8'))
+  const names = topology.publishablePackageNames
+  if (Array.isArray(names) === false || names.length === 0 || names.some((name) => typeof name !== 'string') === true) {
+    fail('Trusted release topology has no valid publishablePackageNames')
+  }
+  if (new Set(names).size !== names.length) fail('Trusted release topology contains duplicate package names')
+  return { packageNames: [...names].toSorted((a, b) => a.localeCompare(b)), topologyDigest: sha256(bytes) }
+}
+
+export const snapshotTag = ({ prNumber, headSha }) => {
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  return `pr-${parsedPrNumber}-${headSha}`
+}
+
+export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => {
+  if (shaPattern.test(headSha) === false || shaPattern.test(currentHeadSha) === false) return false
+  if (headSha !== currentHeadSha || Array.isArray(reviews) === false) return false
+  return reviews.some((review) => review?.state === 'APPROVED' && review?.commit_id === headSha)
+}
+
+const validatePackageManifest = ({ packageJson, expectedName, expectedVersion, packageNames }) => {
+  if (packageJson.name !== expectedName)
+    fail(`Package name mismatch: expected ${expectedName}, got ${packageJson.name}`)
+  if (packageJson.version !== expectedVersion) {
+    fail(`Package version mismatch for ${expectedName}: expected ${expectedVersion}, got ${packageJson.version}`)
+  }
+
+  for (const script of Object.keys(packageJson.scripts ?? {})) {
+    if (lifecycleScripts.has(script) === true) fail(`Package ${expectedName} contains lifecycle script ${script}`)
+  }
+
+  if (packageJson.publishConfig !== undefined) {
+    if (
+      packageJson.publishConfig === null ||
+      typeof packageJson.publishConfig !== 'object' ||
+      Array.isArray(packageJson.publishConfig) === true
+    ) {
+      fail(`Package ${expectedName} has invalid publishConfig`)
+    }
+    assertExactKeys(packageJson.publishConfig, ['access'], `Package ${expectedName} publishConfig`)
+    if (packageJson.publishConfig.access !== 'public') {
+      fail(`Package ${expectedName} publishConfig must set access to public`)
+    }
+  }
+
+  const packageSet = new Set(packageNames)
+  for (const field of dependencyFields) {
+    for (const [name, spec] of Object.entries(packageJson[field] ?? {})) {
+      if (packageSet.has(name) === true && spec !== expectedVersion) {
+        fail(`${expectedName} has non-exact ${field} entry ${name}@${spec}`)
+      }
+    }
+  }
+}
+
+const assertExactKeys = (value, expected, label) => {
+  const actual = Object.keys(value).toSorted((a, b) => a.localeCompare(b))
+  const wanted = [...expected].toSorted((a, b) => a.localeCompare(b))
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    fail(`${label} keys mismatch: expected ${wanted.join(', ')}, got ${actual.join(', ')}`)
+  }
+}
+
+const positiveInteger = (value, label) => {
+  const parsed = Number(value)
+  if (Number.isSafeInteger(parsed) === false || parsed < 1) fail(`Invalid ${label}: ${value}`)
+  return parsed
+}
+
+export const createManifest = async ({
+  artifactDir,
+  topologyPath,
+  repository,
+  prNumber,
+  headSha,
+  runId,
+  runAttempt,
+}) => {
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  const version = `0.0.0-snapshot-${headSha}`
+  const { packageNames, topologyDigest } = await readTopology(topologyPath)
+  const files = (await readdir(artifactDir))
+    .filter((file) => file.endsWith('.tgz'))
+    .toSorted((a, b) => a.localeCompare(b))
+  if (files.length !== packageNames.length) {
+    fail(`Tarball count mismatch: expected ${packageNames.length}, got ${files.length}`)
+  }
+
+  const packages = []
+  let artifactBytes = 0
+  for (const file of files) {
+    if (path.basename(file) !== file || /^[a-zA-Z0-9._-]+\.tgz$/.test(file) === false)
+      fail(`Unsafe tarball name: ${file}`)
+    const fileStat = await lstat(path.join(artifactDir, file))
+    artifactBytes += fileStat.size
+    if (fileStat.isFile() === false || fileStat.size > maxTarballBytes || artifactBytes > maxArtifactBytes)
+      fail(`Tarball is not a bounded regular file: ${file}`)
+    const bytes = await readFile(path.join(artifactDir, file))
+    const packageJson = parsePackage(bytes)
+    if (typeof packageJson.name !== 'string') fail(`Tarball ${file} has no package name`)
+    packages.push({ name: packageJson.name, file, sha256: sha256(bytes) })
+  }
+  packages.sort((a, b) => a.name.localeCompare(b.name))
+  if (JSON.stringify(packages.map(({ name }) => name)) !== JSON.stringify(packageNames)) {
+    fail('Tarball package set does not match release topology')
+  }
+  for (const entry of packages) {
+    const bytes = await readFile(path.join(artifactDir, entry.file))
+    validatePackageManifest({
+      packageJson: parsePackage(bytes),
+      expectedName: entry.name,
+      expectedVersion: version,
+      packageNames,
+    })
+  }
+
+  const manifest = {
+    schemaVersion: 1,
+    repository,
+    prNumber: positiveInteger(prNumber, 'PR number'),
+    headSha,
+    runId: positiveInteger(runId, 'run ID'),
+    runAttempt: positiveInteger(runAttempt, 'run attempt'),
+    version,
+    topologySha256: topologyDigest,
+    packages,
+  }
+  await writeFile(path.join(artifactDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+  return manifest
+}
+
+export const validateManifest = async ({
+  artifactDir,
+  topologyPath,
+  repository,
+  prNumber,
+  headSha,
+  runId,
+  runAttempt,
+  publishListPath,
+}) => {
+  if (shaPattern.test(headSha) === false) fail(`Invalid trusted head SHA: ${headSha}`)
+  const manifestPath = path.join(artifactDir, 'manifest.json')
+  const manifestStat = await lstat(manifestPath)
+  if (manifestStat.isFile() === false || manifestStat.size > 1024 * 1024) fail('Manifest is not a bounded regular file')
+  const manifestBytes = await readFile(manifestPath)
+  const manifest = JSON.parse(manifestBytes.toString('utf8'))
+  assertExactKeys(
+    manifest,
+    [
+      'schemaVersion',
+      'repository',
+      'prNumber',
+      'headSha',
+      'runId',
+      'runAttempt',
+      'version',
+      'topologySha256',
+      'packages',
+    ],
+    'Manifest',
+  )
+
+  const expectedVersion = `0.0.0-snapshot-${headSha}`
+  const expectedIdentity = {
+    schemaVersion: 1,
+    repository,
+    prNumber: positiveInteger(prNumber, 'PR number'),
+    headSha,
+    runId: positiveInteger(runId, 'run ID'),
+    runAttempt: positiveInteger(runAttempt, 'run attempt'),
+    version: expectedVersion,
+  }
+  for (const [key, value] of Object.entries(expectedIdentity)) {
+    if (manifest[key] !== value) fail(`Manifest ${key} mismatch: expected ${value}, got ${manifest[key]}`)
+  }
+
+  const { packageNames, topologyDigest } = await readTopology(topologyPath)
+  if (manifest.topologySha256 !== topologyDigest) {
+    fail(`Manifest topologySha256 mismatch: expected ${topologyDigest}, got ${manifest.topologySha256}`)
+  }
+  if (Array.isArray(manifest.packages) === false || manifest.packages.length !== packageNames.length) {
+    fail(`Manifest package count mismatch: expected ${packageNames.length}`)
+  }
+  const actualFiles = (await readdir(artifactDir)).toSorted((a, b) => a.localeCompare(b))
+  const expectedFiles = ['manifest.json', ...manifest.packages.map(({ file }) => file)].toSorted((a, b) =>
+    a.localeCompare(b),
+  )
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles))
+    fail('Artifact contains missing or unexpected files')
+
+  const seenNames = new Set()
+  const seenFiles = new Set()
+  let artifactBytes = 0
+  for (const entry of manifest.packages) {
+    assertExactKeys(entry, ['name', 'file', 'sha256'], 'Package entry')
+    if (packageNames.includes(entry.name) === false || seenNames.has(entry.name) === true)
+      fail(`Unexpected or duplicate package: ${entry.name}`)
+    if (
+      typeof entry.file !== 'string' ||
+      path.basename(entry.file) !== entry.file ||
+      /^[a-zA-Z0-9._-]+\.tgz$/.test(entry.file) === false ||
+      seenFiles.has(entry.file) === true
+    )
+      fail(`Unsafe or duplicate tarball name: ${entry.file}`)
+    if (digestPattern.test(entry.sha256) === false) fail(`Invalid digest for ${entry.name}`)
+    seenNames.add(entry.name)
+    seenFiles.add(entry.file)
+
+    const tarballPath = path.join(artifactDir, entry.file)
+    const fileStat = await lstat(tarballPath)
+    artifactBytes += fileStat.size
+    if (fileStat.isFile() === false || fileStat.size > maxTarballBytes || artifactBytes > maxArtifactBytes) {
+      fail(`Tarball is not a bounded regular file: ${entry.file}`)
+    }
+    const bytes = await readFile(tarballPath)
+    if (sha256(bytes) !== entry.sha256) fail(`Digest mismatch for ${entry.name}`)
+    validatePackageManifest({
+      packageJson: parsePackage(bytes),
+      expectedName: entry.name,
+      expectedVersion,
+      packageNames,
+    })
+  }
+  if (JSON.stringify([...seenNames].toSorted((a, b) => a.localeCompare(b))) !== JSON.stringify(packageNames))
+    fail('Manifest package set does not match trusted topology')
+
+  const publishEntries = manifest.packages
+    .map(({ name, file }) => `${name}\t${file}`)
+    .toSorted((a, b) => a.localeCompare(b))
+  await writeFile(publishListPath, `${publishEntries.join('\n')}\n`)
+  return {
+    manifestDigest: sha256(manifestBytes),
+    topologyDigest,
+    version: expectedVersion,
+    npmTag: snapshotTag({ prNumber, headSha }),
+    packageCount: packageNames.length,
+  }
+}
+
+const parseArgs = (args) => {
+  const values = {}
+  for (const arg of args) {
+    const match = /^--([a-z-]+)=(.*)$/.exec(arg)
+    if (match === null) fail(`Invalid argument: ${arg}`)
+    values[match[1]] = match[2]
+  }
+  return values
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const [mode, ...rawArgs] = process.argv.slice(2)
+  const args = parseArgs(rawArgs)
+  const common = {
+    artifactDir: args['artifact-dir'],
+    topologyPath: args['topology'],
+    repository: args.repository,
+    prNumber: args['pr-number'],
+    headSha: args['head-sha'],
+    runId: args['run-id'],
+    runAttempt: args['run-attempt'],
+  }
+  const result =
+    mode === 'create'
+      ? await createManifest(common)
+      : mode === 'validate'
+        ? await validateManifest({ ...common, publishListPath: args['publish-list'] })
+        : fail(`Unknown mode: ${mode}`)
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}

--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -115,6 +115,9 @@ export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => 
   return reviews.some((review) => review?.state === 'APPROVED' && review?.commit_id === headSha)
 }
 
+export const isAuthorizedReviewState = ({ headSha, currentHeadSha, reviewDecision, reviews }) =>
+  reviewDecision === 'APPROVED' && hasCurrentHeadApproval({ headSha, currentHeadSha, reviews })
+
 const validatePackageManifest = ({ packageJson, expectedName, expectedVersion, packageNames }) => {
   if (packageJson.name !== expectedName)
     fail(`Package name mismatch: expected ${expectedName}, got ${packageJson.name}`)

--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -122,6 +122,30 @@ export const successfulProducerAttempt = ({ jobs, jobName }) => {
   return Math.max(...matches.map((job) => positiveInteger(job.run_attempt, `${jobName} run attempt`)))
 }
 
+export const selectEligibleProducerRun = ({ runs, prNumber, headSha }) => {
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  if (Array.isArray(runs) === false) fail('Workflow runs response is not an array')
+
+  return (
+    runs
+      .filter(
+        (run) =>
+          run?.event === 'pull_request' &&
+          run?.conclusion === 'success' &&
+          run.pullRequests?.some(
+            (pullRequest) => pullRequest?.number === parsedPrNumber && pullRequest?.headSha === headSha,
+          ) === true &&
+          Number.isSafeInteger(run.packAttempt) === true &&
+          run.packAttempt > 0 &&
+          run.artifacts?.some(
+            (artifact) => artifact?.name === `pr-snapshot-${headSha}-${run.packAttempt}` && artifact?.expired === false,
+          ) === true,
+      )
+      .toSorted((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)))[0] ?? null
+  )
+}
+
 export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => {
   if (shaPattern.test(headSha) === false || shaPattern.test(currentHeadSha) === false) return false
   if (headSha !== currentHeadSha || Array.isArray(reviews) === false) return false

--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -109,6 +109,19 @@ export const snapshotTag = ({ prNumber, headSha }) => {
   return `pr-${parsedPrNumber}-${headSha}`
 }
 
+export const snapshotVersion = ({ prNumber, headSha }) => {
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
+  return `0.0.0-snapshot-pr.${parsedPrNumber}.${headSha}`
+}
+
+export const successfulProducerAttempt = ({ jobs, jobName }) => {
+  if (Array.isArray(jobs) === false) fail('Workflow jobs response is not an array')
+  const matches = jobs.filter((job) => job?.name === jobName && job?.conclusion === 'success')
+  if (matches.length !== 1) fail(`Expected exactly one successful ${jobName} job, found ${matches.length}`)
+  return positiveInteger(matches[0].run_attempt, `${jobName} run attempt`)
+}
+
 export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => {
   if (shaPattern.test(headSha) === false || shaPattern.test(currentHeadSha) === false) return false
   if (headSha !== currentHeadSha || Array.isArray(reviews) === false) return false
@@ -177,7 +190,8 @@ export const createManifest = async ({
   runAttempt,
 }) => {
   if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
-  const version = `0.0.0-snapshot-${headSha}`
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  const version = snapshotVersion({ prNumber: parsedPrNumber, headSha })
   const { packageNames, topologyDigest } = await readTopology(topologyPath)
   const files = (await readdir(artifactDir))
     .filter((file) => file.endsWith('.tgz'))
@@ -217,7 +231,7 @@ export const createManifest = async ({
   const manifest = {
     schemaVersion: 1,
     repository,
-    prNumber: positiveInteger(prNumber, 'PR number'),
+    prNumber: parsedPrNumber,
     headSha,
     runId: positiveInteger(runId, 'run ID'),
     runAttempt: positiveInteger(runAttempt, 'run attempt'),
@@ -261,11 +275,12 @@ export const validateManifest = async ({
     'Manifest',
   )
 
-  const expectedVersion = `0.0.0-snapshot-${headSha}`
+  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+  const expectedVersion = snapshotVersion({ prNumber: parsedPrNumber, headSha })
   const expectedIdentity = {
     schemaVersion: 1,
     repository,
-    prNumber: positiveInteger(prNumber, 'PR number'),
+    prNumber: parsedPrNumber,
     headSha,
     runId: positiveInteger(runId, 'run ID'),
     runAttempt: positiveInteger(runAttempt, 'run attempt'),

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { gzipSync } from 'node:zlib'
+
+import { createManifest, hasCurrentHeadApproval, snapshotTag, validateManifest } from './pr-snapshot-artifact.mjs'
+
+const writeOctal = (header, start, length, value) => {
+  const encoded = value.toString(8).padStart(length - 1, '0')
+  header.write(encoded, start, length - 1, 'ascii')
+  header[start + length - 1] = 0
+}
+
+const tar = (entries) => {
+  const chunks = []
+  for (const [name, content] of entries) {
+    const body = Buffer.from(content)
+    const header = Buffer.alloc(512)
+    header.write(name, 0, 100, 'utf8')
+    writeOctal(header, 100, 8, 0o644)
+    writeOctal(header, 108, 8, 0)
+    writeOctal(header, 116, 8, 0)
+    writeOctal(header, 124, 12, body.length)
+    writeOctal(header, 136, 12, 0)
+    header.fill(0x20, 148, 156)
+    header[156] = '0'.charCodeAt(0)
+    header.write('ustar\0', 257, 6, 'ascii')
+    header.write('00', 263, 2, 'ascii')
+    writeOctal(
+      header,
+      148,
+      8,
+      header.reduce((sum, byte) => sum + byte, 0),
+    )
+    chunks.push(header, body, Buffer.alloc(Math.ceil(body.length / 512) * 512 - body.length))
+  }
+  chunks.push(Buffer.alloc(1024))
+  return gzipSync(Buffer.concat(chunks))
+}
+
+const fixture = async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'livestore-pr-snapshot-'))
+  const artifactDir = path.join(dir, 'artifact')
+  await mkdir(artifactDir)
+  const topologyPath = path.join(dir, 'topology.json')
+  const headSha = 'a'.repeat(40)
+  const version = `0.0.0-snapshot-${headSha}`
+  const packageNames = ['@livestore/a', '@livestore/b']
+  await writeFile(topologyPath, JSON.stringify({ publishablePackageNames: packageNames }))
+  for (const name of packageNames) {
+    const file = `${name.slice('@livestore/'.length)}.tgz`
+    const packageJson = {
+      name,
+      version,
+      dependencies: name.endsWith('/b') === true ? { '@livestore/a': version } : {},
+      scripts: { test: 'node --test' },
+    }
+    await writeFile(
+      path.join(artifactDir, file),
+      tar([
+        ['package/package.json', JSON.stringify(packageJson)],
+        ['package/dist/index.js', 'export {}\n'],
+      ]),
+    )
+  }
+  return { dir: artifactDir, topologyPath, headSha, version }
+}
+
+test('creates and validates an exact-run package cohort', async () => {
+  const { dir, topologyPath, headSha, version } = await fixture()
+  await createManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 2,
+  })
+  const publishListPath = path.join(dir, '..', 'publish-list.txt')
+  const result = await validateManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 2,
+    publishListPath,
+  })
+  assert.equal(result.version, version)
+  assert.equal(result.npmTag, `pr-42-${headSha}`)
+  assert.equal(result.packageCount, 2)
+  assert.match(result.manifestDigest, /^[0-9a-f]{64}$/)
+  assert.equal(await readFile(publishListPath, 'utf8'), '@livestore/a\ta.tgz\n@livestore/b\tb.tgz\n')
+})
+
+test('requires an approval for the unchanged head', () => {
+  const oldHead = 'a'.repeat(40)
+  const currentHead = 'b'.repeat(40)
+  const reviews = [{ state: 'APPROVED', commit_id: oldHead }]
+
+  assert.equal(hasCurrentHeadApproval({ headSha: oldHead, currentHeadSha: currentHead, reviews }), false)
+  assert.equal(hasCurrentHeadApproval({ headSha: currentHead, currentHeadSha: currentHead, reviews }), false)
+  assert.equal(
+    hasCurrentHeadApproval({
+      headSha: currentHead,
+      currentHeadSha: currentHead,
+      reviews: [...reviews, { state: 'APPROVED', commit_id: currentHead }],
+    }),
+    true,
+  )
+})
+
+test('derives an immutable tag for each PR head cohort', () => {
+  const firstHead = 'a'.repeat(40)
+  const secondHead = 'b'.repeat(40)
+  const firstTag = snapshotTag({ prNumber: 42, headSha: firstHead })
+
+  assert.equal(firstTag, `pr-42-${firstHead}`)
+  assert.notEqual(firstTag, snapshotTag({ prNumber: 42, headSha: secondHead }))
+  assert.notEqual(firstTag, snapshotTag({ prNumber: 43, headSha: firstHead }))
+  assert.notEqual(firstTag, 'snapshot')
+})
+
+test('rejects a tarball changed after manifest creation', async () => {
+  const { dir, topologyPath, headSha } = await fixture()
+  await createManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 1,
+  })
+  await writeFile(path.join(dir, 'a.tgz'), Buffer.from('tampered'))
+  await assert.rejects(
+    validateManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+      publishListPath: path.join(dir, '..', 'publish-list.txt'),
+    }),
+    /Digest mismatch/,
+  )
+})
+
+test('rejects identity drift and unexpected artifact files', async () => {
+  const { dir, topologyPath, headSha } = await fixture()
+  await createManifest({
+    artifactDir: dir,
+    topologyPath,
+    repository: 'livestorejs/livestore',
+    prNumber: 42,
+    headSha,
+    runId: 100,
+    runAttempt: 1,
+  })
+  await assert.rejects(
+    validateManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 101,
+      runAttempt: 1,
+      publishListPath: path.join(dir, '..', 'publish-list.txt'),
+    }),
+    /runId mismatch/,
+  )
+
+  await writeFile(path.join(dir, 'unexpected.txt'), 'unexpected')
+  await assert.rejects(
+    validateManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+      publishListPath: path.join(dir, '..', 'publish-list.txt'),
+    }),
+    /missing or unexpected files/,
+  )
+})
+
+test('rejects traversal paths and lifecycle scripts', async () => {
+  const { dir, topologyPath, headSha, version } = await fixture()
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      ['package/../escape', 'x'],
+      ['package/package.json', JSON.stringify({ name: '@livestore/a', version })],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /Unsafe tar entry path/,
+  )
+
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      ['package/package.json', JSON.stringify({ name: '@livestore/a', version, scripts: { prepare: 'echo unsafe' } })],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /lifecycle script prepare/,
+  )
+
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      [
+        'package/package.json',
+        JSON.stringify({
+          name: '@livestore/a',
+          version,
+          publishConfig: { access: 'public', registry: 'https://attacker.example' },
+        }),
+      ],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /publishConfig keys mismatch/,
+  )
+
+  await writeFile(
+    path.join(dir, 'a.tgz'),
+    tar([
+      ['package/.npmrc', 'registry=https://attacker.example'],
+      ['package/package.json', JSON.stringify({ name: '@livestore/a', version })],
+    ]),
+  )
+  await assert.rejects(
+    createManifest({
+      artifactDir: dir,
+      topologyPath,
+      repository: 'livestorejs/livestore',
+      prNumber: 42,
+      headSha,
+      runId: 100,
+      runAttempt: 1,
+    }),
+    /must not contain .npmrc/,
+  )
+})

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -186,7 +186,8 @@ test('generated review workflow checks out only its trusted workflow commit', as
   assert.match(publish, /\.head\.repo\.full_name/)
   assert.doesNotMatch(publish, /npm dist-tag/)
   assert.match(publish, /npm publish/)
-  assert.match(workflow.slice(validateStart, attestStart), /pack-pr-snapshot.*conclusion == "success"/s)
+  assert.match(workflow.slice(validateStart, attestStart), /jobs\?filter=all/)
+  assert.match(workflow.slice(validateStart, attestStart), /sort_by\(\.run_attempt\) \| last/)
   assert.match(workflow, /validated-pr-snapshot-.*release-run-attempt/)
   assert.match(workflow, /promotion-pr-snapshot-.*promotion-attempt/)
 
@@ -226,6 +227,17 @@ test('selects the successful producer attempt when only failed jobs were rerun',
       ],
     }),
     1,
+  )
+
+  assert.equal(
+    successfulProducerAttempt({
+      jobName: 'pack-pr-snapshot',
+      jobs: [
+        { name: 'pack-pr-snapshot', conclusion: 'success', run_attempt: 1 },
+        { name: 'pack-pr-snapshot', conclusion: 'success', run_attempt: 2 },
+      ],
+    }),
+    2,
   )
 })
 

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -10,6 +10,8 @@ import {
   hasCurrentHeadApproval,
   isAuthorizedReviewState,
   snapshotTag,
+  snapshotVersion,
+  successfulProducerAttempt,
   validateManifest,
 } from './pr-snapshot-artifact.mjs'
 
@@ -52,7 +54,7 @@ const fixture = async () => {
   await mkdir(artifactDir)
   const topologyPath = path.join(dir, 'topology.json')
   const headSha = 'a'.repeat(40)
-  const version = `0.0.0-snapshot-${headSha}`
+  const version = `0.0.0-snapshot-pr.42.${headSha}`
   const packageNames = ['@livestore/a', '@livestore/b']
   await writeFile(topologyPath, JSON.stringify({ publishablePackageNames: packageNames }))
   for (const name of packageNames) {
@@ -182,7 +184,11 @@ test('generated review workflow checks out only its trusted workflow commit', as
   assert.match(publish, /group: 'pr-snapshot-\$\{\{ needs\.validate-pr-snapshot\.outputs\.head-sha \}\}'/)
   assert.match(publish, /\.base\.ref/)
   assert.match(publish, /\.head\.repo\.full_name/)
-  assert.match(publish, /npm dist-tag add/)
+  assert.doesNotMatch(publish, /npm dist-tag/)
+  assert.match(publish, /npm publish/)
+  assert.match(workflow.slice(validateStart, attestStart), /pack-pr-snapshot.*conclusion == "success"/s)
+  assert.match(workflow, /validated-pr-snapshot-.*release-run-attempt/)
+  assert.match(workflow, /promotion-pr-snapshot-.*promotion-attempt/)
 
   const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
   assert.match(
@@ -204,6 +210,23 @@ test('derives an immutable tag for each PR head cohort', () => {
   assert.notEqual(firstTag, snapshotTag({ prNumber: 42, headSha: secondHead }))
   assert.notEqual(firstTag, snapshotTag({ prNumber: 43, headSha: firstHead }))
   assert.notEqual(firstTag, 'snapshot')
+  assert.notEqual(
+    snapshotVersion({ prNumber: 42, headSha: firstHead }),
+    snapshotVersion({ prNumber: 43, headSha: firstHead }),
+  )
+})
+
+test('selects the successful producer attempt when only failed jobs were rerun', () => {
+  assert.equal(
+    successfulProducerAttempt({
+      jobName: 'pack-pr-snapshot',
+      jobs: [
+        { name: 'pack-pr-snapshot', conclusion: 'success', run_attempt: 1 },
+        { name: 'lint', conclusion: 'success', run_attempt: 2 },
+      ],
+    }),
+    1,
+  )
 })
 
 test('rejects a tarball changed after manifest creation', async () => {

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -157,9 +157,19 @@ test('requires the authoritative required-review decision', () => {
   )
 })
 
-test('generated review workflow checks out only its trusted workflow commit', async () => {
+test('generated promotion workflow is anchored to trusted main', async () => {
   const workflow = await readFile(new URL('../workflows/release.yml', import.meta.url), 'utf8')
-  assert.match(workflow, /pull_request_review:/)
+  assert.doesNotMatch(workflow, /pull_request_review:/)
+  assert.match(workflow, /cron: '\*\/5 \* \* \* \*'/)
+  const dispatchStart = workflow.indexOf('\n  dispatch-approved-pr-snapshots:')
+  const validateStart = workflow.indexOf('\n  validate-pr-snapshot:', dispatchStart)
+  const dispatch = workflow.slice(dispatchStart, validateStart)
+  assert.match(dispatch, /actions: write/)
+  assert.doesNotMatch(dispatch, /id-token: write/)
+  assert.match(dispatch, /gh workflow run release\.yml.*--ref main/s)
+  assert.match(dispatch, /reviewDecision == "APPROVED"/)
+  assert.match(dispatch, /headRepository\.nameWithOwner/)
+
   const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
   const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
   assert.notEqual(checkoutStart, -1)
@@ -168,12 +178,12 @@ test('generated review workflow checks out only its trusted workflow commit', as
   assert.match(checkout, /ref: \$\{\{ github\.workflow_sha \}\}/)
   assert.doesNotMatch(checkout, /github\.sha|head-sha/)
 
-  const validateStart = workflow.indexOf('\n  validate-pr-snapshot:')
   const attestStart = workflow.indexOf('\n  attest-pr-snapshot:', validateStart)
   const authorizeStart = workflow.indexOf('\n  authorize-pr-snapshot:', attestStart)
   const publishStart = workflow.indexOf('\n  publish-pr-snapshot:', authorizeStart)
   const nextJobStart = workflow.indexOf('\n  create-release-pr:', publishStart)
   assert.match(workflow.slice(validateStart, attestStart), /GITHUB_WORKFLOW_REF.*refs\/heads\/main/)
+  assert.match(workflow.slice(validateStart, attestStart), /workflow_dispatch.*refs\/heads\/main.*promote-pr-snapshot/s)
   assert.doesNotMatch(workflow.slice(validateStart, attestStart), /id-token: write/)
   assert.match(workflow.slice(validateStart, attestStart), /pull-requests: read/)
   assert.match(workflow.slice(attestStart, authorizeStart), /id-token: write/)

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -169,9 +169,30 @@ test('generated review workflow checks out only its trusted workflow commit', as
   const validateStart = workflow.indexOf('\n  validate-pr-snapshot:')
   const attestStart = workflow.indexOf('\n  attest-pr-snapshot:', validateStart)
   const authorizeStart = workflow.indexOf('\n  authorize-pr-snapshot:', attestStart)
+  const publishStart = workflow.indexOf('\n  publish-pr-snapshot:', authorizeStart)
+  const nextJobStart = workflow.indexOf('\n  create-release-pr:', publishStart)
   assert.match(workflow.slice(validateStart, attestStart), /GITHUB_WORKFLOW_REF.*refs\/heads\/main/)
   assert.doesNotMatch(workflow.slice(validateStart, attestStart), /id-token: write/)
+  assert.match(workflow.slice(validateStart, attestStart), /pull-requests: read/)
   assert.match(workflow.slice(attestStart, authorizeStart), /id-token: write/)
+  assert.match(workflow.slice(authorizeStart, publishStart), /pull-requests: read/)
+
+  const publish = workflow.slice(publishStart, nextJobStart)
+  assert.match(publish, /pull-requests: read/)
+  assert.match(publish, /group: 'pr-snapshot-\$\{\{ needs\.validate-pr-snapshot\.outputs\.head-sha \}\}'/)
+  assert.match(publish, /\.base\.ref/)
+  assert.match(publish, /\.head\.repo\.full_name/)
+  assert.match(publish, /npm dist-tag add/)
+
+  const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
+  assert.match(
+    ciWorkflow,
+    /name: 'pr-snapshot-\$\{\{ github\.event\.pull_request\.head\.sha \}\}-\$\{\{ github\.run_attempt \}\}'/,
+  )
+  assert.match(
+    workflow.slice(validateStart, attestStart),
+    /name: 'pr-snapshot-\$\{\{ steps\.identity\.outputs\.head-sha \}\}-\$\{\{ steps\.identity\.outputs\.run-attempt \}\}'/,
+  )
 })
 
 test('derives an immutable tag for each PR head cohort', () => {

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -9,6 +9,7 @@ import {
   createManifest,
   hasCurrentHeadApproval,
   isAuthorizedReviewState,
+  selectEligibleProducerRun,
   snapshotTag,
   snapshotVersion,
   successfulProducerAttempt,
@@ -167,8 +168,13 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(dispatch, /actions: write/)
   assert.doesNotMatch(dispatch, /id-token: write/)
   assert.match(dispatch, /gh workflow run release\.yml.*--ref main/s)
-  assert.match(dispatch, /reviewDecision == "APPROVED"/)
-  assert.match(dispatch, /headRepository\.nameWithOwner/)
+  assert.match(dispatch, /pulls\?state=open&base=main&per_page=100.*--slurp/)
+  assert.match(dispatch, /pullRequest\(number:\$number\)\{reviewDecision\}/)
+  assert.match(dispatch, /reviewDecision.*APPROVED/s)
+  assert.match(dispatch, /any\(\.pull_requests\[\]\?; \.number == \$pr_number and \.head\.sha == \$sha\)/)
+  assert.match(dispatch, /pack-pr-snapshot.*conclusion == "success"/s)
+  assert.match(dispatch, /artifacts\?per_page=100.*expired == false/s)
+  assert.match(dispatch, /ci_run_id="\$selected_run_id"/)
 
   const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
   const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
@@ -198,8 +204,15 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(publish, /npm publish/)
   assert.match(workflow.slice(validateStart, attestStart), /jobs\?filter=all/)
   assert.match(workflow.slice(validateStart, attestStart), /sort_by\(\.run_attempt\) \| last/)
+  assert.match(workflow.slice(validateStart, attestStart), /inputs\.ci_run_id/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.pull_requests\[0\]\.head\.sha/)
   assert.match(workflow, /validated-pr-snapshot-.*release-run-attempt/)
   assert.match(workflow, /promotion-pr-snapshot-.*promotion-attempt/)
+
+  assert.match(publish, /Verify complete immutable registry cohort/)
+  assert.match(publish, /dist\.integrity/)
+  assert.match(publish, /dist-tags/)
+  assert.match(publish, /needs\.validate-pr-snapshot\.outputs\.package-count/)
 
   const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
   assert.match(
@@ -249,6 +262,38 @@ test('selects the successful producer attempt when only failed jobs were rerun',
     }),
     2,
   )
+})
+
+test('selects an exact PR-associated run when multiple PRs share a head SHA', () => {
+  const headSha = 'a'.repeat(40)
+  const artifact = (attempt) => ({ name: `pr-snapshot-${headSha}-${attempt}`, expired: false })
+  const runs = [
+    {
+      id: 100,
+      headSha: 'c'.repeat(40),
+      event: 'pull_request',
+      conclusion: 'success',
+      pullRequests: [{ number: 41, headSha }],
+      packAttempt: 1,
+      artifacts: [artifact(1)],
+      createdAt: '2026-07-18T10:00:00Z',
+    },
+    {
+      id: 101,
+      headSha: 'd'.repeat(40),
+      event: 'pull_request',
+      conclusion: 'success',
+      pullRequests: [{ number: 42, headSha }],
+      packAttempt: 2,
+      artifacts: [artifact(2)],
+      createdAt: '2026-07-18T09:00:00Z',
+    },
+  ]
+
+  assert.equal(selectEligibleProducerRun({ runs, prNumber: 42, headSha })?.id, 101)
+  assert.equal(selectEligibleProducerRun({ runs, prNumber: 43, headSha }), null)
+  runs[1].artifacts[0].expired = true
+  assert.equal(selectEligibleProducerRun({ runs, prNumber: 42, headSha }), null)
 })
 
 test('rejects a tarball changed after manifest creation', async () => {

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -5,7 +5,13 @@ import path from 'node:path'
 import test from 'node:test'
 import { gzipSync } from 'node:zlib'
 
-import { createManifest, hasCurrentHeadApproval, snapshotTag, validateManifest } from './pr-snapshot-artifact.mjs'
+import {
+  createManifest,
+  hasCurrentHeadApproval,
+  isAuthorizedReviewState,
+  snapshotTag,
+  validateManifest,
+} from './pr-snapshot-artifact.mjs'
 
 const writeOctal = (header, start, length, value) => {
   const encoded = value.toString(8).padStart(length - 1, '0')
@@ -112,6 +118,60 @@ test('requires an approval for the unchanged head', () => {
     }),
     true,
   )
+})
+
+test('requires the authoritative required-review decision', () => {
+  const headSha = 'a'.repeat(40)
+  const approvedReview = { state: 'APPROVED', commit_id: headSha }
+
+  assert.equal(
+    isAuthorizedReviewState({
+      headSha,
+      currentHeadSha: headSha,
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [approvedReview],
+    }),
+    false,
+    'a non-counting approval must not authorize',
+  )
+  assert.equal(
+    isAuthorizedReviewState({
+      headSha,
+      currentHeadSha: headSha,
+      reviewDecision: 'CHANGES_REQUESTED',
+      reviews: [approvedReview, { state: 'CHANGES_REQUESTED', commit_id: headSha }],
+    }),
+    false,
+    'a later changes-requested decision must not authorize',
+  )
+  assert.equal(
+    isAuthorizedReviewState({
+      headSha,
+      currentHeadSha: headSha,
+      reviewDecision: 'APPROVED',
+      reviews: [approvedReview],
+    }),
+    true,
+  )
+})
+
+test('generated review workflow checks out only its trusted workflow commit', async () => {
+  const workflow = await readFile(new URL('../workflows/release.yml', import.meta.url), 'utf8')
+  assert.match(workflow, /pull_request_review:/)
+  const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
+  const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
+  assert.notEqual(checkoutStart, -1)
+  assert.notEqual(checkoutEnd, -1)
+  const checkout = workflow.slice(checkoutStart, checkoutEnd)
+  assert.match(checkout, /ref: \$\{\{ github\.workflow_sha \}\}/)
+  assert.doesNotMatch(checkout, /github\.sha|head-sha/)
+
+  const validateStart = workflow.indexOf('\n  validate-pr-snapshot:')
+  const attestStart = workflow.indexOf('\n  attest-pr-snapshot:', validateStart)
+  const authorizeStart = workflow.indexOf('\n  authorize-pr-snapshot:', attestStart)
+  assert.match(workflow.slice(validateStart, attestStart), /GITHUB_WORKFLOW_REF.*refs\/heads\/main/)
+  assert.doesNotMatch(workflow.slice(validateStart, attestStart), /id-token: write/)
+  assert.match(workflow.slice(attestStart, authorizeStart), /id-token: write/)
 })
 
 test('derives an immutable tag for each PR head cohort', () => {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,9 +87,12 @@ npm promotion uses the repository's ordinary required code-review decision as
 its only manual trust boundary. GitHub's authoritative review decision must be
 `APPROVED`, and a counting approval must name the current head commit. An
 approval for an earlier head, a non-counting approval, or a later changes request
-does not authorize publication. Approval before CI
-is observed when CI completes, while approval after CI triggers validation from
-the exact successful CI run automatically. The OIDC job rechecks the unchanged
+does not authorize publication. Approval before CI is observed when CI completes.
+For approval after CI, the trusted default-branch workflow polls approved open
+PRs every five minutes and dispatches `release.yml` explicitly at `main`; it does
+not grant workflow-write authority to PR-controlled review-event code. The
+dispatched run treats PR and head inputs only as selectors, then resolves and
+validates the exact successful CI producer again. The OIDC job rechecks the unchanged
 head and approval immediately before publishing. It never checks out or executes
 the PR head and publishes the validated tarballs directly with scripts disabled
 under the immutable `pr-<number>-<40-character-head-sha>` tag. npm provenance

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -72,7 +72,7 @@ package settings.
 
 A successful `ci.yml` run for a repository-owned pull request also publishes
 an immutable candidate for the exact head as
-`0.0.0-snapshot-<40-character-head-sha>`. Forks are excluded.
+`0.0.0-snapshot-pr.<number>.<40-character-head-sha>`. Forks are excluded.
 The PR job only packs the fixed public package cohort on a GitHub-hosted runner
 without secrets, write permissions, or OIDC. The default-branch `release.yml`
 validation job re-resolves the open PR from the completed run, requires its

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -77,13 +77,17 @@ The PR job only packs the fixed public package cohort on a GitHub-hosted runner
 without secrets, write permissions, or OIDC. The default-branch `release.yml`
 validation job re-resolves the open PR from the completed run, requires its
 current head to match, validates the run-bound manifest and every tarball, and
-uploads a short-lived immutable artifact for pre-review E2E. Validation also
-creates a custom GitHub attestation that binds the package and manifest digests
-to the exact PR head, source CI run, and trusted release topology.
+uploads a short-lived immutable artifact for pre-review E2E. This parser job has
+no OIDC permission. A separate job hashes the validated handoff without parsing
+package archives and creates a custom GitHub attestation that binds the package
+and manifest digests to the exact PR head, source CI run, and trusted release
+topology.
 
-npm promotion uses the repository's ordinary code-review approval as its only
-manual trust boundary. The approval must name the current head commit; an
-approval for an earlier head does not authorize publication. Approval before CI
+npm promotion uses the repository's ordinary required code-review decision as
+its only manual trust boundary. GitHub's authoritative review decision must be
+`APPROVED`, and a counting approval must name the current head commit. An
+approval for an earlier head, a non-counting approval, or a later changes request
+does not authorize publication. Approval before CI
 is observed when CI completes, while approval after CI triggers validation from
 the exact successful CI run automatically. The OIDC job rechecks the unchanged
 head and approval immediately before publishing. It never checks out or executes

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -70,6 +70,28 @@ tokens for package publish jobs. Each published `@livestore/*` package must
 trust `livestorejs/livestore` with workflow filename `release.yml` in npm
 package settings.
 
+A successful `ci.yml` run for a repository-owned pull request also publishes
+an immutable candidate for the exact head as
+`0.0.0-snapshot-<40-character-head-sha>`. Forks are excluded.
+The PR job only packs the fixed public package cohort on a GitHub-hosted runner
+without secrets, write permissions, or OIDC. The default-branch `release.yml`
+validation job re-resolves the open PR from the completed run, requires its
+current head to match, validates the run-bound manifest and every tarball, and
+uploads a short-lived immutable artifact for pre-review E2E. Validation also
+creates a custom GitHub attestation that binds the package and manifest digests
+to the exact PR head, source CI run, and trusted release topology.
+
+npm promotion uses the repository's ordinary code-review approval as its only
+manual trust boundary. The approval must name the current head commit; an
+approval for an earlier head does not authorize publication. Approval before CI
+is observed when CI completes, while approval after CI triggers validation from
+the exact successful CI run automatically. The OIDC job rechecks the unchanged
+head and approval immediately before publishing. It never checks out or executes
+the PR head and publishes the validated tarballs directly with scripts disabled
+under the immutable `pr-<number>-<40-character-head-sha>` tag. npm provenance
+identifies this trusted default-branch promotion workflow; the custom candidate
+attestation supplies the separate link back to PR CI.
+
 Snapshot DevTools Chrome ZIPs are uploaded as short-lived workflow artifacts,
 not GitHub Releases. Public GitHub Releases are reserved for dev/stable release
 versions so the releases page remains a user-facing release history rather than

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,7 @@ jobs:
           bash "$__genie_ci_retry_script" 'devenv tasks run release:snapshot:pack:git-sha' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:snapshot:pack:git-sha'
         env:
           GIT_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
       - name: Create snapshot manifest
         run: |
           node .github/scripts/pr-snapshot-artifact.mjs create \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,7 +567,7 @@ jobs:
       - name: Upload immutable PR snapshot candidate
         uses: actions/upload-artifact@v4
         with:
-          name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}'
+          name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}-${{ github.run_attempt }}'
           path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/'
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,186 @@ jobs:
           process.exit(1)
           NODE
         shell: bash
+  pack-pr-snapshot:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      CACHIX_AUTH_TOKEN: ''
+      SNAPSHOT_OUT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout exact PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Prepare CI helper scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_src='genie/ci-scripts'
+          scripts_dst='${{ runner.temp }}/genie-ci-scripts'
+          if [ ! -d "$scripts_src" ]; then
+            echo "::error::CI helper script directory is missing: $scripts_src"
+            exit 1
+          fi
+          rm -rf "$scripts_dst"
+          mkdir -p "$scripts_dst"
+          cp -R "$scripts_src/." "$scripts_dst/"
+          chmod +x "$scripts_dst"/*.sh
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '\''::error::megarepo.lock missing members["effect-utils"].commit'\''
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf '\''MEGAREPO_STORE=%s\n'\'' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+          fi
+
+          nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
+        shell: bash
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_CONFIG_STORE_DIR=${{ runner.temp }}/pnpm-store/${{ github.job }}" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ runner.temp }}/pnpm-store/${{ github.job }}
+          key: "livestore-pnpm-state-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'Resolve devenv' 'DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '\''::error::devenv.lock missing .nodes.devenv.locked.rev'\''
+            exit 1
+          fi
+
+          resolve_devenv() {
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
+        shell: bash
+      - name: Test snapshot artifact boundary
+        run: node --test .github/scripts/pr-snapshot-artifact.test.mjs
+      - name: Pack exact-SHA snapshot
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'devenv tasks run release:snapshot:pack:git-sha' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ runner.temp }}/pnpm-store/${{ github.job }}}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:snapshot:pack:git-sha'
+        env:
+          GIT_SHA: ${{ github.event.pull_request.head.sha }}
+      - name: Create snapshot manifest
+        run: |
+          node .github/scripts/pr-snapshot-artifact.mjs create \
+            --artifact-dir="$SNAPSHOT_OUT_DIR" \
+            --topology=scripts/src/generated/release-topology.json \
+            --repository="$GITHUB_REPOSITORY" \
+            --pr-number="${{ github.event.pull_request.number }}" \
+            --head-sha="${{ github.event.pull_request.head.sha }}" \
+            --run-id="$GITHUB_RUN_ID" \
+            --run-attempt="$GITHUB_RUN_ATTEMPT"
+      - name: Upload immutable PR snapshot candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}'
+          path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/'
+          if-no-files-found: error
+          retention-days: 7
   lint:
     runs-on: [namespace-profile-linux-x86-64, 'namespace-features:github.run-id=${{ github.run_id }}']
     defaults:

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -175,7 +175,7 @@ export default githubWorkflow({
           name: 'Upload immutable PR snapshot candidate',
           uses: 'actions/upload-artifact@v4',
           with: {
-            name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}',
+            name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}-${{ github.run_attempt }}',
             path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
             'if-no-files-found': 'error',
             'retention-days': 7,

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -158,7 +158,10 @@ export default githubWorkflow({
         {
           name: 'Pack exact-SHA snapshot',
           run: runDevenvTasksBefore('release:snapshot:pack:git-sha'),
-          env: { GIT_SHA: '${{ github.event.pull_request.head.sha }}' },
+          env: {
+            GIT_SHA: '${{ github.event.pull_request.head.sha }}',
+            PR_NUMBER: '${{ github.event.pull_request.number }}',
+          },
         },
         {
           name: 'Create snapshot manifest',

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -132,6 +132,57 @@ export default githubWorkflow({
 
   jobs: {
     'source-policy': livestoreDefaultRefPolicyJob,
+    'pack-pr-snapshot': {
+      if: "github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository",
+      'runs-on': 'ubuntu-24.04',
+      permissions: { contents: 'read' },
+      env: {
+        CACHIX_AUTH_TOKEN: '',
+        SNAPSHOT_OUT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Checkout exact PR head',
+          uses: 'actions/checkout@v4',
+          with: {
+            ref: '${{ github.event.pull_request.head.sha }}',
+            'persist-credentials': false,
+          },
+        },
+        ...livestoreSetupStepsAfterCheckout,
+        {
+          name: 'Test snapshot artifact boundary',
+          run: 'node --test .github/scripts/pr-snapshot-artifact.test.mjs',
+        },
+        {
+          name: 'Pack exact-SHA snapshot',
+          run: runDevenvTasksBefore('release:snapshot:pack:git-sha'),
+          env: { GIT_SHA: '${{ github.event.pull_request.head.sha }}' },
+        },
+        {
+          name: 'Create snapshot manifest',
+          run: `node .github/scripts/pr-snapshot-artifact.mjs create \\
+  --artifact-dir="$SNAPSHOT_OUT_DIR" \\
+  --topology=scripts/src/generated/release-topology.json \\
+  --repository="$GITHUB_REPOSITORY" \\
+  --pr-number="\${{ github.event.pull_request.number }}" \\
+  --head-sha="\${{ github.event.pull_request.head.sha }}" \\
+  --run-id="$GITHUB_RUN_ID" \\
+  --run-attempt="$GITHUB_RUN_ATTEMPT"`,
+        },
+        {
+          name: 'Upload immutable PR snapshot candidate',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'pr-snapshot-${{ github.event.pull_request.head.sha }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+            'if-no-files-found': 'error',
+            'retention-days': 7,
+          },
+        },
+      ],
+    },
     lint: standardCIJob({
       steps: [
         ...livestoreSetupSteps,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: ''
         type: string
+      ci_run_id:
+        description: Exact successful PR CI run selector for trusted snapshot promotion
+        required: false
+        default: '0'
+        type: string
       mode:
         description: Release workflow mode
         required: true
@@ -456,16 +461,24 @@ jobs:
         run: |
           set -euo pipefail
           test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
-          prs_json=$(gh api graphql   -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number isDraft reviewDecision baseRefName headRefOid headRepository{nameWithOwner}}}}}'   -f owner="${GITHUB_REPOSITORY%%/*}"   -f name="${GITHUB_REPOSITORY#*/}")
-
-          jq -r --arg repository "$GITHUB_REPOSITORY"   '.data.repository.pullRequests.nodes[] | select(.isDraft == false and .reviewDecision == "APPROVED" and .baseRefName == "main" and .headRepository.nameWithOwner == $repository) | [.number, .headRefOid] | @tsv'   <<<"$prs_json" |
-          while IFS=$'	' read -r pr_number head_sha; do
+          prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
+          jq -r --arg repository "$GITHUB_REPOSITORY"   '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv'   <<<"$prs_json" |
+          while IFS=$'	' read -r pr_number head_sha head_ref; do
             [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
             [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+            test -n "$head_ref"
+            review_json=$(gh api graphql     -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'     -f owner="${GITHUB_REPOSITORY%%/*}"     -f name="${GITHUB_REPOSITORY#*/}"     -F number="$pr_number")
+            if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+              continue
+            fi
+
             version="0.0.0-snapshot-pr.$pr_number.$head_sha"
+            snapshot_tag="pr-$pr_number-$head_sha"
             complete=true
             while IFS= read -r package_name; do
-              if ! npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+              remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+              remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
+              if [ "$remote_version" != "$version" ] || [ "$remote_tag" != "$version" ]; then
                 complete=false
                 break
               fi
@@ -474,7 +487,31 @@ jobs:
               echo "PR #$pr_number snapshot cohort is already complete"
               continue
             fi
-            gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main     -f mode=promote-pr-snapshot     -f npm_tag=latest     -f pr_number="$pr_number"     -f head_sha="$head_sha"
+
+            selected_run_id=''
+            runs_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs"     -f event=pull_request     -f status=success     -f branch="$head_ref"     -F per_page=100     --slurp)
+            while IFS= read -r candidate_run_id; do
+              [[ "$candidate_run_id" =~ ^[1-9][0-9]*$ ]]
+              jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/jobs?filter=all&per_page=100" --slurp)
+              pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+              if [ "$pack_job" = null ]; then
+                continue
+              fi
+              pack_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
+              [[ "$pack_attempt" =~ ^[1-9][0-9]*$ ]]
+              artifact_name="pr-snapshot-$head_sha-$pack_attempt"
+              artifacts_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/artifacts?per_page=100" --slurp)
+              if ! jq -e --arg name "$artifact_name" 'any(.[] | .artifacts[]; .name == $name and .expired == false)' <<<"$artifacts_json" >/dev/null; then
+                continue
+              fi
+              selected_run_id="$candidate_run_id"
+              break
+            done < <(jq -r --arg sha "$head_sha" --argjson pr_number "$pr_number"     '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == env.GITHUB_REPOSITORY and any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha))] | sort_by(.created_at) | reverse | .[].id'     <<<"$runs_json")
+            if [ -z "$selected_run_id" ]; then
+              echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
+              continue
+            fi
+            gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main     -f mode=promote-pr-snapshot     -f npm_tag=latest     -f pr_number="$pr_number"     -f head_sha="$head_sha"     -f ci_run_id="$selected_run_id"
           done
   validate-pr-snapshot:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')
@@ -512,25 +549,30 @@ jobs:
           [[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
           if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
             run_id='${{ github.event.workflow_run.id }}'
-            head_sha='${{ github.event.workflow_run.head_sha }}'
-            source_run_url='${{ github.event.workflow_run.html_url }}'
-            prs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/pulls")
-            test "$(jq 'length' <<<"$prs_json")" = 1
-            pr_number=$(jq -r '.[0].number' <<<"$prs_json")
           else
             test "$GITHUB_EVENT_NAME" = workflow_dispatch
             pr_number='${{ inputs.pr_number }}'
             head_sha='${{ inputs.head_sha }}'
-            runs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$head_sha&per_page=100")
-            run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
-            test "$run_json" != null
-            run_id=$(jq -r '.id' <<<"$run_json")
-            source_run_url=$(jq -r '.html_url' <<<"$run_json")
+            run_id='${{ inputs.ci_run_id }}'
           fi
 
+          [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          run_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+          test "$(jq -r '.event' <<<"$run_json")" = pull_request
+          test "$(jq -r '.status' <<<"$run_json")" = completed
+          test "$(jq -r '.conclusion' <<<"$run_json")" = success
+          test "$(jq -r '.head_repository.full_name' <<<"$run_json")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.path' <<<"$run_json")" = .github/workflows/ci.yml
+          if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
+            test "$(jq '.pull_requests | length' <<<"$run_json")" = 1
+            pr_number=$(jq -r '.pull_requests[0].number' <<<"$run_json")
+            head_sha=$(jq -r '.pull_requests[0].head.sha' <<<"$run_json")
+          else
+            jq -e --arg sha "$head_sha" --argjson pr_number "$pr_number"     'any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha)' <<<"$run_json" >/dev/null
+          fi
           [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          source_run_url=$(jq -r '.html_url' <<<"$run_json")
           jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" --slurp)
           pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
           test "$pack_job" != null
@@ -774,6 +816,35 @@ jobs:
             fi
             npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance
           done < "$PUBLISH_LIST"
+      - name: Verify complete immutable registry cohort
+        env:
+          SNAPSHOT_TAG: ${{ needs.validate-pr-snapshot.outputs.npm-tag }}
+          SNAPSHOT_VERSION: ${{ needs.validate-pr-snapshot.outputs.version }}
+        run: |
+          set -euo pipefail
+          verified=0
+          while IFS=$'	' read -r package_name file; do
+            tarball="$ARTIFACT_DIR/$file"
+            local_integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 -w0)"
+            matched=false
+            for attempt in $(seq 1 12); do
+              remote_version=$(npm view "$package_name@$SNAPSHOT_VERSION" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+              remote_integrity=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.integrity --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+              remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+              if [ "$remote_version" = "$SNAPSHOT_VERSION" ] &&        [ "$remote_integrity" = "$local_integrity" ] &&        [ "$remote_tag" = "$SNAPSHOT_VERSION" ]; then
+                matched=true
+                break
+              fi
+              sleep 5
+            done
+            if [ "$matched" != true ]; then
+              echo "Registry verification failed for $package_name@$SNAPSHOT_VERSION" >&2
+              exit 1
+            fi
+            verified=$((verified + 1))
+          done < "$PUBLISH_LIST"
+          test "$verified" = '${{ needs.validate-pr-snapshot.outputs.package-count }}'
+          echo "Verified $verified package versions, immutable tags, and SHA-512 integrities." >> "$GITHUB_STEP_SUMMARY"
       - name: Record snapshot provenance
         env:
           SNAPSHOT_VERSION: ${{ needs.validate-pr-snapshot.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,6 +436,7 @@ jobs:
       npm-tag: ${{ steps.validate.outputs.npm-tag }}
       package-count: ${{ steps.validate.outputs.package-count }}
       pr-number: ${{ steps.identity.outputs.pr-number }}
+      release-run-attempt: ${{ steps.validate.outputs.release-run-attempt }}
       run-attempt: ${{ steps.identity.outputs.run-attempt }}
       run-id: ${{ steps.identity.outputs.run-id }}
       source-run-url: ${{ steps.identity.outputs.source-run-url }}
@@ -458,7 +459,6 @@ jobs:
           [[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
           if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
             run_id='${{ github.event.workflow_run.id }}'
-            run_attempt='${{ github.event.workflow_run.run_attempt }}'
             head_sha='${{ github.event.workflow_run.head_sha }}'
             source_run_url='${{ github.event.workflow_run.html_url }}'
             prs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/pulls")
@@ -471,13 +471,16 @@ jobs:
             run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
             test "$run_json" != null
             run_id=$(jq -r '.id' <<<"$run_json")
-            run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
             source_run_url=$(jq -r '.html_url' <<<"$run_json")
           fi
 
           [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
           [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=latest&per_page=100" --slurp)
+          pack_jobs=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")]' <<<"$jobs_json")
+          test "$(jq 'length' <<<"$pack_jobs")" = 1
+          run_attempt=$(jq -r '.[0].run_attempt' <<<"$pack_jobs")
           [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
           pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
 
@@ -533,11 +536,12 @@ jobs:
           echo "topology-digest=$(jq -r '.topologyDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
           echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
           echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "release-run-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
           cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"
       - name: Upload validated snapshot candidate
         uses: actions/upload-artifact@v4
         with:
-          name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}'
+          name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}-${{ steps.validate.outputs.release-run-attempt }}'
           path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/'
           if-no-files-found: error
           retention-days: 1
@@ -556,13 +560,16 @@ jobs:
     defaults:
       run:
         shell: bash
+    outputs:
+      promotion-attempt: ${{ steps.handoff.outputs.promotion-attempt }}
     steps:
       - name: Download validated snapshot candidate
         uses: actions/download-artifact@v4
         with:
-          name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}'
+          name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.release-run-attempt }}'
           path: '${{ github.workspace }}/tmp/validated-pr-snapshot'
-      - name: Verify validated artifact identity and write predicate
+      - id: handoff
+        name: Verify validated artifact identity and write predicate
         env:
           HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
           MANIFEST_DIGEST: ${{ needs.validate-pr-snapshot.outputs.manifest-digest }}
@@ -573,6 +580,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)" = "$MANIFEST_DIGEST"
+          echo "promotion-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
           jq -n   --arg repository "$GITHUB_REPOSITORY"   --argjson prNumber "$PR_NUMBER"   --arg headSha "$HEAD_SHA"   --argjson sourceRunId "$SOURCE_RUN_ID"   --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT"   --arg manifestSha256 "$MANIFEST_DIGEST"   --arg topologySha256 "$TOPOLOGY_DIGEST"   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}'   > "$RUNNER_TEMP/pr-snapshot-attestation.json"
       - name: Attest validated snapshot candidate
         uses: actions/attest@v4
@@ -585,7 +593,7 @@ jobs:
       - name: Upload attested promotion artifact
         uses: actions/upload-artifact@v4
         with:
-          name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}'
+          name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ steps.handoff.outputs.promotion-attempt }}'
           path: '${{ github.workspace }}/tmp/validated-pr-snapshot/'
           if-no-files-found: error
           retention-days: 1
@@ -649,7 +657,7 @@ jobs:
       - name: Download validated promotion artifact
         uses: actions/download-artifact@v4
         with:
-          name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}'
+          name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.attest-pr-snapshot.outputs.promotion-attempt }}'
           path: '${{ github.workspace }}/tmp/validated-pr-snapshot'
       - name: Recheck unchanged-head approval before OIDC publication
         env:
@@ -708,7 +716,6 @@ jobs:
                 exit 1
               fi
               echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
-              npm dist-tag add "$package_name@$SNAPSHOT_VERSION" "$SNAPSHOT_TAG" --registry=https://registry.npmjs.org
               continue
             fi
             npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      pull-requests: read
     outputs:
       head-sha: ${{ steps.identity.outputs.head-sha }}
       manifest-digest: ${{ steps.validate.outputs.manifest-digest }}
@@ -505,7 +506,7 @@ jobs:
       - name: Download exact-run snapshot candidate
         uses: actions/download-artifact@v4
         with:
-          name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}'
+          name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-attempt }}'
           path: '${{ github.workspace }}/tmp/pr-snapshot-artifact'
           github-token: ${{ github.token }}
           run-id: ${{ steps.identity.outputs.run-id }}
@@ -593,6 +594,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       authorized: ${{ steps.approval.outputs.authorized }}
     defaults:
@@ -623,12 +625,13 @@ jobs:
     needs: [validate-pr-snapshot, attest-pr-snapshot, authorize-pr-snapshot]
     runs-on: ubuntu-24.04
     concurrency:
-      group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.pr-number }}'
+      group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}'
       cancel-in-progress: false
     permissions:
       actions: read
       contents: read
       id-token: write
+      pull-requests: read
     env:
       ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot'
       CACHIX_AUTH_TOKEN: ''
@@ -661,6 +664,8 @@ jobs:
           review_decision=$(gh api graphql   -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'   -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"   --jq '.data.repository.pullRequest.reviewDecision')
           test "$(jq -r '.state' <<<"$pr_json")" = open
           test "$(jq -r '.draft' <<<"$pr_json")" = false
+          test "$(jq -r '.base.ref' <<<"$pr_json")" = main
+          test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
           test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
           test "$review_decision" = APPROVED
           jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
@@ -703,6 +708,7 @@ jobs:
                 exit 1
               fi
               echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
+              npm dist-tag add "$package_name@$SNAPSHOT_VERSION" "$SNAPSHOT_TAG" --registry=https://registry.npmjs.org
               continue
             fi
             npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,27 @@ on:
         required: true
         default: latest
         type: string
+      pr_number:
+        description: PR number selector for trusted snapshot promotion
+        required: false
+        default: '0'
+        type: string
+      head_sha:
+        description: Expected PR head selector for trusted snapshot promotion
+        required: false
+        default: ''
+        type: string
       mode:
         description: Release workflow mode
         required: true
         default: create-release-pr
         type: choice
-        options: [create-release-pr, validate-release-plan, publish-release, publish-snapshot]
+        options: [create-release-pr, validate-release-plan, publish-release, publish-snapshot, promote-pr-snapshot]
   workflow_run:
     workflows: [ci]
     types: [completed]
-  pull_request_review:
-    types: [submitted]
+  schedule:
+    - cron: '*/5 * * * *'
   pull_request:
     paths:
       - .github/workflows/release.yml
@@ -422,9 +432,52 @@ jobs:
           process.exit(1)
           NODE
         shell: bash
-    if: github.event_name != 'pull_request_review'
+    if: github.event_name != 'schedule'
+  dispatch-approved-pr-snapshots:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout trusted package topology
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/src/generated/release-topology.json
+      - name: Dispatch incomplete approved cohorts to trusted main workflow
+        run: |
+          set -euo pipefail
+          test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
+          prs_json=$(gh api graphql   -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number isDraft reviewDecision baseRefName headRefOid headRepository{nameWithOwner}}}}}'   -f owner="${GITHUB_REPOSITORY%%/*}"   -f name="${GITHUB_REPOSITORY#*/}")
+
+          jq -r --arg repository "$GITHUB_REPOSITORY"   '.data.repository.pullRequests.nodes[] | select(.isDraft == false and .reviewDecision == "APPROVED" and .baseRefName == "main" and .headRepository.nameWithOwner == $repository) | [.number, .headRefOid] | @tsv'   <<<"$prs_json" |
+          while IFS=$'	' read -r pr_number head_sha; do
+            [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+            [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+            version="0.0.0-snapshot-pr.$pr_number.$head_sha"
+            complete=true
+            while IFS= read -r package_name; do
+              if ! npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+                complete=false
+                break
+              fi
+            done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
+            if [ "$complete" = true ]; then
+              echo "PR #$pr_number snapshot cohort is already complete"
+              continue
+            fi
+            gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main     -f mode=promote-pr-snapshot     -f npm_tag=latest     -f pr_number="$pr_number"     -f head_sha="$head_sha"
+          done
   validate-pr-snapshot:
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')
     runs-on: ubuntu-24.04
     permissions:
       actions: read
@@ -465,8 +518,9 @@ jobs:
             test "$(jq 'length' <<<"$prs_json")" = 1
             pr_number=$(jq -r '.[0].number' <<<"$prs_json")
           else
-            pr_number='${{ github.event.pull_request.number }}'
-            head_sha='${{ github.event.pull_request.head.sha }}'
+            test "$GITHUB_EVENT_NAME" = workflow_dispatch
+            pr_number='${{ inputs.pr_number }}'
+            head_sha='${{ inputs.head_sha }}'
             runs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$head_sha&per_page=100")
             run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
             test "$run_json" != null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,10 +428,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: read
-      attestations: write
-      artifact-metadata: write
       contents: read
-      id-token: write
     outputs:
       head-sha: ${{ steps.identity.outputs.head-sha }}
       manifest-digest: ${{ steps.validate.outputs.manifest-digest }}
@@ -456,6 +453,8 @@ jobs:
         name: Resolve exact successful CI run and current PR head
         run: |
           set -euo pipefail
+          test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
+          [[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
           if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
             run_id='${{ github.event.workflow_run.id }}'
             run_attempt='${{ github.event.workflow_run.run_attempt }}'
@@ -494,7 +493,7 @@ jobs:
       - name: Checkout trusted validator only
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
           sparse-checkout: |
             .github/scripts/pr-snapshot-artifact.mjs
@@ -534,15 +533,46 @@ jobs:
           echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
           echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
           cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"
-      - name: Write trusted snapshot attestation predicate
+      - name: Upload validated snapshot candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}'
+          path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/'
+          if-no-files-found: error
+          retention-days: 1
+  attest-pr-snapshot:
+    needs: [validate-pr-snapshot]
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      attestations: write
+      artifact-metadata: write
+      contents: read
+      id-token: write
+    env:
+      ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot'
+      CACHIX_AUTH_TOKEN: ''
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Download validated snapshot candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}'
+          path: '${{ github.workspace }}/tmp/validated-pr-snapshot'
+      - name: Verify validated artifact identity and write predicate
         env:
-          HEAD_SHA: ${{ steps.identity.outputs.head-sha }}
-          MANIFEST_DIGEST: ${{ steps.validate.outputs.manifest-digest }}
-          PR_NUMBER: ${{ steps.identity.outputs.pr-number }}
-          SOURCE_RUN_ATTEMPT: ${{ steps.identity.outputs.run-attempt }}
-          SOURCE_RUN_ID: ${{ steps.identity.outputs.run-id }}
-          TOPOLOGY_DIGEST: ${{ steps.validate.outputs.topology-digest }}
-        run: jq -n   --arg repository "$GITHUB_REPOSITORY"   --argjson prNumber "$PR_NUMBER"   --arg headSha "$HEAD_SHA"   --argjson sourceRunId "$SOURCE_RUN_ID"   --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT"   --arg manifestSha256 "$MANIFEST_DIGEST"   --arg topologySha256 "$TOPOLOGY_DIGEST"   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}'   > "$RUNNER_TEMP/pr-snapshot-attestation.json"
+          HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
+          MANIFEST_DIGEST: ${{ needs.validate-pr-snapshot.outputs.manifest-digest }}
+          PR_NUMBER: ${{ needs.validate-pr-snapshot.outputs.pr-number }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.validate-pr-snapshot.outputs.run-attempt }}
+          SOURCE_RUN_ID: ${{ needs.validate-pr-snapshot.outputs.run-id }}
+          TOPOLOGY_DIGEST: ${{ needs.validate-pr-snapshot.outputs.topology-digest }}
+        run: |
+          set -euo pipefail
+          test "$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)" = "$MANIFEST_DIGEST"
+          jq -n   --arg repository "$GITHUB_REPOSITORY"   --argjson prNumber "$PR_NUMBER"   --arg headSha "$HEAD_SHA"   --argjson sourceRunId "$SOURCE_RUN_ID"   --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT"   --arg manifestSha256 "$MANIFEST_DIGEST"   --arg topologySha256 "$TOPOLOGY_DIGEST"   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}'   > "$RUNNER_TEMP/pr-snapshot-attestation.json"
       - name: Attest validated snapshot candidate
         uses: actions/attest@v4
         with:
@@ -551,11 +581,11 @@ jobs:
             ${{ env.ARTIFACT_DIR }}/manifest.json
           predicate-type: 'https://livestore.dev/attestations/pr-snapshot-candidate/v1'
           predicate-path: '${{ runner.temp }}/pr-snapshot-attestation.json'
-      - name: Upload validated promotion artifact
+      - name: Upload attested promotion artifact
         uses: actions/upload-artifact@v4
         with:
-          name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}'
-          path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/'
+          name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}'
+          path: '${{ github.workspace }}/tmp/validated-pr-snapshot/'
           if-no-files-found: error
           retention-days: 1
   authorize-pr-snapshot:
@@ -579,15 +609,18 @@ jobs:
           set -euo pipefail
           pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
           reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+          owner="${GITHUB_REPOSITORY%%/*}"
+          name="${GITHUB_REPOSITORY#*/}"
+          review_decision=$(gh api graphql   -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'   -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"   --jq '.data.repository.pullRequest.reviewDecision')
           authorized=false
-          if [ "$(jq -r '.state' <<<"$pr_json")" = open ] &&    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] &&    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] &&    [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] &&    [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] &&    jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
+          if [ "$(jq -r '.state' <<<"$pr_json")" = open ] &&    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] &&    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] &&    [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] &&    [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] &&    [ "$review_decision" = APPROVED ] &&    jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
             authorized=true
           fi
           echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
           echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"
   publish-pr-snapshot:
     if: needs.authorize-pr-snapshot.outputs.authorized == 'true'
-    needs: [validate-pr-snapshot, authorize-pr-snapshot]
+    needs: [validate-pr-snapshot, attest-pr-snapshot, authorize-pr-snapshot]
     runs-on: ubuntu-24.04
     concurrency:
       group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.pr-number }}'
@@ -613,7 +646,7 @@ jobs:
       - name: Download validated promotion artifact
         uses: actions/download-artifact@v4
         with:
-          name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}'
+          name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}'
           path: '${{ github.workspace }}/tmp/validated-pr-snapshot'
       - name: Recheck unchanged-head approval before OIDC publication
         env:
@@ -623,9 +656,13 @@ jobs:
           set -euo pipefail
           pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
           reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+          owner="${GITHUB_REPOSITORY%%/*}"
+          name="${GITHUB_REPOSITORY#*/}"
+          review_decision=$(gh api graphql   -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'   -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"   --jq '.data.repository.pullRequest.reviewDecision')
           test "$(jq -r '.state' <<<"$pr_json")" = open
           test "$(jq -r '.draft' <<<"$pr_json")" = false
           test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
+          test "$review_decision" = APPROVED
           jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
       - name: Verify promotion handoff
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,8 @@ on:
   workflow_run:
     workflows: [ci]
     types: [completed]
-    branches: [main]
+  pull_request_review:
+    types: [submitted]
   pull_request:
     paths:
       - .github/workflows/release.yml
@@ -421,6 +422,276 @@ jobs:
           process.exit(1)
           NODE
         shell: bash
+    if: github.event_name != 'pull_request_review'
+  validate-pr-snapshot:
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      attestations: write
+      artifact-metadata: write
+      contents: read
+      id-token: write
+    outputs:
+      head-sha: ${{ steps.identity.outputs.head-sha }}
+      manifest-digest: ${{ steps.validate.outputs.manifest-digest }}
+      npm-tag: ${{ steps.validate.outputs.npm-tag }}
+      package-count: ${{ steps.validate.outputs.package-count }}
+      pr-number: ${{ steps.identity.outputs.pr-number }}
+      run-attempt: ${{ steps.identity.outputs.run-attempt }}
+      run-id: ${{ steps.identity.outputs.run-id }}
+      source-run-url: ${{ steps.identity.outputs.source-run-url }}
+      topology-digest: ${{ steps.validate.outputs.topology-digest }}
+      version: ${{ steps.validate.outputs.version }}
+    env:
+      ARTIFACT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact'
+      CACHIX_AUTH_TOKEN: ''
+      GH_TOKEN: ${{ github.token }}
+      PUBLISH_LIST: '${{ github.workspace }}/tmp/pr-snapshot-publish-list.tsv'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - id: identity
+        name: Resolve exact successful CI run and current PR head
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
+            run_id='${{ github.event.workflow_run.id }}'
+            run_attempt='${{ github.event.workflow_run.run_attempt }}'
+            head_sha='${{ github.event.workflow_run.head_sha }}'
+            source_run_url='${{ github.event.workflow_run.html_url }}'
+            prs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/pulls")
+            test "$(jq 'length' <<<"$prs_json")" = 1
+            pr_number=$(jq -r '.[0].number' <<<"$prs_json")
+          else
+            pr_number='${{ github.event.pull_request.number }}'
+            head_sha='${{ github.event.pull_request.head.sha }}'
+            runs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$head_sha&per_page=100")
+            run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
+            test "$run_json" != null
+            run_id=$(jq -r '.id' <<<"$run_json")
+            run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
+            source_run_url=$(jq -r '.html_url' <<<"$run_json")
+          fi
+
+          [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
+          pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
+
+          test "$(jq -r '.state' <<<"$pr_json")" = open
+          test "$(jq -r '.base.ref' <<<"$pr_json")" = main
+          test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.head.sha' <<<"$pr_json")" = "$head_sha"
+
+          echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "run-attempt=$run_attempt" >> "$GITHUB_OUTPUT"
+          echo "source-run-url=$source_run_url" >> "$GITHUB_OUTPUT"
+      - name: Checkout trusted validator only
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/pr-snapshot-artifact.mjs
+            scripts/src/generated/release-topology.json
+      - name: Use pinned Node validator runtime
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+      - name: Download exact-run snapshot candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}'
+          path: '${{ github.workspace }}/tmp/pr-snapshot-artifact'
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.identity.outputs.run-id }}
+      - id: validate
+        name: Validate immutable snapshot candidate
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.identity.outputs.head-sha }}
+          EXPECTED_PR_NUMBER: ${{ steps.identity.outputs.pr-number }}
+          EXPECTED_RUN_ID: ${{ steps.identity.outputs.run-id }}
+          EXPECTED_RUN_ATTEMPT: ${{ steps.identity.outputs.run-attempt }}
+        run: |
+          set -euo pipefail
+          result=$(node .github/scripts/pr-snapshot-artifact.mjs validate \
+            --artifact-dir="$ARTIFACT_DIR" \
+            --topology=scripts/src/generated/release-topology.json \
+            --repository="$GITHUB_REPOSITORY" \
+            --pr-number="$EXPECTED_PR_NUMBER" \
+            --head-sha="$EXPECTED_HEAD_SHA" \
+            --run-id="$EXPECTED_RUN_ID" \
+            --run-attempt="$EXPECTED_RUN_ATTEMPT" \
+            --publish-list="$PUBLISH_LIST")
+          echo "version=$(jq -r '.version' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "manifest-digest=$(jq -r '.manifestDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "topology-digest=$(jq -r '.topologyDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
+          cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"
+      - name: Write trusted snapshot attestation predicate
+        env:
+          HEAD_SHA: ${{ steps.identity.outputs.head-sha }}
+          MANIFEST_DIGEST: ${{ steps.validate.outputs.manifest-digest }}
+          PR_NUMBER: ${{ steps.identity.outputs.pr-number }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.identity.outputs.run-attempt }}
+          SOURCE_RUN_ID: ${{ steps.identity.outputs.run-id }}
+          TOPOLOGY_DIGEST: ${{ steps.validate.outputs.topology-digest }}
+        run: jq -n   --arg repository "$GITHUB_REPOSITORY"   --argjson prNumber "$PR_NUMBER"   --arg headSha "$HEAD_SHA"   --argjson sourceRunId "$SOURCE_RUN_ID"   --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT"   --arg manifestSha256 "$MANIFEST_DIGEST"   --arg topologySha256 "$TOPOLOGY_DIGEST"   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}'   > "$RUNNER_TEMP/pr-snapshot-attestation.json"
+      - name: Attest validated snapshot candidate
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            ${{ env.ARTIFACT_DIR }}/*.tgz
+            ${{ env.ARTIFACT_DIR }}/manifest.json
+          predicate-type: 'https://livestore.dev/attestations/pr-snapshot-candidate/v1'
+          predicate-path: '${{ runner.temp }}/pr-snapshot-attestation.json'
+      - name: Upload validated promotion artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}'
+          path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/'
+          if-no-files-found: error
+          retention-days: 1
+  authorize-pr-snapshot:
+    needs: [validate-pr-snapshot]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      authorized: ${{ steps.approval.outputs.authorized }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - id: approval
+        name: Require ordinary approval for the unchanged head
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.validate-pr-snapshot.outputs.pr-number }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+          reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+          authorized=false
+          if [ "$(jq -r '.state' <<<"$pr_json")" = open ] &&    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] &&    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] &&    [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] &&    [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] &&    jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
+            authorized=true
+          fi
+          echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
+          echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"
+  publish-pr-snapshot:
+    if: needs.authorize-pr-snapshot.outputs.authorized == 'true'
+    needs: [validate-pr-snapshot, authorize-pr-snapshot]
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.pr-number }}'
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    env:
+      ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot'
+      CACHIX_AUTH_TOKEN: ''
+      GH_TOKEN: ${{ github.token }}
+      PUBLISH_LIST: '${{ github.workspace }}/tmp/validated-pr-snapshot/trusted-publish-list.tsv'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Use pinned npm trusted-publishing client
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.15.0
+          registry-url: 'https://registry.npmjs.org'
+      - name: Download validated promotion artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}'
+          path: '${{ github.workspace }}/tmp/validated-pr-snapshot'
+      - name: Recheck unchanged-head approval before OIDC publication
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
+          PR_NUMBER: ${{ needs.validate-pr-snapshot.outputs.pr-number }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+          reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+          test "$(jq -r '.state' <<<"$pr_json")" = open
+          test "$(jq -r '.draft' <<<"$pr_json")" = false
+          test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
+          jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
+      - name: Verify promotion handoff
+        env:
+          EXPECTED_MANIFEST_DIGEST: ${{ needs.validate-pr-snapshot.outputs.manifest-digest }}
+        run: |
+          set -euo pipefail
+          test -f "$ARTIFACT_DIR/manifest.json"
+          test -f "$PUBLISH_LIST"
+          actual_manifest_digest=$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)
+          test "$actual_manifest_digest" = "$EXPECTED_MANIFEST_DIGEST"
+          jq -r '.packages[] | [.name, .file] | @tsv' "$ARTIFACT_DIR/manifest.json" > "$RUNNER_TEMP/expected-publish-list.tsv"
+          cmp "$RUNNER_TEMP/expected-publish-list.tsv" "$PUBLISH_LIST"
+          jq -r '.packages[] | [.file, .sha256] | @tsv' "$ARTIFACT_DIR/manifest.json" |
+            while IFS=$'	' read -r file expected_sha256; do
+              [[ "$file" =~ ^[a-zA-Z0-9._-]+[.]tgz$ ]]
+              actual_sha256=$(sha256sum "$ARTIFACT_DIR/$file" | cut -d' ' -f1)
+              test "$actual_sha256" = "$expected_sha256"
+            done
+          if [ -n "${NODE_AUTH_TOKEN:-}" ] || [ -n "${NPM_TOKEN:-}" ]; then
+            echo "PR snapshot publishing must use npm trusted publishing; token auth is not allowed." >&2
+            exit 1
+          fi
+      - name: Publish exact-SHA package cohort
+        env:
+          SNAPSHOT_TAG: ${{ needs.validate-pr-snapshot.outputs.npm-tag }}
+          SNAPSHOT_VERSION: ${{ needs.validate-pr-snapshot.outputs.version }}
+        run: |
+          set -euo pipefail
+          while IFS=$'	' read -r package_name file; do
+            test -n "$package_name"
+            test -n "$file"
+            tarball="$ARTIFACT_DIR/$file"
+            local_sha1=$(sha1sum "$tarball" | cut -d' ' -f1)
+            if remote_sha1=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.shasum --json --registry=https://registry.npmjs.org 2>/dev/null); then
+              remote_sha1=$(jq -r . <<<"$remote_sha1")
+              if [ "$remote_sha1" != "$local_sha1" ]; then
+                echo "$package_name@$SNAPSHOT_VERSION already exists with a different tarball digest" >&2
+                exit 1
+              fi
+              echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
+              continue
+            fi
+            npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance
+          done < "$PUBLISH_LIST"
+      - name: Record snapshot provenance
+        env:
+          SNAPSHOT_VERSION: ${{ needs.validate-pr-snapshot.outputs.version }}
+          MANIFEST_DIGEST: ${{ needs.validate-pr-snapshot.outputs.manifest-digest }}
+          PACKAGE_COUNT: ${{ needs.validate-pr-snapshot.outputs.package-count }}
+          PR_NUMBER: ${{ needs.validate-pr-snapshot.outputs.pr-number }}
+          SNAPSHOT_TAG: ${{ needs.validate-pr-snapshot.outputs.npm-tag }}
+          SOURCE_RUN_URL: ${{ needs.validate-pr-snapshot.outputs.source-run-url }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Repository-owned PR snapshot
+
+          - PR: #$PR_NUMBER
+          - Head: `${{ needs.validate-pr-snapshot.outputs.head-sha }}`
+          - Version: `$SNAPSHOT_VERSION`
+          - Immutable npm tag: `$SNAPSHOT_TAG`
+          - Packages: $PACKAGE_COUNT
+          - Manifest SHA-256: `$MANIFEST_DIGEST`
+          - Source CI run: $SOURCE_RUN_URL
+          - Candidate attestation: binds the validated package and manifest digests to the exact PR head and source CI run.
+          - npm provenance: identifies this trusted default-branch promotion workflow; it does not claim that the PR CI job held npm publishing authority.
+          EOF
   create-release-pr:
     if: github.event_name == 'workflow_dispatch' && inputs.mode == 'create-release-pr'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,10 +477,10 @@ jobs:
           [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
           [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
-          jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=latest&per_page=100" --slurp)
-          pack_jobs=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")]' <<<"$jobs_json")
-          test "$(jq 'length' <<<"$pack_jobs")" = 1
-          run_attempt=$(jq -r '.[0].run_attempt' <<<"$pack_jobs")
+          jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" --slurp)
+          pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+          test "$pack_job" != null
+          run_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
           [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
           pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
 

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -73,6 +73,12 @@ export default githubWorkflow({
           default: '',
           type: 'string',
         },
+        ci_run_id: {
+          description: 'Exact successful PR CI run selector for trusted snapshot promotion',
+          required: false,
+          default: '0',
+          type: 'string',
+        },
         mode: {
           description: 'Release workflow mode',
           required: true,
@@ -142,21 +148,30 @@ export default githubWorkflow({
           name: 'Dispatch incomplete approved cohorts to trusted main workflow',
           run: `set -euo pipefail
 test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
-prs_json=$(gh api graphql \
-  -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number isDraft reviewDecision baseRefName headRefOid headRepository{nameWithOwner}}}}}' \
-  -f owner="\${GITHUB_REPOSITORY%%/*}" \
-  -f name="\${GITHUB_REPOSITORY#*/}")
-
+prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
 jq -r --arg repository "$GITHUB_REPOSITORY" \
-  '.data.repository.pullRequests.nodes[] | select(.isDraft == false and .reviewDecision == "APPROVED" and .baseRefName == "main" and .headRepository.nameWithOwner == $repository) | [.number, .headRefOid] | @tsv' \
+  '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv' \
   <<<"$prs_json" |
-while IFS=$'\t' read -r pr_number head_sha; do
+while IFS=$'\t' read -r pr_number head_sha head_ref; do
   [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
   [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+  test -n "$head_ref"
+  review_json=$(gh api graphql \
+    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+    -f owner="\${GITHUB_REPOSITORY%%/*}" \
+    -f name="\${GITHUB_REPOSITORY#*/}" \
+    -F number="$pr_number")
+  if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+    continue
+  fi
+
   version="0.0.0-snapshot-pr.$pr_number.$head_sha"
+  snapshot_tag="pr-$pr_number-$head_sha"
   complete=true
   while IFS= read -r package_name; do
-    if ! npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+    remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
+    if [ "$remote_version" != "$version" ] || [ "$remote_tag" != "$version" ]; then
       complete=false
       break
     fi
@@ -165,11 +180,43 @@ while IFS=$'\t' read -r pr_number head_sha; do
     echo "PR #$pr_number snapshot cohort is already complete"
     continue
   fi
+
+  selected_run_id=''
+  runs_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
+    -f event=pull_request \
+    -f status=success \
+    -f branch="$head_ref" \
+    -F per_page=100 \
+    --slurp)
+  while IFS= read -r candidate_run_id; do
+    [[ "$candidate_run_id" =~ ^[1-9][0-9]*$ ]]
+    jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/jobs?filter=all&per_page=100" --slurp)
+    pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+    if [ "$pack_job" = null ]; then
+      continue
+    fi
+    pack_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
+    [[ "$pack_attempt" =~ ^[1-9][0-9]*$ ]]
+    artifact_name="pr-snapshot-$head_sha-$pack_attempt"
+    artifacts_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$candidate_run_id/artifacts?per_page=100" --slurp)
+    if ! jq -e --arg name "$artifact_name" 'any(.[] | .artifacts[]; .name == $name and .expired == false)' <<<"$artifacts_json" >/dev/null; then
+      continue
+    fi
+    selected_run_id="$candidate_run_id"
+    break
+  done < <(jq -r --arg sha "$head_sha" --argjson pr_number "$pr_number" \
+    '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == env.GITHUB_REPOSITORY and any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha))] | sort_by(.created_at) | reverse | .[].id' \
+    <<<"$runs_json")
+  if [ -z "$selected_run_id" ]; then
+    echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
+    continue
+  fi
   gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main \
     -f mode=promote-pr-snapshot \
     -f npm_tag=latest \
     -f pr_number="$pr_number" \
-    -f head_sha="$head_sha"
+    -f head_sha="$head_sha" \
+    -f ci_run_id="$selected_run_id"
 done`,
         },
       ],
@@ -211,25 +258,31 @@ test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@
 [[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
 if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
   run_id='\${{ github.event.workflow_run.id }}'
-  head_sha='\${{ github.event.workflow_run.head_sha }}'
-  source_run_url='\${{ github.event.workflow_run.html_url }}'
-  prs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/pulls")
-  test "$(jq 'length' <<<"$prs_json")" = 1
-  pr_number=$(jq -r '.[0].number' <<<"$prs_json")
 else
   test "$GITHUB_EVENT_NAME" = workflow_dispatch
   pr_number='\${{ inputs.pr_number }}'
   head_sha='\${{ inputs.head_sha }}'
-  runs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$head_sha&per_page=100")
-  run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
-  test "$run_json" != null
-  run_id=$(jq -r '.id' <<<"$run_json")
-  source_run_url=$(jq -r '.html_url' <<<"$run_json")
+  run_id='\${{ inputs.ci_run_id }}'
 fi
 
+[[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+run_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+test "$(jq -r '.event' <<<"$run_json")" = pull_request
+test "$(jq -r '.status' <<<"$run_json")" = completed
+test "$(jq -r '.conclusion' <<<"$run_json")" = success
+test "$(jq -r '.head_repository.full_name' <<<"$run_json")" = "$GITHUB_REPOSITORY"
+test "$(jq -r '.path' <<<"$run_json")" = .github/workflows/ci.yml
+if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
+  test "$(jq '.pull_requests | length' <<<"$run_json")" = 1
+  pr_number=$(jq -r '.pull_requests[0].number' <<<"$run_json")
+  head_sha=$(jq -r '.pull_requests[0].head.sha' <<<"$run_json")
+else
+  jq -e --arg sha "$head_sha" --argjson pr_number "$pr_number" \
+    'any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha)' <<<"$run_json" >/dev/null
+fi
 [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
 [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-[[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+source_run_url=$(jq -r '.html_url' <<<"$run_json")
 jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" --slurp)
 pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
 test "$pack_job" != null
@@ -529,6 +582,39 @@ while IFS=$'\t' read -r package_name file; do
   fi
   npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance
 done < "$PUBLISH_LIST"`,
+        },
+        {
+          name: 'Verify complete immutable registry cohort',
+          env: {
+            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+          },
+          run: `set -euo pipefail
+verified=0
+while IFS=$'\t' read -r package_name file; do
+  tarball="$ARTIFACT_DIR/$file"
+  local_integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 -w0)"
+  matched=false
+  for attempt in $(seq 1 12); do
+    remote_version=$(npm view "$package_name@$SNAPSHOT_VERSION" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_integrity=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.integrity --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+    if [ "$remote_version" = "$SNAPSHOT_VERSION" ] && \
+       [ "$remote_integrity" = "$local_integrity" ] && \
+       [ "$remote_tag" = "$SNAPSHOT_VERSION" ]; then
+      matched=true
+      break
+    fi
+    sleep 5
+  done
+  if [ "$matched" != true ]; then
+    echo "Registry verification failed for $package_name@$SNAPSHOT_VERSION" >&2
+    exit 1
+  fi
+  verified=$((verified + 1))
+done < "$PUBLISH_LIST"
+test "$verified" = '\${{ needs.validate-pr-snapshot.outputs.package-count }}'
+echo "Verified $verified package versions, immutable tags, and SHA-512 integrities." >> "$GITHUB_STEP_SUMMARY"`,
         },
         {
           name: 'Record snapshot provenance',

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -108,6 +108,7 @@ export default githubWorkflow({
       permissions: {
         actions: 'read',
         contents: 'read',
+        'pull-requests': 'read',
       },
       outputs: {
         'head-sha': '${{ steps.identity.outputs.head-sha }}',
@@ -192,7 +193,7 @@ scripts/src/generated/release-topology.json`,
           name: 'Download exact-run snapshot candidate',
           uses: 'actions/download-artifact@v4',
           with: {
-            name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}',
+            name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-attempt }}',
             path: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
             'github-token': '${{ github.token }}',
             'run-id': '${{ steps.identity.outputs.run-id }}',
@@ -307,7 +308,7 @@ jq -n \
     'authorize-pr-snapshot': {
       needs: ['validate-pr-snapshot'],
       'runs-on': 'ubuntu-24.04',
-      permissions: { contents: 'read' },
+      permissions: { contents: 'read', 'pull-requests': 'read' },
       outputs: { authorized: '${{ steps.approval.outputs.authorized }}' },
       defaults: bashShellDefaults,
       steps: [
@@ -348,13 +349,14 @@ echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
       needs: ['validate-pr-snapshot', 'attest-pr-snapshot', 'authorize-pr-snapshot'],
       'runs-on': 'ubuntu-24.04',
       concurrency: {
-        group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+        group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}',
         'cancel-in-progress': false,
       },
       permissions: {
         actions: 'read',
         contents: 'read',
         'id-token': 'write',
+        'pull-requests': 'read',
       },
       env: {
         ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
@@ -397,6 +399,8 @@ review_decision=$(gh api graphql \
   --jq '.data.repository.pullRequest.reviewDecision')
 test "$(jq -r '.state' <<<"$pr_json")" = open
 test "$(jq -r '.draft' <<<"$pr_json")" = false
+test "$(jq -r '.base.ref' <<<"$pr_json")" = main
+test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
 test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
 test "$review_decision" = APPROVED
 jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null`,
@@ -441,6 +445,7 @@ while IFS=$'\t' read -r package_name file; do
       exit 1
     fi
     echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
+    npm dist-tag add "$package_name@$SNAPSHOT_VERSION" "$SNAPSHOT_TAG" --registry=https://registry.npmjs.org
     continue
   fi
   npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -107,10 +107,7 @@ export default githubWorkflow({
       'runs-on': 'ubuntu-24.04',
       permissions: {
         actions: 'read',
-        attestations: 'write',
-        'artifact-metadata': 'write',
         contents: 'read',
-        'id-token': 'write',
       },
       outputs: {
         'head-sha': '${{ steps.identity.outputs.head-sha }}',
@@ -136,6 +133,8 @@ export default githubWorkflow({
           id: 'identity',
           name: 'Resolve exact successful CI run and current PR head',
           run: `set -euo pipefail
+test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
+[[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
 if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
   run_id='\${{ github.event.workflow_run.id }}'
   run_attempt='\${{ github.event.workflow_run.run_attempt }}'
@@ -176,7 +175,7 @@ echo "source-run-url=$source_run_url" >> "$GITHUB_OUTPUT"`,
           name: 'Checkout trusted validator only',
           uses: 'actions/checkout@v4',
           with: {
-            ref: '${{ github.sha }}',
+            ref: '${{ github.workflow_sha }}',
             'persist-credentials': false,
             'sparse-checkout': `.github/scripts/pr-snapshot-artifact.mjs
 scripts/src/generated/release-topology.json`,
@@ -226,16 +225,54 @@ echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
 cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
         },
         {
-          name: 'Write trusted snapshot attestation predicate',
-          env: {
-            HEAD_SHA: '${{ steps.identity.outputs.head-sha }}',
-            MANIFEST_DIGEST: '${{ steps.validate.outputs.manifest-digest }}',
-            PR_NUMBER: '${{ steps.identity.outputs.pr-number }}',
-            SOURCE_RUN_ATTEMPT: '${{ steps.identity.outputs.run-attempt }}',
-            SOURCE_RUN_ID: '${{ steps.identity.outputs.run-id }}',
-            TOPOLOGY_DIGEST: '${{ steps.validate.outputs.topology-digest }}',
+          name: 'Upload validated snapshot candidate',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+            'if-no-files-found': 'error',
+            'retention-days': 1,
           },
-          run: `jq -n \
+        },
+      ],
+    },
+    'attest-pr-snapshot': {
+      needs: ['validate-pr-snapshot'],
+      'runs-on': 'ubuntu-24.04',
+      permissions: {
+        actions: 'read',
+        attestations: 'write',
+        'artifact-metadata': 'write',
+        contents: 'read',
+        'id-token': 'write',
+      },
+      env: {
+        ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+        CACHIX_AUTH_TOKEN: '',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Download validated snapshot candidate',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+          },
+        },
+        {
+          name: 'Verify validated artifact identity and write predicate',
+          env: {
+            HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+            SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            TOPOLOGY_DIGEST: '${{ needs.validate-pr-snapshot.outputs.topology-digest }}',
+          },
+          run: `set -euo pipefail
+test "$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)" = "$MANIFEST_DIGEST"
+jq -n \
   --arg repository "$GITHUB_REPOSITORY" \
   --argjson prNumber "$PR_NUMBER" \
   --arg headSha "$HEAD_SHA" \
@@ -256,11 +293,11 @@ cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
           },
         },
         {
-          name: 'Upload validated promotion artifact',
+          name: 'Upload attested promotion artifact',
           uses: 'actions/upload-artifact@v4',
           with: {
-            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}',
-            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}',
+            path: '${{ github.workspace }}/tmp/validated-pr-snapshot/',
             'if-no-files-found': 'error',
             'retention-days': 1,
           },
@@ -285,12 +322,19 @@ cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
           run: `set -euo pipefail
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
 reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+owner="\${GITHUB_REPOSITORY%%/*}"
+name="\${GITHUB_REPOSITORY#*/}"
+review_decision=$(gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+  -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewDecision')
 authorized=false
 if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] && \
    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] && \
    [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] && \
    [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] && \
+   [ "$review_decision" = APPROVED ] && \
    jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
   authorized=true
 fi
@@ -301,7 +345,7 @@ echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
     },
     'publish-pr-snapshot': {
       if: "needs.authorize-pr-snapshot.outputs.authorized == 'true'",
-      needs: ['validate-pr-snapshot', 'authorize-pr-snapshot'],
+      needs: ['validate-pr-snapshot', 'attest-pr-snapshot', 'authorize-pr-snapshot'],
       'runs-on': 'ubuntu-24.04',
       concurrency: {
         group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.pr-number }}',
@@ -332,7 +376,7 @@ echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
           name: 'Download validated promotion artifact',
           uses: 'actions/download-artifact@v4',
           with: {
-            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}',
             path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
           },
         },
@@ -345,9 +389,16 @@ echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
           run: `set -euo pipefail
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
 reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+owner="\${GITHUB_REPOSITORY%%/*}"
+name="\${GITHUB_REPOSITORY#*/}"
+review_decision=$(gh api graphql \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+  -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewDecision')
 test "$(jq -r '.state' <<<"$pr_json")" = open
 test "$(jq -r '.draft' <<<"$pr_json")" = false
 test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
+test "$review_decision" = APPROVED
 jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null`,
         },
         {

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -73,7 +73,9 @@ export default githubWorkflow({
     workflow_run: {
       workflows: ['ci'],
       types: ['completed'],
-      branches: ['main'],
+    },
+    pull_request_review: {
+      types: ['submitted'],
     },
     pull_request: {
       paths: releasePlanPaths,
@@ -96,7 +98,329 @@ export default githubWorkflow({
   },
 
   jobs: {
-    'source-policy': livestoreDefaultRefPolicyJob,
+    'source-policy': {
+      ...livestoreDefaultRefPolicyJob,
+      if: "github.event_name != 'pull_request_review'",
+    },
+    'validate-pr-snapshot': {
+      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.head.repo.full_name == github.repository)",
+      'runs-on': 'ubuntu-24.04',
+      permissions: {
+        actions: 'read',
+        attestations: 'write',
+        'artifact-metadata': 'write',
+        contents: 'read',
+        'id-token': 'write',
+      },
+      outputs: {
+        'head-sha': '${{ steps.identity.outputs.head-sha }}',
+        'manifest-digest': '${{ steps.validate.outputs.manifest-digest }}',
+        'npm-tag': '${{ steps.validate.outputs.npm-tag }}',
+        'package-count': '${{ steps.validate.outputs.package-count }}',
+        'pr-number': '${{ steps.identity.outputs.pr-number }}',
+        'run-attempt': '${{ steps.identity.outputs.run-attempt }}',
+        'run-id': '${{ steps.identity.outputs.run-id }}',
+        'source-run-url': '${{ steps.identity.outputs.source-run-url }}',
+        'topology-digest': '${{ steps.validate.outputs.topology-digest }}',
+        version: '${{ steps.validate.outputs.version }}',
+      },
+      env: {
+        ARTIFACT_DIR: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+        CACHIX_AUTH_TOKEN: '',
+        GH_TOKEN: '${{ github.token }}',
+        PUBLISH_LIST: '${{ github.workspace }}/tmp/pr-snapshot-publish-list.tsv',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          id: 'identity',
+          name: 'Resolve exact successful CI run and current PR head',
+          run: `set -euo pipefail
+if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
+  run_id='\${{ github.event.workflow_run.id }}'
+  run_attempt='\${{ github.event.workflow_run.run_attempt }}'
+  head_sha='\${{ github.event.workflow_run.head_sha }}'
+  source_run_url='\${{ github.event.workflow_run.html_url }}'
+  prs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/pulls")
+  test "$(jq 'length' <<<"$prs_json")" = 1
+  pr_number=$(jq -r '.[0].number' <<<"$prs_json")
+else
+  pr_number='\${{ github.event.pull_request.number }}'
+  head_sha='\${{ github.event.pull_request.head.sha }}'
+  runs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$head_sha&per_page=100")
+  run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
+  test "$run_json" != null
+  run_id=$(jq -r '.id' <<<"$run_json")
+  run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
+  source_run_url=$(jq -r '.html_url' <<<"$run_json")
+fi
+
+[[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+[[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+[[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
+pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
+
+test "$(jq -r '.state' <<<"$pr_json")" = open
+test "$(jq -r '.base.ref' <<<"$pr_json")" = main
+test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
+test "$(jq -r '.head.sha' <<<"$pr_json")" = "$head_sha"
+
+echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
+echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
+echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+echo "run-attempt=$run_attempt" >> "$GITHUB_OUTPUT"
+echo "source-run-url=$source_run_url" >> "$GITHUB_OUTPUT"`,
+        },
+        {
+          name: 'Checkout trusted validator only',
+          uses: 'actions/checkout@v4',
+          with: {
+            ref: '${{ github.sha }}',
+            'persist-credentials': false,
+            'sparse-checkout': `.github/scripts/pr-snapshot-artifact.mjs
+scripts/src/generated/release-topology.json`,
+          },
+        },
+        {
+          name: 'Use pinned Node validator runtime',
+          uses: 'actions/setup-node@v4',
+          with: {
+            'node-version': '24.15.0',
+          },
+        },
+        {
+          name: 'Download exact-run snapshot candidate',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'pr-snapshot-${{ steps.identity.outputs.head-sha }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact',
+            'github-token': '${{ github.token }}',
+            'run-id': '${{ steps.identity.outputs.run-id }}',
+          },
+        },
+        {
+          id: 'validate',
+          name: 'Validate immutable snapshot candidate',
+          env: {
+            EXPECTED_HEAD_SHA: '${{ steps.identity.outputs.head-sha }}',
+            EXPECTED_PR_NUMBER: '${{ steps.identity.outputs.pr-number }}',
+            EXPECTED_RUN_ID: '${{ steps.identity.outputs.run-id }}',
+            EXPECTED_RUN_ATTEMPT: '${{ steps.identity.outputs.run-attempt }}',
+          },
+          run: `set -euo pipefail
+result=$(node .github/scripts/pr-snapshot-artifact.mjs validate \\
+  --artifact-dir="$ARTIFACT_DIR" \\
+  --topology=scripts/src/generated/release-topology.json \\
+  --repository="$GITHUB_REPOSITORY" \\
+  --pr-number="$EXPECTED_PR_NUMBER" \\
+  --head-sha="$EXPECTED_HEAD_SHA" \\
+  --run-id="$EXPECTED_RUN_ID" \\
+  --run-attempt="$EXPECTED_RUN_ATTEMPT" \\
+  --publish-list="$PUBLISH_LIST")
+echo "version=$(jq -r '.version' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "manifest-digest=$(jq -r '.manifestDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "topology-digest=$(jq -r '.topologyDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
+cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
+        },
+        {
+          name: 'Write trusted snapshot attestation predicate',
+          env: {
+            HEAD_SHA: '${{ steps.identity.outputs.head-sha }}',
+            MANIFEST_DIGEST: '${{ steps.validate.outputs.manifest-digest }}',
+            PR_NUMBER: '${{ steps.identity.outputs.pr-number }}',
+            SOURCE_RUN_ATTEMPT: '${{ steps.identity.outputs.run-attempt }}',
+            SOURCE_RUN_ID: '${{ steps.identity.outputs.run-id }}',
+            TOPOLOGY_DIGEST: '${{ steps.validate.outputs.topology-digest }}',
+          },
+          run: `jq -n \
+  --arg repository "$GITHUB_REPOSITORY" \
+  --argjson prNumber "$PR_NUMBER" \
+  --arg headSha "$HEAD_SHA" \
+  --argjson sourceRunId "$SOURCE_RUN_ID" \
+  --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT" \
+  --arg manifestSha256 "$MANIFEST_DIGEST" \
+  --arg topologySha256 "$TOPOLOGY_DIGEST" \
+  '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, manifestSha256, topologySha256}' \
+  > "$RUNNER_TEMP/pr-snapshot-attestation.json"`,
+        },
+        {
+          name: 'Attest validated snapshot candidate',
+          uses: 'actions/attest@v4',
+          with: {
+            'subject-path': ['${{ env.ARTIFACT_DIR }}/*.tgz', '${{ env.ARTIFACT_DIR }}/manifest.json'].join('\n'),
+            'predicate-type': 'https://livestore.dev/attestations/pr-snapshot-candidate/v1',
+            'predicate-path': '${{ runner.temp }}/pr-snapshot-attestation.json',
+          },
+        },
+        {
+          name: 'Upload validated promotion artifact',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}',
+            path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
+            'if-no-files-found': 'error',
+            'retention-days': 1,
+          },
+        },
+      ],
+    },
+    'authorize-pr-snapshot': {
+      needs: ['validate-pr-snapshot'],
+      'runs-on': 'ubuntu-24.04',
+      permissions: { contents: 'read' },
+      outputs: { authorized: '${{ steps.approval.outputs.authorized }}' },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          id: 'approval',
+          name: 'Require ordinary approval for the unchanged head',
+          env: {
+            EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            GH_TOKEN: '${{ github.token }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+          },
+          run: `set -euo pipefail
+pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+authorized=false
+if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
+   [ "$(jq -r '.draft' <<<"$pr_json")" = false ] && \
+   [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] && \
+   [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] && \
+   [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] && \
+   jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
+  authorized=true
+fi
+echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
+echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
+        },
+      ],
+    },
+    'publish-pr-snapshot': {
+      if: "needs.authorize-pr-snapshot.outputs.authorized == 'true'",
+      needs: ['validate-pr-snapshot', 'authorize-pr-snapshot'],
+      'runs-on': 'ubuntu-24.04',
+      concurrency: {
+        group: 'pr-snapshot-${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+        'cancel-in-progress': false,
+      },
+      permissions: {
+        actions: 'read',
+        contents: 'read',
+        'id-token': 'write',
+      },
+      env: {
+        ARTIFACT_DIR: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+        CACHIX_AUTH_TOKEN: '',
+        GH_TOKEN: '${{ github.token }}',
+        PUBLISH_LIST: '${{ github.workspace }}/tmp/validated-pr-snapshot/trusted-publish-list.tsv',
+      },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Use pinned npm trusted-publishing client',
+          uses: 'actions/setup-node@v4',
+          with: {
+            'node-version': '24.15.0',
+            'registry-url': 'https://registry.npmjs.org',
+          },
+        },
+        {
+          name: 'Download validated promotion artifact',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
+          },
+        },
+        {
+          name: 'Recheck unchanged-head approval before OIDC publication',
+          env: {
+            EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+          },
+          run: `set -euo pipefail
+pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+test "$(jq -r '.state' <<<"$pr_json")" = open
+test "$(jq -r '.draft' <<<"$pr_json")" = false
+test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
+jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null`,
+        },
+        {
+          name: 'Verify promotion handoff',
+          env: { EXPECTED_MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}' },
+          run: `set -euo pipefail
+test -f "$ARTIFACT_DIR/manifest.json"
+test -f "$PUBLISH_LIST"
+actual_manifest_digest=$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)
+test "$actual_manifest_digest" = "$EXPECTED_MANIFEST_DIGEST"
+jq -r '.packages[] | [.name, .file] | @tsv' "$ARTIFACT_DIR/manifest.json" > "$RUNNER_TEMP/expected-publish-list.tsv"
+cmp "$RUNNER_TEMP/expected-publish-list.tsv" "$PUBLISH_LIST"
+jq -r '.packages[] | [.file, .sha256] | @tsv' "$ARTIFACT_DIR/manifest.json" |
+  while IFS=$'\t' read -r file expected_sha256; do
+    [[ "$file" =~ ^[a-zA-Z0-9._-]+[.]tgz$ ]]
+    actual_sha256=$(sha256sum "$ARTIFACT_DIR/$file" | cut -d' ' -f1)
+    test "$actual_sha256" = "$expected_sha256"
+  done
+if [ -n "\${NODE_AUTH_TOKEN:-}" ] || [ -n "\${NPM_TOKEN:-}" ]; then
+  echo "PR snapshot publishing must use npm trusted publishing; token auth is not allowed." >&2
+  exit 1
+fi`,
+        },
+        {
+          name: 'Publish exact-SHA package cohort',
+          env: {
+            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+          },
+          run: `set -euo pipefail
+while IFS=$'\t' read -r package_name file; do
+  test -n "$package_name"
+  test -n "$file"
+  tarball="$ARTIFACT_DIR/$file"
+  local_sha1=$(sha1sum "$tarball" | cut -d' ' -f1)
+  if remote_sha1=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.shasum --json --registry=https://registry.npmjs.org 2>/dev/null); then
+    remote_sha1=$(jq -r . <<<"$remote_sha1")
+    if [ "$remote_sha1" != "$local_sha1" ]; then
+      echo "$package_name@$SNAPSHOT_VERSION already exists with a different tarball digest" >&2
+      exit 1
+    fi
+    echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
+    continue
+  fi
+  npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance
+done < "$PUBLISH_LIST"`,
+        },
+        {
+          name: 'Record snapshot provenance',
+          env: {
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            PACKAGE_COUNT: '${{ needs.validate-pr-snapshot.outputs.package-count }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            SNAPSHOT_TAG: '${{ needs.validate-pr-snapshot.outputs.npm-tag }}',
+            SOURCE_RUN_URL: '${{ needs.validate-pr-snapshot.outputs.source-run-url }}',
+          },
+          run: `cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+## Repository-owned PR snapshot
+
+- PR: #$PR_NUMBER
+- Head: \`\${{ needs.validate-pr-snapshot.outputs.head-sha }}\`
+- Version: \`$SNAPSHOT_VERSION\`
+- Immutable npm tag: \`$SNAPSHOT_TAG\`
+- Packages: $PACKAGE_COUNT
+- Manifest SHA-256: \`$MANIFEST_DIGEST\`
+- Source CI run: $SOURCE_RUN_URL
+- Candidate attestation: binds the validated package and manifest digests to the exact PR head and source CI run.
+- npm provenance: identifies this trusted default-branch promotion workflow; it does not claim that the PR CI job held npm publishing authority.
+EOF`,
+        },
+      ],
+    },
     'create-release-pr': {
       if: "github.event_name == 'workflow_dispatch' && inputs.mode == 'create-release-pr'",
       'runs-on': 'ubuntu-latest',

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -157,10 +157,10 @@ fi
 [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
 [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
 [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
-jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=latest&per_page=100" --slurp)
-pack_jobs=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")]' <<<"$jobs_json")
-test "$(jq 'length' <<<"$pack_jobs")" = 1
-run_attempt=$(jq -r '.[0].run_attempt' <<<"$pack_jobs")
+jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=all&per_page=100" --slurp)
+pack_job=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")] | sort_by(.run_attempt) | last' <<<"$jobs_json")
+test "$pack_job" != null
+run_attempt=$(jq -r '.run_attempt' <<<"$pack_job")
 [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
 

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -116,6 +116,7 @@ export default githubWorkflow({
         'npm-tag': '${{ steps.validate.outputs.npm-tag }}',
         'package-count': '${{ steps.validate.outputs.package-count }}',
         'pr-number': '${{ steps.identity.outputs.pr-number }}',
+        'release-run-attempt': '${{ steps.validate.outputs.release-run-attempt }}',
         'run-attempt': '${{ steps.identity.outputs.run-attempt }}',
         'run-id': '${{ steps.identity.outputs.run-id }}',
         'source-run-url': '${{ steps.identity.outputs.source-run-url }}',
@@ -138,7 +139,6 @@ test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@
 [[ "$GITHUB_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
 if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
   run_id='\${{ github.event.workflow_run.id }}'
-  run_attempt='\${{ github.event.workflow_run.run_attempt }}'
   head_sha='\${{ github.event.workflow_run.head_sha }}'
   source_run_url='\${{ github.event.workflow_run.html_url }}'
   prs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/pulls")
@@ -151,13 +151,16 @@ else
   run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
   test "$run_json" != null
   run_id=$(jq -r '.id' <<<"$run_json")
-  run_attempt=$(jq -r '.run_attempt' <<<"$run_json")
   source_run_url=$(jq -r '.html_url' <<<"$run_json")
 fi
 
 [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
 [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
 [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+jobs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?filter=latest&per_page=100" --slurp)
+pack_jobs=$(jq -c '[.[] | .jobs[] | select(.name == "pack-pr-snapshot" and .conclusion == "success")]' <<<"$jobs_json")
+test "$(jq 'length' <<<"$pack_jobs")" = 1
+run_attempt=$(jq -r '.[0].run_attempt' <<<"$pack_jobs")
 [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
 
@@ -223,13 +226,14 @@ echo "manifest-digest=$(jq -r '.manifestDigest' <<<"$result")" >> "$GITHUB_OUTPU
 echo "topology-digest=$(jq -r '.topologyDigest' <<<"$result")" >> "$GITHUB_OUTPUT"
 echo "npm-tag=$(jq -r '.npmTag' <<<"$result")" >> "$GITHUB_OUTPUT"
 echo "package-count=$(jq -r '.packageCount' <<<"$result")" >> "$GITHUB_OUTPUT"
+echo "release-run-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
         },
         {
           name: 'Upload validated snapshot candidate',
           uses: 'actions/upload-artifact@v4',
           with: {
-            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}',
+            name: 'validated-pr-snapshot-${{ steps.identity.outputs.head-sha }}-${{ steps.identity.outputs.run-id }}-${{ steps.validate.outputs.release-run-attempt }}',
             path: '${{ github.workspace }}/tmp/pr-snapshot-artifact/',
             'if-no-files-found': 'error',
             'retention-days': 1,
@@ -252,16 +256,18 @@ cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
         CACHIX_AUTH_TOKEN: '',
       },
       defaults: bashShellDefaults,
+      outputs: { 'promotion-attempt': '${{ steps.handoff.outputs.promotion-attempt }}' },
       steps: [
         {
           name: 'Download validated snapshot candidate',
           uses: 'actions/download-artifact@v4',
           with: {
-            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}',
+            name: 'validated-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.release-run-attempt }}',
             path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
           },
         },
         {
+          id: 'handoff',
           name: 'Verify validated artifact identity and write predicate',
           env: {
             HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
@@ -273,6 +279,7 @@ cp "$PUBLISH_LIST" "$ARTIFACT_DIR/trusted-publish-list.tsv"`,
           },
           run: `set -euo pipefail
 test "$(sha256sum "$ARTIFACT_DIR/manifest.json" | cut -d' ' -f1)" = "$MANIFEST_DIGEST"
+echo "promotion-attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 jq -n \
   --arg repository "$GITHUB_REPOSITORY" \
   --argjson prNumber "$PR_NUMBER" \
@@ -297,7 +304,7 @@ jq -n \
           name: 'Upload attested promotion artifact',
           uses: 'actions/upload-artifact@v4',
           with: {
-            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}',
+            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ steps.handoff.outputs.promotion-attempt }}',
             path: '${{ github.workspace }}/tmp/validated-pr-snapshot/',
             'if-no-files-found': 'error',
             'retention-days': 1,
@@ -378,7 +385,7 @@ echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
           name: 'Download validated promotion artifact',
           uses: 'actions/download-artifact@v4',
           with: {
-            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ github.run_id }}',
+            name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.attest-pr-snapshot.outputs.promotion-attempt }}',
             path: '${{ github.workspace }}/tmp/validated-pr-snapshot',
           },
         },
@@ -445,7 +452,6 @@ while IFS=$'\t' read -r package_name file; do
       exit 1
     fi
     echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
-    npm dist-tag add "$package_name@$SNAPSHOT_VERSION" "$SNAPSHOT_TAG" --registry=https://registry.npmjs.org
     continue
   fi
   npm publish "$tarball" --registry=https://registry.npmjs.org --tag="$SNAPSHOT_TAG" --access=public --ignore-scripts --provenance

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -61,12 +61,30 @@ export default githubWorkflow({
           default: 'latest',
           type: 'string',
         },
+        pr_number: {
+          description: 'PR number selector for trusted snapshot promotion',
+          required: false,
+          default: '0',
+          type: 'string',
+        },
+        head_sha: {
+          description: 'Expected PR head selector for trusted snapshot promotion',
+          required: false,
+          default: '',
+          type: 'string',
+        },
         mode: {
           description: 'Release workflow mode',
           required: true,
           default: 'create-release-pr',
           type: 'choice',
-          options: ['create-release-pr', 'validate-release-plan', 'publish-release', 'publish-snapshot'],
+          options: [
+            'create-release-pr',
+            'validate-release-plan',
+            'publish-release',
+            'publish-snapshot',
+            'promote-pr-snapshot',
+          ],
         },
       },
     },
@@ -74,9 +92,7 @@ export default githubWorkflow({
       workflows: ['ci'],
       types: ['completed'],
     },
-    pull_request_review: {
-      types: ['submitted'],
-    },
+    schedule: [{ cron: '*/5 * * * *' }],
     pull_request: {
       paths: releasePlanPaths,
     },
@@ -100,10 +116,66 @@ export default githubWorkflow({
   jobs: {
     'source-policy': {
       ...livestoreDefaultRefPolicyJob,
-      if: "github.event_name != 'pull_request_review'",
+      if: "github.event_name != 'schedule'",
+    },
+    'dispatch-approved-pr-snapshots': {
+      if: "github.event_name == 'schedule'",
+      'runs-on': 'ubuntu-24.04',
+      permissions: {
+        actions: 'write',
+        contents: 'read',
+        'pull-requests': 'read',
+      },
+      env: { GH_TOKEN: '${{ github.token }}' },
+      defaults: bashShellDefaults,
+      steps: [
+        {
+          name: 'Checkout trusted package topology',
+          uses: 'actions/checkout@v4',
+          with: {
+            ref: '${{ github.workflow_sha }}',
+            'persist-credentials': false,
+            'sparse-checkout': 'scripts/src/generated/release-topology.json',
+          },
+        },
+        {
+          name: 'Dispatch incomplete approved cohorts to trusted main workflow',
+          run: `set -euo pipefail
+test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
+prs_json=$(gh api graphql \
+  -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN,orderBy:{field:UPDATED_AT,direction:DESC}){nodes{number isDraft reviewDecision baseRefName headRefOid headRepository{nameWithOwner}}}}}' \
+  -f owner="\${GITHUB_REPOSITORY%%/*}" \
+  -f name="\${GITHUB_REPOSITORY#*/}")
+
+jq -r --arg repository "$GITHUB_REPOSITORY" \
+  '.data.repository.pullRequests.nodes[] | select(.isDraft == false and .reviewDecision == "APPROVED" and .baseRefName == "main" and .headRepository.nameWithOwner == $repository) | [.number, .headRefOid] | @tsv' \
+  <<<"$prs_json" |
+while IFS=$'\t' read -r pr_number head_sha; do
+  [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
+  [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+  version="0.0.0-snapshot-pr.$pr_number.$head_sha"
+  complete=true
+  while IFS= read -r package_name; do
+    if ! npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+      complete=false
+      break
+    fi
+  done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
+  if [ "$complete" = true ]; then
+    echo "PR #$pr_number snapshot cohort is already complete"
+    continue
+  fi
+  gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main \
+    -f mode=promote-pr-snapshot \
+    -f npm_tag=latest \
+    -f pr_number="$pr_number" \
+    -f head_sha="$head_sha"
+done`,
+        },
+      ],
     },
     'validate-pr-snapshot': {
-      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.head.repo.full_name == github.repository)",
+      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')",
       'runs-on': 'ubuntu-24.04',
       permissions: {
         actions: 'read',
@@ -145,8 +217,9 @@ if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
   test "$(jq 'length' <<<"$prs_json")" = 1
   pr_number=$(jq -r '.[0].number' <<<"$prs_json")
 else
-  pr_number='\${{ github.event.pull_request.number }}'
-  head_sha='\${{ github.event.pull_request.head.sha }}'
+  test "$GITHUB_EVENT_NAME" = workflow_dispatch
+  pr_number='\${{ inputs.pr_number }}'
+  head_sha='\${{ inputs.head_sha }}'
   runs_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?event=pull_request&status=success&head_sha=$head_sha&per_page=100")
   run_json=$(jq -c --arg sha "$head_sha" '[.workflow_runs[] | select(.head_sha == $sha and .event == "pull_request" and .conclusion == "success")] | sort_by(.created_at) | reverse | .[0]' <<<"$runs_json")
   test "$run_json" != null

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -418,6 +418,17 @@ in
       after = [ "setup:strict" ];
     };
 
+    "release:snapshot:pack:git-sha" = {
+      description = "Pack an exact-SHA snapshot without registry credentials";
+      exec = ''
+        set -euo pipefail
+        : "''${GIT_SHA:?GIT_SHA is required}"
+        : "''${SNAPSHOT_OUT_DIR:?SNAPSHOT_OUT_DIR is required}"
+        mono release snapshot-pack --git-sha="$GIT_SHA" --out-dir="$SNAPSHOT_OUT_DIR"
+      '';
+      after = [ "setup:strict" ];
+    };
+
     "release:plan" = {
       description = "Write release/release-plan.json for a stable release PR";
       exec = ''

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -423,8 +423,9 @@ in
       exec = ''
         set -euo pipefail
         : "''${GIT_SHA:?GIT_SHA is required}"
+        : "''${PR_NUMBER:?PR_NUMBER is required}"
         : "''${SNAPSHOT_OUT_DIR:?SNAPSHOT_OUT_DIR is required}"
-        mono release snapshot-pack --git-sha="$GIT_SHA" --out-dir="$SNAPSHOT_OUT_DIR"
+        mono release snapshot-pack --git-sha="$GIT_SHA" --pr-number="$PR_NUMBER" --out-dir="$SNAPSHOT_OUT_DIR"
       '';
       after = [ "setup:strict" ];
     };

--- a/scripts/src/commands/command-effects.test.ts
+++ b/scripts/src/commands/command-effects.test.ts
@@ -33,6 +33,7 @@ describe('command Effect operations', () => {
     const operation = packSnapshot({
       cwd: '/tmp/livestore',
       gitSha: 'a'.repeat(40),
+      prNumber: 42,
       outDir: '/tmp/livestore-snapshot',
       tscBin: 'tsc',
     })

--- a/scripts/src/commands/command-effects.test.ts
+++ b/scripts/src/commands/command-effects.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { Effect } from '@livestore/utils/effect'
 
 import { exportMarkdown } from './docs-export.ts'
-import { releaseSnapshot } from './release.ts'
+import { packSnapshot, releaseSnapshot } from './release.ts'
 
 describe('command Effect operations', () => {
   it('exposes markdown export as a lazy Effect with plain-value options', () => {
@@ -23,6 +23,17 @@ describe('command Effect operations', () => {
       version: '0.0.0-snapshot-abc123',
       dryRun: true,
       yes: true,
+      tscBin: 'tsc',
+    })
+
+    expect(Effect.isEffect(operation)).toBe(true)
+  })
+
+  it('exposes snapshot packing as a lazy Effect without publishing options', () => {
+    const operation = packSnapshot({
+      cwd: '/tmp/livestore',
+      gitSha: 'a'.repeat(40),
+      outDir: '/tmp/livestore-snapshot',
       tscBin: 'tsc',
     })
 

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -1,3 +1,6 @@
+import { copyFile, mkdir, rm } from 'node:fs/promises'
+import path from 'node:path'
+
 import semver from 'semver'
 
 import { shouldNeverHappen } from '@livestore/utils'
@@ -379,8 +382,10 @@ const formatReleaseSummaryMarkdown = ({
 const restoreGeneratedReleaseFiles = (cwd: string) =>
   Effect.gen(function* () {
     /** Restore original dev versions (read-only) and verify files are in sync. */
-    yield* cmd('DT_PASSTHROUGH=1 genie', { shell: true }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
-    yield* cmd('DT_PASSTHROUGH=1 genie --check', { shell: true }).pipe(
+    yield* cmd('DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 genie', { shell: true }).pipe(
+      Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
+    )
+    yield* cmd('DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 genie --check', { shell: true }).pipe(
       Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
     )
   }).pipe(
@@ -403,9 +408,9 @@ const packPackageForPublish = ({ cwd, pkg, version }: { cwd: string; pkg: string
      * `publishConfig`. `pnpm pack` materializes those mappings into the tarball;
      * plain `npm publish <directory>` would publish the source mappings instead.
      */
-    yield* cmd(`DT_PASSTHROUGH=1 pnpm --dir ${pkgDir} pack --pack-destination ${packDir}`, { shell: true }).pipe(
-      Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
-    )
+    yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 pnpm --dir ${pkgDir} pack --pack-destination ${packDir}`, {
+      shell: true,
+    }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
 
     const tarballs = (yield* fsEffect.readDirectory(packDir)).filter((entry) => entry.endsWith('.tgz'))
     if (tarballs.length !== 1) {
@@ -442,16 +447,16 @@ const publishReleasePackages = ({
      * TODO: Replace CLI invocations with genie SDK once skipValidation is available
      * (https://github.com/overengineeringstudio/effect-utils/issues/196)
      */
-    yield* cmd(`DT_PASSTHROUGH=1 LIVESTORE_RELEASE_VERSION=${version} genie --writeable`, { shell: true }).pipe(
-      Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
-    )
+    yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 LIVESTORE_RELEASE_VERSION=${version} genie --writeable`, {
+      shell: true,
+    }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
 
     yield* rewriteSnapshotInternalDependencyRanges({ cwd, snapshotPackages: packages, snapshotVersion: version })
 
     /** Rebuild TypeScript so dist/ picks up the release version from package.json (emit-only, type checking is separate). */
-    yield* cmd(`DT_PASSTHROUGH=1 ${tscBin} --build tsconfig.dev.json --noCheck`, { shell: true }).pipe(
-      Effect.provide(CurrentWorkingDirectory.fromPath(cwd)),
-    )
+    yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 ${tscBin} --build tsconfig.dev.json --noCheck`, {
+      shell: true,
+    }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
 
     for (const pkg of packages) {
       const pkgDir = `${cwd}/packages/${pkg}`
@@ -490,7 +495,7 @@ const publishReleasePackages = ({
         Effect.as(true),
         Effect.catchTag('CmdError', () => Effect.succeed(false)),
       )
-      yield* cmd(`DT_PASSTHROUGH=1 ${publishArgs.join(' ')}`, { shell: true }).pipe(
+      yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 ${publishArgs.join(' ')}`, { shell: true }).pipe(
         Effect.provide(cwdLayer),
         Effect.catchTag('CmdError', (error) => {
           if (isCI === false || dryRun === true || isSnapshotVersion(version) === false) return Effect.fail(error)
@@ -654,6 +659,85 @@ export const releaseSnapshot = Effect.fn(function* ({
   })
 })
 
+export const packSnapshot = Effect.fn(function* ({
+  gitSha,
+  cwd,
+  outDir,
+  tscBin = 'tsc',
+}: {
+  gitSha: string
+  cwd: string
+  outDir: string
+  tscBin?: string
+}) {
+  if (/^[0-9a-f]{40}$/.test(gitSha) === false) {
+    return yield* Effect.fail(
+      new Error(`Snapshot Git SHA must be exactly 40 lowercase hexadecimal characters: ${gitSha}`),
+    )
+  }
+
+  const version = `0.0.0-snapshot-${gitSha}`
+  const packages = yield* listSnapshotPackages(cwd)
+
+  if (packages.length === 0) {
+    return yield* Effect.fail(new Error('Snapshot package topology is empty'))
+  }
+
+  yield* Effect.tryPromise({
+    try: async () => {
+      await rm(outDir, { recursive: true, force: true })
+      await mkdir(outDir, { recursive: true })
+    },
+    catch: (cause) => new Error(`Failed to prepare snapshot artifact directory ${outDir}`, { cause }),
+  })
+
+  const tarballs = yield* Effect.gen(function* () {
+    yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 LIVESTORE_RELEASE_VERSION=${version} genie --writeable`, {
+      shell: true,
+    }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
+    yield* rewriteSnapshotInternalDependencyRanges({ cwd, snapshotPackages: packages, snapshotVersion: version })
+    yield* cmd(`DT_PASSTHROUGH=1 DEVENV_TASK_PASSTHROUGH=1 ${tscBin} --build tsconfig.dev.json --noCheck`, {
+      shell: true,
+    }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(cwd)))
+
+    return yield* Effect.forEach(packages, (pkg) => packPackageForPublish({ cwd, pkg, version }), {
+      concurrency: 1,
+    })
+  }).pipe(Effect.ensuring(restoreGeneratedReleaseFiles(cwd)))
+
+  yield* Effect.tryPromise({
+    try: async () => {
+      for (const tarball of tarballs) {
+        await copyFile(tarball, path.join(outDir, path.basename(tarball)))
+      }
+    },
+    catch: (cause) => new Error(`Failed to stage snapshot tarballs in ${outDir}`, { cause }),
+  })
+
+  yield* Effect.log(`Packed ${tarballs.length} package(s) as ${version} in ${outDir}`)
+})
+
+export const packSnapshotCommand = Cli.Command.make(
+  'snapshot-pack',
+  {
+    gitSha: Cli.Flag.string('git-sha'),
+    outDir: Cli.Flag.string('out-dir'),
+    cwd: Cli.Flag.string('cwd').pipe(
+      Cli.Flag.withDefault(
+        process.env.WORKSPACE_ROOT ?? shouldNeverHappen(`WORKSPACE_ROOT is not set. Make sure to run 'direnv allow'`),
+      ),
+    ),
+    tscBin: Cli.Flag.string('tsc-bin').pipe(Cli.Flag.optional),
+  },
+  ({ gitSha, outDir, cwd, tscBin }) =>
+    packSnapshot({
+      gitSha,
+      cwd,
+      outDir,
+      ...(tscBin._tag === 'Some' ? { tscBin: tscBin.value } : {}),
+    }),
+)
+
 export const releaseSnapshotCommand = Cli.Command.make(
   'snapshot',
   {
@@ -705,6 +789,7 @@ export const releaseCommand = Cli.Command.make('release').pipe(
     releasePlanCommand,
     releaseStableCommand,
     releaseSnapshotCommand,
+    packSnapshotCommand,
     releaseNotesExtractCommand,
   ]),
 )

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -661,11 +661,13 @@ export const releaseSnapshot = Effect.fn(function* ({
 
 export const packSnapshot = Effect.fn(function* ({
   gitSha,
+  prNumber,
   cwd,
   outDir,
   tscBin = 'tsc',
 }: {
   gitSha: string
+  prNumber: number
   cwd: string
   outDir: string
   tscBin?: string
@@ -675,8 +677,11 @@ export const packSnapshot = Effect.fn(function* ({
       new Error(`Snapshot Git SHA must be exactly 40 lowercase hexadecimal characters: ${gitSha}`),
     )
   }
+  if (Number.isSafeInteger(prNumber) === false || prNumber < 1) {
+    return yield* Effect.fail(new Error(`Snapshot PR number must be a positive integer: ${prNumber}`))
+  }
 
-  const version = `0.0.0-snapshot-${gitSha}`
+  const version = `0.0.0-snapshot-pr.${prNumber}.${gitSha}`
   const packages = yield* listSnapshotPackages(cwd)
 
   if (packages.length === 0) {
@@ -721,6 +726,7 @@ export const packSnapshotCommand = Cli.Command.make(
   'snapshot-pack',
   {
     gitSha: Cli.Flag.string('git-sha'),
+    prNumber: Cli.Flag.integer('pr-number'),
     outDir: Cli.Flag.string('out-dir'),
     cwd: Cli.Flag.string('cwd').pipe(
       Cli.Flag.withDefault(
@@ -729,9 +735,10 @@ export const packSnapshotCommand = Cli.Command.make(
     ),
     tscBin: Cli.Flag.string('tsc-bin').pipe(Cli.Flag.optional),
   },
-  ({ gitSha, outDir, cwd, tscBin }) =>
+  ({ gitSha, prNumber, outDir, cwd, tscBin }) =>
     packSnapshot({
       gitSha,
+      prNumber,
       cwd,
       outDir,
       ...(tscBin._tag === 'Some' ? { tscBin: tscBin.value } : {}),


### PR DESCRIPTION
Closes #1455.

## What changed

- packs the fixed public package cohort in unprivileged repository-owned PR CI and uploads an immutable exact-run candidate
- validates tar structure, package identity, topology, dependency pins, lifecycle absence, file bounds, and digests in a trusted workflow job with no OIDC permission
- derives the actual PR head from the Actions run's embedded PR association rather than the synthetic pull-request merge SHA
- uses a trusted default-branch schedule to discover every open, ready, approved same-repository PR, and dispatches only after an exact successful CI run, successful pack attempt, and non-expired exact-name artifact exist
- passes the exact CI run ID into the trusted child workflow, which independently rechecks run workflow identity, PR number, current head, artifact attempt, and review state
- publishes the cohort under a PR/head-specific version and immutable `pr-<number>-<full-sha>` tag, then verifies all package versions, tags, and SHA-512 registry integrities
- creates a custom candidate attestation linking package digests to the PR CI run; npm provenance separately identifies the trusted promotion workflow

## Trust boundaries

The repository's ordinary required-review decision is the only manual publication boundary. No label or snapshot-specific approval is introduced. The scheduled dispatcher runs only from the default-branch workflow, has no OIDC permission, paginates all open PRs, and can only dispatch `release.yml@main`. Fork PRs are excluded.

PR jobs receive no secrets, write permission, or OIDC. Archive parsing also has no OIDC; a separate non-parsing attestation/handoff job has candidate-attestation authority. The publisher never checks out or executes PR code and rechecks authoritative `reviewDecision == APPROVED`, an exact-head counting approval, current PR identity, and artifact identity immediately before npm OIDC publication.

## Verification

- `prek run check-quick --all-files` via the devenv shell
- `devenv tasks run -m single genie:check --show-output`
- `node --test .github/scripts/pr-snapshot-artifact.test.mjs` (10/10, including stale review, shared-SHA/different-PR, rerun attempt, generated workflow, and archive negatives)
- live GitHub API proof that a PR run's synthetic merge SHA differs from `pull_requests[].head.sha`, and that branch-filtered discovery selects the exact PR number/head association
- `pnpm exec vitest run scripts/src/commands/command-effects.test.ts scripts/src/commands/release.test.ts` (10/10)
- real 14-package no-publish pack, manifest creation, and trusted validation
- `git diff --check`

No package publication was invoked. Independent exact-head review found no P0/P1/P2 issues; auto-merge remains disabled.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-18-trusted-pr-snapshots |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->