### PR TITLE
Adopt shared GitHub label IaC + align tooling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Report a bug or unexpected behavior in LiveStore
 title: '[Bug]: '
-labels: ['bug']
+labels: ['type:bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature Request
 description: Propose a new feature or enhancement for LiveStore
 title: '[Feature]: '
-labels: ['enhancement']
+labels: ['type:feature']
 body:
   - type: markdown
     attributes:

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,460 @@
+{
+  "labels": [
+    {
+      "name": "adapter:cf-worker",
+      "color": "aaaaaa",
+      "description": "Cloudflare Worker adapter · Set: manual"
+    },
+    {
+      "name": "adapter:electron",
+      "color": "aaaaaa",
+      "description": "Electron adapter · Set: manual"
+    },
+    {
+      "name": "adapter:expo",
+      "color": "0e4046",
+      "description": "Expo / React Native adapter · Set: manual"
+    },
+    {
+      "name": "adapter:node",
+      "color": "417e38",
+      "description": "Node adapter · Set: manual"
+    },
+    {
+      "name": "adapter:tauri",
+      "color": "a179c5",
+      "description": "Tauri adapter · Set: manual"
+    },
+    {
+      "name": "adapter:web",
+      "color": "e5760f",
+      "description": "Web adapter (browser / worker) · Set: manual"
+    },
+    {
+      "name": "api",
+      "color": "ededed",
+      "description": "Public API surface · Set: manual"
+    },
+    {
+      "name": "area:ci",
+      "color": "1d76db",
+      "description": "CI workflows, runners, and pipeline configuration · Set: manual"
+    },
+    {
+      "name": "area:devenv",
+      "color": "1d76db",
+      "description": "devenv tasks, inputs, and environment configuration · Set: manual"
+    },
+    {
+      "name": "area:effect",
+      "color": "1d76db",
+      "description": "Effect framework usage · Set: manual"
+    },
+    {
+      "name": "area:megarepo",
+      "color": "1d76db",
+      "description": "megarepo CLI and conventions · Set: manual"
+    },
+    {
+      "name": "area:nix",
+      "color": "1d76db",
+      "description": "Nix flakes, derivations, FOD hashes, builders · Set: manual"
+    },
+    {
+      "name": "area:storybook",
+      "color": "1d76db",
+      "description": "Storybook configuration and stories · Set: manual"
+    },
+    {
+      "name": "area:tooling",
+      "color": "1d76db",
+      "description": "Developer tooling, scripts, and utilities · Set: manual"
+    },
+    {
+      "name": "area:typescript",
+      "color": "1d76db",
+      "description": "TypeScript code, tsconfig, and type definitions · Set: manual"
+    },
+    {
+      "name": "breaking-change",
+      "color": "b60205",
+      "description": "Breaking change · Set: manual"
+    },
+    {
+      "name": "ci:deploy-docs",
+      "color": "0e8a16",
+      "description": "Trigger docs deployment for fork PRs · Set: manual"
+    },
+    {
+      "name": "cli",
+      "color": "d23bad",
+      "description": "CLI · Set: manual"
+    },
+    {
+      "name": "commands",
+      "color": "1d76db",
+      "description": "Commands API · Set: manual"
+    },
+    {
+      "name": "compatibility",
+      "color": "e569ae",
+      "description": "Compatibility · Set: manual"
+    },
+    {
+      "name": "contributor-experience",
+      "color": "ededed",
+      "description": "Contributor experience · Set: manual"
+    },
+    {
+      "name": "cross-store",
+      "color": "6b8e23",
+      "description": "Cross-store communication and synchronization · Set: manual"
+    },
+    {
+      "name": "design decision",
+      "color": "4d75c6",
+      "description": "Design decision / RFC · Set: manual"
+    },
+    {
+      "name": "devtools",
+      "color": "95b190",
+      "description": "Devtools · Set: manual"
+    },
+    {
+      "name": "DX",
+      "color": "516c68",
+      "description": "Developer experience · Set: manual"
+    },
+    {
+      "name": "encryption",
+      "color": "79abc2",
+      "description": "Encryption · Set: manual"
+    },
+    {
+      "name": "ergonomics",
+      "color": "aaaaaa",
+      "description": "API ergonomics · Set: manual"
+    },
+    {
+      "name": "error-handling",
+      "color": "aaaaaa",
+      "description": "Error handling · Set: manual"
+    },
+    {
+      "name": "event-sourcing",
+      "color": "379fa5",
+      "description": "Event sourcing / eventlog · Set: manual"
+    },
+    {
+      "name": "example",
+      "color": "2484b8",
+      "description": "Example app · Set: manual"
+    },
+    {
+      "name": "examples",
+      "color": "ededed",
+      "description": "Examples · Set: manual"
+    },
+    {
+      "name": "experiment",
+      "color": "49eee7",
+      "description": "Bounded experiment / spike · Set: manual"
+    },
+    {
+      "name": "exploration",
+      "color": "ededed",
+      "description": "Open-ended exploration · Set: manual"
+    },
+    {
+      "name": "feedback-wanted",
+      "color": "d27a82",
+      "description": "Feedback wanted · Set: manual"
+    },
+    {
+      "name": "has-workaround",
+      "color": "aaaaaa",
+      "description": "Has a known workaround · Set: manual"
+    },
+    {
+      "name": "infrastructure",
+      "color": "ededed",
+      "description": "Repo infrastructure · Set: manual"
+    },
+    {
+      "name": "integration",
+      "color": "ededed",
+      "description": "Framework integration (general) · Set: manual"
+    },
+    {
+      "name": "integration:react",
+      "color": "f59f2a",
+      "description": "React integration · Set: manual"
+    },
+    {
+      "name": "integration:redwood",
+      "color": "aaaaaa",
+      "description": "RedwoodJS integration · Set: manual"
+    },
+    {
+      "name": "integration:solid",
+      "color": "aedf23",
+      "description": "Solid integration · Set: manual"
+    },
+    {
+      "name": "integration:svelte",
+      "color": "aaaaaa",
+      "description": "Svelte integration · Set: manual"
+    },
+    {
+      "name": "migrations",
+      "color": "aec97d",
+      "description": "Schema / data migrations · Set: manual"
+    },
+    {
+      "name": "mono-cli",
+      "color": "ededed",
+      "description": "mono CLI · Set: manual"
+    },
+    {
+      "name": "needs-info",
+      "color": "fef2c0",
+      "description": "More information needed · Set: manual"
+    },
+    {
+      "name": "needs-repro",
+      "color": "1382d1",
+      "description": "Needs a reproduction · Set: manual"
+    },
+    {
+      "name": "optimization",
+      "color": "aaaaaa",
+      "description": "Optimization · Set: manual"
+    },
+    {
+      "name": "origin:agent",
+      "color": "6f42c1",
+      "description": "Filed or primarily produced by an AI agent · Set: AI agent or manual"
+    },
+    {
+      "name": "origin:janitor",
+      "color": "6f42c1",
+      "description": "Filed by janitor automation · Set: janitor-cli"
+    },
+    {
+      "name": "otel",
+      "color": "80bbda",
+      "description": "OpenTelemetry · Set: manual"
+    },
+    {
+      "name": "performance",
+      "color": "71b373",
+      "description": "Performance · Set: manual"
+    },
+    {
+      "name": "queries",
+      "color": "0e7203",
+      "description": "Queries · Set: manual"
+    },
+    {
+      "name": "query-builder",
+      "color": "aaaaaa",
+      "description": "Query builder · Set: manual"
+    },
+    {
+      "name": "schema",
+      "color": "aaaaaa",
+      "description": "Schema / state definition · Set: manual"
+    },
+    {
+      "name": "setup",
+      "color": "1df145",
+      "description": "Setup / getting started · Set: manual"
+    },
+    {
+      "name": "sqlite",
+      "color": "044a64",
+      "description": "SQLite / storage engine · Set: manual"
+    },
+    {
+      "name": "state:blocked",
+      "color": "6e7781",
+      "description": "Blocked on an external dependency or decision · Set: manual"
+    },
+    {
+      "name": "state:declined",
+      "color": "6e7781",
+      "description": "Reviewed and declined; will not be acted on · Set: manual"
+    },
+    {
+      "name": "state:duplicate",
+      "color": "6e7781",
+      "description": "Duplicate of an existing item; tracked elsewhere · Set: manual"
+    },
+    {
+      "name": "state:needs-research",
+      "color": "6e7781",
+      "description": "Needs research / investigation before scope or approach is clear · Set: manual"
+    },
+    {
+      "name": "state:triage",
+      "color": "6e7781",
+      "description": "Needs classification or owner decision · Set: manual"
+    },
+    {
+      "name": "syncing",
+      "color": "a7f49d",
+      "description": "Sync engine and protocol · Set: manual"
+    },
+    {
+      "name": "syncing:cf",
+      "color": "aaaaaa",
+      "description": "Cloudflare sync provider · Set: manual"
+    },
+    {
+      "name": "syncing:electric",
+      "color": "f62dc9",
+      "description": "ElectricSQL sync provider · Set: manual"
+    },
+    {
+      "name": "testing",
+      "color": "5d3ac4",
+      "description": "Testing · Set: manual"
+    },
+    {
+      "name": "type:agent-tooling",
+      "color": "1f8fb8",
+      "description": "Agent, automation, AI workflow, or developer-agent tooling · Set: manual"
+    },
+    {
+      "name": "type:bug",
+      "color": "d73a4a",
+      "description": "Something broken or a regression · Set: manual"
+    },
+    {
+      "name": "type:chore",
+      "color": "bfd4e2",
+      "description": "Maintenance, cleanup, dependencies, or CI · Set: manual"
+    },
+    {
+      "name": "type:docs",
+      "color": "0075ca",
+      "description": "Documentation-only change or documentation task · Set: manual"
+    },
+    {
+      "name": "type:epic",
+      "color": "8250df",
+      "description": "Large tracking issue with child tasks · Set: manual"
+    },
+    {
+      "name": "type:feature",
+      "color": "0e8a16",
+      "description": "New user-visible or system capability · Set: manual"
+    },
+    {
+      "name": "type:incident",
+      "color": "b60205",
+      "description": "Live or recent operational incident · Set: manual or andon CLI"
+    },
+    {
+      "name": "type:rca",
+      "color": "5319e7",
+      "description": "Root-cause analysis or investigation record · Set: manual"
+    },
+    {
+      "name": "type:refactor",
+      "color": "c5def5",
+      "description": "Behavior-preserving code restructuring · Set: manual"
+    },
+    {
+      "name": "type:task",
+      "color": "cdc5e2",
+      "description": "Scoped implementation/follow-up work (not bug/feature/docs/incident/RCA/epic) · Set: manual"
+    },
+    {
+      "name": "vite-plugin",
+      "color": "907c03",
+      "description": "Vite plugin · Set: manual"
+    },
+    {
+      "name": "web:ssr",
+      "color": "f2e7f6",
+      "description": "SSR / server rendering · Set: manual"
+    },
+    {
+      "name": "webmesh",
+      "color": "aaaaaa",
+      "description": "Webmesh transport · Set: manual"
+    },
+    {
+      "name": "website",
+      "color": "aaaaaa",
+      "description": "Website / docs site · Set: manual"
+    }
+  ],
+  "deprecated": [
+    "bug",
+    "documentation",
+    "duplicate",
+    "enhancement",
+    "invalid",
+    "mq:agent-active",
+    "mq:blocked",
+    "mq:ci-admitted",
+    "mq:enrolled",
+    "mq:merge-held",
+    "mq:needs-agent",
+    "mq:needs-human",
+    "mq:priority-0",
+    "mq:priority-1",
+    "mq:priority-10",
+    "mq:priority-100",
+    "mq:priority-20",
+    "mq:priority-30",
+    "mq:queue-head",
+    "mq:status",
+    "question",
+    "wontfix"
+  ],
+  "legacyMigrations": [
+    {
+      "from": "blocked-upstream",
+      "to": "state:blocked"
+    },
+    {
+      "from": "bug",
+      "to": "type:bug"
+    },
+    {
+      "from": "ci",
+      "to": "area:ci"
+    },
+    {
+      "from": "docs",
+      "to": "type:docs"
+    },
+    {
+      "from": "documentation",
+      "to": "type:docs"
+    },
+    {
+      "from": "effect",
+      "to": "area:effect"
+    },
+    {
+      "from": "enhancement",
+      "to": "type:feature"
+    },
+    {
+      "from": "needs-research",
+      "to": "state:needs-research"
+    },
+    {
+      "from": "refactor",
+      "to": "type:refactor"
+    },
+    {
+      "from": "tooling",
+      "to": "area:tooling"
+    }
+  ]
+}

--- a/.github/labels.json.genie.ts
+++ b/.github/labels.json.genie.ts
@@ -1,0 +1,125 @@
+import {
+  commonLabels,
+  deprecatedDefaults,
+  githubLabels,
+  type LabelDef,
+  legacyMigrations,
+  mqDeprecated,
+} from '#mr/effect-utils/genie/external.ts'
+
+/**
+ * Core-local `area:*` / domain labels for livestore. The cross-cutting axes
+ * (`type:*`, `state:*`, `origin:*`, and the shared `area:*` baseline) come from
+ * `commonLabels`; the labels below are livestore's own product taxonomy, which
+ * is finer-grained than the shared `area:*` baseline (e.g. `adapter:web` vs
+ * `adapter:expo`) and is preserved rather than flattened.
+ *
+ * Colors are kept at their existing live values so adoption does not recolor the
+ * established public taxonomy. Community labels (`help wanted`, `good first
+ * issue`, `needs-sponsor`) are intentionally NOT enumerated here so they survive
+ * untouched (the reconciler only creates/patches listed labels and deletes
+ * `deprecated` ones).
+ */
+const livestoreAdapterLabels: readonly LabelDef[] = [
+  { name: 'adapter:web', color: 'E5760F', description: 'Web adapter (browser / worker) · Set: manual' },
+  { name: 'adapter:expo', color: '0E4046', description: 'Expo / React Native adapter · Set: manual' },
+  { name: 'adapter:node', color: '417e38', description: 'Node adapter · Set: manual' },
+  { name: 'adapter:tauri', color: 'A179C5', description: 'Tauri adapter · Set: manual' },
+  { name: 'adapter:electron', color: 'aaaaaa', description: 'Electron adapter · Set: manual' },
+  { name: 'adapter:cf-worker', color: 'aaaaaa', description: 'Cloudflare Worker adapter · Set: manual' },
+]
+
+const livestoreSyncLabels: readonly LabelDef[] = [
+  { name: 'syncing', color: 'A7F49D', description: 'Sync engine and protocol · Set: manual' },
+  { name: 'syncing:cf', color: 'aaaaaa', description: 'Cloudflare sync provider · Set: manual' },
+  { name: 'syncing:electric', color: 'f62dc9', description: 'ElectricSQL sync provider · Set: manual' },
+]
+
+const livestoreIntegrationLabels: readonly LabelDef[] = [
+  { name: 'integration:react', color: 'F59F2A', description: 'React integration · Set: manual' },
+  { name: 'integration:solid', color: 'AEDF23', description: 'Solid integration · Set: manual' },
+  { name: 'integration:svelte', color: 'aaaaaa', description: 'Svelte integration · Set: manual' },
+  { name: 'integration:redwood', color: 'aaaaaa', description: 'RedwoodJS integration · Set: manual' },
+  { name: 'integration', color: 'ededed', description: 'Framework integration (general) · Set: manual' },
+]
+
+const livestoreDomainLabels: readonly LabelDef[] = [
+  { name: 'devtools', color: '95B190', description: 'Devtools · Set: manual' },
+  { name: 'sqlite', color: '044a64', description: 'SQLite / storage engine · Set: manual' },
+  { name: 'event-sourcing', color: '379FA5', description: 'Event sourcing / eventlog · Set: manual' },
+  { name: 'performance', color: '71B373', description: 'Performance · Set: manual' },
+  { name: 'testing', color: '5D3AC4', description: 'Testing · Set: manual' },
+  { name: 'schema', color: 'aaaaaa', description: 'Schema / state definition · Set: manual' },
+  { name: 'api', color: 'ededed', description: 'Public API surface · Set: manual' },
+  { name: 'error-handling', color: 'aaaaaa', description: 'Error handling · Set: manual' },
+  { name: 'cli', color: 'd23bad', description: 'CLI · Set: manual' },
+  { name: 'mono-cli', color: 'ededed', description: 'mono CLI · Set: manual' },
+  { name: 'migrations', color: 'AEC97D', description: 'Schema / data migrations · Set: manual' },
+  { name: 'otel', color: '80bbda', description: 'OpenTelemetry · Set: manual' },
+  { name: 'compatibility', color: 'E569AE', description: 'Compatibility · Set: manual' },
+  { name: 'commands', color: '1d76db', description: 'Commands API · Set: manual' },
+  { name: 'cross-store', color: '6B8E23', description: 'Cross-store communication and synchronization · Set: manual' },
+  { name: 'vite-plugin', color: '907C03', description: 'Vite plugin · Set: manual' },
+  { name: 'queries', color: '0E7203', description: 'Queries · Set: manual' },
+  { name: 'query-builder', color: 'aaaaaa', description: 'Query builder · Set: manual' },
+  { name: 'encryption', color: '79ABC2', description: 'Encryption · Set: manual' },
+  { name: 'webmesh', color: 'aaaaaa', description: 'Webmesh transport · Set: manual' },
+  { name: 'breaking-change', color: 'B60205', description: 'Breaking change · Set: manual' },
+  { name: 'web:ssr', color: 'f2e7f6', description: 'SSR / server rendering · Set: manual' },
+  { name: 'website', color: 'aaaaaa', description: 'Website / docs site · Set: manual' },
+  { name: 'ci:deploy-docs', color: '0E8A16', description: 'Trigger docs deployment for fork PRs · Set: manual' },
+]
+
+/** Workflow / process / experience labels specific to livestore. */
+const livestoreProcessLabels: readonly LabelDef[] = [
+  { name: 'DX', color: '516C68', description: 'Developer experience · Set: manual' },
+  { name: 'design decision', color: '4D75C6', description: 'Design decision / RFC · Set: manual' },
+  { name: 'feedback-wanted', color: 'D27A82', description: 'Feedback wanted · Set: manual' },
+  { name: 'setup', color: '1DF145', description: 'Setup / getting started · Set: manual' },
+  { name: 'infrastructure', color: 'ededed', description: 'Repo infrastructure · Set: manual' },
+  { name: 'contributor-experience', color: 'ededed', description: 'Contributor experience · Set: manual' },
+  { name: 'exploration', color: 'ededed', description: 'Open-ended exploration · Set: manual' },
+  { name: 'experiment', color: '49EEE7', description: 'Bounded experiment / spike · Set: manual' },
+  { name: 'ergonomics', color: 'aaaaaa', description: 'API ergonomics · Set: manual' },
+  { name: 'optimization', color: 'aaaaaa', description: 'Optimization · Set: manual' },
+  { name: 'example', color: '2484B8', description: 'Example app · Set: manual' },
+  { name: 'examples', color: 'ededed', description: 'Examples · Set: manual' },
+  { name: 'needs-repro', color: '1382D1', description: 'Needs a reproduction · Set: manual' },
+  { name: 'needs-info', color: 'fef2c0', description: 'More information needed · Set: manual' },
+  { name: 'has-workaround', color: 'aaaaaa', description: 'Has a known workaround · Set: manual' },
+]
+
+/**
+ * Legacy migrations before deletion. The shared `legacyMigrations` covers the
+ * GitHub defaults (`bug`/`enhancement`/`documentation`). livestore adds:
+ *   - `docs` → `type:docs` (livestore used `docs`, not `documentation`)
+ *   - `needs-research` / `blocked-upstream` → `state:*`
+ *   - `refactor` → `type:refactor` (the label that motivated the shared axis)
+ *   - the three bare `area:*` collisions (`ci`/`effect`/`tooling`)
+ * The reconciler moves issues onto the target then leaves the (now-empty) source
+ * label in place; a follow-up can delete the emptied legacy labels.
+ */
+const livestoreLegacyMigrations = [
+  { from: 'docs', to: 'type:docs' },
+  { from: 'needs-research', to: 'state:needs-research' },
+  { from: 'blocked-upstream', to: 'state:blocked' },
+  { from: 'refactor', to: 'type:refactor' },
+  { from: 'ci', to: 'area:ci' },
+  { from: 'effect', to: 'area:effect' },
+  { from: 'tooling', to: 'area:tooling' },
+] as const
+
+export default githubLabels({
+  labels: [
+    ...commonLabels,
+    ...livestoreAdapterLabels,
+    ...livestoreSyncLabels,
+    ...livestoreIntegrationLabels,
+    ...livestoreDomainLabels,
+    ...livestoreProcessLabels,
+  ],
+  // Delete the vestigial `mq:*` merge-queue labels (livestore is not Hypermerge-enrolled)
+  // alongside the GitHub defaults.
+  deprecated: [...deprecatedDefaults, ...mqDeprecated],
+  legacyMigrations: [...legacyMigrations, ...livestoreLegacyMigrations],
+})

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1783704936,
-        "narHash": "sha256-NyHNhgLp0eQSv2J4UWV0JEabje63zbWV2boDMz/BJ3I=",
+        "lastModified": 1784468935,
+        "narHash": "sha256-zkeEeD2ykW0PbejEHVfzmXHvngHvuSzgAwCMUyzvkbk=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "348be5df590265d02d6a5bc11b5b4990b8f0157e",
+        "rev": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1783704936,
-        "narHash": "sha256-NyHNhgLp0eQSv2J4UWV0JEabje63zbWV2boDMz/BJ3I=",
+        "lastModified": 1784468935,
+        "narHash": "sha256-zkeEeD2ykW0PbejEHVfzmXHvngHvuSzgAwCMUyzvkbk=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "348be5df590265d02d6a5bc11b5b4990b8f0157e",
+        "rev": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -324,6 +324,8 @@ in
     inputs.playwright.devenvModules.default
     # Shared task modules from effect-utils
     taskModules.genie
+    # gh:apply-labels / gh:check-labels — reconcile .github/labels.json with live labels.
+    (taskModules.gh-labels { repo = "livestorejs/livestore"; })
     (taskModules.megarepo { syncAll = !ci; })
     (taskModules.ts {
       tsconfigFile = "tsconfig.dev.json";

--- a/genie/projections/core/pnpm-workspace.yaml
+++ b/genie/projections/core/pnpm-workspace.yaml
@@ -14,11 +14,7 @@ peerDependencyRules:
     typescript: '>=6.0.0'
     vitest: '>=4.0.0'
 
-enableGlobalVirtualStore: true
-
-storeDir: .devenv/pnpm-store-pure-v1
-
-packageImportMethod: clone-or-copy
+packageImportMethod: auto
 
 sideEffectsCache: false
 

--- a/genie/projections/tooling/pnpm-workspace.yaml
+++ b/genie/projections/tooling/pnpm-workspace.yaml
@@ -14,11 +14,7 @@ peerDependencyRules:
     typescript: '>=6.0.0'
     vitest: '>=4.0.0'
 
-enableGlobalVirtualStore: true
-
-storeDir: .devenv/pnpm-store-pure-v1
-
-packageImportMethod: clone-or-copy
+packageImportMethod: auto
 
 sideEffectsCache: false
 
@@ -58,10 +54,6 @@ allowBuilds:
   workerd: true
 
 packageExtensions:
-  react-error-boundary:
-    dependencies:
-      '@types/react': 19.2.7
-      '@types/react-dom': 19.2.3
   '@livestore/devtools-vite':
     dependencies:
       '@parcel/watcher': ^2.5.6

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "348be5df590265d02d6a5bc11b5b4990b8f0157e",
+      "commit": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
       "pinned": true,
-      "lockedAt": "2026-07-15T13:22:56.365Z"
+      "lockedAt": "2026-07-19T14:46:24.673Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/pnpm-install-contract.json
+++ b/pnpm-install-contract.json
@@ -64,12 +64,6 @@
           "@parcel/watcher": "^2.5.6"
         }
       },
-      "react-error-boundary": {
-        "dependencies": {
-          "@types/react": "19.2.7",
-          "@types/react-dom": "19.2.3"
-        }
-      },
       "starlight-auto-sidebar": {
         "dependencies": {
           "astro": ">=6.0.0"
@@ -101,7 +95,7 @@
     "ignoreScripts": true,
     "minimumReleaseAgeExclude": ["@effect/platform", "@types/node", "effect"],
     "optimisticRepeatInstall": false,
-    "packageImportMethod": "clone-or-copy",
+    "packageImportMethod": "auto",
     "pmOnFail": "ignore",
     "sideEffectsCache": false,
     "strictPeerDependencies": false,
@@ -135,16 +129,13 @@
   },
   "schemaVersion": 1,
   "storeContract": {
-    "globalVirtualStore": {
-      "enabled": true
-    },
+    "globalVirtualStore": {},
     "layoutVersion": "v11",
     "owner": "pnpm",
     "sharedFilesStore": {
       "disabledInCi": true,
       "enabledForLocalDev": true
-    },
-    "storeDir": ".devenv/pnpm-store-pure-v1"
+    }
   },
   "workspaceManifestContract": {
     "injectWorkspacePackages": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   '@tanstack/start-server-core': 1.145.7
   '@tanstack/start-client-core': 1.145.7
 
-packageExtensionsChecksum: sha256-6QRcYLQaei02Zt3wQj7DyvIhJqzSdeJ8crzELgh/JTI=
+packageExtensionsChecksum: sha256-3AN3Jmlp4NTZShupTave7A7boFs1CLxO47lvh/A45h8=
 
 importers:
 
@@ -28001,8 +28001,6 @@ snapshots:
 
   react-error-boundary@6.1.1(react@19.2.3):
     dependencies:
-      '@types/react': 19.2.7
-      '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.3
 
   react-icons@5.5.0(react@19.2.3):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,10 +55,6 @@ overrides:
   '@tanstack/start-client-core': 1.145.7
 
 packageExtensions:
-  react-error-boundary:
-    dependencies:
-      '@types/react': 19.2.7
-      '@types/react-dom': 19.2.3
   '@livestore/devtools-vite':
     dependencies:
       '@parcel/watcher': ^2.5.6
@@ -104,11 +100,7 @@ strictPeerDependencies: false
 
 injectWorkspacePackages: false
 
-enableGlobalVirtualStore: true
-
-storeDir: .devenv/pnpm-store-pure-v1
-
-packageImportMethod: clone-or-copy
+packageImportMethod: auto
 
 optimisticRepeatInstall: false
 


### PR DESCRIPTION
Brings livestore onto the shared GitHub label Infrastructure-as-Code (generated `.github/labels.json` + a `gh:apply-labels` / `gh:check-labels` reconciler), replacing the previously ad-hoc label set.

## What & why
livestore had ~74 hand-managed labels with no source of truth. This adopts the shared, generated catalog while **preserving** livestore's own finer-grained product taxonomy (which is more specific than the shared baseline).

- **Add `.github/labels.json.genie.ts`** — composes the shared cross-cutting axes (`type:*`, `state:*`, `origin:*`, and a lean `area:*` baseline) and keeps livestore's domain labels (`adapter:web`/`adapter:expo`/…, `syncing:*`, `integration:*`, `sqlite`, `event-sourcing`, `devtools`, `commands`, …), preserving their existing colors.
- **Migrate legacy labels** via `legacyMigrations`: `bug`→`type:bug`, `enhancement`→`type:feature`, `docs`→`type:docs`, `needs-research`→`state:needs-research`, `blocked-upstream`→`state:blocked`, `refactor`→`type:refactor`, and the bare `ci`/`effect`/`tooling` → `area:ci`/`area:effect`/`area:tooling`.
- **Deprecate the `mq:*` merge-queue labels** (livestore is not enrolled in the merge automation, so nothing acts on them).
- **Wire the `gh-labels` devenv module** — `gh:apply-labels` (idempotent upsert/migrate/delete) and `gh:check-labels` (drift report).
- **Update the issue templates** to `type:bug` / `type:feature` so newly-filed issues don't recreate the deprecated defaults.
- **Repin the shared tooling dependency to its latest main** and refresh the derived `pnpm-workspace.yaml` projections + lockfile.

## Preserved untouched
`help wanted`, `good first issue`, and `needs-sponsor` are intentionally not enumerated, so they (and any saved filters over them) survive unchanged. The legacy source labels linger empty after migration (the reconciler keeps migration sources); a follow-up can delete them.

## Validation
`genie:check` and `check:quick` pass locally. The live reconcile against this repo's labels is 25 creates + 53 description patches + ~461 issue relabels + 8 `mq:*` deletes.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌬️ cl1-gust |
| `agent_session_id` | 9edd38a7-802d-42b6-a585-8811e148a65f |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.206 |
| `agent_runtime` | Claude Code 2.1.206 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/1n76sy6i9y3ki3k4w04jksqvygw67sj0-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/jn6r0r7r59x3a525jch4pwzwykszqp60-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-19-label-catalog-adopt |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@4eac376 |
</details>
<!-- agent-footer:end -->