### PR TITLE
Make PR snapshot retries verifiable

### DIFF
--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -155,6 +155,30 @@ export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => 
 export const isAuthorizedReviewState = ({ headSha, currentHeadSha, reviewDecision, reviews }) =>
   reviewDecision === 'APPROVED' && hasCurrentHeadApproval({ headSha, currentHeadSha, reviews })
 
+export const assessRegistryCohort = ({ expectedVersion, packageStates, hasVerifiedReceipt }) => {
+  if (typeof expectedVersion !== 'string' || expectedVersion === '') fail('Expected registry version is required')
+  if (Array.isArray(packageStates) === false || packageStates.length === 0) fail('Registry package states are required')
+  if (typeof hasVerifiedReceipt !== 'boolean') fail('Verified receipt state must be boolean')
+
+  for (const state of packageStates) {
+    if (
+      state === null ||
+      typeof state !== 'object' ||
+      typeof state.name !== 'string' ||
+      typeof state.version !== 'string' ||
+      typeof state.tag !== 'string'
+    ) {
+      fail('Invalid registry package state')
+    }
+    if (state.tag !== '' && state.tag !== expectedVersion) {
+      return { action: 'conflict', packageName: state.name, conflictingVersion: state.tag }
+    }
+  }
+
+  const allVersionsPresent = packageStates.every((state) => state.version === expectedVersion)
+  return allVersionsPresent === true && hasVerifiedReceipt === true ? { action: 'complete' } : { action: 'dispatch' }
+}
+
 const validatePackageManifest = ({ packageJson, expectedName, expectedVersion, packageNames }) => {
   if (packageJson.name !== expectedName)
     fail(`Package name mismatch: expected ${expectedName}, got ${packageJson.name}`)
@@ -404,6 +428,12 @@ if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === path.res
       ? await createManifest(common)
       : mode === 'validate'
         ? await validateManifest({ ...common, publishListPath: args['publish-list'] })
-        : fail(`Unknown mode: ${mode}`)
+        : mode === 'assess-registry'
+          ? assessRegistryCohort({
+              expectedVersion: args.version,
+              packageStates: JSON.parse(await readFile(args['state-file'], 'utf8')),
+              hasVerifiedReceipt: args['verified-receipt'] === 'true',
+            })
+          : fail(`Unknown mode: ${mode}`)
   process.stdout.write(`${JSON.stringify(result)}\n`)
 }

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test'
 import { gzipSync } from 'node:zlib'
 
 import {
+  assessRegistryCohort,
   createManifest,
   hasCurrentHeadApproval,
   isAuthorizedReviewState,
@@ -15,6 +16,39 @@ import {
   successfulProducerAttempt,
   validateManifest,
 } from './pr-snapshot-artifact.mjs'
+
+test('requires a trusted verification receipt before declaring a registry cohort complete', () => {
+  const version = `0.0.0-snapshot-pr.42.${'a'.repeat(40)}`
+  const matching = [
+    { name: '@livestore/common', version, tag: '' },
+    { name: '@livestore/utils', version, tag: version },
+  ]
+
+  assert.deepEqual(
+    assessRegistryCohort({ expectedVersion: version, packageStates: matching, hasVerifiedReceipt: false }),
+    { action: 'dispatch' },
+  )
+  assert.deepEqual(
+    assessRegistryCohort({ expectedVersion: version, packageStates: matching, hasVerifiedReceipt: true }),
+    { action: 'complete' },
+  )
+  assert.deepEqual(
+    assessRegistryCohort({
+      expectedVersion: version,
+      packageStates: [{ name: '@livestore/common', version: '', tag: '' }],
+      hasVerifiedReceipt: true,
+    }),
+    { action: 'dispatch' },
+  )
+  assert.deepEqual(
+    assessRegistryCohort({
+      expectedVersion: version,
+      packageStates: [{ name: '@livestore/common', version, tag: 'another-version' }],
+      hasVerifiedReceipt: true,
+    }),
+    { action: 'conflict', packageName: '@livestore/common', conflictingVersion: 'another-version' },
+  )
+})
 
 const writeOctal = (header, start, length, value) => {
   const encoded = value.toString(8).padStart(length - 1, '0')
@@ -175,6 +209,11 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(dispatch, /pack-pr-snapshot.*conclusion == "success"/s)
   assert.match(dispatch, /artifacts\?per_page=100.*expired == false/s)
   assert.match(dispatch, /ci_run_id="\$selected_run_id"/)
+  assert.match(dispatch, /selected_pack_attempt="\$pack_attempt"/)
+  assert.match(dispatch, /verified-pr-snapshot-\$head_sha-\$selected_run_id-\$selected_pack_attempt/)
+  assert.match(dispatch, /assess-registry.*--verified-receipt="\$verified_receipt"/s)
+  assert.match(dispatch, /cohort_failed=true.*scan_failed=true.*continue/s)
+  assert.match(dispatch, /if \[ "\$scan_failed" = true \]; then\s+exit 1/s)
 
   const checkoutStart = workflow.indexOf('- name: Checkout trusted validator only')
   const checkoutEnd = workflow.indexOf('\n      - name: Use pinned Node validator runtime', checkoutStart)
@@ -212,7 +251,15 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(publish, /Verify complete immutable registry cohort/)
   assert.match(publish, /dist\.integrity/)
   assert.match(publish, /dist-tags/)
+  assert.match(publish, /\[ -n "\$remote_tag" \].*\[ "\$remote_tag" != "\$SNAPSHOT_VERSION" \]/s)
+  assert.match(publish, /mutable tag \$SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags/)
+  assert.match(publish, /\[ "\$remote_integrity" = "\$local_integrity" \]/)
+  assert.doesNotMatch(publish, /\[ "\$remote_tag" = "\$SNAPSHOT_VERSION" \]/)
   assert.match(publish, /needs\.validate-pr-snapshot\.outputs\.package-count/)
+  assert.match(publish, /Upload trusted verification receipt/)
+  assert.match(publish, /verified-pr-snapshot-.*outputs\.head-sha.*outputs\.run-id.*outputs\.run-attempt/s)
+  assert.match(publish, /sourceRunAttempt/)
+  assert.match(publish, /overwrite: true/)
 
   const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
   assert.match(
@@ -225,7 +272,7 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   )
 })
 
