### PR TITLE
Require a declared, expiring quarantine to tolerate a failing test

### DIFF
--- a/context/02-system/09-verification/01-lanes/.delta/DELTA-003-integration-lane-unpoliced.md
+++ b/context/02-system/09-verification/01-lanes/.delta/DELTA-003-integration-lane-unpoliced.md
@@ -1,0 +1,26 @@
+# DELTA-003 — Browser integration lane bypasses the test policy
+
+Status: open
+
+## Divergence
+
+LS.SYS.VER.LANE-R04 requires that tolerating a failing test is expressible only
+as a declared quarantine. The `runTestTarget` helper enforces this for the
+targets the `mono test` runner invokes directly (unit, sync-provider, SQLite
+substrate, perf), but the browser integration lane is dispatched through
+`@local/tests-integration`'s `runMiscTest` / `runTodomvcTest` /
+`runDevtoolsTest`, which call Playwright without passing through the helper.
+
+A suppression added inside that module would therefore not require a ledger
+entry, and would not be rejected by the type checker.
+
+## VRS
+
+[spec.md](../spec.md) §Test Policy.
+
+## Close condition
+
+Route the integration lane's invocations through `runTestTarget`, so every lane
+in the table above is covered by the same policy. Close when adding an
+`Effect.ignore` to an integration-lane invocation fails to compile without a
+ledger entry, the same way it now does for the other lanes.

--- a/context/02-system/09-verification/01-lanes/requirements.md
+++ b/context/02-system/09-verification/01-lanes/requirements.md
@@ -23,3 +23,8 @@ workflows) are owned by `../../../03-delivery/`.
   exactly one `mono test`/devenv command, and the table stays in sync with
   the CI job decomposition. Adopted 2026-07-16 (interview); not met — see
   [.delta/DELTA-002-lane-ci-mismatches.md](./.delta/DELTA-002-lane-ci-mismatches.md).
+- **LS.SYS.VER.LANE-R04 Honest gates:** A required check reports success only
+  if every test it represents executed and passed. Tolerating a known failure
+  is expressible only as a declared quarantine carrying a reason, a tracking
+  issue, and an expiry date (mechanism in [spec.md](./spec.md) §Test Policy).
+  Adopted 2026-07-25.

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -13,6 +13,7 @@ Draft.
 | --- | --- | --- | --- | --- | --- |
 | Unit | Pure semantics per package | `*.test.ts(x)` colocated | Vitest | `mono test unit` | `test-unit` |
 | Package integration | Cross-package engine behavior (materializer, sync processors, client documents) | `tests/package-common/` | Vitest | folded into `mono test unit` | `test-unit` |
+| Repo tooling | `mono` CLI commands (release, docs export, test policy) | `scripts/` | Vitest | folded into `mono test unit` | `test-unit` |
 | Browser integration | Adapter/devtools behavior in real browsers | `tests/integration/` | Playwright | `mono test integration` | `test-integration-playwright` (suite matrix: misc, todomvc, devtools) |
 | Sync-provider conformance | Provider contract (see [../02-conformance/](../02-conformance/spec.md)) | `tests/sync-provider/` | Vitest | `mono test integration sync-provider` | `test-integration-sync-provider` (7-provider matrix) |
 | SQLite substrate | wa-sqlite API, session extension, serialize | `tests/wa-sqlite/` | Vitest | `mono test integration wa-sqlite` | `wa-sqlite-test` |
@@ -29,10 +30,41 @@ command column). Two characteristics are deliberate, not drift:
 - `mono test integration` is a CLI parent grouping the three integration lanes
   (Browser, Sync-provider, SQLite) — each is still its own row with its own CI
   job.
