### PR TITLE
Stop the unit lane from converting test failures into a passing check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@
 
 - Removed redundant devenv package entries now owned by the task guard modules.
 
+### Internal Changes
+
+For maintainers and contributors:
+
+- **Tooling:** Failing tests now block merges. The unit lane
+  (`packages/@livestore/webmesh`, `tests/package-common`), the six Cloudflare
+  sync-provider matrix cells, and the DevTools Playwright suite previously
+  converted test failures into passing required checks, so a green check could
+  mean "the tests passed, or they failed and were ignored". Those suppressions
+  are removed, which also restores the intent-layer invariant suite as a real
+  gate on `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
+
 ## 0.4.0 - 2026-06-02
 
 > **Installing v0.4.0:** Make sure all LiveStore packages use the same version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,11 @@
 
 For maintainers and contributors:
 
-- **Tooling:** Failing tests now block merges. The unit lane
-  (`packages/@livestore/webmesh`, `tests/package-common`), the six Cloudflare
-  sync-provider matrix cells, and the DevTools Playwright suite previously
-  converted test failures into passing required checks, so a green check could
-  mean "the tests passed, or they failed and were ignored". Those suppressions
-  are removed, which also restores the intent-layer invariant suite as a real
-  gate on `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
+- **Tooling:** Unit-test failures now block merges. The `test-unit` job ran
+  `packages/@livestore/webmesh` and `tests/package-common` through
+  `Effect.ignore` on CI, so their failures produced a passing required check.
+  Removing that also restores the intent-layer invariant suite as a real gate on
+  `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
 
 ## 0.4.0 - 2026-06-02
 

--- a/context/.delta/DELTA-002-enforcement-not-ci-blocking.md
+++ b/context/.delta/DELTA-002-enforcement-not-ci-blocking.md
@@ -1,6 +1,6 @@
 # DELTA-002 — Intent-layer enforcement suite does not hard-block CI
 
-Status: open
+Status: closed (2026-07-25) — resolved by removing the `Effect.ignore` outright.
 
 ## Divergence
 
@@ -21,13 +21,16 @@ expected; only the CI wrapper drops the failure.
 
 [spec.md](../spec.md) §Enforcement.
 
-## Close condition
+## Resolution
 
-Run the intent-layer suite as a dedicated **non-ignored** step in the
-`test-unit` path — e.g. a `vitest run tests/package-common/src/intent-layer`
-invocation outside the `Effect.ignore`'d sequential loop — so a failing
-invariant fails the job, without un-ignoring the genuinely-flaky `webmesh` /
-`package-common` tests. Close when a deliberately-broken invariant reds
-`test-unit` in CI. (Deferred here as a CI-runner change requiring a working
-`devenv`/`mono` env to verify; the shared effect-utils store is currently
-dirtied by a concurrent tsgo-bump workstream.)
+The `Effect.ignore` was removed from the sequential loop entirely, so both
+`tests/package-common` and `packages/@livestore/webmesh` now fail `test-unit`.
+This supersedes the remedy proposed above — a dedicated non-ignored step for the
+intent-layer suite — which would have left the rest of `tests/package-common`
+swallowed.
+
+Carving out only the intent-layer suite was rejected because the quarantine was
+never scoped to the flake it was added for: it covered two complete targets, and
+a survey of 20 `main` runs and 18 pull-request runs found no evidence of the
+`webmesh` flakiness still occurring. Quarantining a specific test, if one proves
+unreliable, is now a per-test declaration rather than a package-wide wrapper.

--- a/context/spec.md
+++ b/context/spec.md
@@ -210,13 +210,8 @@ committed `.proposed/`), and the maturity vocabulary (only `experimental` is a
 legal marker; `proposal` is rejected — see Maturity Markers). Semantic review
 (testability, decision evidence quality) remains human/agent judgment.
 
-The suite runs in CI but its failures do **not yet hard-block the run**:
-`tests/package-common` sits in the CI runner's `sequentialPackages` group, which
-is executed through `Effect.ignore` (a workaround for flaky `webmesh` tests,
-`scripts/src/commands/test-commands.ts`), so a failing invariant is logged, not
-gated. Making this suite fail the `test-unit` job — by running it as a dedicated
-non-ignored step — is tracked in
-[.delta/DELTA-002-enforcement-not-ci-blocking.md](./.delta/DELTA-002-enforcement-not-ci-blocking.md).
+A failing invariant hard-blocks the run: `test-unit` is a required check, and the
+suite's failures reach its exit code.
 
 ## Open Design Questions
 

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -112,6 +112,14 @@ in
           exit 1
         fi
 
+        if [[ "$provider" == cf-* ]]; then
+          if mono test integration sync-provider --provider "$provider"; then
+            exit 0
+          fi
+          echo "::warning::Cloudflare sync-provider tests for $provider failed (flaky; see https://github.com/livestorejs/livestore/issues/625 and upstream https://github.com/cloudflare/workers-sdk/issues/11122)"
+          exit 0
+        fi
+
         mono test integration sync-provider --provider "$provider"
       '';
       after = [ "setup:strict" ];
@@ -126,6 +134,11 @@ in
         if [ -z "$suite" ]; then
           echo "Error: PLAYWRIGHT_SUITE is required"
           exit 1
+        fi
+
+        if [ "$suite" = "devtools" ]; then
+          mono test integration devtools || echo "::warning::Script failed but continuing"
+          exit 0
         fi
 
         mono test integration "$suite"

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -112,14 +112,6 @@ in
           exit 1
         fi
 
-        if [[ "$provider" == cf-* ]]; then
-          if mono test integration sync-provider --provider "$provider"; then
-            exit 0
-          fi
-          echo "::warning::Cloudflare sync-provider tests for $provider failed (flaky; see https://github.com/livestorejs/livestore/issues/625 and upstream https://github.com/cloudflare/workers-sdk/issues/11122)"
-          exit 0
-        fi
-
         mono test integration sync-provider --provider "$provider"
       '';
       after = [ "setup:strict" ];
@@ -134,11 +126,6 @@ in
         if [ -z "$suite" ]; then
           echo "Error: PLAYWRIGHT_SUITE is required"
           exit 1
-        fi
-
-        if [ "$suite" = "devtools" ]; then
-          mono test integration devtools || echo "::warning::Script failed but continuing"
-          exit 0
         fi
 
         mono test integration "$suite"

--- a/scripts/src/commands/test-commands.test.ts
+++ b/scripts/src/commands/test-commands.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { Effect, Exit } from '@livestore/utils/effect'
+
+import { assertTestsExecuted } from './test-commands.ts'
+
+const writeReport = (report: Record<string, unknown>): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'livestore-test-report-'))
+  const reportPath = path.join(dir, 'report.json')
+  fs.writeFileSync(reportPath, JSON.stringify(report))
+  return reportPath
+}
+
+describe('assertTestsExecuted', () => {
+  it('fails a run that executed no tests', async () => {
+    // The shape Vitest emits when every test is filtered or skipped: `success: true`, zero passed.
+    const reportPath = writeReport({ numTotalTests: 116, numPassedTests: 0, numPendingTests: 116, success: true })
+
+    const exit = await Effect.runPromiseExit(assertTestsExecuted(reportPath))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it('accepts a run that executed at least one test', async () => {
+    const reportPath = writeReport({ numTotalTests: 20, numPassedTests: 16, numPendingTests: 4, success: true })
+
+    const exit = await Effect.runPromiseExit(assertTestsExecuted(reportPath))
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+  })
+})

--- a/scripts/src/commands/test-commands.test.ts
+++ b/scripts/src/commands/test-commands.test.ts
@@ -8,28 +8,45 @@ import { Effect, Exit } from '@livestore/utils/effect'
 
 import { assertTestsExecuted } from './test-commands.ts'
 
-const writeReport = (report: Record<string, unknown>): string => {
+const suiteFile = 'sync-provider.test.ts'
+
+/** Builds a Vitest JSON report from `{ fileName: [statuses] }`. */
+const writeReport = (files: Record<string, readonly string[]>): string => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'livestore-test-report-'))
   const reportPath = path.join(dir, 'report.json')
-  fs.writeFileSync(reportPath, JSON.stringify(report))
+  const testResults = Object.entries(files).map(([name, statuses]) => ({
+    name: `/repo/tests/sync-provider/src/${name}`,
+    assertionResults: statuses.map((status) => ({ status })),
+  }))
+  fs.writeFileSync(reportPath, JSON.stringify({ testResults }))
   return reportPath
 }
 
+const run = (files: Record<string, readonly string[]>) =>
+  Effect.runPromiseExit(assertTestsExecuted({ reportPath: writeReport(files), suiteFile }))
+
 describe('assertTestsExecuted', () => {
-  it('fails a run that executed no tests', async () => {
-    // The shape Vitest emits when every test is filtered or skipped: `success: true`, zero passed.
-    const reportPath = writeReport({ numTotalTests: 116, numPassedTests: 0, numPendingTests: 116, success: true })
-
-    const exit = await Effect.runPromiseExit(assertTestsExecuted(reportPath))
-
-    expect(Exit.isFailure(exit)).toBe(true)
+  it('accepts a run that executed the conformance suite', async () => {
+    expect(Exit.isSuccess(await run({ [suiteFile]: ['passed', 'passed'] }))).toBe(true)
   })
 
-  it('accepts a run that executed at least one test', async () => {
-    const reportPath = writeReport({ numTotalTests: 20, numPassedTests: 16, numPendingTests: 4, success: true })
+  it('counts failures as executed, so a quarantined run still satisfies the guard', async () => {
+    expect(Exit.isSuccess(await run({ [suiteFile]: ['failed', 'failed'] }))).toBe(true)
+  })
 
-    const exit = await Effect.runPromiseExit(assertTestsExecuted(reportPath))
+  it('rejects a run where the conformance suite was entirely skipped', async () => {
+    expect(Exit.isSuccess(await run({ [suiteFile]: ['skipped', 'skipped'] }))).toBe(false)
+  })
 
-    expect(Exit.isSuccess(exit)).toBe(true)
+  it('rejects a skipped conformance suite even when utility suites passed', async () => {
+    // `registry.test.ts` runs in every provider cell; counting the run's total would let its
+    // passes mask a conformance suite that never ran.
+    const exit = await run({ [suiteFile]: ['skipped'], 'registry.test.ts': ['passed', 'passed', 'passed'] })
+
+    expect(Exit.isSuccess(exit)).toBe(false)
+  })
+
+  it('rejects a run missing the conformance suite entirely', async () => {
+    expect(Exit.isSuccess(await run({ 'registry.test.ts': ['passed'] }))).toBe(false)
   })
 })

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -197,12 +197,8 @@ const runUnitTests = Effect.fn(function* ({ filter }: { filter: Option.Option<st
 
     const vitestPathsToRunSequentially = sequentialPackages.map((pkg) => `${workspaceRoot}/${pkg}`)
 
-    // Currently getting a bunch of flaky webmesh tests on CI (https://share.cleanshot.com/Q2WWD144)
-    // Ignoring them for now but we should fix them eventually
     for (const vitestPath of vitestPathsToRunSequentially) {
-      yield* runTestGroup(vitestPath)(
-        cmd(`vitest run ${vitestPath}`).pipe(Effect.ignore, Effect.provide(LivestoreWorkspace.toCwd())),
-      )
+      yield* runTestGroup(vitestPath)(cmd(`vitest run ${vitestPath}`).pipe(Effect.provide(LivestoreWorkspace.toCwd())))
     }
 
     // Run the rest of the tests in parallel (each config as separate vitest invocation)

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -272,25 +272,52 @@ export const waSqliteTest = Cli.Command.make('wa-sqlite', {}, runWaSqliteTests)
 // the sync provider tests are actually part of another tests package but for now we run them from here too
 // TODO clean this up at some point
 
-/** A run that reported success without executing a single test. */
+/** A run in which the suite that had to prove something never executed. */
 export class NoTestsExecutedError extends Schema.TaggedErrorClass<NoTestsExecutedError>()('NoTestsExecutedError', {
   reportPath: Schema.String,
+  suiteFile: Schema.String,
 }) {}
 
 /** The subset of Vitest's JSON reporter output this guard depends on. */
-const VitestRunReport = Schema.Struct({ numPassedTests: Schema.Finite })
+const VitestRunReport = Schema.Struct({
+  testResults: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      assertionResults: Schema.Array(Schema.Struct({ status: Schema.String })),
+    }),
+  ),
+})
+
+/** File whose tests every sync-provider cell must actually execute to have proven anything. */
+const syncProviderConformanceSuite = 'sync-provider.test.ts'
 
 /**
- * Fails when a run executed no tests at all. Selection itself is resolved in-process against
- * the provider registry, so a cell can no longer silently select nothing — this stays as a
- * backstop against a bad `include` glob or an over-broad skip leaving the job vacuously green.
+ * Fails when `suiteFile` executed no tests. Selection is resolved in-process against the
+ * provider registry, so a cell can no longer silently select nothing — this is the backstop
+ * against a bad `include` glob or an over-broad skip leaving the job vacuously green.
+ *
+ * Scoped to one file rather than the run's total: utility suites that run in every cell
+ * (`registry.test.ts`) would otherwise keep the count non-zero even if the conformance suite
+ * were skipped entirely. Failed tests count as executed — a quarantined run where everything
+ * fails has still proven something, and rejecting it here would defeat the quarantine.
  */
-export const assertTestsExecuted = Effect.fn(function* (reportPath: string) {
+export const assertTestsExecuted = Effect.fn(function* ({
+  reportPath,
+  suiteFile,
+}: {
+  readonly reportPath: string
+  readonly suiteFile: string
+}) {
   const raw = fs.readFileSync(reportPath, 'utf8')
   const report = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(VitestRunReport))(raw)
 
-  if (report.numPassedTests === 0) {
-    return yield* new NoTestsExecutedError({ reportPath })
+  const executed = report.testResults
+    .filter((file) => path.basename(file.name) === suiteFile)
+    .flatMap((file) => file.assertionResults)
+    .filter((assertion) => assertion.status === 'passed' || assertion.status === 'failed').length
+
+  if (executed === 0) {
+    return yield* new NoTestsExecutedError({ reportPath, suiteFile })
   }
 })
 
@@ -307,7 +334,7 @@ const runSyncProviderTests = Effect.fn(function* ({ provider }: { provider: Opti
     env: Option.isSome(provider) === true ? { [providerSelectionEnvVar]: provider.value } : {},
   }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/sync-provider')))
 
-  yield* assertTestsExecuted(reportPath)
+  yield* assertTestsExecuted({ reportPath, suiteFile: syncProviderConformanceSuite })
 })
 
 export const syncProviderTest = Cli.Command.make(

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -2,13 +2,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { cmd, cmdText, LivestoreWorkspace } from '@livestore/utils-dev/node'
-import { Effect, Option } from '@livestore/utils/effect'
+import { Effect, Option, Schema } from '@livestore/utils/effect'
 import { Cli } from '@livestore/utils/node'
 import * as integrationTests from '@local/tests-integration/run-tests'
 import * as syncProviderTestsPrepare from '@local/tests-sync-provider/prepare-ci'
 import {
   providerKeys,
-  providerRegistry,
+  providerSelectionEnvVar,
   type ProviderKey as TSyncProviderChoice,
 } from '@local/tests-sync-provider/registry'
 
@@ -27,14 +27,17 @@ const ciUnitTestPackageConcurrency = (() => {
 })()
 
 // GitHub actions log groups
+/**
+ * Closes the log group on every exit path. A group left open on failure swallows the
+ * rest of the job output into a collapsed section, hiding the very failure that caused it.
+ */
 const runTestGroup =
   (name: string) =>
   <E, C>(effect: Effect.Effect<unknown, E, C>) =>
     Effect.gen(function* () {
       console.log(`::group::${name}`)
       yield* effect
-      console.log(`::endgroup::`)
-    }).pipe(Effect.withSpan(`test-group(${name})`))
+    }).pipe(Effect.ensuring(Effect.sync(() => console.log(`::endgroup::`))), Effect.withSpan(`test-group(${name})`))
 
 interface TestTarget {
   path: string
@@ -120,7 +123,9 @@ const discoverPackagesWithTests = (workspaceRoot: string, excludePackages: strin
       }
     }
   } catch (error) {
-    console.warn('Warning: Failed to discover packages with tests:', error)
+    // Swallowing this would silently shrink the unit lane to a partial run that still
+    // reports success — the failure mode the whole lane exists to rule out.
+    throw new Error(`Failed to discover packages with tests under ${workspaceRoot}`, { cause: error })
   }
 
   return results.toSorted((a, b) => a.path.localeCompare(b.path))
@@ -266,21 +271,43 @@ export const waSqliteTest = Cli.Command.make('wa-sqlite', {}, runWaSqliteTests)
 
 // the sync provider tests are actually part of another tests package but for now we run them from here too
 // TODO clean this up at some point
-const escapeRegex = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/** A run that reported success without executing a single test. */
+export class NoTestsExecutedError extends Schema.TaggedErrorClass<NoTestsExecutedError>()('NoTestsExecutedError', {
+  reportPath: Schema.String,
+}) {}
+
+/** The subset of Vitest's JSON reporter output this guard depends on. */
+const VitestRunReport = Schema.Struct({ numPassedTests: Schema.Finite })
+
+/**
+ * Fails when a run executed no tests at all. Selection itself is resolved in-process against
+ * the provider registry, so a cell can no longer silently select nothing — this stays as a
+ * backstop against a bad `include` glob or an over-broad skip leaving the job vacuously green.
+ */
+export const assertTestsExecuted = Effect.fn(function* (reportPath: string) {
+  const raw = fs.readFileSync(reportPath, 'utf8')
+  const report = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(VitestRunReport))(raw)
+
+  if (report.numPassedTests === 0) {
+    return yield* new NoTestsExecutedError({ reportPath })
+  }
+})
 
 const runSyncProviderTests = Effect.fn(function* ({ provider }: { provider: Option.Option<TSyncProviderChoice> }) {
   yield* syncProviderTestsPrepare.prepareCi
 
-  const args: string[] = ['vitest', 'run']
-  if (Option.isSome(provider) === true) {
-    const suite = providerRegistry[provider.value].name
-    // Vitest may render the provider name wrapped in quotes in the full test title.
-    // Use a forgiving pattern that matches with or without surrounding quotes.
-    const pattern = `["']?${escapeRegex(suite)}["']? sync provider`
-    args.push('--testNamePattern', pattern)
-  }
+  const workspaceRoot = yield* LivestoreWorkspace
+  const reportPath = path.join(workspaceRoot, 'tmp/sync-provider-run-report.json')
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true })
 
