### PR TITLE
Fix browser rebase rollback metadata retention

### DIFF
--- a/.changeset/fix-browser-rebase-metadata.md
+++ b/.changeset/fix-browser-rebase-metadata.md
@@ -1,0 +1,5 @@
+---
+'@livestore/common': patch
+---
+
+Fix browser rollback and rebase after conflicting backend events by retaining leader-generated rollback metadata before publishing accepted local events.

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -372,10 +372,19 @@ export const make = Effect.fnUntraced(function* ({
           }
         }
 
+        // A local push appends accepted events after the existing pending events. Materialize that
+        // retained suffix so leader rollback metadata stays on the canonical events used by a later rebase.
+        const newPendingEvents = mergeResult.newSyncState.pending.slice(syncState.pending.length)
+        if (newPendingEvents.length !== mergeResult.newEvents.length) {
+          return yield* Effect.dieDebugger('Local push events must be retained in pending state')
+        }
+
+        yield* materializeEventsBatch({ batchItems: newPendingEvents, deferreds })
+
         yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
 
         yield* connectedClientSessionPullQueues.offer({
-          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: mergeResult.newEvents }),
+          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: newPendingEvents }),
           leaderHead: mergeResult.newSyncState.localHead,
         })
 
@@ -385,11 +394,9 @@ export const make = Effect.fnUntraced(function* ({
         })
 
         // Don't sync client-only events
-        const globalOrUnknownEvents = mergeResult.newEvents.filter((e) => !isClientOnlyEvent(e))
+        const globalOrUnknownEvents = newPendingEvents.filter((e) => !isClientOnlyEvent(e))
 
         yield* TxQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
-
-        yield* materializeEventsBatch({ batchItems: mergeResult.newEvents, deferreds })
       }).pipe(localPushBackendPullMutex.withPermits(1))
     }
   })

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -372,19 +372,20 @@ export const make = Effect.fnUntraced(function* ({
           }
         }
 
-        // A local push appends accepted events after the existing pending events. Materialize that
-        // retained suffix so leader rollback metadata stays on the canonical events used by a later rebase.
-        const newPendingEvents = mergeResult.newSyncState.pending.slice(syncState.pending.length)
-        if (newPendingEvents.length !== mergeResult.newEvents.length) {
+        // For a local-push advance, `newEvents` and the appended pending suffix describe the same logical
+        // events but serve different roles and may be distinct instances. Materialize the retained pending
+        // instances so their rollback metadata remains available if a later backend event causes a rebase.
+        const acceptedPendingEvents = mergeResult.newSyncState.pending.slice(syncState.pending.length)
+        if (acceptedPendingEvents.length !== mergeResult.newEvents.length) {
           return yield* Effect.dieDebugger('Local push events must be retained in pending state')
         }
 
-        yield* materializeEventsBatch({ batchItems: newPendingEvents, deferreds })
+        yield* materializeEventsBatch({ batchItems: acceptedPendingEvents, deferreds })
 
         yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
 
         yield* connectedClientSessionPullQueues.offer({
-          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: newPendingEvents }),
+          payload: SyncState.PayloadUpstreamAdvance.make({ newEvents: acceptedPendingEvents }),
           leaderHead: mergeResult.newSyncState.localHead,
         })
 
@@ -394,7 +395,7 @@ export const make = Effect.fnUntraced(function* ({
         })
 
         // Don't sync client-only events
-        const globalOrUnknownEvents = newPendingEvents.filter((e) => !isClientOnlyEvent(e))
+        const globalOrUnknownEvents = acceptedPendingEvents.filter((e) => !isClientOnlyEvent(e))
 
         yield* TxQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
       }).pipe(localPushBackendPullMutex.withPermits(1))

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -116,6 +116,41 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     }).pipe(withTestCtx()(test)),
   )
 