-- `tests/package-common/` folds into the unit lane
-  (`scripts/src/commands/test-commands.ts`) rather than getting a separate CI
-  job, and examples-as-tests run on demand (not a required gate) — both are
-  documented in the table above, by design.
+- `tests/package-common/` and `scripts/` fold into the unit lane
+  (`scripts/src/commands/test-commands.ts`) rather than getting separate CI
+  jobs, and examples-as-tests run on demand (not a required gate) — all are
+  documented in the table above, by design. The unit lane's discovery walks
+  `packages/@livestore/*`, `packages/@local/*`, and those two extra roots; a
+  test root absent from that list runs nowhere in CI.
+
+## Test Policy
+
+Every test target runs under an explicit policy (LS.SYS.VER.LANE-R04), stated at
+its invocation in `scripts/src/shared/test-policy.ts`:
+
+| Policy | Effect on the job |
+| --- | --- |
+| `blocking` | Failures fail the job. The default for every target. |
+| `quarantined(key)` | Failures are announced and tolerated, under a ledger entry. |
+
+`key` must name an entry in `quarantineLedger`, so a quarantine cannot be
+expressed without a checked-in record of its target, reason, tracking issue, and
+expiry date. The ledger is empty in the steady state; with no entries the
+quarantine constructor is uninhabited and the type checker rejects any attempt to
+suppress a failure.
+
+Two properties keep a quarantine from becoming permanent and invisible:
+
+- **Expiry.** `test-policy.test.ts` fails once an entry's `expires` date passes,
+  forcing a renew-or-remove decision in the unit lane, which is a required check.
+- **Distinguishable signal.** A tolerated failure is announced with its own
+  annotation title and a job-summary line, so it cannot be mistaken for a pass or
+  lost among unrelated Actions warnings.
+
+Test selection is resolved against source-of-truth registries rather than by
+matching test titles — the sync-provider matrix pins a cell with
+`TEST_SYNC_PROVIDER`, validated against `providerRegistry`. A cell therefore
+cannot select an empty set, and renaming a suite cannot remove it from CI.
 
 ## Coverage Skew
 

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -39,8 +39,12 @@ command column). Two characteristics are deliberate, not drift:
 
 ## Test Policy
 
