### PR TITLE
ci(megarepo): cache the megarepo store to avoid redundant per-job clones (closes #1480)

### DIFF
--- a/.changeset/cache-megarepo-store.md
+++ b/.changeset/cache-megarepo-store.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. CI: cache the megarepo store (bare repos + worktrees) keyed on `megarepo.lock`, so jobs stop cold-cloning the large members (`effect` etc.) from GitHub on every run — the ~700MB-of-bares × ~13-jobs redundant-clone exposure behind #1473 (#1480). On a cache hit `mr apply` sees the pinned commits present and no-ops; the key changes only when a member commit moves. Verified a relocated store re-applies with zero re-clones (git/mr repair moved worktrees).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -464,6 +470,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -617,6 +629,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -635,6 +653,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -783,6 +807,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -801,6 +831,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -956,6 +992,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -974,6 +1016,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1121,6 +1169,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1139,6 +1193,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1296,6 +1356,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1314,6 +1380,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1477,6 +1549,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1495,6 +1573,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1671,6 +1755,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1689,6 +1779,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1850,6 +1946,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1868,6 +1970,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2038,6 +2146,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2056,6 +2170,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2246,6 +2366,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2264,6 +2390,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2442,6 +2574,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -2460,6 +2598,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -439,6 +439,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -457,6 +463,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -643,6 +655,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -661,6 +679,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -823,6 +847,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -841,6 +871,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -473,6 +473,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -491,6 +497,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -991,6 +991,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1009,6 +1015,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1221,6 +1233,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1239,6 +1257,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1458,6 +1482,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1476,6 +1506,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1738,6 +1774,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -1756,6 +1798,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -74,6 +74,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -92,6 +98,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -246,6 +258,12 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
@@ -264,6 +282,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          key: "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -367,6 +367,41 @@ const withNixSetupRetry = <TStep extends { readonly name: string; readonly run: 
   withNixRetry(step, setupMegarepoRun(step.run))
 
 /**
+ * Job-local megarepo store path — MUST match `jobLocalMegarepoStore` inside
+ * effect-utils' `applyMegarepoLockStep` (the sync step's `MEGAREPO_STORE` env). Kept
+ * literal here so the cache steps can address it before the sync step sets the env. If
+ * effect-utils changes the path the cache simply misses (graceful — no correctness impact).
+ */
+const megarepoStorePath =
+  '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+
+/**
+ * Cache the megarepo store (bare git repos + worktrees) keyed on `megarepo.lock`, so jobs
+ * stop cold-cloning the large members (`effect` etc., ~700MB of bares total) from GitHub on
+ * every run — the redundant-clone exposure behind #1473 (#1480). On a hit `mr apply` sees
+ * the pinned commits already present and no-ops; the key changes only when a member commit
+ * moves. A relocated store re-applies cleanly (verified: git/mr repair moved worktrees, no
+ * re-clone), so the run-scoped path in the key's *value* is irrelevant to correctness.
+ */
+const megarepoStoreCacheKey =
+  "livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+
+const restoreMegarepoStoreStep = {
+  name: 'Restore megarepo store',
+  id: 'restore-megarepo-store',
+  uses: 'actions/cache/restore@v4',
+  with: { path: megarepoStorePath, key: megarepoStoreCacheKey },
+} as const
+
+const saveMegarepoStoreStep = {
+  name: 'Save megarepo store',
+  // Only the first job to finish a cold run writes the key; the rest no-op (key exists).
+  if: "${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}",
+  uses: 'actions/cache/save@v4',
+  with: { path: megarepoStorePath, key: megarepoStoreCacheKey },
+} as const
+
+/**
  * Setup steps for livestore CI jobs (without checkout).
  * Uses shared step atoms from effect-utils/genie/ci-workflow.ts.
  */
@@ -384,7 +419,9 @@ export const livestoreSetupStepsAfterCheckout = [
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
     return { ...base, with: { ...base.with, skipPush: true } }
   })(),
+  restoreMegarepoStoreStep,
   withNixSetupRetry(applyMegarepoLockStep()),
+  saveMegarepoStoreStep,
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
   restorePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),


### PR DESCRIPTION
## What

Cache the megarepo store keyed on `megarepo.lock`, so CI jobs stop cold-cloning the large members (`effect` etc., ~700MB of bares) from GitHub on every run. Closes #1480.

Each of the ~13 jobs currently runs `mr apply --all` against a job-local, always-cold `MEGAREPO_STORE`, so every job re-clones every member — the redundant-clone exposure that was behind the intermittent clone timeouts (#1473, now fixed by the operation-aware git deadline). This is the follow-up bandwidth/throughput win.

## How

Mirrors the existing `livestore-pnpm-state` cache:

- `actions/cache/restore@v4` before the sync step, key `livestore-megarepo-store-v1-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}`.
- On **hit**: `mr apply` sees the pinned commits already present → no-ops, **zero network clone**.
- On **miss**: normal clone, then `actions/cache/save@v4` (first cold job writes the key; the rest no-op).
- Key invalidates only when a member commit moves.

## Correctness of a relocated store

`MEGAREPO_STORE` embeds `run_id`, so the store lands at a different absolute path each run, and git worktrees embed absolute paths. Verified locally that this is a non-issue: copying a populated store to a new path and re-running `mr apply --all` **reuses the bares with zero re-clones** and the worktrees resolve (git/mr repair the moved worktrees). So the run-scoped path in the cache value doesn't affect correctness — only the lock-keyed content matters.

## Validation

- `genie --check` clean; `oxlint`/`oxfmt` clean.
- **This PR's CI is a cold cache MISS** (new key) → proves the cache steps don't break the sync path. A follow-up rerun with the same lock demonstrates the HIT (sync no-ops, no clone) — I'll confirm that on the PR before marking ready.

Closes #1480

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-25-ci-cache-megarepo-store |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->