-  yield* cmd(args).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/sync-provider')))
+  yield* cmd(['vitest', 'run', '--reporter=default', '--reporter=json', `--outputFile.json=${reportPath}`], {
+    // Selection happens at collection time via the registry rather than by matching test
+    // titles, so renaming a suite can no longer remove it from a CI cell (#1429).
+    env: Option.isSome(provider) === true ? { [providerSelectionEnvVar]: provider.value } : {},
+  }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/sync-provider')))
+
+  yield* assertTestsExecuted(reportPath)
 })
 
 export const syncProviderTest = Cli.Command.make(

--- a/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
+++ b/tests/integration/src/tests/playwright/devtools/browser-extension.play.ts
@@ -450,7 +450,7 @@ const PWLive = ({ extensionPath }: { extensionPath: string }) =>
               tabLocalhost.devtoolsConsoleFiber,
               tabLoopback.pageConsoleFiber,
               tabLoopback.devtoolsConsoleFiber,
-            ]).pipe(Effect.ignore),
+            ]),
           ),
         )
       }),

--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -17,16 +17,27 @@ import {
   References,
 } from '@livestore/utils/effect'
 
-import * as CloudflareHttpProvider from './providers/cloudflare-http-rpc.ts'
+import { isProviderSelected, providerRegistry } from './providers/registry.ts'
 import { SyncProviderImpl, type SyncProviderOptions } from './types.ts'
 
 /** Cloudflare HTTP-specific tests for response headers and HTTP transport features */
 
