### PR TITLE
refactor: use composable SQLite savepoints

### DIFF
--- a/.changeset/empty-composable-sqlite-savepoints.md
+++ b/.changeset/empty-composable-sqlite-savepoints.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Refactors rebase rollback to use composable SQLite savepoints.

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -56,8 +56,10 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   current pending, offers the payload to session pull queues, and persists
   sync metadata for confirmed events; rebase additionally rolls back
   state+eventlog rows and re-seeds pushing from rebased pending
-  (`:466-516`). Backend head advances via `Eventlog.updateBackendHead`
-  (`:462-464`).
+  (`:466-516`). State changeset application and changeset-row deletion are
+  enclosed in a composable SQLite savepoint; eventlog deletion remains a
+  coordinated write to the separate eventlog database. Backend head advances
+  via `Eventlog.updateBackendHead` (`:462-464`).
 - **Pull precedence** (`:241, 393, 408-438`): a 1-permit semaphore
   (`localPushBackendPullMutex`) makes local-push application and pull-chunk
   application mutually exclusive; the pull side holds the permit for a
@@ -94,20 +96,23 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   materializer hashes written back, then `refreshTables` runs once per
   merge (`:232-250`).
 - **Rebase critical section** (`:209-272`): interrupt the push fiber → roll
-  back session changesets in reverse order (`meta.sessionChangeset`, then mark
-  `unset`) → **atomically reconcile** the push queue (clear + re-offer the
+  back session changesets in reverse order inside a composable SQLite
+  savepoint → mark `meta.sessionChangeset` as `unset` only after the savepoint
+  is released → **atomically reconcile** the push queue (clear + re-offer the
   _live_ `syncStateRef.current.pending` inside one `Effect.tx`, with no async
-  park between the read, clear, and offer) → restart the push fiber. Re-reading
-  the live pending (rather than the stale merge-time snapshot) is what
-  serializes `push` against rebase **without blocking it**: `push` runs via
-  `Effect.runSyncWith` as an indivisible unit that can only interleave in the
-  pull fiber's async gaps, so a synchronous commit admitted during a rebase
-  park is folded into the reconciliation instead of being torn away by the
-  clear. This replaces the earlier blocking `rebaseOwnership` permit on `push`,
-  which violated the synchronous-commit invariant (LS.SYS.STORE-R09) by
-  suspending the commit path (see `.decisions/`, #1465). Deterministic
-  `rebaseBarriers` hooks at 3 labeled points let tests inject a concurrent
-  push/shutdown into this window (the F1 no-loss oracle).
+  park between the read, clear, and offer) → restart the push fiber. Failure or
+  interruption rolls the entire session-state rollback back before the original
+  cause is re-emitted. Re-reading the live pending (rather than the stale
+  merge-time snapshot) is what serializes `push` against rebase **without
+  blocking it**: `push` runs via `Effect.runSyncWith` as an indivisible unit
+  that can only interleave in the pull fiber's async gaps, so a synchronous
+  commit admitted during a rebase park is folded into the reconciliation
+  instead of being torn away by the clear. This replaces the earlier blocking
+  `rebaseOwnership` permit on `push`, which violated the synchronous-commit
+  invariant (LS.SYS.STORE-R09) by suspending the commit path (see
+  `.decisions/`, #1465). Deterministic `rebaseBarriers` hooks at 3 labeled
+  points let tests inject a concurrent push/shutdown into this window (the F1
+  no-loss oracle).
 - **Shutdown drain:** orderly shutdown closes new `push()` admission, stops
   pull processing while holding the state-ownership permit (which still
   serializes shutdown↔rebase — only `push` was taken off that permit), ends the

--- a/packages/@livestore/common/src/leader-thread/materialize-event.ts
+++ b/packages/@livestore/common/src/leader-thread/materialize-event.ts
@@ -7,6 +7,7 @@ import { logDeprecationWarnings } from '../schema/EventDef/deprecated.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, resolveEventDef, SystemTables, UNKNOWN_EVENT_SCHEMA_HASH } from '../schema/mod.ts'
 import { insertRow } from '../sql-queries/index.ts'
+import * as SqliteDbHelper from '../sqlite-db-helper.ts'
 import { sql } from '../util.ts'
 import { execSql, execSqlPrepared } from './connection.ts'
 import * as Eventlog from './eventlog.ts'
@@ -192,24 +193,30 @@ export const rollback = ({
       }))
       .toSorted((a, b) => EventSequenceNumber.Client.compare(a.seqNum, b.seqNum))
 
-    // Apply changesets in reverse order
-    for (let i = rollbackEvents.length - 1; i >= 0; i--) {
-      const { changeset } = rollbackEvents[i]!
-      if (changeset !== null) {
-        dbState.makeChangeset(changeset).invert().apply()
-      }
-    }
-
     const eventNumPairChunks = ReadonlyArray.chunksOf(100)(
       eventNumsToRollback.map((seqNum) => `(${seqNum.global}, ${seqNum.client})`),
     )
 
-    // Delete the changeset rows
-    for (const eventNumPairChunk of eventNumPairChunks) {
-      dbState.execute(
-        sql`DELETE FROM ${SystemTables.SESSION_CHANGESET_META_TABLE} WHERE (seqNumGlobal, seqNumClient) IN (${eventNumPairChunk.join(', ')})`,
-      )
-    }
+    yield* SqliteDbHelper.withSavepoint({
+      db: dbState,
+      savepointName: 'livestore_materialization_rollback',
+      effect: Effect.sync(() => {
+        // Apply changesets in reverse order.
+        for (let i = rollbackEvents.length - 1; i >= 0; i--) {
+          const { changeset } = rollbackEvents[i]!
+          if (changeset !== null) {
+            dbState.makeChangeset(changeset).invert().apply()
+          }
+        }
+
+        // Delete rollback records only after every changeset has been applied.
+        for (const eventNumPairChunk of eventNumPairChunks) {
+          dbState.execute(
+            sql`DELETE FROM ${SystemTables.SESSION_CHANGESET_META_TABLE} WHERE (seqNumGlobal, seqNumClient) IN (${eventNumPairChunk.join(', ')})`,
+          )
+        }
+      }),
+    })
 
     // Delete the eventlog rows
     for (const eventNumPairChunk of eventNumPairChunks) {

--- a/packages/@livestore/common/src/sqlite-db-helper.ts
+++ b/packages/@livestore/common/src/sqlite-db-helper.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@livestore/utils/effect'
+import { Effect, Exit, Schema } from '@livestore/utils/effect'
 
 import { type SqliteDb, SqliteError } from './adapter-types.ts'
 import { getResultSchema, isQueryBuilder } from './schema/state/sqlite/query-builder/mod.ts'
@@ -40,6 +40,90 @@ export const makeSelect = <T>(
   }
 }
 
+/**
+ * Runs synchronous SQLite work inside a savepoint.
+ *
+ * @remarks
+ *
+ * Unlike `BEGIN TRANSACTION`, savepoints can be nested inside an existing SQLite
+ * transaction. If `fn` throws, all writes since the savepoint are rolled back and
+ * the original error is re-thrown. If `fn` returns, the savepoint is released.
+ *
+ * `savepointName` is interpolated as an SQLite identifier, so it must be a plain
+ * identifier matching `/^[A-Za-z_][A-Za-z0-9_]*$/`.
+ */
+export const withSavepointSync = <T>({
+  db,
+  savepointName,
+  fn,
+}: {
+  db: SqliteDb
+  savepointName: string
+  fn: () => T
+}): T => {
+  assertValidSavepointName(savepointName)
+
+  db.execute(`SAVEPOINT ${savepointName}`)
+
+  try {
+    const result = fn()
+    db.execute(`RELEASE SAVEPOINT ${savepointName}`)
+    return result
+  } catch (cause) {
+    db.execute(`ROLLBACK TO SAVEPOINT ${savepointName}`)
+    db.execute(`RELEASE SAVEPOINT ${savepointName}`)
+    throw cause
+  }
+}
+
+/**
+ * Runs an Effect inside an SQLite savepoint.
+ *
+ * @remarks
+ *
+ * This is the Effect equivalent of {@link withSavepointSync}. It starts a
+ * savepoint before running `effect`, releases the savepoint on success, and rolls
+ * back to the savepoint before re-emitting the original failure on failure.
+ *
+ * Use this for atomic DB updates that need to compose with callers that may
+ * already have an open transaction.
+ *
+ * `savepointName` is interpolated as an SQLite identifier, so it must be a plain
+ * identifier matching `/^[A-Za-z_][A-Za-z0-9_]*$/`.
+ */
+export const withSavepoint = <A, E, R>({
+  db,
+  savepointName,
+  effect,
+}: {
+  db: SqliteDb
+  savepointName: string
+  effect: Effect.Effect<A, E, R>
+}): Effect.Effect<A, E, R> => {
+  assertValidSavepointName(savepointName)
+
+  return Effect.uninterruptibleMask((restore) =>
+    Effect.sync(() => {
+      db.execute(`SAVEPOINT ${savepointName}`)
+    }).pipe(
+      Effect.andThen(restore(effect)),
+      Effect.exit,
+      Effect.flatMap((exit) => {
+        const cleanup = Effect.sync(() => {
+          if (Exit.isSuccess(exit) === true) {
+            db.execute(`RELEASE SAVEPOINT ${savepointName}`)
+          } else {
+            db.execute(`ROLLBACK TO SAVEPOINT ${savepointName}`)
+            db.execute(`RELEASE SAVEPOINT ${savepointName}`)
+          }
+        })
+
+        return cleanup.pipe(Effect.andThen(exit))
+      }),
+    ),
+  )
+}
+
 export const validateSnapshot = (snapshot: Uint8Array) => {
   const headerBytes = new TextDecoder().decode(snapshot.slice(0, 16))
   const hasValidHeader = headerBytes.startsWith('SQLite format 3')
@@ -56,4 +140,13 @@ export const makeExport = (exportFn: () => Uint8Array<ArrayBuffer>) => () => {
   const snapshot = exportFn()
   validateSnapshot(snapshot)
   return snapshot
+}
+
+const assertValidSavepointName = (savepointName: string) => {
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(savepointName) === false) {
+    throw new SqliteError({
+      cause: `Invalid SQLite savepoint name: ${savepointName}`,
+      note: 'Savepoint names must be plain SQLite identifiers.',
+    })
+  }
 }

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -24,6 +24,7 @@ import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { resolveSessionIdSymbolInEventArgs } from '../session-id-symbol.ts'
+import * as SqliteDbHelper from '../sqlite-db-helper.ts'
 import * as SyncState from './syncstate.ts'
 
 /** Serialize value to JSON string for trace attributes */
@@ -232,11 +233,29 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
             // Roll back the optimistic session changesets for the events this rebase discards.
             // (Independent of the push queue below; order relative to the queue reconcile is irrelevant.)
-            for (let i = mergeResult.rollbackEvents.length - 1; i >= 0; i--) {
-              const event = mergeResult.rollbackEvents[i]!
-              if (event.meta.sessionChangeset._tag !== 'no-op' && event.meta.sessionChangeset._tag !== 'unset') {
-                rollback(event.meta.sessionChangeset.data)
-                event.meta.sessionChangeset = { _tag: 'unset' }
+            const rollbackEventsWithChangesets = mergeResult.rollbackEvents.filter(
+              (event) => event.meta.sessionChangeset._tag === 'sessionChangeset',
+            )
+
+            if (rollbackEventsWithChangesets.length > 0) {
+              yield* SqliteDbHelper.withSavepoint({
+                db: clientSession.sqliteDb,
+                savepointName: 'livestore_materialization_rollback',
+                effect: Effect.sync(() => {
+                  for (let i = rollbackEventsWithChangesets.length - 1; i >= 0; i--) {
+                    const event = rollbackEventsWithChangesets[i]!
+                    if (event.meta.sessionChangeset._tag === 'sessionChangeset') {
+                      rollback(event.meta.sessionChangeset.data)
+                    }
+                  }
+                }),
+              })
+
+              // Only discard rollback data after the savepoint was released successfully.
+              for (const event of rollbackEventsWithChangesets) {
+                if (event.meta.sessionChangeset._tag === 'sessionChangeset') {
+                  event.meta.sessionChangeset = { _tag: 'unset' }
+                }
               }
             }
 

--- a/tests/package-common/src/sqlite-db-helper.test.ts
+++ b/tests/package-common/src/sqlite-db-helper.test.ts
@@ -1,0 +1,141 @@
+import { expect } from 'vitest'
+
+import { SqliteDbHelper } from '@livestore/common'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Deferred, Effect, Fiber } from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+const setup = Effect.gen(function* () {
+  const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+  const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+  const db = yield* makeSqliteDb({ _tag: 'in-memory' })
+
+  db.execute('CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)')
+
+  return { db }
+})
+
+Vitest.describe.concurrent('SqliteDbHelper', () => {
+  Vitest.live('withSavepointSync commits successful changes', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+
+      SqliteDbHelper.withSavepointSync({
+        db,
+        savepointName: 'test_savepoint',
+        fn: () => {
+          db.execute("INSERT INTO test (id, value) VALUES (1, 'committed')")
+        },
+      })
+
+      const rows = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rows).toEqual([{ value: 'committed' }])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('withSavepointSync rolls back failed changes', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+
+      expect(() =>
+        SqliteDbHelper.withSavepointSync({
+          db,
+          savepointName: 'test_savepoint',
+          fn: () => {
+            db.execute("INSERT INTO test (id, value) VALUES (1, 'rolled-back')")
+            throw new Error('rollback')
+          },
+        }),
+      ).toThrow('rollback')
+
+      const rows = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rows).toEqual([])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('withSavepoint rolls back failed effects', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+
+      const exit = yield* SqliteDbHelper.withSavepoint({
+        db,
+        savepointName: 'test_savepoint',
+        effect: Effect.gen(function* () {
+          db.execute("INSERT INTO test (id, value) VALUES (1, 'rolled-back')")
+          return yield* Effect.fail('rollback')
+        }),
+      }).pipe(Effect.exit)
+
+      expect(exit._tag).toEqual('Failure')
+
+      const rows = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rows).toEqual([])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('withSavepoint composes inside an outer transaction', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+
+      db.execute('BEGIN TRANSACTION')
+
+      db.execute("INSERT INTO test (id, value) VALUES (1, 'outer')")
+
+      yield* SqliteDbHelper.withSavepoint({
+        db,
+        savepointName: 'inner_savepoint',
+        effect: Effect.sync(() => {
+          db.execute("INSERT INTO test (id, value) VALUES (2, 'inner')")
+        }),
+      })
+
+      expect(() =>
+        SqliteDbHelper.withSavepointSync({
+          db,
+          savepointName: 'failing_inner_savepoint',
+          fn: () => {
+            db.execute("INSERT INTO test (id, value) VALUES (3, 'rolled-back')")
+            throw new Error('rollback inner')
+          },
+        }),
+      ).toThrow('rollback inner')
+
+      db.execute('COMMIT')
+
+      const rows = db.select<{ id: number; value: string }>('SELECT id, value FROM test ORDER BY id ASC')
+      expect(rows).toEqual([
+        { id: 1, value: 'outer' },
+        { id: 2, value: 'inner' },
+      ])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('withSavepoint rolls back and releases on interruption', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+      const started = yield* Deferred.make<void>()
+
+      const fiber = yield* SqliteDbHelper.withSavepoint({
+        db,
+        savepointName: 'interrupted_savepoint',
+        effect: Effect.gen(function* () {
+          db.execute("INSERT INTO test (id, value) VALUES (1, 'interrupted')")
+          yield* Deferred.succeed(started, undefined)
+          yield* Effect.never
+        }),
+      }).pipe(Effect.forkScoped)
+
+      yield* Deferred.await(started)
+      yield* Fiber.interrupt(fiber)
+
+      const rows = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rows).toEqual([])
+
+      db.execute("INSERT INTO test (id, value) VALUES (2, 'after-interrupt')")
+      const rowsAfterInterrupt = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rowsAfterInterrupt).toEqual([{ value: 'after-interrupt' }])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+})


### PR DESCRIPTION
## Problem

Leader and client-session rebases apply multiple inverse SQLite changesets incrementally. If one rollback step fails or the Effect is interrupted, the state database can be left partially rolled back. A regular `BEGIN TRANSACTION` is not composable because these paths may already run inside a transaction.

## Solution

* add synchronous and Effect-based SQLite savepoint helpers
* make Effect cleanup uninterruptible while preserving interruption for the wrapped operation
* validate savepoint names before interpolating them as SQLite identifiers
* wrap leader changeset application and rollback-record deletion in one savepoint
* wrap client-session changeset rollback in one savepoint and mark rollback data as consumed only after release
* document the rebase critical-section invariant in the intent layer
* add focused coverage for commit, failure, nested transaction, and interruption behavior

The eventlog is a separate SQLite database, so its deletion remains a coordinated write after the state savepoint rather than part of the same atomic SQLite operation.

This is an internal refactor and carries an empty changeset.

## Validation

* `vitest run tests/package-common/src/sqlite-db-helper.test.ts tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts`
  * 3 files passed
  * 34 tests passed, 13 skipped
* `mono ts`
  * passed
* `oxfmt --check` on all changed files
  * passed
* `mono test unit`
  * relevant common, LiveStore, SQLite, and package-common suites passed
  * Docker/Wrangler suites that require Docker or local listening sockets reported environment failures in the sandbox

The mandated `devenv tasks run lint:full:fix` and `devenv tasks run test:run` entry points could not evaluate because the local effect-utils task module does not define `gh-labels`, which is referenced by `devenv.nix`. The pre-commit `check-quick` hook is blocked by the same unrelated environment error.

### Demo

```text
SAVEPOINT livestore_materialization_rollback
  apply inverse changesets in reverse order
  delete consumed rollback records
RELEASE

failure or interruption
  -> ROLLBACK TO SAVEPOINT
  -> RELEASE SAVEPOINT
  -> re-emit the original cause
```

## Related issues

* Extracted from livestorejs/livestore#1299
* Related rebase rollback context: livestorejs/livestore#641
* Related changeset-apply failure context: livestorejs/livestore#998