### PR TITLE
fix(devenv): detect drifted effect-utils checkout instead of failing opaquely

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -24,16 +24,16 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1784468935,
-        "narHash": "sha256-zkeEeD2ykW0PbejEHVfzmXHvngHvuSzgAwCMUyzvkbk=",
+        "lastModified": 1784627611,
+        "narHash": "sha256-cvBFGX5hU7cbvkFmZM17GBm/xBQQSN7/78yiGzTGlRg=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
+        "rev": "73f8b93fcd5bc227b614a7c423a0ebfe5d505886",
         "type": "github"
       },
       "original": {
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "ref": "schickling-assistant/2026-07-21-megarepo-member-lockstep",
         "repo": "effect-utils",
         "type": "github"
       }
@@ -190,17 +190,17 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1784468935,
-        "narHash": "sha256-zkeEeD2ykW0PbejEHVfzmXHvngHvuSzgAwCMUyzvkbk=",
+        "lastModified": 1784627611,
+        "narHash": "sha256-cvBFGX5hU7cbvkFmZM17GBm/xBQQSN7/78yiGzTGlRg=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
+        "rev": "73f8b93fcd5bc227b614a7c423a0ebfe5d505886",
         "type": "github"
       },
       "original": {
         "dir": "nix/playwright-flake",
         "owner": "overengineeringstudio",
-        "ref": "main",
+        "ref": "schickling-assistant/2026-07-21-megarepo-member-lockstep",
         "repo": "effect-utils",
         "type": "github"
       }

--- a/devenv.nix
+++ b/devenv.nix
@@ -8,11 +8,20 @@ let
   # Prefer the megarepo-materialized effect-utils checkout when present so the
   # downstream shell/task CLIs match the exact generator sources imported from
   # ./repos/effect-utils during CI and local megarepo workflows.
+  #
+  # Resolved through the shared helper so that a checkout which has drifted from
+  # megarepo.lock fails with an actionable error instead of an opaque missing
+  # attribute during evaluation (livestorejs/livestore#1467). The helper is loaded
+  # from the pinned input rather than the checkout, since resolving the checkout
+  # is precisely what it decides. Tracking worktrees (`mr config pin ... -c <ref>`)
+  # are left alone so co-development keeps working.
   effectUtils =
-    if builtins.pathExists ./repos/effect-utils/flake.nix then
-      builtins.getFlake (toString ./repos/effect-utils)
-    else
-      inputs.effect-utils;
+    (inputs.effect-utils.lib.megarepoMember { inherit lib; }).resolve {
+      name = "effect-utils";
+      memberPath = ./repos/effect-utils;
+      lockFile = ./megarepo.lock;
+      pinned = inputs.effect-utils;
+    };
   effectUtilsPackages = effectUtils.packages.${pkgs.system};
   effectTsgo = effectUtilsPackages.effect-tsgo;
   taskModules = effectUtils.devenvModules.tasks;