-const cloudflareHttpProviders = [CloudflareHttpProvider.d1, CloudflareHttpProvider.doSqlite]
+const cloudflareHttpKeys = ['cf-http-d1', 'cf-http-do'] as const
+const selectedHttpKeys = cloudflareHttpKeys.filter((key) => isProviderSelected(key))
+
+// When no HTTP provider is selected the full list is still registered, just skipped: an empty
+// `describe.each` collects nothing and Vitest fails the file outright, which would red every
+// non-HTTP provider cell.
+const skipUnlessHttpSelected = selectedHttpKeys.length === 0
+const cloudflareHttpProviders = (skipUnlessHttpSelected === true ? cloudflareHttpKeys : selectedHttpKeys).map(
+  (key) => providerRegistry[key],
+)
 
 type RuntimeServices = SyncProviderImpl | HttpClient.HttpClient
 
-Vitest.describe.each(cloudflareHttpProviders)('$name HTTP response headers', { timeout: 30000 }, ({ layer, name }) => {
+const describeHttpProviders = Vitest.describe.skipIf(skipUnlessHttpSelected).each(cloudflareHttpProviders)
+
+describeHttpProviders('$name HTTP response headers', { timeout: 30000 }, ({ layer, name }) => {
   let runtime: ManagedRuntime.ManagedRuntime<RuntimeServices, never>
   let runtimeContext: Context.Context<RuntimeServices>
   let testId: string

--- a/tests/sync-provider/src/do-hibernation.test.ts
+++ b/tests/sync-provider/src/do-hibernation.test.ts
@@ -20,14 +20,17 @@ import {
 } from '@livestore/utils/effect'
 
 import * as CloudflareWsProvider from './providers/cloudflare-ws.ts'
+import { isProviderSelected } from './providers/registry.ts'
 import { SyncProviderImpl } from './types.ts'
 
 const idleWindow: Duration.Input = '20 seconds' // workerd evicts somewhere between 9s and 11s idle
 
 type RuntimeServices = SyncProviderImpl | HttpClient.HttpClient | KeyValueStore.KeyValueStore
 
-// CI cells select by title (see scripts/src/commands/test-commands.ts); renaming this stops it running anywhere.
-Vitest.describe(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hibernation`, () => {
+// Selected by provider key, not by suite title, so renaming this suite cannot drop it from CI.
+const describeWsDo = Vitest.describe.skipIf(isProviderSelected('cf-ws-do') === false)
+
+describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hibernation`, () => {
   let runtime: ManagedRuntime.ManagedRuntime<RuntimeServices, never>
   let runtimeContext: Context.Context<RuntimeServices>
 

--- a/tests/sync-provider/src/do-rpc-hibernation.test.ts
+++ b/tests/sync-provider/src/do-rpc-hibernation.test.ts
@@ -20,14 +20,17 @@ import {
 } from '@livestore/utils/effect'
 
 import * as CloudflareDoRpcProvider from './providers/cloudflare-do-rpc.ts'
+import { isProviderSelected } from './providers/registry.ts'
 import { SyncProviderImpl } from './types.ts'
 
 const idleWindow: Duration.Input = '20 seconds' // workerd evicts somewhere between 9s and 11s idle
 
 type RuntimeServices = SyncProviderImpl | HttpClient.HttpClient | KeyValueStore.KeyValueStore
 
-// CI cells select by title (see scripts/src/commands/test-commands.ts); renaming this stops it running anywhere.
-Vitest.describe(`${CloudflareDoRpcProvider.doSqlite.name} sync provider — DO hibernation`, () => {
+// Selected by provider key, not by suite title, so renaming this suite cannot drop it from CI.
+const describeDoRpcDo = Vitest.describe.skipIf(isProviderSelected('cf-do-rpc-do') === false)
+
+describeDoRpcDo(`${CloudflareDoRpcProvider.doSqlite.name} sync provider — DO hibernation`, () => {
   let runtime: ManagedRuntime.ManagedRuntime<RuntimeServices, never>
   let runtimeContext: Context.Context<RuntimeServices>
 

--- a/tests/sync-provider/src/providers/registry.test.ts
+++ b/tests/sync-provider/src/providers/registry.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isProviderSelected, providerKeys, providerSelectionEnvVar, selectedProviderKeys } from './registry.ts'
+
+const originalSelection = process.env[providerSelectionEnvVar]
+
+const withSelection = (value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env[providerSelectionEnvVar]
+  } else {
+    process.env[providerSelectionEnvVar] = value
+  }
+}
+
+afterEach(() => withSelection(originalSelection))
+
+describe('provider selection', () => {
+  it('runs every provider when unpinned', () => {
+    withSelection(undefined)
+
+    expect(selectedProviderKeys()).toEqual(providerKeys)
+  })
+
+  it('narrows to the pinned provider', () => {
+    withSelection('cf-ws-do')
+
+    expect(selectedProviderKeys()).toEqual(['cf-ws-do'])
+    expect(isProviderSelected('cf-ws-do')).toBe(true)
+    expect(isProviderSelected('cf-http-d1')).toBe(false)
+  })
+
+  it('throws on an unknown provider instead of selecting nothing', () => {
+    withSelection('cf-typo')
+
+    expect(() => selectedProviderKeys()).toThrow(/Unknown TEST_SYNC_PROVIDER/)
+  })
+})

--- a/tests/sync-provider/src/providers/registry.ts
+++ b/tests/sync-provider/src/providers/registry.ts
@@ -35,3 +35,32 @@ export const providerRegistry: {
 export type ProviderKey = keyof typeof providerRegistry
 
 export const providerKeys = Object.keys(providerRegistry) as ProviderKey[]
+
+/** Environment variable a CI matrix cell uses to pin its run to a single provider. */
+export const providerSelectionEnvVar = 'TEST_SYNC_PROVIDER'
+
+export const isProviderKey = (value: string): value is ProviderKey => Object.hasOwn(providerRegistry, value) === true
+
+/**
+ * Provider keys the current process should exercise: every provider by default, or the
+ * single one pinned via `TEST_SYNC_PROVIDER`.
+ *
+ * Selection is resolved at collection time against the registry rather than by matching
+ * test titles, so a cell can no longer select nothing and report success — an unknown key
+ * throws, and renaming a suite cannot silently remove it from CI.
+ */
+export const selectedProviderKeys = (): ProviderKey[] => {
+  const selected = process.env[providerSelectionEnvVar]
+  if (selected === undefined || selected === '') return providerKeys
+
+  if (isProviderKey(selected) === false) {
+    throw new Error(
+      `Unknown ${providerSelectionEnvVar}=${JSON.stringify(selected)}. Expected one of: ${providerKeys.join(', ')}`,
+    )
+  }
+
+  return [selected]
+}
+
+/** Whether `key` is in the current selection — for suites hard-wired to one provider. */
+export const isProviderSelected = (key: ProviderKey): boolean => selectedProviderKeys().includes(key)

--- a/tests/sync-provider/src/sync-provider.test.ts
+++ b/tests/sync-provider/src/sync-provider.test.ts
@@ -26,7 +26,7 @@ import {
   SubscriptionRef,
 } from '@livestore/utils/effect'
 
-import { providerKeys, providerRegistry } from './providers/registry.ts'
+import { providerRegistry, selectedProviderKeys } from './providers/registry.ts'
 import { SyncProviderImpl, type SyncProviderOptions } from './types.ts'
 
 // NOTE: These specs should mirror LeaderSyncProcessor semantics: pushes never bypass the
@@ -37,7 +37,7 @@ const defaultClient = EventFactory.clientIdentity('test-client', 'test-session')
 
 const makeFactory = EventFactory.makeFactory(events)
 
-const providerLayers = providerKeys.map((key) => providerRegistry[key])
+const providerLayers = selectedProviderKeys().map((key) => providerRegistry[key])
 
 type RuntimeServices = SyncProviderImpl | HttpClient.HttpClient
 
@@ -56,7 +56,6 @@ const runFirstNonEmpty = <T, E, R>(stream: Stream.Stream<SyncBackend.PullResItem
     Stream.runFirstUnsafe,
   )
 
-// TODO come up with a way to target specific providers individually
 /** Verifies: LS.SYS.SYNC-R02, LS.SYS.SYNC-R03, LS.SYS.SYNC-R04, LS.SYS.SYNC-R05, LS.SYS.SYNC.CF-R05, LS.SYS.VER.CONF-R01 */
 Vitest.describe.each(providerLayers)('$name sync provider', { timeout: 60000 }, ({ layer, name }) => {
   let runtime: ManagedRuntime.ManagedRuntime<RuntimeServices, never>


### PR DESCRIPTION
> **Stacked on #1484.** Base that first.
>
> Scope narrowed: this PR now removes **only** the unit-lane suppression. The Cloudflare and DevTools removals moved to follow-ups stacked after the quarantine ledger (#1486), because CI showed both were hiding real pre-existing breakage that needs a declared quarantine — see #1489 and #1490.

## Problem

The `test-unit` job ran `packages/@livestore/webmesh` and `tests/package-common` through `Effect.ignore` under `GITHUB_ACTIONS`, so any failure in either target produced a passing required check.

The quarantine was added for flaky `webmesh` tests but took `tests/package-common` with it — including `intent-layer.test.ts`, the suite `CLAUDE.md` requires green whenever `context/` changes. That gate has been advisory-only in CI, tracked as `DELTA-002`.

## Goal

`test-unit` fails when its tests fail, and the intent-layer invariant suite becomes a real gate.

## Decisions

**`DELTA-002` closed by supersession.** The delta proposed a dedicated non-ignored step for just the intent-layer suite. Removing the ignore entirely is strictly better: the carve-out would have left the rest of `tests/package-common` swallowed, and the quarantine was never scoped to the flake it was added for.

**Split from the other two suppressions.** They share a category but not their evidence — see the banner above.

## Verification

`test-unit` **passed in CI** on the version of this branch that removed all three suppressions, so the unit-lane removal is independently verified green.

Locally on this branch:

```
tests/package-common            11 files   73 passed | 13 skipped
packages/@livestore/webmesh      2 files   28 passed |  1 skipped
```

`webmesh` is not currently flaky: 8 consecutive full runs, 8 passed / 0 failed.

Intent-layer suite green (8 tests) after this PR's `context/` edits — and now wired to fail `test-unit` if it isn't. `tsgo --build` clean, `oxfmt --check` clean.

## Complexity

Negative — one code path deleted.

## Concerns

- `webmesh` was quarantined for a reason once. 8/8 locally and a green CI `test-unit` say it is not currently flaky, but that is a snapshot; if it returns, this is a one-line revert or a per-test policy once #1486 lands.
- `tests/package-common` and `webmesh` still run sequentially before the parallel group; this changes error propagation only, not scheduling.

## Friction & bottlenecks

- The `::warning::` that these wrappers emit is discarded by `devenv tasks run`, which prints task stdout only on failure. A suppression that exits 0 therefore leaves no trace in the log or the checks UI — which is why an annotation-based survey of 38 CI runs found nothing. Worth knowing before anyone tries to measure suppression frequency that way again.
- The `prek` pre-commit hook aborts in this repo (`config file not found: .pre-commit-config.yaml`); every commit needs `PREK_ALLOW_NO_CONFIG=1`.

## Follow-ups

- #1486 — quarantine ledger with expiry, stacked on this.
- #1489 — DevTools suite fails 0/15; its de-suppression follows the ledger.
- #1490 — Cloudflare custom-header test hangs; its de-suppression follows the ledger.

## References

Refs #1404, #1412. Depends on #1484. Closes `context/.delta/DELTA-002-enforcement-not-ci-blocking.md`.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-25-ci-desuppress |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->