### PR TITLE
ci(megarepo): raise git clone timeout for megarepo dependency sync

### DIFF
--- a/.changeset/megarepo-git-clone-timeout-stopgap.md
+++ b/.changeset/megarepo-git-clone-timeout-stopgap.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. CI-contract change: raise the git subprocess deadline for the "Sync megarepo dependencies" step (`MEGAREPO_GIT_COMMAND_TIMEOUT_MS=600000`) so the cold bare clone of the large `effect` member no longer intermittently hits the pinned megarepo's flat 30s bound on shared CI runners (#1473). Temporary stopgap until effect-utils ships the operation-aware git deadline (overengineeringstudio/effect-utils#965) and is repinned, after which the network default supersedes this override.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -620,6 +621,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -786,6 +788,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -959,6 +962,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1124,6 +1128,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1299,6 +1304,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1480,6 +1486,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1674,6 +1681,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1853,6 +1861,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2041,6 +2050,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2249,6 +2259,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2445,6 +2456,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -442,6 +442,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -646,6 +647,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -826,6 +828,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -476,6 +476,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -994,6 +994,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1224,6 +1225,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1461,6 +1463,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1741,6 +1744,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -249,6 +250,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -367,6 +367,20 @@ const withNixSetupRetry = <TStep extends { readonly name: string; readonly run: 
   withNixRetry(step, setupMegarepoRun(step.run))
 
 /**
+ * Raise the git subprocess deadline for the megarepo sync step. The currently pinned
+ * effect-utils applies a single flat 30s bound to every git command, which
+ * intermittently kills the cold bare clone of the large `effect` member on shared CI
+ * runners (livestore#1473). 10min is generous for the clone while the job's own
+ * `timeout-minutes` still bounds a genuine hang. Once effect-utils ships the
+ * operation-aware deadline (overengineeringstudio/effect-utils#965) and is repinned,
+ * this override becomes redundant with the network default and can be dropped.
+ */
+const withMegarepoGitTimeout = <TStep extends { readonly env?: Record<string, string> }>(step: TStep): TStep => ({
+  ...step,
+  env: { ...step.env, MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000' },
+})
+
+/**
  * Setup steps for livestore CI jobs (without checkout).
  * Uses shared step atoms from effect-utils/genie/ci-workflow.ts.
  */
@@ -384,7 +398,7 @@ export const livestoreSetupStepsAfterCheckout = [
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
     return { ...base, with: { ...base.with, skipPush: true } }
   })(),
-  withNixSetupRetry(applyMegarepoLockStep()),
+  withNixSetupRetry(withMegarepoGitTimeout(applyMegarepoLockStep())),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
   restorePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),


### PR DESCRIPTION
## Problem

CI intermittently fails on `main` in the **Sync megarepo dependencies** step with:

```text
git clone --bare https://github.com/effect-ts/effect .../.bare/
timed out after 30000ms
```

Root cause (full write-up in #1473): the pinned `@overeng/megarepo` wraps **every** git subprocess in a single flat 30s deadline. That is a liveness bound sized for millisecond-scale local ops, but the cold bare clone of the large `effect` member (~140MB pack) legitimately exceeds it under shared-runner contention. The timeout is excluded from the transient-retry set, so it is fatal — the whole `mr apply` step (and the job) fails. Each CI job uses a fresh, job-local `MEGAREPO_STORE`, so every job clones `effect` cold and independently rolls the timeout dice — hence "six jobs across three runs".

## Solution (stopgap)

Set `MEGAREPO_GIT_COMMAND_TIMEOUT_MS=600000` (10 min) on the sync step, via a small genie wrapper (`withMegarepoGitTimeout`) around the shared `applyMegarepoLockStep()`. The clone gets a generous budget; the job's own `timeout-minutes: 30` still bounds a genuine hang.

This works **today** without a repin: the currently pinned effect-utils already honors this existing env var (it's the override knob for the flat deadline).

Because all five workflows source their setup from the shared `livestoreSetupSteps` / `livestoreSetupStepsAfterCheckout`, one wrapper covers every occurrence — the regeneration touches `ci.yml`, `deploy-prod.yml`, `devtools-artifact.yml`, `release.yml`, and `repo-settings.yml` (22 sync-step env blocks, one identical line each).

## The real fix (separate PR, upstream)

The principled root-cause fix — an **operation-aware** git deadline (network ops get a generous default, local ops keep 30s) — lands in `@overeng/megarepo`: **overengineeringstudio/effect-utils#965**. Once that merges and livestore repins effect-utils, the network default supersedes this override and it can be dropped.

A further highest-leverage optimization (not required for correctness) is to warm-seed/cache the per-job megarepo store keyed on the pinned `effect` SHA, which removes ~1.7GB of redundant per-job clone bandwidth. Tracked as a follow-up.

## Validation

- `genie --check` clean — generated workflows are consistent with `genie/repo.ts`.
- Generated diff is exactly 22 identical `MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '600000'` insertions, each directly after `MEGAREPO_STORE` in a sync step; nothing else changed.
- `oxlint` / `oxfmt` clean on `genie/repo.ts`. The wrapper mirrors the existing `withNixSetupRetry` helper pattern (`{ ...step, <field> }` returned as `TStep`).
- Full `devenv tasks run check:quick` (tsgo) could not be run in this headless environment; the genie gate and lint/format checks above pass, and CI runs the authoritative typecheck.
- No-release-impact changeset included.

Relates to #1473

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-25-megarepo-git-timeout-stopgap |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->