-test('derives an immutable tag for each PR head cohort', () => {
+test('derives a deterministic publish-time tag for each PR head cohort', () => {
   const firstHead = 'a'.repeat(40)
   const secondHead = 'b'.repeat(40)
   const firstTag = snapshotTag({ prNumber: 42, headSha: firstHead })

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -95,9 +95,15 @@ dispatched run treats PR and head inputs only as selectors, then resolves and
 validates the exact successful CI producer again. The OIDC job rechecks the unchanged
 head and approval immediately before publishing. It never checks out or executes
 the PR head and publishes the validated tarballs directly with scripts disabled
-under the immutable `pr-<number>-<40-character-head-sha>` tag. npm provenance
-identifies this trusted default-branch promotion workflow; the custom candidate
-attestation supplies the separate link back to PR CI.
+under the deterministic `pr-<number>-<40-character-head-sha>` tag. Exact package
+versions and registry digests are the immutable cohort identity. The mutable npm
+tag is convenience metadata: retries accept it when absent, reject it when bound
+to another version, and do not introduce a long-lived token to repair it because
+npm trusted publishing authenticates publish operations only. A trusted
+verification receipt is uploaded only after every registry integrity matches the
+validated candidate; the scheduler redispatches until that exact PR head, CI run,
+and pack attempt receipt exists. npm provenance identifies this trusted default-branch promotion
+workflow; the custom candidate attestation supplies the separate link back to PR CI.
 
 Snapshot DevTools Chrome ZIPs are uploaded as short-lived workflow artifacts,
 not GitHub Releases. Public GitHub Releases are reserved for dev/stable release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,14 +456,24 @@ jobs:
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
-          sparse-checkout: scripts/src/generated/release-topology.json
+          sparse-checkout: |
+            .github/scripts/pr-snapshot-artifact.mjs
+            scripts/src/generated/release-topology.json
       - name: Dispatch incomplete approved cohorts to trusted main workflow
         run: |
           set -euo pipefail
           test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
           prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
-          jq -r --arg repository "$GITHUB_REPOSITORY"   '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv'   <<<"$prs_json" |
+          release_workflow_id=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)
+          [[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
+          scan_failed=false
           while IFS=$'	' read -r pr_number head_sha head_ref; do
+            cohort_failed=false
+            verified_receipt=false
+            registry_state_file="$RUNNER_TEMP/registry-state-$pr_number.json"
+            printf '[]
+          ' > "$registry_state_file"
+
             [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
             [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
             test -n "$head_ref"
@@ -474,21 +484,9 @@ jobs:
 
             version="0.0.0-snapshot-pr.$pr_number.$head_sha"
             snapshot_tag="pr-$pr_number-$head_sha"
-            complete=true
-            while IFS= read -r package_name; do
-              remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
-              remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
-              if [ "$remote_version" != "$version" ] || [ "$remote_tag" != "$version" ]; then
-                complete=false
-                break
-              fi
-            done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
-            if [ "$complete" = true ]; then
-              echo "PR #$pr_number snapshot cohort is already complete"
-              continue
-            fi
 
             selected_run_id=''
+            selected_pack_attempt=''
             runs_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs"     -f event=pull_request     -f status=success     -f branch="$head_ref"     -F per_page=100     --slurp)
             while IFS= read -r candidate_run_id; do
               [[ "$candidate_run_id" =~ ^[1-9][0-9]*$ ]]
@@ -505,14 +503,57 @@ jobs:
                 continue
               fi
               selected_run_id="$candidate_run_id"
+              selected_pack_attempt="$pack_attempt"
               break
             done < <(jq -r --arg sha "$head_sha" --argjson pr_number "$pr_number"     '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == env.GITHUB_REPOSITORY and any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha))] | sort_by(.created_at) | reverse | .[].id'     <<<"$runs_json")
             if [ -z "$selected_run_id" ]; then
               echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
               continue
             fi
+
+            receipt_name="verified-pr-snapshot-$head_sha-$selected_run_id-$selected_pack_attempt"
+            receipts_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/artifacts"     -f name="$receipt_name"     -F per_page=100     --slurp)
+            while IFS= read -r receipt_run_id; do
+              [[ "$receipt_run_id" =~ ^[1-9][0-9]*$ ]]
+              receipt_run=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$receipt_run_id")
+              if [ "$(jq -r .workflow_id <<<"$receipt_run")" = "$release_workflow_id" ] &&        [ "$(jq -r .event <<<"$receipt_run")" = workflow_dispatch ] &&        [ "$(jq -r .head_branch <<<"$receipt_run")" = main ] &&        [ "$(jq -r .conclusion <<<"$receipt_run")" = success ]; then
+                verified_receipt=true
+                break
+              fi
+            done < <(jq -r --arg name "$receipt_name" '.[] | .artifacts[]? | select(.name == $name and .expired == false) | .workflow_run.id' <<<"$receipts_json")
+
+            while IFS= read -r package_name; do
+              remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+              remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
+              jq --arg name "$package_name" --arg version "$remote_version" --arg tag "$remote_tag"       '. + [{name: $name, version: $version, tag: $tag}]' "$registry_state_file" > "$registry_state_file.next"
+              mv "$registry_state_file.next" "$registry_state_file"
+            done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
+
+            assessment=$(node .github/scripts/pr-snapshot-artifact.mjs assess-registry     --state-file="$registry_state_file"     --version="$version"     --verified-receipt="$verified_receipt")
+            action=$(jq -r .action <<<"$assessment")
+            if [ "$action" = conflict ]; then
+              package_name=$(jq -r .packageName <<<"$assessment")
+              conflicting_version=$(jq -r .conflictingVersion <<<"$assessment")
+              echo "::error::PR #$pr_number package $package_name tag $snapshot_tag points to unexpected version $conflicting_version"
+              cohort_failed=true
+            elif [ "$action" = complete ]; then
+              echo "PR #$pr_number snapshot cohort has a trusted verification receipt"
+              continue
+            elif [ "$action" != dispatch ]; then
+              echo "Unknown registry assessment action: $action" >&2
+              cohort_failed=true
+            fi
+
+            if [ "$cohort_failed" = true ]; then
+              scan_failed=true
+              continue
+            fi
+
             gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main     -f mode=promote-pr-snapshot     -f npm_tag=latest     -f pr_number="$pr_number"     -f head_sha="$head_sha"     -f ci_run_id="$selected_run_id"
-          done
+          done < <(jq -r --arg repository "$GITHUB_REPOSITORY"   '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv'   <<<"$prs_json")
+          if [ "$scan_failed" = true ]; then
+            exit 1
+          fi
   validate-pr-snapshot:
     if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')
     runs-on: ubuntu-24.04
@@ -811,6 +852,14 @@ jobs:
                 echo "$package_name@$SNAPSHOT_VERSION already exists with a different tarball digest" >&2
                 exit 1
               fi
+              remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+              if [ -n "$remote_tag" ] && [ "$remote_tag" != "$SNAPSHOT_VERSION" ]; then
+                echo "$package_name tag $SNAPSHOT_TAG points to unexpected version $remote_tag" >&2
+                exit 1
+              fi
+              if [ -z "$remote_tag" ]; then
+                echo "::warning::$package_name@$SNAPSHOT_VERSION matches the candidate but mutable tag $SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags"
+              fi
               echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
               continue
             fi
@@ -831,7 +880,11 @@ jobs:
               remote_version=$(npm view "$package_name@$SNAPSHOT_VERSION" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
               remote_integrity=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.integrity --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
               remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
-              if [ "$remote_version" = "$SNAPSHOT_VERSION" ] &&        [ "$remote_integrity" = "$local_integrity" ] &&        [ "$remote_tag" = "$SNAPSHOT_VERSION" ]; then
+              if [ -n "$remote_tag" ] && [ "$remote_tag" != "$SNAPSHOT_VERSION" ]; then
+                echo "$package_name tag $SNAPSHOT_TAG points to unexpected version $remote_tag" >&2
+                exit 1
+              fi
+              if [ "$remote_version" = "$SNAPSHOT_VERSION" ] &&        [ "$remote_integrity" = "$local_integrity" ]; then
                 matched=true
                 break
               fi
@@ -844,7 +897,24 @@ jobs:
             verified=$((verified + 1))
           done < "$PUBLISH_LIST"
           test "$verified" = '${{ needs.validate-pr-snapshot.outputs.package-count }}'
-          echo "Verified $verified package versions, immutable tags, and SHA-512 integrities." >> "$GITHUB_STEP_SUMMARY"
+          echo "Verified $verified immutable package versions and SHA-512 integrities; tag bindings are present or absent, never conflicting." >> "$GITHUB_STEP_SUMMARY"
+      - name: Write trusted verification receipt
+        env:
+          HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
+          MANIFEST_DIGEST: ${{ needs.validate-pr-snapshot.outputs.manifest-digest }}
+          PR_NUMBER: ${{ needs.validate-pr-snapshot.outputs.pr-number }}
+          SNAPSHOT_VERSION: ${{ needs.validate-pr-snapshot.outputs.version }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.validate-pr-snapshot.outputs.run-attempt }}
+          SOURCE_RUN_ID: ${{ needs.validate-pr-snapshot.outputs.run-id }}
+        run: jq -n   --arg repository "$GITHUB_REPOSITORY"   --argjson prNumber "$PR_NUMBER"   --arg headSha "$HEAD_SHA"   --argjson sourceRunId "$SOURCE_RUN_ID"   --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT"   --arg version "$SNAPSHOT_VERSION"   --arg manifestSha256 "$MANIFEST_DIGEST"   '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, version, manifestSha256}'   > "$RUNNER_TEMP/verified-pr-snapshot.json"
+      - name: Upload trusted verification receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'verified-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.run-attempt }}'
+          path: '${{ runner.temp }}/verified-pr-snapshot.json'
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 30
       - name: Record snapshot provenance
         env:
           SNAPSHOT_VERSION: ${{ needs.validate-pr-snapshot.outputs.version }}
@@ -860,7 +930,7 @@ jobs:
           - PR: #$PR_NUMBER
           - Head: `${{ needs.validate-pr-snapshot.outputs.head-sha }}`
           - Version: `$SNAPSHOT_VERSION`
-          - Immutable npm tag: `$SNAPSHOT_TAG`
+          - Publish-time npm tag (best-effort mutable metadata): `$SNAPSHOT_TAG`
           - Packages: $PACKAGE_COUNT
           - Manifest SHA-256: `$MANIFEST_DIGEST`
           - Source CI run: $SOURCE_RUN_URL

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -141,7 +141,8 @@ export default githubWorkflow({
           with: {
             ref: '${{ github.workflow_sha }}',
             'persist-credentials': false,
-            'sparse-checkout': 'scripts/src/generated/release-topology.json',
+            'sparse-checkout': `.github/scripts/pr-snapshot-artifact.mjs
+scripts/src/generated/release-topology.json`,
           },
         },
         {
@@ -149,10 +150,15 @@ export default githubWorkflow({
           run: `set -euo pipefail
 test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
 prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
-jq -r --arg repository "$GITHUB_REPOSITORY" \
-  '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv' \
-  <<<"$prs_json" |
+release_workflow_id=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)
+[[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
+scan_failed=false
 while IFS=$'\t' read -r pr_number head_sha head_ref; do
+  cohort_failed=false
+  verified_receipt=false
+  registry_state_file="$RUNNER_TEMP/registry-state-$pr_number.json"
+  printf '[]\n' > "$registry_state_file"
+
   [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
   [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
   test -n "$head_ref"
@@ -167,21 +173,9 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
 
   version="0.0.0-snapshot-pr.$pr_number.$head_sha"
   snapshot_tag="pr-$pr_number-$head_sha"
-  complete=true
-  while IFS= read -r package_name; do
-    remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
-    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
-    if [ "$remote_version" != "$version" ] || [ "$remote_tag" != "$version" ]; then
-      complete=false
-      break
-    fi
-  done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
-  if [ "$complete" = true ]; then
-    echo "PR #$pr_number snapshot cohort is already complete"
-    continue
-  fi
 
   selected_run_id=''
+  selected_pack_attempt=''
   runs_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
     -f event=pull_request \
     -f status=success \
@@ -203,6 +197,7 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
       continue
     fi
     selected_run_id="$candidate_run_id"
+    selected_pack_attempt="$pack_attempt"
     break
   done < <(jq -r --arg sha "$head_sha" --argjson pr_number "$pr_number" \
     '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == env.GITHUB_REPOSITORY and any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha))] | sort_by(.created_at) | reverse | .[].id' \
@@ -211,13 +206,67 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
     echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
     continue
   fi
+
+  receipt_name="verified-pr-snapshot-$head_sha-$selected_run_id-$selected_pack_attempt"
+  receipts_json=$(gh api --paginate --method GET "/repos/$GITHUB_REPOSITORY/actions/artifacts" \
+    -f name="$receipt_name" \
+    -F per_page=100 \
+    --slurp)
+  while IFS= read -r receipt_run_id; do
+    [[ "$receipt_run_id" =~ ^[1-9][0-9]*$ ]]
+    receipt_run=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$receipt_run_id")
+    if [ "$(jq -r .workflow_id <<<"$receipt_run")" = "$release_workflow_id" ] && \
+       [ "$(jq -r .event <<<"$receipt_run")" = workflow_dispatch ] && \
+       [ "$(jq -r .head_branch <<<"$receipt_run")" = main ] && \
+       [ "$(jq -r .conclusion <<<"$receipt_run")" = success ]; then
+      verified_receipt=true
+      break
+    fi
+  done < <(jq -r --arg name "$receipt_name" '.[] | .artifacts[]? | select(.name == $name and .expired == false) | .workflow_run.id' <<<"$receipts_json")
+
+  while IFS= read -r package_name; do
+    remote_version=$(npm view "$package_name@$version" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$snapshot_tag" '.[$tag] // empty' || true)
+    jq --arg name "$package_name" --arg version "$remote_version" --arg tag "$remote_tag" \
+      '. + [{name: $name, version: $version, tag: $tag}]' "$registry_state_file" > "$registry_state_file.next"
+    mv "$registry_state_file.next" "$registry_state_file"
+  done < <(jq -r '.publishablePackageNames[]' scripts/src/generated/release-topology.json)
+
+  assessment=$(node .github/scripts/pr-snapshot-artifact.mjs assess-registry \
+    --state-file="$registry_state_file" \
+    --version="$version" \
+    --verified-receipt="$verified_receipt")
+  action=$(jq -r .action <<<"$assessment")
+  if [ "$action" = conflict ]; then
+    package_name=$(jq -r .packageName <<<"$assessment")
+    conflicting_version=$(jq -r .conflictingVersion <<<"$assessment")
+    echo "::error::PR #$pr_number package $package_name tag $snapshot_tag points to unexpected version $conflicting_version"
+    cohort_failed=true
+  elif [ "$action" = complete ]; then
+    echo "PR #$pr_number snapshot cohort has a trusted verification receipt"
+    continue
+  elif [ "$action" != dispatch ]; then
+    echo "Unknown registry assessment action: $action" >&2
+    cohort_failed=true
+  fi
+
+  if [ "$cohort_failed" = true ]; then
+    scan_failed=true
+    continue
+  fi
+
   gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main \
     -f mode=promote-pr-snapshot \
     -f npm_tag=latest \
     -f pr_number="$pr_number" \
     -f head_sha="$head_sha" \
     -f ci_run_id="$selected_run_id"
-done`,
+done < <(jq -r --arg repository "$GITHUB_REPOSITORY" \
+  '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv' \
+  <<<"$prs_json")
+if [ "$scan_failed" = true ]; then
+  exit 1
+fi`,
         },
       ],
     },
@@ -577,6 +626,14 @@ while IFS=$'\t' read -r package_name file; do
       echo "$package_name@$SNAPSHOT_VERSION already exists with a different tarball digest" >&2
       exit 1
     fi
+    remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+    if [ -n "$remote_tag" ] && [ "$remote_tag" != "$SNAPSHOT_VERSION" ]; then
+      echo "$package_name tag $SNAPSHOT_TAG points to unexpected version $remote_tag" >&2
+      exit 1
+    fi
+    if [ -z "$remote_tag" ]; then
+      echo "::warning::$package_name@$SNAPSHOT_VERSION matches the candidate but mutable tag $SNAPSHOT_TAG is absent; OIDC publishing cannot repair dist-tags"
+    fi
     echo "$package_name@$SNAPSHOT_VERSION already matches candidate; skipping"
     continue
   fi
@@ -599,9 +656,12 @@ while IFS=$'\t' read -r package_name file; do
     remote_version=$(npm view "$package_name@$SNAPSHOT_VERSION" version --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
     remote_integrity=$(npm view "$package_name@$SNAPSHOT_VERSION" dist.integrity --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r . || true)
     remote_tag=$(npm view "$package_name" dist-tags --json --registry=https://registry.npmjs.org 2>/dev/null | jq -r --arg tag "$SNAPSHOT_TAG" '.[$tag] // empty' || true)
+    if [ -n "$remote_tag" ] && [ "$remote_tag" != "$SNAPSHOT_VERSION" ]; then
+      echo "$package_name tag $SNAPSHOT_TAG points to unexpected version $remote_tag" >&2
+      exit 1
+    fi
     if [ "$remote_version" = "$SNAPSHOT_VERSION" ] && \
-       [ "$remote_integrity" = "$local_integrity" ] && \
-       [ "$remote_tag" = "$SNAPSHOT_VERSION" ]; then
+       [ "$remote_integrity" = "$local_integrity" ]; then
       matched=true
       break
     fi
@@ -614,7 +674,39 @@ while IFS=$'\t' read -r package_name file; do
   verified=$((verified + 1))
 done < "$PUBLISH_LIST"
 test "$verified" = '\${{ needs.validate-pr-snapshot.outputs.package-count }}'
-echo "Verified $verified package versions, immutable tags, and SHA-512 integrities." >> "$GITHUB_STEP_SUMMARY"`,
+echo "Verified $verified immutable package versions and SHA-512 integrities; tag bindings are present or absent, never conflicting." >> "$GITHUB_STEP_SUMMARY"`,
+        },
+        {
+          name: 'Write trusted verification receipt',
+          env: {
+            HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
+            MANIFEST_DIGEST: '${{ needs.validate-pr-snapshot.outputs.manifest-digest }}',
+            PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
+            SNAPSHOT_VERSION: '${{ needs.validate-pr-snapshot.outputs.version }}',
+            SOURCE_RUN_ATTEMPT: '${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+            SOURCE_RUN_ID: '${{ needs.validate-pr-snapshot.outputs.run-id }}',
+          },
+          run: `jq -n \
+  --arg repository "$GITHUB_REPOSITORY" \
+  --argjson prNumber "$PR_NUMBER" \
+  --arg headSha "$HEAD_SHA" \
+  --argjson sourceRunId "$SOURCE_RUN_ID" \
+  --argjson sourceRunAttempt "$SOURCE_RUN_ATTEMPT" \
+  --arg version "$SNAPSHOT_VERSION" \
+  --arg manifestSha256 "$MANIFEST_DIGEST" \
+  '{repository, prNumber, headSha, sourceRunId, sourceRunAttempt, version, manifestSha256}' \
+  > "$RUNNER_TEMP/verified-pr-snapshot.json"`,
+        },
+        {
+          name: 'Upload trusted verification receipt',
+          uses: 'actions/upload-artifact@v4',
+          with: {
+            name: 'verified-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.validate-pr-snapshot.outputs.run-attempt }}',
+            path: '${{ runner.temp }}/verified-pr-snapshot.json',
+            'if-no-files-found': 'error',
+            overwrite: true,
+            'retention-days': 30,
+          },
         },
         {
           name: 'Record snapshot provenance',
@@ -632,7 +724,7 @@ echo "Verified $verified package versions, immutable tags, and SHA-512 integriti
 - PR: #$PR_NUMBER
 - Head: \`\${{ needs.validate-pr-snapshot.outputs.head-sha }}\`
 - Version: \`$SNAPSHOT_VERSION\`
-- Immutable npm tag: \`$SNAPSHOT_TAG\`
+- Publish-time npm tag (best-effort mutable metadata): \`$SNAPSHOT_TAG\`
 - Packages: $PACKAGE_COUNT
 - Manifest SHA-256: \`$MANIFEST_DIGEST\`
 - Source CI run: $SOURCE_RUN_URL


### PR DESCRIPTION
## Problem

PR #1458 treated its deterministic npm dist-tag as part of snapshot completeness. npm trusted publishing cannot repair a missing dist-tag without introducing a long-lived token, so a successful publish followed by a missing tag could redispatch forever.

## Goal

Make exact package versions and registry integrities the authoritative cohort identity while retaining the PR/head tag as best-effort mutable metadata. Retries must heal interrupted verification without accepting a stale candidate.

## Decisions

- A trusted verification receipt is required before the scheduler declares an already-published cohort complete.
- Receipt identity binds the PR head, source CI run, and exact pack attempt. A rerun cannot reuse a receipt for different candidate bytes.
- Missing tags are accepted after digest verification; conflicting tags still fail closed.
- Receipt uploads use `overwrite: true` so promotion workflow reruns are idempotent.
- Conflicting cohorts fail the scan after other eligible PRs have still been considered.

## Verification

- `node --test .github/scripts/pr-snapshot-artifact.test.mjs` (11/11 passed)
- `devenv tasks run -m single genie:check` (passed)
- `devenv tasks run check:quick --mode before --no-tui` (passed on the current `main`-based head)
- `git diff --check` (passed)
- Independent final review: no P0/P1/P2 findings

## Complexity

The receipt is the minimum durable evidence needed to distinguish an interrupted publish from a fully integrity-verified cohort without adding a long-lived npm token.

## Concerns

Receipt expiry and transient npm metadata failures deliberately cause conservative re-verification dispatches. They cannot cause false completion.

## Friction & bottlenecks

PR #1458 auto-merged while its review fix was being finalized, so this focused follow-up carries the correction. The `gh pr-review --reviewer @me` connector-identity mismatch is tracked separately in agent tooling feedback.

## Follow-ups

None.

## References

- Follow-up to #1458
- Addresses https://github.com/livestorejs/livestore/pull/1458#discussion_r3609057312

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | ☁️ co3-billow |
| `agent_session_id` | 7f3b9666-034f-4e9e-890b-491957f7f75b |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.144.1 |
| `agent_runtime` | Codex CLI 0.144.1 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore-1458-followup/schickling-assistant/2026-07-19-snapshot-retry-receipts |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->