@@ -330,7 +339,6 @@ in
     (taskModules.ts {
       tsconfigFile = "tsconfig.dev.json";
       tsBinPkg = effectTsgo;
-      tscBin = "$DEVENV_ROOT/node_modules/.bin/tsc";
     })
     (taskModules.check {
       hasTests = false;

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -7,9 +7,14 @@ inputs:
       nixpkgs:
         follows: nixpkgs
   playwright:
-    url: github:overengineeringstudio/effect-utils/main?dir=nix/playwright-flake
+    # TEMPORARY (megarepo alignment phase 1): tracks the same effect-utils PR
+    # branch as the `effect-utils` input so both stay lock-synced. Retarget to
+    # `main` together once that PR merges.
+    url: github:overengineeringstudio/effect-utils/schickling-assistant/2026-07-21-megarepo-member-lockstep?dir=nix/playwright-flake
     inputs:
       nixpkgs:
         follows: nixpkgs
   effect-utils:
-    url: github:overengineeringstudio/effect-utils/main
+    # TEMPORARY (megarepo alignment phase 1): pinned to the upstream PR branch
+    # that adds `lib.megarepoMember`. Retarget to `main` once that PR merges.
+    url: github:overengineeringstudio/effect-utils/schickling-assistant/2026-07-21-megarepo-member-lockstep

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,5 +1,5 @@
 members {
-    effect-utils "overengineeringstudio/effect-utils#main"
+    effect-utils "overengineeringstudio/effect-utils#schickling-assistant/2026-07-21-megarepo-member-lockstep"
     effect "effect-ts/effect"
     livestore-contrib "livestorejs/livestore-contrib"
 }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
+      "ref": "schickling-assistant/2026-07-21-megarepo-member-lockstep",
+      "commit": "73f8b93fcd5bc227b614a7c423a0ebfe5d505886",
       "pinned": true,
-      "lockedAt": "2026-07-19T14:46:24.673Z"
+      "lockedAt": "2026-07-21T10:01:52.904Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
Fixes #1467.

## Problem

`devenv shell` from a clean checkout died during Nix evaluation with `error: attribute 'gh-labels' missing`, before the shell could be entered.

`repos/` is gitignored, so a `git status`-clean checkout says nothing about whether members match `megarepo.lock`. `devenv.nix` prefers the materialized `repos/effect-utils` checkout — deliberately, so that Nix helpers and the TypeScript generator sources come from the same revision — but that feeds an **untracked, unversioned directory into Nix evaluation**. When the checkout drifts from the lock, evaluation reads helpers from the stale revision and fails opaquely.

The check that would have explained it, `mr:lock-sync-check`, only runs **inside** the shell — so the diagnostic was unreachable exactly when it was needed.

Worth noting: the reported checkout was at `b5e983b0` while the lock said `f007561eb`, and I reproduced `mr apply` itself materializing a stale revision despite an unmodified lock. So this drift is not simply "someone forgot to run `mr apply`".

## Change

Resolve the member through the shared `lib.megarepoMember` helper. It preserves the existing lockstep behaviour and makes drift explicit:

| state | result |
|---|---|
| member not materialized | pinned flake input |
| tracking worktree | local checkout (deliberate co-development) |
| commit worktree, matches lock | local checkout — unchanged behaviour |
| commit worktree, drifted | error naming both revisions + `mr apply` |

Tracking worktrees created by `mr config pin <member> --checkout <ref>` are deliberately left alone, so co-developing effect-utils keeps working.

Also adopts the upstream `taskModules.ts` change that moved emit to `tsgo` and dropped the now-removed `tscBin` argument.

## Verification

End to end in this repo, all three states:

- **member absent** → falls back to the pinned input, shell enters (exit 0)
- **member matches lock** (`f007561eb`) → resolves to the local checkout, shell enters (exit 0) — no behaviour change
- **member drifted** (`b5e983b0` vs lock `f007561eb`, i.e. the exact reported state) → fails with:

```
error: megarepo member 'effect-utils' is out of sync with megarepo.lock.

  materialized: b5e983b0be87c4ae5c06d64bbd6852c9518a77c3
  expected:     f007561eb40e1a4c3a0fad3adafb14cd420bafc0

  ...
  mr apply
```

`check:quick` passes.

One caveat found while testing: devenv caches evaluation, so an already-warm shell will not re-detect drift until something invalidates the cache (`devenv --refresh-eval-cache`). The guard fires whenever evaluation actually happens — which is precisely when the opaque failure would otherwise occur.

## Merge order

⚠️ **Phase 1 — do not merge before the upstream PR.** `devenv.yaml` (both the `effect-utils` and `playwright` inputs) and `megarepo.kdl` are temporarily pinned to the effect-utils branch that introduces `lib.megarepoMember`. Once that PR merges, all of these must be retargeted to `main` and the locks refreshed.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌄 cl2-vale |
| `agent_session_id` | d1dbf622-1045-4840-aa99-085f5211d5cf |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/r0yyx5vd9frm4d8klx3i3c1930d9k2ix-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/1rg1cdw91rx4gris2kh0sdwyd4d39nxf-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-21-fix-1467-member-lockstep |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->