### PR TITLE
Make Cloudflare sync-provider failures block merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ For maintainers and contributors:
   `Effect.ignore` on CI, so their failures produced a passing required check.
   Removing that also restores the intent-layer invariant suite as a real gate on
   `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
+- **Tooling:** Cloudflare sync-provider failures now block merges. All six `cf-*`
+  matrix cells previously exited 0 on failure, which is why the Durable Object
+  hibernation guards could not gate merges
+  ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
 
 ## 0.4.0 - 2026-06-02
 

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -112,14 +112,6 @@ in
           exit 1
         fi
 
-        if [[ "$provider" == cf-* ]]; then
-          if mono test integration sync-provider --provider "$provider"; then
-            exit 0
-          fi
-          echo "::warning::Cloudflare sync-provider tests for $provider failed (flaky; see https://github.com/livestorejs/livestore/issues/625 and upstream https://github.com/cloudflare/workers-sdk/issues/11122)"
-          exit 0
-        fi
-
         mono test integration sync-provider --provider "$provider"
       '';
       after = [ "setup:strict" ];

--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -72,7 +72,11 @@ describeHttpProviders('$name HTTP response headers', { timeout: 30000 }, ({ laye
       ).pipe(Effect.provide(runtimeContext)),
     )
 
-  Vitest.live('HTTP responses include custom headers', (test) =>
+  // Skipped: the hand-rolled RPC envelope below no longer completes, so the server's 10s
+  // timeout fires before `responseHeaders` is applied and the assertion sees `undefined`.
+  // The header feature itself works; the test's coupling to the wire format is the problem.
+  // https://github.com/livestorejs/livestore/issues/1490
+  Vitest.live.skip('HTTP responses include custom headers', (test) =>
     Effect.gen(function* () {
       const syncBackend = yield* makeProvider(test.task.name)
       const http = yield* HttpClient.HttpClient


### PR DESCRIPTION
> **Stacked on #1486** (→ #1485 → #1484). Merge in that order.

## Problem

All six `cf-*` sync-provider matrix cells exited 0 on failure:

```sh
if [[ "$provider" == cf-* ]]; then
  if mono test integration sync-provider --provider "$provider"; then exit 0; fi
  echo "::warning::Cloudflare sync-provider tests for $provider failed (flaky; …)"
  exit 0
fi
```

This is what @IGassmann flagged on #1404: the DO-hibernation guards from #1427/#1435 cannot gate merges, so a reintroduced pending timer could break hibernation — and raise idle billing — while CI stays green.

The `::warning::` was never observable either. `devenv tasks run` prints a task's stdout only when the task fails, so a task that echoes a warning and exits 0 has that warning discarded before it reaches the runner.

## Goal

A green `test-integration-sync-provider (cf-*)` check means that provider's tests ran and passed.

## Decisions

**Skip the one broken test rather than quarantine the cell.** Un-suppressing surfaced a deterministic failure in `cloudflare-http-specific.test.ts`. Routing it through the ledger from #1486 would have been consistent, but the ledger is target-granular — quarantining the `cf-http-*` cells would suppress 21 passing tests to tolerate one, repeating the over-broad granularity #1404 is about. A per-test skip with an issue link is the right size.

**Not `retry`.** I initially read this as flaky, because it passed on #1484 and failed on #1485. That was wrong: #1484 still carries this suppression, so its `cf-*` cells exit 0 unconditionally and their "pass" carries no information. Both HTTP cells fail identically and reproducibly; a retry would only burn CI time.

## Verification

That test had **never run in CI**. Cells selected by title (`--testNamePattern '<name> sync provider'`) and its suites are titled `$name HTTP response headers`, so it matched nothing until #1484 moved selection to the provider registry.

Root cause (detail in #1490): the test hand-rolls an RPC envelope, the request never completes, and the server's `Effect.timeout(10000)` fires — at a measured 10 136 ms — before `responseHeaders` is applied, so the assertion sees `undefined`. The feature is fine: `responseHeaders` is threaded from `makeDurableObject` (`durable-object.ts:236`) through `createHttpRpcHandler` (`http-rpc-server.ts:28-32`), and `can ping sync backend` passes via the real client on every provider.

Local runs with the skip in place:

```
cf-http-d1   Test Files 2 passed | 3 skipped (5)    Tests 19 passed | 3 skipped (22)
mock         Test Files 2 passed | 3 skipped (5)    Tests 19 passed | 4 skipped (23)
```

`oxlint` clean.

## Complexity

Negative — one branch deleted from a shell wrapper, plus a skip.

## Concerns

- **This can redden `main`.** The `cf-*` cells become genuinely blocking for the first time. #625 (Cloudflare timeouts) is still open; if that flake returns, six required cells go red. One-line revert, or a ledger entry via #1486.
- **A public API is now untested.** `responseHeaders` on `makeDurableObject` has no working test until #1490 is resolved. It was equally untested before — the test never ran — but this makes it explicit rather than accidental.
- The skip is a suppression outside the ledger. It is per-test, in-source, greppable, and visible as `skipped` in the report, but the ledger does not currently express test-level granularity. Noted as a limitation on #1486.

## Follow-ups

- #1490 — repair or re-express the custom-header test.
- #625 — Cloudflare sync-provider timeouts, if the cells prove flaky under real gating.

## References

Refs #1404, #1429, #1412. Depends on #1486, #1485, #1484.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-26-ci-desuppress-cf |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->