### PR TITLE
test(ci): validate effect-utils git-timeout fix in real livestore CI [do-not-merge]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -620,6 +621,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -786,6 +788,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -959,6 +962,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1124,6 +1128,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1299,6 +1304,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1480,6 +1486,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1674,6 +1681,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1853,6 +1861,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2041,6 +2050,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2249,6 +2259,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2445,6 +2456,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -442,6 +442,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -646,6 +647,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -826,6 +828,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -476,6 +476,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -994,6 +994,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1224,6 +1225,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1461,6 +1463,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1741,6 +1744,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -249,6 +250,7 @@ jobs:
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -367,6 +367,21 @@ const withNixSetupRetry = <TStep extends { readonly name: string; readonly run: 
   withNixRetry(step, setupMegarepoRun(step.run))
 
 /**
+ * VALIDATION-ONLY probe (not for merge). Sets the legacy `MEGAREPO_GIT_COMMAND_TIMEOUT_MS=1`
+ * on the sync step as a green discriminator for overengineeringstudio/effect-utils#965:
+ * the FIXED megarepo retires that var, so it ignores this and the `effect` clone gets the
+ * 600s network budget → sync is GREEN. The OLD (pre-fix) megarepo obeys it → 1ms flat
+ * deadline → the clone dies instantly → sync would be RED. A green sync step therefore
+ * proves the fixed operation-aware code is what runs in livestore's real CI.
+ */
+const withGitTimeoutProbe = <TStep extends { readonly env?: Record<string, string> }>(
+  step: TStep,
+): TStep => ({
+  ...step,
+  env: { ...step.env, MEGAREPO_GIT_COMMAND_TIMEOUT_MS: '1' },
+})
+
+/**
  * Setup steps for livestore CI jobs (without checkout).
  * Uses shared step atoms from effect-utils/genie/ci-workflow.ts.
  */
@@ -384,7 +399,7 @@ export const livestoreSetupStepsAfterCheckout = [
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
     return { ...base, with: { ...base.with, skipPush: true } }
   })(),
-  withNixSetupRetry(applyMegarepoLockStep()),
+  withNixSetupRetry(withGitTimeoutProbe(applyMegarepoLockStep())),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
   restorePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),

--- a/megarepo.kdl
+++ b/megarepo.kdl
@@ -1,5 +1,5 @@
 members {
-    effect-utils "overengineeringstudio/effect-utils#main"
+    effect-utils "overengineeringstudio/effect-utils#schickling-assistant/2026-07-25-validate-git-timeout-on-pin"
     effect "effect-ts/effect"
     livestore-contrib "livestorejs/livestore-contrib"
 }

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -3,10 +3,10 @@
   "members": {
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
-      "ref": "main",
-      "commit": "f007561eb40e1a4c3a0fad3adafb14cd420bafc0",
+      "ref": "schickling-assistant/2026-07-25-validate-git-timeout-on-pin",
+      "commit": "450be74d0f466acc4aba24d8cb79b38962c677af",
       "pinned": true,
-      "lockedAt": "2026-07-19T14:46:24.673Z"
+      "lockedAt": "2026-07-25T13:30:01.687Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Purpose — do not merge

End-to-end validation, in livestore's **real CI**, that overengineeringstudio/effect-utils#965 fixes the megarepo dependency-clone timeout (#1473). Closes after serving its purpose.

## Why a plain repin wouldn't prove anything

The `effect` clone almost always finishes under 30s, and CI can't reproduce the runner contention that intermittently pushes it over — so a green sync step would be green with the **old** code too. To make one run actually discriminate fixed-vs-unfixed, this PR uses the fact that #965 **retires** the `MEGAREPO_GIT_COMMAND_TIMEOUT_MS` knob:

- The sync step sets **`MEGAREPO_GIT_COMMAND_TIMEOUT_MS=1`**.
- **Fixed** megarepo ignores that (retired) var → the `effect` clone gets the 600s network budget → **sync GREEN**.
- **Pre-fix** megarepo obeys it → 1ms flat deadline on every git op → the clone dies instantly → **sync RED**.

So a **green sync step under this hostile env** deterministically proves the fixed, operation-aware code is what runs in livestore's CI.

## Isolation

To keep the signal attributable to the fix alone, effect-utils is pinned to a throwaway commit = livestore's current pin (`f007561`) **+ only #965's `git.ts` change** — not #965's head, which also carries 10 commits / 87 files of unrelated effect-utils main progression that could red the build for reasons unrelated to the timeout. `git.ts` is byte-identical between `f007561` and main, so this is #965's exact runtime change.

## What to look at

- **Any test job's "Sync megarepo dependencies" step = GREEN** → the fix works here. (Every test job runs it; they're identical.)
- **`source-policy` job = RED, expected.** It's the upstream-first guard (a first-party member pinned to an unmerged commit isn't reachable from `main`). It's a *separate* job — no test job `needs:` it — so the sync steps still run. This red is inherent to validating any unmerged pin and is unrelated to the fix.

## Honest scope

This proves the fixed megarepo **runs correctly in livestore's real CI and applies the 600s network budget** (a green result here is impossible with the old flat-30s code under `=1`). It does **not** reproduce the intermittent >30s contention itself — that's inherently unreproducible on demand. The enforcement (a real clone actually bounded by the new budget) is separately proven by the unit + real-subprocess integration tests in #965.

## Teardown

Close after CI reports; revert the effect-utils pin to `main` (`f007561`) — never merge. The real fix lands via #965 + a normal repin.

Relates to #1473 · validates overengineeringstudio/effect-utils#965

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-25-megarepo-ci |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->