+  Vitest.live('retains leader materialization metadata for pending local events', (test) =>
+    Effect.gen(function* () {
+      const leaderThreadCtx = yield* LeaderThreadCtx
+      const testContext = yield* TestContext
+      const sourceSessionChangeset = Uint8Array.from([255])
+
+      yield* testContext.mockSyncBackend.disconnect
+
+      const localEvent = new LiveStoreEvent.Client.EncodedWithMeta({
+        ...LiveStoreEvent.Global.toClientEncoded(
+          testContext.eventFactory.todoCreated.next({ id: 'local', text: 'local', completed: false }),
+        ),
+      })
+      localEvent.meta.sessionChangeset = {
+        _tag: 'sessionChangeset',
+        data: sourceSessionChangeset,
+        debug: undefined,
+      }
+
+      yield* leaderThreadCtx.syncProcessor.push([localEvent])
+
+      const downstreamItem = yield* Queue.take(testContext.pullQueue)
+      assert(downstreamItem.payload._tag === 'upstream-advance')
+
+      const retainedEvent = (yield* leaderThreadCtx.syncProcessor.syncState.get).pending[0]!
+      const publishedEvent = downstreamItem.payload.newEvents[0]!
+      assert(retainedEvent.meta.sessionChangeset._tag === 'sessionChangeset')
+      assert(publishedEvent.meta.sessionChangeset._tag === 'sessionChangeset')
+
+      expect([...retainedEvent.meta.sessionChangeset.data]).toEqual([...publishedEvent.meta.sessionChangeset.data])
+      expect([...retainedEvent.meta.sessionChangeset.data]).not.toEqual([...sourceSessionChangeset])
+      expect(retainedEvent.meta.materializerHashLeader).toEqual(publishedEvent.meta.materializerHashLeader)
+    }).pipe(withTestCtx()(test)),
+  )
+
   Vitest.live('non-live paginated pull does not stall local pushes', (test) =>
     Effect.gen(function* () {
       const leaderThreadCtx = yield* LeaderThreadCtx


### PR DESCRIPTION
## Problem

A browser session sends a local event to its leader as `LiveStoreEvent.Client.Encoded`. This is intentional: the session changeset belongs to the session and should not cross the worker RPC boundary. The leader must materialize the event in its own database and create its own changeset.

After accepting a local event, the leader retains it as pending until the sync backend confirms or rebases it. Previously, the leader published that pending state, notified sessions, and queued the backend push before materializing the event. It then materialized a separate `newEvents` instance, so the leader-generated changeset never reached the event retained in pending state.

If a conflicting backend event later caused a rebase, the leader could roll back its own database from its persisted changeset. But the rollback event sent to the browser session came from pending state and had no changeset. The session could not undo its earlier local materialization before applying the rebased event, which could produce a duplicate primary-key error.

Direct in-process profiles masked this because metadata could survive through shared object references. Serialized browser workers exposed the missing leader metadata.

## Solution

The accepted local-push flow is now:

1. Merge and validate the local events.
2. Take the newly appended events from the candidate pending state.
3. Materialize those pending event instances in the leader database and eventlog.
4. Publish the new sync state and notify sessions.
5. Enqueue metadata-free global events for the sync backend.

This puts the leader-generated rollback changeset directly on the events that a later rebase will use. It moves the existing materialization; it does not add another materialization, copy metadata between event instances, or change either RPC boundary.

The new ordering also means sessions and the backend-push fiber cannot observe an accepted leader state unless leader materialization has succeeded. Backend acceptance remains asynchronous, and a conflicting backend event still follows the normal rollback and rebase flow.

## Validation

- Added a LeaderSyncProcessor regression proving that retained and published pending events contain the leader-generated changeset rather than a source-session changeset.
- Focused regression — 1 passed.
- `pnpm exec vitest run tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts` — 18 passed, 1 skipped.
- `pnpm exec tsc --build packages/@livestore/common/tsconfig.json tests/package-common/tsconfig.json --pretty false` — passed.
- `pnpm exec changeset status --since upstream/main` — passed.
- Targeted `oxfmt --check` and `git diff --check` — passed.

A full automated browser rebase regression would require extending the existing boot-focused browser fixture with commit and backend-conflict controls. This bug was discovered while developing the scenario-testing approach, and the solution was confirmed against the original scenario in a real browser session.