### PR TITLE
Resolve inconsistent intent-layer RFC guidance by folding accepted intent before implementation

### DIFF
--- a/.changeset/rfc-intent-before-code.md
+++ b/.changeset/rfc-intent-before-code.md
@@ -1,0 +1,6 @@
+---
+---
+
+No release impact. Reconciles contributor guidance so accepted RFC contracts
+fold into the intent layer before implementation, with implementation gaps
+tracked and closed through deltas.

--- a/context/05-contributing/requirements.md
+++ b/context/05-contributing/requirements.md
@@ -19,11 +19,13 @@ absorbed surfaces per root DELTA-001).
 
 - **LS.CONTRIB-R01 RFC gate:** Significant changes to public APIs or core
   architecture are proposed as RFCs before implementation.
-- **LS.CONTRIB-R02 Fold-in rule:** When an RFC is accepted and its
-  implementation lands, its durable content is folded into the owning VRS
-  nodes (requirements/spec clauses; choices and rejected alternatives as
-  decision records citing the RFC). The RFC then becomes a historical record
-  and is never updated to track reality. `refines: LS-R15`
+- **LS.CONTRIB-R02 Fold-in rule:** When an RFC is accepted, its durable content
+  is folded into the owning VRS nodes (requirements/spec clauses; choices and
+  rejected alternatives as decision records citing the RFC). Any accepted
+  contract that is not yet implemented is represented by a `.delta/` record
+  with an explicit close condition; each delta is closed as the implementation
+  and its required evidence land. The RFC then becomes a historical record and
+  is never updated to track reality. `refines: LS-R15`
 
 ### Contribution workflow
 

--- a/context/05-contributing/spec.md
+++ b/context/05-contributing/spec.md
@@ -16,23 +16,33 @@ see [01-collaboration/](./01-collaboration/spec.md).
 ## RFC Lifecycle (LS.CONTRIB-R01, R02)
 
 ```
-draft ──► review PR ──► accepted (PR merged) ──► implemented
-                                                     │
-                                              fold-in to VRS
-                                                     │
-                                            RFC = historical record
+draft ──► review PR ──► accepted (PR merged) ──► fold-in to VRS
+                                                               │
+                                                    RFC = historical record
+                                                               │
+                                             unimplemented intent = deltas
+                                                               │
+                                                    implementation lands
+                                                               │
+                                                       deltas closed
 ```
 
 1. **Draft** — copy `contributor-docs/rfcs/0000-template.md` to the next
    sequential number. Required sections: Context (facts), Problem, Proposed
    Solution, Alternatives Considered, Open Questions.
 2. **Review** — open a PR, gather feedback, iterate until consensus.
-3. **Accept** — merge the PR; implementation may begin.
-4. **Fold in** (normative addition per decision 0002) — with the landed
-   implementation, move durable content into the owning VRS nodes; record
-   the choice and rejected alternatives as `.decisions/` entries citing the
-   RFC. The published RFC process description includes this step
+3. **Accept** — merge the RFC PR. Acceptance triggers intent-layer fold-in;
+   implementation follows the canonical intent rather than preceding it.
+4. **Fold in** (normative addition per decision 0002) — move durable content
+   into the owning VRS nodes; record the choice and rejected alternatives as
+   `.decisions/` entries citing the RFC. The RFC becomes a historical record.
+   For every accepted contract that is not yet implemented, add a `.delta/`
+   record that states the divergence and its close condition. The published
+   RFC process description derives from this rule
    (`contributor-docs/rfcs/index.md` §4, added 2026-07-16).
+5. **Implement and close deltas** — track implementation against the folded-in
+   intent. Close each delta as the implementation and its required evidence
+   land.
 
 Current RFC state: RFC 0001 (multi-store API) is shipped and folded into
 [`02-system/05-store/`](../02-system/05-store/spec.md) — whose spec records

--- a/contributor-docs/rfcs/index.md
+++ b/contributor-docs/rfcs/index.md
@@ -54,14 +54,19 @@ Include:
 Once the RFC has been reviewed and refined:
 
 - Merge the PR to formally accept the RFC
-- Implementation can begin
+- Fold its durable contracts into the intent layer before implementation begins
 
 ### 4. Fold into the intent layer
 
-Once an accepted RFC is implemented, its durable content moves into the
-intent layer (`context/`): contracts land as requirements/spec clauses in
-the owning nodes, and the decision — including rejected alternatives — is
-recorded under the owning node's `.decisions/`, citing the RFC. The RFC
-itself remains as a historical record and is no longer updated. See
+Acceptance triggers fold-in. The RFC's durable content moves into the intent
+layer (`context/`) before implementation: contracts land as requirements/spec
+clauses in the owning nodes, and the decision — including rejected
+alternatives — is recorded under the owning node's `.decisions/`, citing the
+RFC. The RFC itself remains as a historical record and is no longer updated.
+
+If any accepted contract is not yet implemented, record the divergence in the
+owning node's `.delta/` directory with an explicit close condition. Track the
+implementation against that canonical intent and close each delta as the
+implementation and its required evidence land. See
 [`context/05-contributing/spec.md`](../../context/05-contributing/spec.md)
 for the normative rule.


### PR DESCRIPTION
## Problem

The intent-layer instructions currently encode two conflicting RFC lifecycle directions. This PR resolves the inconsistency by choosing the lifecycle already established by decisions 0002 and 0004: acceptance makes an RFC's durable contracts canonical intent, and implementation follows that intent. Any accepted contract not yet implemented is tracked explicitly through a delta until the implementation and its required evidence land.

We choose this direction because the VRS tree is the always-current source of truth. Allowing implementation to precede fold-in would make shipping code, rather than accepted intent, the effective authority and would contradict the repository's intent-layer precedence rules.

RFC 0003 in #1442 already follows the intended acceptance → fold-in → delta-tracked implementation sequence. This PR reconciles the general process only; it does not fold RFC 0003 into the intent layer.

## Solution

- Update the protected `LS.CONTRIB-R02` requirement, with maintainer confirmation, so acceptance triggers fold-in and unimplemented accepted contracts are tracked as deltas.
- Rewrite the normative lifecycle diagram and steps in `context/05-contributing/spec.md` so acceptance triggers fold-in before implementation.
- State that accepted but unimplemented contracts receive `.delta/` records with explicit close conditions, and that those deltas close as implementation and evidence land.
- Update the derived contributor-facing RFC guide to match the canonical `context/` process.
- Add an empty changeset because the process correction has no release impact.

## Validation

- Targeted intent-layer invariant suite: 1 file passed, 8 tests passed (`vitest 4.1.9`; run with a temporary empty config because `devenv` and workspace dependencies were unavailable in this checkout).
- Relative Markdown links in all three lifecycle files resolve locally.
- Conflict-pattern check confirms the implementation-before-fold-in wording is gone.
- `git diff --check` passes.
- Not run: `devenv tasks run lint:full:fix` because `devenv` is unavailable in the current shell.

### Demo (optional)

```text
RFC draft → review → acceptance → intent-layer fold-in
                                  → implementation tracked by delta
                                  → delta closed
```

## Related issues

- Related RFC: #1442
