### PR TITLE
Replace the DevTools suppression with a declared, expiring quarantine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ For maintainers and contributors:
   `Effect.ignore` on CI, so their failures produced a passing required check.
   Removing that also restores the intent-layer invariant suite as a real gate on
   `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
+- **Tooling:** DevTools Playwright failures are no longer silently discarded. The
+  suite is currently broken (0/15) and carries a declared, expiring quarantine
+  entry instead of an unrecorded `|| echo` wrapper
+  ([#1489](https://github.com/livestorejs/livestore/issues/1489)).
 - **Tooling:** Cloudflare sync-provider failures now block merges. All six `cf-*`
   matrix cells previously exited 0 on failure, which is why the Durable Object
   hibernation guards could not gate merges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ For maintainers and contributors:
   `Effect.ignore` on CI, so their failures produced a passing required check.
   Removing that also restores the intent-layer invariant suite as a real gate on
   `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
-- **Tooling:** DevTools Playwright failures are no longer silently discarded. The
-  suite is currently broken (0/15) and carries a declared, expiring quarantine
-  entry instead of an unrecorded `|| echo` wrapper
-  ([#1489](https://github.com/livestorejs/livestore/issues/1489)).
+- **Tooling:** The DevTools Playwright suite is currently broken (0/15) and
+  carries a declared, expiring quarantine entry instead of an unrecorded
+  `|| echo` wrapper. Its check does **not** gate merges yet — the quarantine
+  records the failure with a reason, an issue, and an expiry date rather than
+  hiding it ([#1489](https://github.com/livestorejs/livestore/issues/1489)).
 - **Tooling:** Cloudflare sync-provider failures now block merges. All six `cf-*`
   matrix cells previously exited 0 on failure, which is why the Durable Object
   hibernation guards could not gate merges

--- a/context/.delta/DELTA-002-enforcement-not-ci-blocking.md
+++ b/context/.delta/DELTA-002-enforcement-not-ci-blocking.md
@@ -25,12 +25,18 @@ expected; only the CI wrapper drops the failure.
 
 The `Effect.ignore` was removed from the sequential loop entirely, so both
 `tests/package-common` and `packages/@livestore/webmesh` now fail `test-unit`.
-This supersedes the remedy proposed above — a dedicated non-ignored step for the
-intent-layer suite — which would have left the rest of `tests/package-common`
-swallowed.
+This supersedes the originally proposed remedy — running the intent-layer suite
+as a dedicated non-ignored step — which would have left the rest of
+`tests/package-common` swallowed.
 
 Carving out only the intent-layer suite was rejected because the quarantine was
 never scoped to the flake it was added for: it covered two complete targets, and
 a survey of 20 `main` runs and 18 pull-request runs found no evidence of the
-`webmesh` flakiness still occurring. Quarantining a specific test, if one proves
-unreliable, is now a per-test declaration rather than a package-wide wrapper.
+`webmesh` flakiness still occurring. Quarantining a target, if one proves unreliable, is a
+declared ledger entry carrying a reason, tracking issue, and expiry date rather
+than a package-wide wrapper. Test-level suppression remains outside the ledger
+(see `../02-system/09-verification/01-lanes/.delta/DELTA-004-test-level-suppressions-unledgered.md`).
+
+Closure rests on the code change and on `test-unit` being a required check whose
+exit code now reflects these targets; a deliberately-broken invariant reddening
+CI has not been demonstrated end to end.

--- a/context/02-system/09-verification/01-lanes/.delta/DELTA-003-integration-lane-unpoliced.md
+++ b/context/02-system/09-verification/01-lanes/.delta/DELTA-003-integration-lane-unpoliced.md
@@ -1,18 +1,23 @@
-# DELTA-003 — Browser integration lane bypasses the test policy
+# DELTA-003 — Parts of the browser integration lane bypass the test policy
 
 Status: open
 
 ## Divergence
 
 LS.SYS.VER.LANE-R04 requires that tolerating a failing test is expressible only
-as a declared quarantine. The `runTestTarget` helper enforces this for the
-targets the `mono test` runner invokes directly (unit, sync-provider, SQLite
-substrate, perf), but the browser integration lane is dispatched through
-`@local/tests-integration`'s `runMiscTest` / `runTodomvcTest` /
-`runDevtoolsTest`, which call Playwright without passing through the helper.
+as a declared quarantine. `runTestTarget` enforces that for the unit lane,
+sync-provider, the SQLite substrate, perf, and the DevTools browser cell — the
+last via a wrapper in `scripts/src/commands/test-commands.ts` carrying the
+`devtools-suite` ledger entry.
 
-A suppression added inside that module would therefore not require a ledger
-entry, and would not be rejected by the type checker.
+Three invocation paths remain outside it:
+
+- The `misc` and `todomvc` browser cells register `@local/tests-integration`'s
+  commands directly, so neither states a policy.
+- `mono test integration all` calls `runDevtoolsTest` without the wrapper, so the
+  DevTools quarantine applies on the CI path but not the aggregate one. The same
+  suite behaves differently depending on which command reached it.
+- `@local/tests-integration` exposes its own unwrapped CLI entrypoint.
 
 ## VRS
 
@@ -20,7 +25,6 @@ entry, and would not be rejected by the type checker.
 
 ## Close condition
 
-Route the integration lane's invocations through `runTestTarget`, so every lane
-in the table above is covered by the same policy. Close when adding an
-`Effect.ignore` to an integration-lane invocation fails to compile without a
-ledger entry, the same way it now does for the other lanes.
+Route every browser-integration invocation through `runTestTarget`, so a suite's
+policy does not depend on how it was invoked. Close when `mono test integration
+all` and the `misc`/`todomvc` cells apply the same policy as the DevTools cell.

--- a/context/02-system/09-verification/01-lanes/.delta/DELTA-004-test-level-suppressions-unledgered.md
+++ b/context/02-system/09-verification/01-lanes/.delta/DELTA-004-test-level-suppressions-unledgered.md
@@ -1,0 +1,32 @@
+# DELTA-004 — Test-level suppressions bypass the quarantine ledger
+
+Status: open
+
+## Divergence
+
+LS.SYS.VER.LANE-R04 requires that tolerating a known failure carry a reason, a
+tracking issue, and an expiry date. The quarantine ledger delivers that for a
+whole *target* — a package path, provider key, or suite. It has no equivalent for
+a single test.
+
+`it.skip`, `describe.skip`, `test.todo`, `.only`, and `exclude` globs therefore
+remain a permanent, expiry-free way to keep a required check green. None is a
+type error, none appears in the ledger, and nothing reds a lane when one is
+forgotten. The unit lane alone carries roughly fifteen such suppressions,
+including nine in `tests/package-common/src/client-session/`.
+
+One is load-bearing for a public API: the only test covering
+`makeDurableObject`'s `http.responseHeaders` option is skipped, so that option has
+no executing test in any lane.
+
+## VRS
+
+[spec.md](../spec.md) §Test Policy.
+
+## Close condition
+
+Give test-level suppressions the same declared, expiring treatment as targets —
+either by extending the ledger to name individual tests, or by asserting an
+expected executed-test count per lane so an emptied suite reds its own cell.
+Close when a forgotten `it.skip` fails a required check the way a lapsed ledger
+entry does.

--- a/context/02-system/09-verification/01-lanes/requirements.md
+++ b/context/02-system/09-verification/01-lanes/requirements.md
@@ -24,7 +24,11 @@ workflows) are owned by `../../../03-delivery/`.
   the CI job decomposition. Adopted 2026-07-16 (interview); not met — see
   [.delta/DELTA-002-lane-ci-mismatches.md](./.delta/DELTA-002-lane-ci-mismatches.md).
 - **LS.SYS.VER.LANE-R04 Honest gates:** A required check reports success only
-  if every test it represents executed and passed. Tolerating a known failure
-  is expressible only as a declared quarantine carrying a reason, a tracking
-  issue, and an expiry date (mechanism in [spec.md](./spec.md) §Test Policy).
-  Adopted 2026-07-25.
+  if every test it represents executed and either passed or is covered by a
+  declared quarantine carrying a reason, a tracking issue, and an expiry date
+  (mechanism in [spec.md](./spec.md) §Test Policy). Adopted 2026-07-25; not met
+  — execution is only asserted for the sync-provider lane, and test-level
+  suppressions bypass the ledger, see
+  [.delta/DELTA-003-integration-lane-unpoliced.md](./.delta/DELTA-003-integration-lane-unpoliced.md)
+  and
+  [.delta/DELTA-004-test-level-suppressions-unledgered.md](./.delta/DELTA-004-test-level-suppressions-unledgered.md).

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -34,16 +34,19 @@ command column). Two characteristics are deliberate, not drift:
   (`scripts/src/commands/test-commands.ts`) rather than getting separate CI
   jobs, and examples-as-tests run on demand (not a required gate) — all are
   documented in the table above, by design. The unit lane's discovery walks
-  `packages/@livestore/*`, `packages/@local/*`, and those two extra roots; a
-  test root absent from that list runs nowhere in CI.
+  `packages/@livestore/*`, `packages/@local/*`, and those two extra roots; a test
+  root that is neither in that list nor served by its own lane job runs nowhere in
+  CI.
 
 ## Test Policy
 
-Test targets invoked by the `mono test` runner (unit, sync-provider, SQLite
-substrate, perf) run under an explicit policy (LS.SYS.VER.LANE-R04), stated at
-their invocation in `scripts/src/shared/test-policy.ts`. The browser integration
-lane is dispatched through `@local/tests-integration` and is not yet routed
-through the helper — tracked in
+Test targets invoked through `runTestTarget` state an explicit policy
+(LS.SYS.VER.LANE-R04). The mechanism lives in
+`scripts/src/shared/test-policy.ts`; the invocations are in
+`scripts/src/commands/test-commands.ts`. Covered: the unit lane, sync-provider,
+the SQLite substrate, perf, and the DevTools browser cell. The `misc` and
+`todomvc` browser cells and the `mono test integration all` aggregate are not
+covered — see
 [.delta/DELTA-003-integration-lane-unpoliced.md](./.delta/DELTA-003-integration-lane-unpoliced.md).
 
 | Policy | Effect on the job |
@@ -51,19 +54,26 @@ through the helper — tracked in
 | `blocking` | Failures fail the job. The default for every target. |
 | `quarantined(key)` | Failures are announced and tolerated, under a ledger entry. |
 
-`key` must name an entry in `quarantineLedger`, so a quarantine cannot be
-expressed without a checked-in record of its target, reason, tracking issue, and
-expiry date. The ledger is empty in the steady state; with no entries the
-quarantine constructor is uninhabited and the type checker rejects any attempt to
-suppress a failure.
+`key` must name an entry in `quarantineLedger`, so a quarantine *on this path*
+cannot be expressed without a checked-in record of its target, reason, tracking
+issue, and expiry date. When the ledger is empty the quarantine constructor is
+uninhabited and the type checker rejects any such attempt.
+
+The policy governs whole invocations, not individual tests, and it is opt-in.
+`it.skip`, `test.todo`, an `exclude` glob, piping `Effect.ignore` onto the
+result, or bypassing the helper all still tolerate a failure without a ledger
+entry, and none are type errors — see
+[.delta/DELTA-004-test-level-suppressions-unledgered.md](./.delta/DELTA-004-test-level-suppressions-unledgered.md).
 
 Two properties keep a quarantine from becoming permanent and invisible:
 
 - **Expiry.** `test-policy.test.ts` fails once an entry's `expires` date passes,
   forcing a renew-or-remove decision in the unit lane, which is a required check.
-- **Distinguishable signal.** A tolerated failure is announced with its own
-  annotation title and a job-summary line, so it cannot be mistaken for a pass or
-  lost among unrelated Actions warnings.
+- **Distinguishable signal.** A tolerated failure appends a line to the job
+  summary naming the target, reason, issue, and expiry. That file-based channel is
+  load-bearing; the accompanying `::warning::` annotation is best-effort, because
+  `devenv tasks run` prints a task's stdout only when the task fails and a
+  tolerated failure exits 0.
 
 Test selection is resolved against source-of-truth registries rather than by
 matching test titles — the sync-provider matrix pins a cell with

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -128,11 +128,6 @@ in
           exit 1
         fi
 
-        if [ "$suite" = "devtools" ]; then
-          mono test integration devtools || echo "::warning::Script failed but continuing"
-          exit 0
-        fi
-
         mono test integration "$suite"
       '';
       after = [ "setup:strict" ];

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -359,6 +359,9 @@ const runSyncProviderTests = Effect.fn(function* ({ provider }: { provider: Opti
   const workspaceRoot = yield* LivestoreWorkspace
   const reportPath = path.join(workspaceRoot, 'tmp/sync-provider-run-report.json')
   fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+  // A run that dies before writing the report would otherwise be validated against the
+  // previous run's data — the guard has to fail closed.
+  fs.rmSync(reportPath, { force: true })
 
   yield* TestPolicy.runTestTarget({
     label: Option.isSome(provider) === true ? `sync-provider:${provider.value}` : 'sync-provider',
@@ -366,7 +369,11 @@ const runSyncProviderTests = Effect.fn(function* ({ provider }: { provider: Opti
     run: cmd(['vitest', 'run', '--reporter=default', '--reporter=json', `--outputFile.json=${reportPath}`], {
       // Selection happens at collection time via the registry rather than by matching test
       // titles, so renaming a suite can no longer remove it from a CI cell (#1429).
-      env: Option.isSome(provider) === true ? { [providerSelectionEnvVar]: provider.value } : {},
+      //
+      // Explicitly cleared when no provider is pinned: CI sets TEST_SYNC_PROVIDER at step
+      // level, so inheriting it would silently collapse a full sweep to a single provider
+      // while still reporting success as a full run.
+      env: { [providerSelectionEnvVar]: Option.isSome(provider) === true ? provider.value : undefined },
     }).pipe(Effect.provide(LivestoreWorkspace.toCwd('tests/sync-provider'))),
   })
 

--- a/scripts/src/commands/test-commands.ts
+++ b/scripts/src/commands/test-commands.ts
@@ -412,9 +412,27 @@ const testIntegrationAllCommand = Cli.Command.make(
   runIntegrationAllTests,
 ).pipe(Cli.Command.withDescription('Run all integration tests'))
 
+/**
+ * Wraps the DevTools suite so its declared quarantine is enforced at the invocation, rather
+ * than as an `|| echo` in the CI task wrapper that nothing records and devenv discards.
+ */
+const devtoolsCommand = Cli.Command.make(
+  'devtools',
+  { mode: integrationTests.modeOption, localDevtoolsPreview: integrationTests.localDevtoolsPreviewOption },
+  (args) =>
+    TestPolicy.runTestTarget({
+      label: 'tests/integration:devtools',
+      policy: TestPolicy.quarantined('devtools-suite'),
+      run: integrationTests.runDevtoolsTest(args),
+    }),
+)
+
 export const testIntegrationCommand = Cli.Command.make('integration').pipe(
   Cli.Command.withSubcommands([
-    ...integrationTests.commands,
+    integrationTests.miscTest,
+    integrationTests.todomvcTest,
+    integrationTests.setupDevtools,
+    devtoolsCommand,
     syncProviderTest,
     waSqliteTest,
     testIntegrationAllCommand,

--- a/scripts/src/shared/test-policy.test.ts
+++ b/scripts/src/shared/test-policy.test.ts
@@ -29,6 +29,19 @@ describe('quarantine ledger', () => {
     expect(expiredEntries({ lapsed, live }, today()).map(([key]) => key)).toEqual(['lapsed'])
   })
 
+  it('treats a malformed expiry as expired rather than never-expiring', () => {
+    // Lexicographic comparison would sort 'someday' above every real date, so a typo would
+    // otherwise create a permanent quarantine.
+    const malformed = new QuarantineEntry({
+      target: 'packages/@livestore/example',
+      reason: 'typo in the expiry',
+      issue: 'https://github.com/livestorejs/livestore/issues/1404',
+      expires: 'someday',
+    })
+
+    expect(expiredEntries({ malformed }, today()).map(([key]) => key)).toEqual(['malformed'])
+  })
+
   it('rejects a malformed entry', () => {
     // Exercises the decode used by the shape check above, which otherwise never runs while
     // the ledger is empty — an unexercised assertion is the failure mode this PR exists to stop.
@@ -69,6 +82,27 @@ describe('runTestTarget', () => {
     expect(() =>
       runTestTarget({ label: 'packages/@livestore/unrelated', policy: fakePolicy(), run: Effect.void }),
     ).toThrow(/has no entry in the ledger/)
+  })
+
+  it('refuses a real quarantine applied to a target it does not declare', () => {
+    const [key, entry] = Object.entries(quarantineLedger as Record<string, QuarantineEntry>)[0] ?? []
+    if (key === undefined || entry === undefined) return
+
+    expect(() =>
+      runTestTarget({ label: `${entry.target}-but-not-really`, policy: fakePolicy(key), run: Effect.void }),
+    ).toThrow(/declares target/)
+  })
+
+  it('swallows a failure for a correctly declared quarantine', async () => {
+    // The mechanism's whole point. Without this, dropping the `Effect.ignore` would pass the suite.
+    const [key, entry] = Object.entries(quarantineLedger as Record<string, QuarantineEntry>)[0] ?? []
+    if (key === undefined || entry === undefined) return
+
+    const exit = await Effect.runPromiseExit(
+      runTestTarget({ label: entry.target, policy: fakePolicy(key), run: Effect.fail('boom' as const) }),
+    )
+
+    expect(Exit.isSuccess(exit)).toBe(true)
   })
 })
 

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -5,11 +5,17 @@ import { Effect, Schema } from '@livestore/utils/effect'
 /**
  * How a test target's failures reach the job's exit code.
  *
- * Every test invocation states its policy explicitly, so weakening a required check is a
- * deliberate, reviewable act rather than a `.pipe(Effect.ignore)` or a `|| true` buried in a
- * task wrapper. Quarantining is reachable only through {@link quarantined}, which accepts a
- * key of {@link quarantineLedger} — so a quarantine cannot exist without a checked-in entry
- * carrying a reason, a tracking issue, and an expiry date.
+ * Test targets invoked through {@link runTestTarget} state their policy explicitly, so
+ * weakening one is a deliberate, reviewable act rather than a `.pipe(Effect.ignore)` or a
+ * `|| true` buried in a task wrapper. Quarantining is reachable only through
+ * {@link quarantined}, which accepts a key of {@link quarantineLedger} — so a quarantine here
+ * cannot exist without a checked-in entry carrying a reason, tracking issue, and expiry date.
+ *
+ * What this is NOT: a chokepoint. It governs whole invocations, not individual tests, and it
+ * is opt-in — `it.skip`, `test.todo`, an `exclude` glob, piping `Effect.ignore` onto the
+ * result, or bypassing the helper entirely all still tolerate a failure without a ledger
+ * entry, and none of them are type errors. Treat this as the honest path for suppressing a
+ * target, not a guarantee that no other path exists.
  */
 export type TestPolicy = { readonly _tag: 'blocking' } | { readonly _tag: 'quarantined'; readonly key: QuarantineKey }
 
@@ -104,7 +110,18 @@ export const expiredEntries = (
   ledger: Record<string, QuarantineEntry>,
   today: string,
 ): readonly (readonly [string, QuarantineEntry])[] =>
-  Object.entries(ledger).filter(([, entry]) => entry.expires < today)
+  Object.entries(ledger).filter(([, entry]) => isExpired(entry.expires, today))
+
+const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * A malformed `expires` counts as expired.
+ *
+ * Comparison is lexicographic, so any free-form string (`'someday'`) sorts above every real
+ * date and would otherwise never expire — turning a typo into a permanent quarantine, which
+ * is the outcome the expiry rule exists to prevent.
+ */
+const isExpired = (expires: string, today: string): boolean => isoDatePattern.test(expires) === false || expires < today
 
 const announceQuarantinedFailure = (label: string, entry: QuarantineEntry): void => {
   const summary = `Quarantined failure: ${label} — ${entry.reason} Tracking ${entry.issue}, expires ${entry.expires}.`

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -38,7 +38,15 @@ export class QuarantineEntry extends Schema.Class<QuarantineEntry>('QuarantineEn
  * `test-policy.test.ts`, so a forgotten quarantine reds `test-unit` instead of
  * silently becoming permanent.
  */
-export const quarantineLedger = {} as const satisfies Record<string, QuarantineEntry>
+export const quarantineLedger = {
+  'devtools-suite': new QuarantineEntry({
+    target: 'tests/integration:devtools',
+    reason:
+      'Every test in the suite fails (0/15). All browser-extension tests die at "No devtools page found"; the rest time out on locators. Pre-existing — the suite was silently suppressed from 2025-05-10 until #1404.',
+    issue: 'https://github.com/livestorejs/livestore/issues/1489',
+    expires: '2026-09-30',
+  }),
+} as const satisfies Record<string, QuarantineEntry>
 
 export type QuarantineKey = keyof typeof quarantineLedger
 
@@ -99,11 +107,16 @@ export const expiredEntries = (
   Object.entries(ledger).filter(([, entry]) => entry.expires < today)
 
 const announceQuarantinedFailure = (label: string, entry: QuarantineEntry): void => {
-  const summary = `Quarantined failure: ${label} (${entry.target}) — ${entry.reason}. Tracking ${entry.issue}, expires ${entry.expires}.`
-  console.log(`::warning title=Quarantined test failure::${summary}`)
+  const summary = `Quarantined failure: ${label} — ${entry.reason} Tracking ${entry.issue}, expires ${entry.expires}.`
 
+  // The job summary is the load-bearing channel. The annotation below is best-effort: a
+  // tolerated failure exits 0, and `devenv tasks run` prints a task's stdout only when the
+  // task fails, so this line is discarded whenever the run happens under devenv — the same
+  // trap that made the old `|| echo "::warning::"` wrappers invisible for over a year.
   const summaryPath = process.env.GITHUB_STEP_SUMMARY
   if (summaryPath !== undefined && summaryPath !== '') {
     fs.appendFileSync(summaryPath, `- ${summary}\n`)
   }
+
+  console.log(`::warning title=Quarantined test failure::${summary}`)
 }

--- a/tests/integration/scripts/run-tests.ts
+++ b/tests/integration/scripts/run-tests.ts
@@ -10,7 +10,9 @@ import { downloadChromeExtension } from './download-chrome-extension.ts'
 
 const cwd = path.resolve(import.meta.dirname, '..')
 
-const modeOption = Cli.Flag.choice('mode', ['headless', 'ui', 'dev-server']).pipe(Cli.Flag.withDefault('headless'))
+export const modeOption = Cli.Flag.choice('mode', ['headless', 'ui', 'dev-server']).pipe(
+  Cli.Flag.withDefault('headless'),
+)
 
 export const localDevtoolsPreviewOption = Cli.Flag.boolean('local-devtools-preview').pipe(Cli.Flag.withDefault(false))
 


### PR DESCRIPTION
> **Stacked on #1491** (→ #1486 → #1485 → #1484). Last in the sequence.

## Problem

`test-integration-playwright (devtools)` fails **completely** — 0 of 15 tests pass — and has done since at least **2025-05-10**, when `mono test integration devtools || echo "::warning::Script failed but continuing"` first appeared. It survived the genie migration, the shared-ci-blocks refactor, and the creation of `mono-wrappers.nix`.

Nothing recorded it, in either channel:

- the wrapper hid the failure from the required check, and
- `devenv tasks run` prints a task's stdout only when the task **fails**, so the `::warning::` a suppressed run emitted was itself discarded before reaching the runner.

Fourteen months of a required check reporting success on a suite where nothing passed, with no trace in the checks UI or the job log.

## Goal

The DevTools failure becomes a declared, dated, visible quarantine instead of an unrecorded one — so it is impossible to forget, and it reds CI if nobody deals with it.

## Decisions

**Quarantine rather than repair.** This is the one place in the sequence where "fix it" lost on evidence rather than convenience. It reproduces locally, identically to CI — good news for whoever fixes it — but it is layered:

- All 8 `browser-extension.play.ts` tests die at `No devtools page found`, with only the app page open.
- Adding `--auto-open-devtools-for-tabs` to the extension branch of `browserContext` **does** clear that (96 occurrences → 0), but the suite still fails 13, now with `locator.click: strict mode violation: getByTitle` (72) and `locator.waitFor` timeouts (45). Not a one-flag fix — and that flag opens DevTools for every tab, so it may itself cause the duplicates.

**The structural question is left open deliberately.** `browser-extension.play.ts` downloads the **published** v0.4.0 release extension and asserts against selectors that track current `main`. A suite comparing a shipped artifact to today's UI drifts by construction, and `getByTitle` matching multiple elements is what that drift looks like. Whether this lane should test the released extension (a compatibility gate) or one built from source (a regression gate — there is an existing `localDevtoolsPreview` path) determines whether repair is a bug hunt or a redesign. That belongs with whoever owns #1445/#1456, not with this PR.

**Routed through `runTestTarget`.** The quarantine has to be enforced at the invocation to be a ledger entry rather than another shell wrapper, so `modeOption` is exported from `run-tests.ts` and the DevTools command is wrapped in `test-commands.ts`. This closes `DELTA-003` for the DevTools lane.

## Verification

End to end with the entry in place:

```
13 failed
mono exit 0
```

and the job summary records:

```
- Quarantined failure: tests/integration:devtools — Every test in the suite fails (0/15) …
  Tracking https://github.com/livestorejs/livestore/issues/1489, expires 2026-09-30.
```

`tsgo --build` clean, `oxlint` clean, scripts suite 33 passed (the ledger's shape and expiry checks now run against a real entry rather than an empty record).

## Complexity

One shell branch deleted, one command wrapped, one ledger entry added.

## Concerns

- **The annotation channel is unreliable, by the same mechanism this PR is about.** A tolerated failure exits 0, so under `devenv tasks run` the `::warning::` is discarded. The **job summary** is the load-bearing signal — it writes to a file and survives. Called out in a comment at the emit site so nobody later "fixes" it by trusting the annotation.
- **The expiry will fire.** On 2026-09-30 this entry reds `test-unit` — a required check — on whatever PR happens to run next, not on the one that owns it. That is the mechanism working as designed, but it is real friction and someone needs to own #1489 before then.
- The quarantine is target-granular: it tolerates the whole suite. Appropriate here because the whole suite is broken, unlike the single-test case in #1491.

## Follow-ups

- #1489 — the breakage itself, with the full diagnosis and the released-vs-built question.

## References

Refs #1404, #1412. Depends on #1491, #1486, #1485, #1484. Closes `DELTA-003` for the DevTools lane.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-26-ci-desuppress-devtools |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->