### PR TITLE
ci(megarepo): cache store at stable path via shared effect-utils primitive

### DIFF
--- a/.changeset/megarepo-store-cache-stable.md
+++ b/.changeset/megarepo-store-cache-stable.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Experiment (#1480): cache the megarepo store at a STABLE path so the actions/cache version is stable across runs and restores actually hit (the run-scoped default path made each run a unique cache version →always misses). Overrides the sync step's `MEGAREPO_STORE` to `${{ runner.temp }}/megarepo-store` and adds restore/save cache steps keyed on `megarepo.lock`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,9 +446,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -464,6 +470,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -617,9 +629,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -635,6 +653,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -783,9 +807,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -801,6 +831,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -956,9 +992,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -974,6 +1016,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1121,9 +1169,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1139,6 +1193,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1296,9 +1356,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1314,6 +1380,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1477,9 +1549,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1495,6 +1573,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1671,9 +1755,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1689,6 +1779,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1850,9 +1946,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1868,6 +1970,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2038,9 +2146,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2056,6 +2170,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2246,9 +2366,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2264,6 +2390,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2442,9 +2574,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -2460,6 +2598,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,7 +451,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -475,7 +475,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -634,7 +634,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -658,7 +658,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -812,7 +812,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -836,7 +836,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -997,7 +997,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1021,7 +1021,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1174,7 +1174,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1198,7 +1198,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1361,7 +1361,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1385,7 +1385,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1554,7 +1554,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1578,7 +1578,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1760,7 +1760,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1784,7 +1784,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1951,7 +1951,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1975,7 +1975,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2151,7 +2151,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -2175,7 +2175,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2371,7 +2371,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -2395,7 +2395,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -2579,7 +2579,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -2603,7 +2603,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -439,9 +439,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -457,6 +463,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -643,9 +655,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -661,6 +679,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -823,9 +847,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -841,6 +871,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -444,7 +444,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -468,7 +468,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -660,7 +660,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -684,7 +684,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -852,7 +852,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -876,7 +876,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -473,9 +473,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -491,6 +497,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -478,7 +478,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -502,7 +502,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -996,7 +996,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1020,7 +1020,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1238,7 +1238,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1262,7 +1262,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1487,7 +1487,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1511,7 +1511,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1779,7 +1779,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -1803,7 +1803,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -991,9 +991,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1009,6 +1015,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1221,9 +1233,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1239,6 +1257,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1458,9 +1482,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1476,6 +1506,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -1738,9 +1774,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -1756,6 +1798,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -74,9 +74,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -92,6 +98,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -246,9 +258,15 @@ jobs:
           name: livestore
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
           skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
-          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store/${{ github.run_id }}/${{ github.run_attempt }}/${{ github.job }}'
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
@@ -264,6 +282,12 @@ jobs:
 
           nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
         shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -103,7 +103,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
@@ -263,7 +263,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Sync megarepo dependencies
         env:
           MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
@@ -287,7 +287,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: '${{ runner.temp }}/megarepo-store'
-          key: "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
       - name: Use pinned devenv from lock
         run: |
           DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1784990224,
-        "narHash": "sha256-YH0BoEKGoVs3ISVPfBnAaXuHaNRM98b4X+dRtOdgpvI=",
+        "lastModified": 1785011204,
+        "narHash": "sha256-D9vZ9tWh+YlDoUJFun//NeI7cD1w5ME4nFAQ3kQg3lM=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "47ee69b737fcd95050883b4499bfaa3e75d377a8",
+        "rev": "ba4e4c260a8066a32e74329bbcc0f281af30e6e9",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1784990224,
-        "narHash": "sha256-YH0BoEKGoVs3ISVPfBnAaXuHaNRM98b4X+dRtOdgpvI=",
+        "lastModified": 1785011204,
+        "narHash": "sha256-D9vZ9tWh+YlDoUJFun//NeI7cD1w5ME4nFAQ3kQg3lM=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "47ee69b737fcd95050883b4499bfaa3e75d377a8",
+        "rev": "ba4e4c260a8066a32e74329bbcc0f281af30e6e9",
         "type": "github"
       },
       "original": {

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -299,9 +299,11 @@ import {
   prepareCiScriptsStep,
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
+  restoreMegarepoStoreStep,
   restorePnpmStateStep,
   runDevenvTasksBefore,
   nixDiagnosticsArtifactStep,
+  saveMegarepoStoreStep,
   savePnpmStateStep,
   validateNixStoreStep,
   workflowReportCollectorStep,
@@ -367,39 +369,14 @@ const withNixSetupRetry = <TStep extends { readonly name: string; readonly run: 
   withNixRetry(step, setupMegarepoRun(step.run))
 
 /**
- * EXPERIMENT (#1480): cache the megarepo store to stop cold-cloning large members each run.
- *
- * Key finding: GitHub derives an actions/cache *version* from the cache `path`. The default
- * `MEGAREPO_STORE` embeds `run_id`/`run_attempt`/`job`, so the version changes every run and
- * restores never hit (and each job writes a duplicate). Fix: pin the store to a STABLE path
- * (like the pnpm-state cache's `${{ github.workspace }}` path), so the version is stable
- * across runs → restore hits and GitHub's reserve dedups the concurrent saves. Safe here:
- * GitHub runs one job per (ephemeral) runner, so `${{ runner.temp }}` is already per-job.
+ * The megarepo-store sync step, opted into the shared cacheable-store path (#1480). Paired with
+ * {@link restoreMegarepoStoreStep} / {@link saveMegarepoStoreStep} (from effect-utils) it stops CI
+ * from cold-cloning large members (e.g. `effect-ts/effect`) every run: the store lives at the
+ * stable `cacheableMegarepoStore` path so the actions/cache version is stable across runs and
+ * restores hit. `withNixSetupRetry` preserves the step's `env` (the cacheable path) while
+ * rewriting the run for the codeload override.
  */
-const megarepoStorePath = '${{ runner.temp }}/megarepo-store'
-
-const megarepoStoreCacheKey =
-  "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
-
-const restoreMegarepoStoreStep = {
-  name: 'Restore megarepo store',
-  id: 'restore-megarepo-store',
-  uses: 'actions/cache/restore@v4',
-  with: { path: megarepoStorePath, key: megarepoStoreCacheKey },
-} as const
-
-const saveMegarepoStoreStep = {
-  name: 'Save megarepo store',
-  if: "${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}",
-  uses: 'actions/cache/save@v4',
-  with: { path: megarepoStorePath, key: megarepoStoreCacheKey },
-} as const
-
-/** The sync step with its run-scoped `MEGAREPO_STORE` overridden to the stable, cacheable path. */
-const stableStoreSyncStep = (() => {
-  const step = applyMegarepoLockStep()
-  return { ...step, env: { ...step.env, MEGAREPO_STORE: megarepoStorePath } }
-})()
+const stableStoreSyncStep = applyMegarepoLockStep({ cacheableStore: true })
 
 /**
  * Setup steps for livestore CI jobs (without checkout).
@@ -419,9 +396,9 @@ export const livestoreSetupStepsAfterCheckout = [
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
     return { ...base, with: { ...base.with, skipPush: true } }
   })(),
-  restoreMegarepoStoreStep,
+  restoreMegarepoStoreStep(),
   withNixSetupRetry(stableStoreSyncStep),
-  saveMegarepoStoreStep,
+  saveMegarepoStoreStep(),
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
   restorePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -367,6 +367,41 @@ const withNixSetupRetry = <TStep extends { readonly name: string; readonly run: 
   withNixRetry(step, setupMegarepoRun(step.run))
 
 /**
+ * EXPERIMENT (#1480): cache the megarepo store to stop cold-cloning large members each run.
+ *
+ * Key finding: GitHub derives an actions/cache *version* from the cache `path`. The default
+ * `MEGAREPO_STORE` embeds `run_id`/`run_attempt`/`job`, so the version changes every run and
+ * restores never hit (and each job writes a duplicate). Fix: pin the store to a STABLE path
+ * (like the pnpm-state cache's `${{ github.workspace }}` path), so the version is stable
+ * across runs → restore hits and GitHub's reserve dedups the concurrent saves. Safe here:
+ * GitHub runs one job per (ephemeral) runner, so `${{ runner.temp }}` is already per-job.
+ */
+const megarepoStorePath = '${{ runner.temp }}/megarepo-store'
+
+const megarepoStoreCacheKey =
+  "livestore-megarepo-store-v2-${{ runner.os }}-${{ hashFiles('megarepo.lock') }}"
+
+const restoreMegarepoStoreStep = {
+  name: 'Restore megarepo store',
+  id: 'restore-megarepo-store',
+  uses: 'actions/cache/restore@v4',
+  with: { path: megarepoStorePath, key: megarepoStoreCacheKey },
+} as const
+
+const saveMegarepoStoreStep = {
+  name: 'Save megarepo store',
+  if: "${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}",
+  uses: 'actions/cache/save@v4',
+  with: { path: megarepoStorePath, key: megarepoStoreCacheKey },
+} as const
+
+/** The sync step with its run-scoped `MEGAREPO_STORE` overridden to the stable, cacheable path. */
+const stableStoreSyncStep = (() => {
+  const step = applyMegarepoLockStep()
+  return { ...step, env: { ...step.env, MEGAREPO_STORE: megarepoStorePath } }
+})()
+
+/**
  * Setup steps for livestore CI jobs (without checkout).
  * Uses shared step atoms from effect-utils/genie/ci-workflow.ts.
  */
@@ -384,7 +419,9 @@ export const livestoreSetupStepsAfterCheckout = [
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })
     return { ...base, with: { ...base.with, skipPush: true } }
   })(),