-Every test target runs under an explicit policy (LS.SYS.VER.LANE-R04), stated at
-its invocation in `scripts/src/shared/test-policy.ts`:
+Test targets invoked by the `mono test` runner (unit, sync-provider, SQLite
+substrate, perf) run under an explicit policy (LS.SYS.VER.LANE-R04), stated at
+their invocation in `scripts/src/shared/test-policy.ts`. The browser integration
+lane is dispatched through `@local/tests-integration` and is not yet routed
+through the helper — tracked in
+[.delta/DELTA-003-integration-lane-unpoliced.md](./.delta/DELTA-003-integration-lane-unpoliced.md).
 
 | Policy | Effect on the job |
 | --- | --- |

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -181,11 +181,20 @@ const runUnitTests = Effect.fn(function* ({ filter }: { filter: Option.Option<st
     if (configs.length > 0) {
       yield* Effect.forEach(
         configs,
-        (config) => cmd(['vitest', 'run', '--config', config]).pipe(Effect.provide(LivestoreWorkspace.toCwd())),
+        (config) =>
+          TestPolicy.runTestTarget({
+            label: config,
+            policy: TestPolicy.blocking,
+            run: cmd(['vitest', 'run', '--config', config]).pipe(Effect.provide(LivestoreWorkspace.toCwd())),
+          }),
         { concurrency: 'unbounded' },
       )
     } else {
-      yield* cmd(['vitest', 'run', target]).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+      yield* TestPolicy.runTestTarget({
+        label: target,
+        policy: TestPolicy.blocking,
+        run: cmd(['vitest', 'run', target]).pipe(Effect.provide(LivestoreWorkspace.toCwd())),
+      })
     }
     return
   }
@@ -244,10 +253,14 @@ const runUnitTests = Effect.fn(function* ({ filter }: { filter: Option.Option<st
             : ['vitest', 'run', `${workspaceRoot}/${target.path}`]
         const label = target.config ?? target.path
         // TODO use this https://x.com/luxdav/status/1942532247833436656
-        return cmdText(args.join(' '), { stderr: 'pipe' }).pipe(
-          Effect.provide(LivestoreWorkspace.toCwd()),
-          Effect.tap((text) => Effect.sync(() => console.log(`Output for ${label}:\n\n${text}\n\n`))),
-        )
+        return TestPolicy.runTestTarget({
+          label,
+          policy: TestPolicy.blocking,
+          run: cmdText(args.join(' '), { stderr: 'pipe' }).pipe(
+            Effect.provide(LivestoreWorkspace.toCwd()),
+            Effect.tap((text) => Effect.sync(() => console.log(`Output for ${label}:\n\n${text}\n\n`))),
+          ),
+        })
       },
       { concurrency: 'unbounded' },
     )
@@ -266,16 +279,24 @@ export const testUnitCommand = Cli.Command.make(
 )
 
 const runPerfTests = Effect.fn(function* () {
-  yield* cmd('NODE_OPTIONS=--disable-warning=ExperimentalWarning pnpm playwright test', {
-    shell: true,
-    env: { FORCE_PLAYWRIGHT_VIA_CLI: '1' },
-  }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/perf')))
+  yield* TestPolicy.runTestTarget({
+    label: 'tests/perf',
+    policy: TestPolicy.blocking,
+    run: cmd('NODE_OPTIONS=--disable-warning=ExperimentalWarning pnpm playwright test', {
+      shell: true,
+      env: { FORCE_PLAYWRIGHT_VIA_CLI: '1' },
+    }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/perf'))),
+  })
 })
 
 export const testPerfCommand = Cli.Command.make('perf', {}, runPerfTests)
 
 const runWaSqliteTests = Effect.fn(function* () {
-  yield* cmd('vitest run').pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/wa-sqlite')))
+  yield* TestPolicy.runTestTarget({
+    label: 'tests/wa-sqlite',
+    policy: TestPolicy.blocking,
+    run: cmd('vitest run').pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/wa-sqlite'))),
+  })
 })
 
 export const waSqliteTest = Cli.Command.make('wa-sqlite', {}, runWaSqliteTests)

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -12,6 +12,8 @@ import {
   type ProviderKey as TSyncProviderChoice,
 } from '@local/tests-sync-provider/registry'
 
+import * as TestPolicy from '../shared/test-policy.ts'
+
 const isGithubAction = process.env.GITHUB_ACTIONS === 'true'
 
 const ciUnitTestPackageConcurrency = (() => {
@@ -115,11 +117,14 @@ const discoverPackagesWithTests = (workspaceRoot: string, excludePackages: strin
       }
     }
 
-    // Also check tests/package-common if not excluded
-    if (excludePackages.includes('tests/package-common') === false) {
-      const packageCommonPath = path.join(workspaceRoot, 'tests/package-common')
-      if (fs.existsSync(packageCommonPath) === true && hasTestFiles(packageCommonPath) === true) {
-        addPackage(packageCommonPath, 'tests/package-common')
+    // Test roots outside packages/*. Without these the unit lane silently omits suites that
+    // exist and pass locally — `scripts/` carried 4 test files that no CI job ever ran.
+    for (const extraRoot of ['tests/package-common', 'scripts']) {
+      if (excludePackages.includes(extraRoot) === true) continue
+
+      const extraPath = path.join(workspaceRoot, extraRoot)
+      if (fs.existsSync(extraPath) === true && hasTestFiles(extraPath) === true) {
+        addPackage(extraPath, extraRoot)
       }
     }
   } catch (error) {
@@ -198,7 +203,13 @@ const runUnitTests = Effect.fn(function* ({ filter }: { filter: Option.Option<st
     const vitestPathsToRunSequentially = sequentialPackages.map((pkg) => `${workspaceRoot}/${pkg}`)
 
     for (const vitestPath of vitestPathsToRunSequentially) {
-      yield* runTestGroup(vitestPath)(cmd(`vitest run ${vitestPath}`).pipe(Effect.provide(LivestoreWorkspace.toCwd())))
+      yield* runTestGroup(vitestPath)(
+        TestPolicy.runTestTarget({
+          label: vitestPath,
+          policy: TestPolicy.blocking,
+          run: cmd(`vitest run ${vitestPath}`).pipe(Effect.provide(LivestoreWorkspace.toCwd())),
+        }),
+      )
     }
 
     // Run the rest of the tests in parallel (each config as separate vitest invocation)
@@ -211,7 +222,11 @@ const runUnitTests = Effect.fn(function* ({ filter }: { filter: Option.Option<st
               target.config !== undefined
                 ? ['vitest', 'run', '--config', target.config]
                 : ['vitest', 'run', `${workspaceRoot}/${target.path}`]
-            return cmd(args).pipe(Effect.provide(LivestoreWorkspace.toCwd()))
+            return TestPolicy.runTestTarget({
+              label: target.config ?? target.path,
+              policy: TestPolicy.blocking,
+              run: cmd(args).pipe(Effect.provide(LivestoreWorkspace.toCwd())),
+            })
           },
           { concurrency: ciUnitTestPackageConcurrency },
         ),
@@ -324,11 +339,15 @@ const runSyncProviderTests = Effect.fn(function* ({ provider }: { provider: Opti
   const reportPath = path.join(workspaceRoot, 'tmp/sync-provider-run-report.json')
   fs.mkdirSync(path.dirname(reportPath), { recursive: true })
 
-  yield* cmd(['vitest', 'run', '--reporter=default', '--reporter=json', `--outputFile.json=${reportPath}`], {
-    // Selection happens at collection time via the registry rather than by matching test
-    // titles, so renaming a suite can no longer remove it from a CI cell (#1429).
-    env: Option.isSome(provider) === true ? { [providerSelectionEnvVar]: provider.value } : {},
-  }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/sync-provider')))
+  yield* TestPolicy.runTestTarget({
+    label: Option.isSome(provider) === true ? `sync-provider:${provider.value}` : 'sync-provider',
+    policy: TestPolicy.blocking,
+    run: cmd(['vitest', 'run', '--reporter=default', '--reporter=json', `--outputFile.json=${reportPath}`], {
+      // Selection happens at collection time via the registry rather than by matching test
+      // titles, so renaming a suite can no longer remove it from a CI cell (#1429).
+      env: Option.isSome(provider) === true ? { [providerSelectionEnvVar]: provider.value } : {},
+    }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/sync-provider'))),
+  })
 
   yield* assertTestsExecuted({ reportPath, suiteFile: syncProviderConformanceSuite })
 })

--- a/scripts/src/shared/test-policy.test.ts
+++ b/scripts/src/shared/test-policy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { Effect, Exit, Schema } from '@livestore/utils/effect'
+
+import { blocking, expiredEntries, QuarantineEntry, quarantineLedger, runTestTarget } from './test-policy.ts'
+
+const isoDate = /^\d{4}-\d{2}-\d{2}$/
+
+const today = (): string => new Date().toISOString().slice(0, 10)
+
+describe('quarantine ledger', () => {
+  it('has no expired entries', () => {
+    // A quarantine past its expiry reds `test-unit` rather than quietly becoming permanent.
+    // Renew it with a new date and a fresh justification, or delete it.
+    expect(expiredEntries(quarantineLedger, today())).toEqual([])
+  })
+
+  it('flags a lapsed entry and leaves a live one alone', () => {
+    const lapsed = new QuarantineEntry({
+      target: 'packages/@livestore/example',
+      reason: 'demonstrates the expiry rule',
+      issue: 'https://github.com/livestorejs/livestore/issues/1404',
+      expires: '2020-01-01',
+    })
+    const live = new QuarantineEntry({ ...lapsed, expires: '2999-01-01' })
+
+    expect(expiredEntries({ lapsed, live }, today()).map(([key]) => key)).toEqual(['lapsed'])
+  })
+
+  it('records a target, reason, issue and a well-formed expiry for every entry', () => {
+    for (const [key, entry] of Object.entries(quarantineLedger as Record<string, QuarantineEntry>)) {
+      expect(Exit.isSuccess(Schema.decodeUnknownExit(QuarantineEntry)(entry)), `${key} shape`).toBe(true)
+      expect(entry.issue, `${key} issue`).toMatch(/^https:\/\/github\.com\//)
+      expect(entry.expires, `${key} expires`).toMatch(isoDate)
+      expect(entry.reason.length, `${key} reason`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('runTestTarget', () => {
+  it('propagates failure under the blocking policy', async () => {
+    const exit = await Effect.runPromiseExit(
+      runTestTarget({ label: 'demo', policy: blocking, run: Effect.fail('boom' as const) }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it('passes success through under the blocking policy', async () => {
+    const exit = await Effect.runPromiseExit(
+      runTestTarget({ label: 'demo', policy: blocking, run: Effect.succeed('ok' as const) }),
+    )
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+  })
+})

--- a/scripts/src/shared/test-policy.test.ts
+++ b/scripts/src/shared/test-policy.test.ts
@@ -62,4 +62,16 @@ describe('runTestTarget', () => {
 
     expect(Exit.isSuccess(exit)).toBe(true)
   })
+
+  it('refuses a quarantine key with no ledger entry', () => {
+    // The type checker rejects this statically; a cast or a JS caller can still reach it, and
+    // treating an unknown quarantine as "suppress everything" is the failure mode to avoid.
+    expect(() =>
+      runTestTarget({ label: 'packages/@livestore/unrelated', policy: fakePolicy(), run: Effect.void }),
+    ).toThrow(/has no entry in the ledger/)
+  })
 })
+
+/** A quarantine policy the type checker would reject, to reach the runtime guards. */
+const fakePolicy = (key = 'demo-entry'): Parameters<typeof runTestTarget>[0]['policy'] =>
+  ({ _tag: 'quarantined', key }) as unknown as Parameters<typeof runTestTarget>[0]['policy']

--- a/scripts/src/shared/test-policy.test.ts
+++ b/scripts/src/shared/test-policy.test.ts
@@ -8,6 +8,8 @@ const isoDate = /^\d{4}-\d{2}-\d{2}$/
 
 const today = (): string => new Date().toISOString().slice(0, 10)
 
+const decodeEntry = Schema.decodeUnknownExit(QuarantineEntry)
+
 describe('quarantine ledger', () => {
   it('has no expired entries', () => {
     // A quarantine past its expiry reds `test-unit` rather than quietly becoming permanent.
@@ -27,9 +29,16 @@ describe('quarantine ledger', () => {
     expect(expiredEntries({ lapsed, live }, today()).map(([key]) => key)).toEqual(['lapsed'])
   })
 
+  it('rejects a malformed entry', () => {
+    // Exercises the decode used by the shape check above, which otherwise never runs while
+    // the ledger is empty — an unexercised assertion is the failure mode this PR exists to stop.
+    expect(Exit.isSuccess(decodeEntry({ target: 'x', reason: 'y', issue: 'z', expires: '2999-01-01' }))).toBe(true)
+    expect(Exit.isSuccess(decodeEntry({ target: 'x', reason: 'y', issue: 'z' }))).toBe(false)
+  })
+
   it('records a target, reason, issue and a well-formed expiry for every entry', () => {
     for (const [key, entry] of Object.entries(quarantineLedger as Record<string, QuarantineEntry>)) {
-      expect(Exit.isSuccess(Schema.decodeUnknownExit(QuarantineEntry)(entry)), `${key} shape`).toBe(true)
+      expect(Exit.isSuccess(decodeEntry(entry)), `${key} shape`).toBe(true)
       expect(entry.issue, `${key} issue`).toMatch(/^https:\/\/github\.com\//)
       expect(entry.expires, `${key} expires`).toMatch(isoDate)
       expect(entry.reason.length, `${key} reason`).toBeGreaterThan(0)

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -60,7 +60,7 @@ export const runTestTarget = <A, E, R>({
 }): Effect.Effect<void, E, R> => {
   if (policy._tag === 'blocking') return run.pipe(Effect.asVoid)
 
-  const entry = (quarantineLedger as Record<string, QuarantineEntry>)[policy.key] as QuarantineEntry | undefined
+  const entry = (quarantineLedger as Record<string, QuarantineEntry>)[policy.key]
 
   // The type checker rejects an unknown key, but a cast or a JS caller can still get here, and
   // silently treating an unknown quarantine as "suppress everything" is the failure this whole

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -57,14 +57,33 @@ export const runTestTarget = <A, E, R>({
   readonly label: string
   readonly policy: TestPolicy
   readonly run: Effect.Effect<A, E, R>
-}): Effect.Effect<void, E, R> =>
-  policy._tag === 'blocking'
-    ? run.pipe(Effect.asVoid)
-    : run.pipe(
-        Effect.asVoid,
-        Effect.tapError(() => Effect.sync(() => announceQuarantinedFailure(label, quarantineLedger[policy.key]))),
-        Effect.ignore,
-      )
+}): Effect.Effect<void, E, R> => {
+  if (policy._tag === 'blocking') return run.pipe(Effect.asVoid)
+
+  const entry = (quarantineLedger as Record<string, QuarantineEntry>)[policy.key] as QuarantineEntry | undefined
+
+  // The type checker rejects an unknown key, but a cast or a JS caller can still get here, and
+  // silently treating an unknown quarantine as "suppress everything" is the failure this whole
+  // mechanism exists to prevent.
+  if (entry === undefined) {
+    throw new Error(`Quarantine '${String(policy.key)}' has no entry in the ledger.`)
+  }
+
+  // The ledger's `target` is the declaration of what is suppressed, so it has to be enforced
+  // rather than decorative: without this, one entry's key could silently suppress an unrelated
+  // target under another target's reason, issue, and expiry.
+  if (entry.target !== label) {
+    throw new Error(
+      `Quarantine '${String(policy.key)}' declares target ${JSON.stringify(entry.target)} but was applied to ${JSON.stringify(label)}.`,
+    )
+  }
+
+  return run.pipe(
+    Effect.asVoid,
+    Effect.tapError(() => Effect.sync(() => announceQuarantinedFailure(label, entry))),
+    Effect.ignore,
+  )
+}
 
 /**
  * Entries whose expiry has passed, relative to `today` (`YYYY-MM-DD`).

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs'
+
+import { Effect, Schema } from '@livestore/utils/effect'
+
+/**
+ * How a test target's failures reach the job's exit code.
+ *
+ * Every test invocation states its policy explicitly, so weakening a required check is a
+ * deliberate, reviewable act rather than a `.pipe(Effect.ignore)` or a `|| true` buried in a
+ * task wrapper. Quarantining is reachable only through {@link quarantined}, which accepts a
+ * key of {@link quarantineLedger} — so a quarantine cannot exist without a checked-in entry
+ * carrying a reason, a tracking issue, and an expiry date.
+ */
+export type TestPolicy = { readonly _tag: 'blocking' } | { readonly _tag: 'quarantined'; readonly key: QuarantineKey }
+
+/** Failures fail the job. The default for every target. */
+export const blocking: TestPolicy = { _tag: 'blocking' }
+
+/** Failures are reported but do not fail the job, under a declared, expiring ledger entry. */
+export const quarantined = (key: QuarantineKey): TestPolicy => ({ _tag: 'quarantined', key })
+
+export class QuarantineEntry extends Schema.Class<QuarantineEntry>('QuarantineEntry')({
+  /** What is quarantined — a package path, provider key, or suite name. */
+  target: Schema.String,
+  /** Why its failures are currently tolerated. */
+  reason: Schema.String,
+  /** Issue tracking the underlying problem. */
+  issue: Schema.String,
+  /** `YYYY-MM-DD`. Past this date the ledger check fails, forcing a renew-or-remove decision. */
+  expires: Schema.String,
+}) {}
+
+/**
+ * Every currently-tolerated test failure in the repository.
+ *
+ * Empty is the intended steady state: it means no required check is lying. Entries are
+ * expected to be rare and short-lived — `expires` is enforced by
+ * `test-policy.test.ts`, so a forgotten quarantine reds `test-unit` instead of
+ * silently becoming permanent.
+ */
+export const quarantineLedger = {} as const satisfies Record<string, QuarantineEntry>
+
+export type QuarantineKey = keyof typeof quarantineLedger
+
+/**
+ * Runs a test target under its stated policy.
+ *
+ * A quarantined failure is announced on its own line and in the job summary, so a suppressed
+ * failure is distinguishable from a genuine pass — the property the previous `::warning::`
+ * wrappers lacked, being indistinguishable from unrelated Actions warnings.
+ */
+export const runTestTarget = <A, E, R>({
+  label,
+  policy,
+  run,
+}: {
+  readonly label: string
+  readonly policy: TestPolicy
+  readonly run: Effect.Effect<A, E, R>
+}): Effect.Effect<void, E, R> =>
+  policy._tag === 'blocking'
+    ? run.pipe(Effect.asVoid)
+    : run.pipe(
+        Effect.asVoid,
+        Effect.tapError(() => Effect.sync(() => announceQuarantinedFailure(label, quarantineLedger[policy.key]))),
+        Effect.ignore,
+      )
+
+/**
+ * Entries whose expiry has passed, relative to `today` (`YYYY-MM-DD`).
+ *
+ * Takes the ledger as an argument so the expiry rule stays testable while the real ledger is
+ * empty — otherwise the check that keeps quarantines from becoming permanent would itself be
+ * unverified.
+ */
+export const expiredEntries = (
+  ledger: Record<string, QuarantineEntry>,
+  today: string,
+): readonly (readonly [string, QuarantineEntry])[] =>
+  Object.entries(ledger).filter(([, entry]) => entry.expires < today)
+
+const announceQuarantinedFailure = (label: string, entry: QuarantineEntry): void => {
+  const summary = `Quarantined failure: ${label} (${entry.target}) — ${entry.reason}. Tracking ${entry.issue}, expires ${entry.expires}.`
+  console.log(`::warning title=Quarantined test failure::${summary}`)
+
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (summaryPath !== undefined && summaryPath !== '') {
+    fs.appendFileSync(summaryPath, `- ${summary}\n`)
+  }
+}

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    name: '@local/scripts',
+    // Without this, `vitest run --config scripts/vitest.config.ts` from the workspace root
+    // resolves `include` against the root and finds nothing.
+    root: import.meta.dirname,
     include: ['src/**/*.test.ts'],
     environment: 'node',
     env: {


### PR DESCRIPTION
> **Stacked on #1485, which is stacked on #1484.** Merge in that order. This PR's diff is the policy module, its wiring, the discovery fix, and the intent-layer update.
>
> The whole stack inherits #1484's overlap with #1338 on `tests/sync-provider/src/do-rpc-hibernation.test.ts` — if #1338 lands first, the rebase cascades through all three.

## Problem

#1484 and #1485 remove the suppressions that made a green required check meaningless. Nothing stops the next one being added exactly the same way.

That is the reason this class recurred rather than being fixed once. Suppression lived in three unrelated layers — a task wrapper's shell (`|| echo`, `exit 0`), the TypeScript runner (`Effect.ignore`), and test source (`Effect.ignore` inside a `raceFirst`) — with:

- **no inventory** — nowhere to look up what is currently tolerated;
- **no expiry** — nothing re-checked whether the flake that motivated a suppression still existed, and two of the three turned out to be dormant;
- **no distinguishable signal** — a fired suppression emitted `::warning::`, indistinguishable from the `Node.js 20 is deprecated` and `Cache save failed` warnings on every job;
- **wrong granularity** — the flake was per-test; the suppression was per-package, per-provider, per-suite. The unit-lane quarantine was added for `webmesh` and took `tests/package-common` with it.

## Goal

Tolerating a known failure remains possible — sometimes it is the right call — but only as a declared, dated, visible act. Adding one the old way should not typecheck.

## Decisions

**Type-routed policy over a lint-style detector.** The obvious alternative was a check that scans for suppression shapes (`Effect.ignore`, `|| true`, `exit 0`) and demands a ledger entry for each. Rejected: a grep for `Effect.ignore` false-positives on at least five legitimate uses in this repo — both hibernation keep-warm loops, `LeaderSyncProcessor.test.ts:442`, and the ten bare `raceFirst` sites that are correct as written. A detector that cries wolf gets disabled, and then enforces nothing.

Routing every invocation through one helper inverts this: rather than detecting suppression after the fact, suppression becomes inexpressible without a ledger entry. After #1485 the nix wrappers are policy-free plain `mono test` calls, so the entire policy surface is TypeScript and this is actually enforceable.

**An empty ledger is the intended steady state, and is not vacuous.** With no entries, `QuarantineKey` is `never` and the quarantine constructor is uninhabited — the type checker rejects any attempt to suppress. Seeding it with the just-removed suppressions was considered and rejected: "quarantined" and "recently un-quarantined, watch this" are different things, and merging them muddies the schema.

**Expiry takes the ledger as an argument.** Otherwise the rule that keeps quarantines from becoming permanent would itself be untested while the ledger is empty.

## Verification

**An undeclared quarantine is a type error.** Probe file, compiled and then deleted:

```ts
import { quarantined } from './test-policy.ts'
export const attempt = quarantined('webmesh-is-flaky-trust-me')
```

```
scripts/src/shared/__enforcement-probe.ts(2,36): error TS2345: Argument of type
'"webmesh-is-flaky-trust-me"' is not assignable to parameter of type 'never'.
```

**The expiry rule works on a non-empty ledger** — `expiredEntries` flags a lapsed entry and leaves a live one alone (unit test), alongside the assertion that the real ledger has none expired.

**The discovery gap is closed.** Unit-lane targets went 11 → 12, and the `scripts` suite from *never run in CI* to 28 tests:

```
scripts   Test Files  5 passed (5)    Tests  28 passed (28)
```

**Intent-layer invariants green** (8 tests) after the `context/` edits. `tsgo --build` clean, `oxlint` 0/0, `oxfmt --check` clean.

## Complexity

This is the one PR in the sequence that *adds* machinery: ~90 lines for the policy module plus its test. Justification: it is what stops #1404 from having a sequel, and it is the minimum that makes the guarantee structural rather than advisory. The alternative with comparable strength — a detector — is more code, more brittle, and enforces less.

The cost when the ledger is empty is a policy argument at each call site that can only be `blocking`. That is the affordance working: the moment someone needs a quarantine, the type system routes them to a record with a reason, an issue, and a date.

## Concerns

- **The expiry check is clock-dependent by design.** `test-unit` can change verdict with no code change: the day an entry lapses, it reds whichever PRs run next, not the one that owns the quarantine. That is the forcing function working — a quarantine cannot quietly outlive its date — but it means an unrelated PR can be blocked by someone else's expired entry, and the fix is to renew or remove the entry rather than to touch the failing PR. With an empty ledger this cannot fire today.
- **Enforcement is not total.** It covers the invocations in `test-commands.ts`. A future contributor could still call `cmd('vitest …')` directly and pipe `Effect.ignore` onto it, or add a `|| true` to a nix task's `exec`. Type routing makes the declared path the easy one; it does not make the undeclared path impossible. Closing that fully would need the detector I rejected, or a lint rule scoped to the wrapper layer.
- Nothing enforces that a quarantine's tracking issue is *open*, or that the target still exists. Both are checkable later if entries ever accumulate.
- The lint rule set run locally skips the custom `overeng/*` plugins, so CI is the first full lint of these files.

## Friction & bottlenecks

- Determining which `Schema` APIs the pinned Effect beta exposes was slow: several `rg` passes over `node_modules` returned mangled identifiers, so the typechecker was the fastest oracle. Wrote the code, let `tsgo` arbitrate.
- The `prek` pre-commit hook aborts in this repo (`config file not found: .pre-commit-config.yaml`); every commit needs `PREK_ALLOW_NO_CONFIG=1`. Logged as agent feedback.

## Follow-ups

- `tests/perf-eventlog/` has one test file and no CI job — the same never-run class as `scripts/` and the sync-provider suite in #1484. Left alone here because perf suites are plausibly excluded on purpose; worth confirming rather than assuming.
- Vitest 4.1.9 ships `strictTags` and per-test `tags` / `retry` / `repeats`. Once a genuinely flaky test is identified by the now-honest gates, per-test policy is the natural companion to a ledger entry.
- Wiring the remaining test invocations (`integrationTests.*`, perf, wa-sqlite) through the policy helper.

## References

Refs #1404, #1412. Depends on #1485 and #1484. Adds `LS.SYS.VER.LANE-R04`.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-25-ci-test-policy |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->