### PR TITLE
fix(devenv): resolve effect-utils from the pinned input

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,14 +5,20 @@
   ...
 }:
 let
-  # Prefer the megarepo-materialized effect-utils checkout when present so the
-  # downstream shell/task CLIs match the exact generator sources imported from
-  # ./repos/effect-utils during CI and local megarepo workflows.
-  effectUtils =
-    if builtins.pathExists ./repos/effect-utils/flake.nix then
-      builtins.getFlake (toString ./repos/effect-utils)
-    else
-      inputs.effect-utils;
+  # Resolve effect-utils from the pinned flake input, never from the
+  # megarepo-materialized checkout.
+  #
+  # This previously preferred ./repos/effect-utils so the shell/task CLIs would
+  # match the generator sources imported from that same checkout. That coupling
+  # is already guaranteed elsewhere: `mr:lock-sync-check` keeps devenv.lock in
+  # step with megarepo.lock, so the pinned input *is* the locked member revision.
+  # Reading the checkout added nothing but a dependency on untracked state —
+  # `repos/` is gitignored, so a git-clean tree says nothing about whether
+  # members match the lock, and a drifted checkout made evaluation fail with an
+  # opaque missing attribute before the shell could be entered (#1467).
+  #
+  # Every other megarepo member already resolves effect-utils this way.
+  effectUtils = inputs.effect-utils;
   effectUtilsPackages = effectUtils.packages.${pkgs.system};
   effectTsgo = effectUtilsPackages.effect-tsgo;
   taskModules = effectUtils.devenvModules.tasks;

--- a/devenv.nix
+++ b/devenv.nix
@@ -5,19 +5,9 @@
   ...
 }:
 let
-  # Resolve effect-utils from the pinned flake input, never from the
-  # megarepo-materialized checkout.
-  #
-  # This previously preferred ./repos/effect-utils so the shell/task CLIs would
-  # match the generator sources imported from that same checkout. That coupling
-  # is already guaranteed elsewhere: `mr:lock-sync-check` keeps devenv.lock in
-  # step with megarepo.lock, so the pinned input *is* the locked member revision.
-  # Reading the checkout added nothing but a dependency on untracked state —
-  # `repos/` is gitignored, so a git-clean tree says nothing about whether
-  # members match the lock, and a drifted checkout made evaluation fail with an
-  # opaque missing attribute before the shell could be entered (#1467).
-  #
-  # Every other megarepo member already resolves effect-utils this way.
+  # Pinned input, not ./repos/effect-utils: `mr:lock-sync-check` already keeps
+  # devenv.lock in step with megarepo.lock, so reading the gitignored checkout
+  # only added a way for a drifted member to break evaluation (#1467).
   effectUtils = inputs.effect-utils;
   effectUtilsPackages = effectUtils.packages.${pkgs.system};
   effectTsgo = effectUtilsPackages.effect-tsgo;


### PR DESCRIPTION
Fixes #1467.

## Problem

`devenv shell` from a clean checkout died during Nix evaluation with `error: attribute 'gh-labels' missing`, before the shell could be entered.

`devenv.nix` preferred the megarepo-materialized `./repos/effect-utils` checkout — deliberately, so the shell/task CLIs would match the generator sources imported from that same checkout. But `repos/` is **gitignored**, so a `git status`-clean tree says nothing about whether members match `megarepo.lock`. With a drifted checkout, evaluation read Nix helpers from the stale revision and failed. The check that would have explained it, `mr:lock-sync-check`, only runs **inside** the shell that no longer starts.

Two things worth noting:

- The reported checkout was at `b5e983b0` while the lock recorded `f007561eb`. I also reproduced **`mr apply` itself materializing a stale revision despite an unmodified lock**, so this drift is not simply "someone forgot to run `mr apply`". Filed separately.
- CI could never have caught this: every job runs `applyMegarepoLockStep`, so `repos/` is always materialized at exactly the locked revision. CI can only reach the one state that works.

## Change

Resolve effect-utils from the pinned flake input:

```nix
effectUtils = inputs.effect-utils;
```

The lockstep this replaces is **already guaranteed elsewhere**: `mr:lock-sync-check` keeps `devenv.lock` in step with `megarepo.lock`, so the pinned input *is* the locked member revision. Reading the checkout bought no capability — the member's flake is the same content as the input — only a dependency on untracked state.

It also removes a divergence rather than adding machinery. Every other megarepo member already resolves effect-utils exactly this way; this repo and its contrib companion were the only two feeding an untracked directory into Nix evaluation.

No effect-utils bump is needed: the currently pinned `f007561eb` is the commit that added the `gh-labels` export, so the input resolves it fine.

## Verification

Reproduced the reported state — member materialized at `b5e983b0`, `megarepo.lock` recording `f007561eb`:

- **before:** `error: attribute 'gh-labels' missing`
- **after:** `devenv shell` enters successfully (exit 0)

`check:quick` passes. Diff is one file.

## Follow-ups (not in this PR)

- Gate workspace-vs-lock drift in shared checks — `mr status` already computes it (`syncNeeded` / `syncReasons`), but nothing currently fails on it. This restores a *loud* signal for the drift class, at task time rather than eval time.
- Fix `mr apply` drifting from its own lock.
- Apply the same convergence to the contrib companion, which carries the identical conditional.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | 🌄 cl2-vale |
| `agent_session_id` | d1dbf622-1045-4840-aa99-085f5211d5cf |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/r0yyx5vd9frm4d8klx3i3c1930d9k2ix-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/1rg1cdw91rx4gris2kh0sdwyd4d39nxf-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-21-fix-1467-converge |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->