-  withNixSetupRetry(applyMegarepoLockStep()),
+  restoreMegarepoStoreStep,
+  withNixSetupRetry(stableStoreSyncStep),
+  saveMegarepoStoreStep,
   preparePinnedDevenvStep,
   pnpmStateSetupStep,
   restorePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "47ee69b737fcd95050883b4499bfaa3e75d377a8",
+      "commit": "ba4e4c260a8066a32e74329bbcc0f281af30e6e9",
       "pinned": true,
-      "lockedAt": "2026-07-25T15:04:02.320Z"
+      "lockedAt": "2026-07-25T20:29:35.292Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Problem

CI intermittently cold-clones large megarepo members (e.g. `effect-ts/effect`) on every run, which is slow and was the source of the clone-timeout flake (#1473). The megarepo store was never cached because the default `MEGAREPO_STORE` path embeds `run_id`/`run_attempt`/`job` — and GitHub derives an `actions/cache` **version from the path**, so a run-scoped path mints a new version every run: restores never hit and each job writes a duplicate cache.

## Solution

Cache the megarepo store at a **stable path** so the cache version is stable across runs (restores hit, GitHub's reserve dedups concurrent saves). This logic now lives as a reusable primitive in effect-utils (overengineeringstudio/effect-utils#967, merged) so every megarepo consumer can opt in:

- repin effect-utils to the merged commit `ba4e4c26` (`megarepo.lock` + `devenv.lock` effect-utils/playwright inputs, in lockstep)
- `applyMegarepoLockStep({ cacheableStore: true })` pins `MEGAREPO_STORE` to the shared `cacheableMegarepoStore` path (`${{ runner.temp }}/megarepo-store`)
- `restoreMegarepoStoreStep()` / `saveMegarepoStoreStep()` wrap the sync with the shared, **skip-partitioned** cache key `megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}`

This replaces the earlier local stable-path override on this branch; the only workflow delta vs. that experiment is the cache key moving to the shared `…-full-…` key. Path/env are unchanged.

## Validation

- **Mechanism proven earlier on this branch** (local override, runs 1→2): 1 deduped cache (not 12), cross-run restore hit in ~5s, member clone eliminated.
- **This revision**: switched to the shared primitive; the first run under the new key is cold by design, subsequent runs restore. genie generation is idempotent (`ci.yml` hash-stable across runs); the 5 regenerated workflows differ only in the cache-key string.
- effect-utils #967 is green and merged; its Codex review (skip-partitioned key + test marker) is resolved.

Closes #1480.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-helix |
| `agent_session_id` | b8292c41-20df-491a-abbd-cae8a64a3e82 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.215 |
| `agent_runtime` | Claude Code 2.1.215 |
| `agent_model` | claude-opus-4-8 |
| `runtime_profile` | /nix/store/yyh1q3l36718in0fh2q5r1yn1nkyzn7x-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/yydfgyf01y70ksvp15x1dacgkvcf6h5q-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-25-ci-cache-megarepo-stable |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@ee9fb0f |
</details>
<!-- agent-footer:end -->