### PR TITLE
Clarify SQLite rollback ownership by separating changesets from events

### DIFF
--- a/context/02-system/01-event-model/spec.md
+++ b/context/02-system/01-event-model/spec.md
@@ -56,6 +56,13 @@ processors, and rebase actually move around. Its `meta` carries:
 | `syncMetadata` | provider-opaque per-event sync metadata (persisted as `syncMetadataJson`) |
 | `materializerHashLeader` / `materializerHashSession` | dev-mode determinism hashes compared across materialization sites |
 
+Current limitation: an event occurrence and the SQLite changeset produced when
+a node materializes it share one mutable schema value. Normalization and
+serialization can copy an event or remove its metadata, while the changeset is
+meaningful only for the node-local SQLite state that produced it. Changeset
+ownership and lifetime are therefore not represented independently from event
+identity. This limitation motivates root LS-DQ3.
+
 Conversions: `toGlobal()` / `EncodedWithMeta.fromGlobal` and
 `Global.toClientEncoded` (`global.ts:32`, mapping global seqNums into
 composite ones via `Client.fromGlobal`). All shapes are Effect Schema
@@ -147,3 +154,8 @@ the shipping contract.
   events beyond warn-and-tolerate. What is the durable evolution story?
 - **LS.SYS.EVT-DQ2 Facts graduation:** What evidence (see
   `09-verification/`) graduates facts from experimental to shipping?
+- **LS.SYS.EVT-DQ3 Event occurrence versus SQLite changeset:** Should event
+  shapes stop carrying mutable SQLite changesets, and what identity should
+  connect an occurrence to the node-local rollback data produced when it is
+  materialized? Cross-reference: root LS-DQ3; the proposal remains outside
+  this shipping spec until accepted.

--- a/context/02-system/02-state/01-sqlite/spec.md
+++ b/context/02-system/02-state/01-sqlite/spec.md
@@ -80,9 +80,29 @@ databases: changeset rows live in the *state* DB while event rows live in
 the *eventlog* DB; `getEventsSince` joins across both to serve rebase
 rollback.
 
+Current limitations:
+
+- Leader materialization persists changesets in the state DB and also copies
+  them onto mutable event metadata; leader rollback trusts the table, whereas
+  client-session rollback trusts event metadata.
+- `__livestore_session_changeset` stores `seqNumRebaseGeneration`, but has no
+  primary key and its lookup/deletion paths identify rows by only
+  `(seqNumGlobal, seqNumClient)`. The persisted identity is therefore broader
+  than the operational rollback key.
+- The web fast path derives its initial leader head from this rollback table,
+  coupling rollback-retention policy to session boot metadata.
+
 ## Schema Change
 
 Owned by [02-schema-management](./02-schema-management/spec.md): hash-based
 rebuild via adapter file naming, `auto`/`manual` strategies + hooks
 (contracted by LS.SYS.STATE.SQLITE-R08), and the state-vs-eventlog
 versioning asymmetry.
+
+## Open Design Questions
+
+- **LS.SYS.STATE.SQLITE-DQ1 Rollback-data ownership and keying:** What exact
+  occurrence key, lifetime, and state-snapshot contract should govern SQLite
+  changesets independently at the leader and each session? Cross-reference:
+  root LS-DQ3; the proposed storage abstraction lives in RFC 0004 until
+  accepted.

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -100,6 +100,12 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   harness perturbs (`simSleep` hooks at 5 labeled points, `:83-86,
   414-422`; `SIMULATION_ENABLED` is hardcoded `true` with a build-macro
   TODO, `:410-411`).
+- **Rollback-lifetime limitation:** session pending means unconfirmed by the
+  leader, but a leader-accepted event can remain rollbackable until the
+  leader's backend confirms it. Once the session drops its matching pending
+  occurrence, session rollback data remains available only when a later
+  downstream event object carries a usable `meta.sessionChangeset`; receipt
+  lifetime is not modeled independently from event-object reachability.
 - **Observability** (`:98-99, 358-361`): sync-state updates surface via a
   separate queue explicitly not relied on for correctness; a devtools
   latch can pause upstream application (`:152-153`).
@@ -114,3 +120,11 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 - Per-event `materializerHashLeader` beyond the first item of a pull chunk
   is unknown (TODO, `:555-556`, issue #503).
 - Metrics for retry/queue health are an acknowledged TODO (`:599`).
+
+## Open Design Questions
+
+- **LS.SYS.SYNC.PROC-DQ1 Changeset lookup and lifetime:** How should each
+  processor record and locate its own SQLite changesets independently from
+  event-object metadata, and what signal makes a stored changeset safe to
+  reclaim? Cross-reference: root LS-DQ3; the proposed storage direction lives
+  in RFC 0004 until accepted.

--- a/context/02-system/04-runtime/spec.md
+++ b/context/02-system/04-runtime/spec.md
@@ -87,6 +87,13 @@ Realizations may expose a superset over their worker RPC (web adds
 `GetLeaderHead`, `Shutdown`, `WebmeshWorker.CreateConnection`, boot-status
 streaming — `worker-schema.ts`); the proxy above is the portable contract.
 
+Current boundary limitation: the portable push type is plain
+`Client.Encoded`, while pull payloads contain `EncodedWithMeta`. Web RPC schema
+encoding therefore omits SQLite changesets on push but can carry leader
+changeset bytes on pull. Direct in-process realizations can preserve that
+mutable event metadata across calls. Rollback behavior can consequently depend
+on whether an adapter uses a serialized boundary.
+
 ## Session Boot
 
 Two boot paths produce the session's initial in-memory state:
@@ -186,3 +193,8 @@ The session ⇄ leader boundary has a typed failure contract:
   leader death (new leader re-pushes the same events and must recover via
   pull + rebase) is not explicitly contracted or covered by a targeted test
   per realization.
+- **LS.SYS.RT-DQ2 SQLite changesets across the session boundary.** How should
+  session snapshots adopt the rollback data matching their materialized state
+  while excluding changesets from ordinary leader/session event transport?
+  Cross-reference: root LS-DQ3; the proposed boundary change lives in RFC 0004
+  until accepted.

--- a/context/open-questions.md
+++ b/context/open-questions.md
@@ -11,5 +11,18 @@
   conventions in [spec.md](./spec.md)). This is the single tree anchor for the
   proposal; node `DQ`s (e.g. LS.SYS.STORE-DQ1) cross-reference it.
 
+- **LS-DQ3 SQLite changeset ownership.**
+  [RFC 0004](../contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md)
+  proposes removing SQLite changesets from event values and storing them with
+  the node-local state they describe. The current implementation persists
+  leader changesets separately but uses mutable event metadata for session
+  rollback, making ownership and lifetime depend on event representation.
+  Unresolved: whether to accept the separation and its lookup-key, retention,
+  snapshot, and recovery contracts. The design and coined terms live in the
+  RFC per
+  [.decisions/0004-rfc-vrs-boundary.md](./.decisions/0004-rfc-vrs-boundary.md).
+  This is the single tree anchor for the proposal; affected node `DQ`s
+  cross-reference it.
+
 All branch nodes are populated as drafts (2026-07-15); node-local design
 questions live in each node's spec.

--- a/context/spec.md
+++ b/context/spec.md
@@ -225,6 +225,12 @@ non-ignored step — is tracked in
   [decision 0004](./.decisions/0004-rfc-vrs-boundary.md); the open part is
   whether to accept and fold it in. See
   [open-questions.md](./open-questions.md).
+- **LS-DQ3 SQLite changeset ownership** —
+  [RFC 0004](../contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md)
+  proposes removing SQLite changesets from event values and storing them with
+  the node-local state they describe. Its design lives in the RFC; the open
+  part is whether to accept it and resolve its keying, retention, snapshot, and
+  recovery questions. See [open-questions.md](./open-questions.md).
 
 (LS-DQ2 was resolved 2026-07-16 into
 [.decisions/0003-contrib-referencing.md](./.decisions/0003-contrib-referencing.md).)

--- a/contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md
+++ b/contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md
@@ -35,7 +35,9 @@ changesets from event metadata and introduces explicit `MaterializationJournal`
 and `StateHead` services, including storage, rollback, snapshot-head, and
 processor integration work. It also makes unresolved lifecycle questions
 concrete, notably how a client session learns that a changeset is safe to
-reclaim after global confirmation.
+reclaim after global confirmation. Leader acceptance is not sufficient: it can
+remove an event from session pending while that event remains rollbackable
+relative to the backend.
 
 This RFC takes an intent-layer-first starting point: establish the ownership,
 lifetime, snapshot, and transport contracts before choosing the implementation
@@ -95,6 +97,13 @@ changeset store associated with the SQLite state database they describe.
 6. **Changesets do not cross ordinary sync RPC.** Push and pull messages carry
    event and sync data; they do not use another node's changeset as their
    rollback mechanism.
+7. **Reclamation is ordered with finality.** A node deletes rollback data only
+   after it has committed the transition establishing an immutable upstream
+   frontier beyond that occurrence. A session must receive that frontier in an
+   ordered, replayable relationship with the corresponding leader transition,
+   apply the transition before pruning, and commit both effects locally. The
+   transport itself is published after the leader commit; it is not assumed to
+   be atomic with SQLite.
 
 The existing `__livestore_session_changeset` table is the natural starting
 point for a shared storage contract. The contract may be exposed through a
@@ -107,9 +116,12 @@ eventlog and changeset table. The implementation must validate whether that key
 remains stable and unique for every required rollback flow before making it a
 permanent contract.
 
-Retention may require a minimal leader/session signal establishing that an
-occurrence can no longer be rolled back. Adding such a reclamation signal is
-within scope; redesigning the merge-result algebra is not.
+Retention requires a minimal leader/session finality signal establishing that
+an occurrence can no longer be rolled back. The signal must also cover
+confirmation-only advances, where no event needs to be materialized. This RFC
+does not prescribe whether it is represented as a transition field, checkpoint
+message, or versioned state; redesigning the merge-result algebra is not
+required.
 
 ### Intent-layer impact
 
@@ -210,8 +222,8 @@ on a broader sync redesign.
 
 1. Is the full composite sequence position a sufficient changeset key across
    every rebase, or is a separate immutable occurrence identifier required?
-2. What exact signal establishes that a leader or session changeset can no
-   longer be needed for rollback?
+2. What replayable protocol shape should carry the ordered finality checkpoint
+   between leader and session?
 3. Should the changeset store remain part of the state database, and what
    transaction boundary must join a state write with its changeset record?
 4. How should missing or duplicate changesets be handled: defect, rebuild

--- a/contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md
+++ b/contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md
@@ -27,6 +27,28 @@ objects, so a changeset attached to one representation was absent from the
 representation retained for later rollback. This is evidence of the ownership
 problem, rather than the scope of this proposal.
 
+## Related Implementation Exploration
+
+[#1299](https://github.com/livestorejs/livestore/pull/1299) explores the same
+direction from an implementation-first starting point. It removes SQLite
+changesets from event metadata and introduces explicit `MaterializationJournal`
+and `StateHead` services, including storage, rollback, snapshot-head, and
+processor integration work. It also makes unresolved lifecycle questions
+concrete, notably how a client session learns that a changeset is safe to
+reclaim after global confirmation.
+
+This RFC takes an intent-layer-first starting point: establish the ownership,
+lifetime, snapshot, and transport contracts before choosing the implementation
+shape. That sequencing does not reject the abstractions or complexity in
+#1299. Explicit Effect services may be an appropriate way to isolate these
+responsibilities, and some of the complexity may be inherent in making the
+current implicit contracts explicit.
+
+It remains open whether implementation should continue from #1299, adapt that
+work after the intent is accepted, or use another implementation approach. The
+RFC is intended to provide criteria for that decision rather than preselect the
+implementation PR.
+
 ## Problem
 
 > **Problem statement:** SQLite changesets are node-local rollback data, but

--- a/contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md
+++ b/contributor-docs/rfcs/0004-separate-sqlite-changesets-from-events.md
@@ -1,0 +1,198 @@
+# Separate SQLite Changesets from Event Values
+
+Status: Draft
+
+## Context
+
+LiveStore uses SQLite session changesets to reverse materialized state during a
+rebase. A changeset describes the writes produced when one LiveStore node
+materializes an event against that node's current SQLite state.
+
+Today, `LiveStoreEvent.Client.EncodedWithMeta` carries the changeset in mutable
+event metadata. This makes an event value serve two roles:
+
+- a description of an event occurrence moving through sync and persistence;
+- a container for rollback data produced by one materialization of that event.
+
+Those roles have different ownership and lifetime. A session and its leader can
+materialize the same occurrence independently and therefore produce changesets
+owned by different SQLite databases. Event values may also be copied,
+normalized, persisted, or serialized across runtime boundaries, while a
+changeset is meaningful only with the materialized state that produced it.
+
+The browser rebase rollback failure investigated in
+[#1472](https://github.com/livestorejs/livestore/pull/1472) exposed one
+consequence: equivalent event occurrences in a sync transition were distinct
+objects, so a changeset attached to one representation was absent from the
+representation retained for later rollback. This is evidence of the ownership
+problem, rather than the scope of this proposal.
+
+## Problem
+
+> **Problem statement:** SQLite changesets are node-local rollback data, but
+> LiveStore currently stores and retrieves them through mutable event values.
+
+This creates several implicit dependencies:
+
+- rollback correctness can depend on JavaScript object identity and mutation;
+- the lifetime of rollback data follows event-object reachability rather than
+  the period in which the materialized occurrence may be rebased;
+- serialized and in-process adapters can behave differently because event
+  metadata crosses their boundaries differently;
+- the leader persists changesets in `__livestore_session_changeset`, while
+  session rollback reads changesets from event metadata, giving equivalent
+  responsibilities different storage contracts; and
+- state snapshots and restart recovery do not explicitly state that
+  materialized state and its rollback data form one coherent image.
+
+These concerns exist independently of the shape of `SyncState.merge` results.
+Changing the merge algebra may be useful later, but it is not required to give
+changesets explicit ownership.
+
+## Proposed Solution
+
+Remove SQLite changesets from event values and store them in a node-local
+changeset store associated with the SQLite state database they describe.
+
+### Intended contract
+
+1. **Changesets are not event data.** Event schemas, eventlog rows, sync state,
+   and ordinary event transport do not contain SQLite changeset bytes.
+2. **Each materializing node owns its changesets.** The leader and every client
+   session record and consume the changesets produced against their own state
+   database.
+3. **Rollback uses an occurrence key.** Processors locate rollback data by a
+   stable key for the materialized occurrence, not by event-object reference.
+4. **Storage lifetime follows rollbackability.** A node retains a changeset for
+   as long as that occurrence may need to be reversed, even if the occurrence
+   is no longer present in that node's pending sync state.
+5. **Snapshots are coherent.** A state snapshot used to boot a session includes
+   or is paired with the changeset data needed to roll back the materialized
+   state represented by that snapshot. The receiving session adopts ownership
+   of that paired rollback data.
+6. **Changesets do not cross ordinary sync RPC.** Push and pull messages carry
+   event and sync data; they do not use another node's changeset as their
+   rollback mechanism.
+
+The existing `__livestore_session_changeset` table is the natural starting
+point for a shared storage contract. The contract may be exposed through a
+small abstraction, but this RFC does not prescribe its final API or require a
+new database.
+
+The initial lookup key can be the event's composite sequence position
+`{ global, client, rebaseGeneration }`, which is already represented in the
+eventlog and changeset table. The implementation must validate whether that key
+remains stable and unique for every required rollback flow before making it a
+permanent contract.
+
+Retention may require a minimal leader/session signal establishing that an
+occurrence can no longer be rolled back. Adding such a reclamation signal is
+within scope; redesigning the merge-result algebra is not.
+
+### Intent-layer impact
+
+If accepted, the proposal should fold into the owning intent nodes as follows:
+
+- **Event model:** classify SQLite changesets as execution data outside event
+  values.
+- **SQLite state:** define the node-local changeset store, occurrence key,
+  retention, rollback ordering, and snapshot/rebuild relationship.
+- **Sync processors:** require materialization to record a changeset and rebase
+  rollback to retrieve it from the local store.
+- **Runtime:** exclude changesets from ordinary leader/session event transport
+  while preserving rollback data when a state snapshot is adopted.
+
+No new shipping requirement is added to those nodes until the RFC is accepted;
+the current VRS records the existing limitation and links to this proposal.
+
+### Scope
+
+This RFC includes:
+
+- leader and session ownership of SQLite changesets;
+- storage, lookup, retention, rollback, and reclamation;
+- persistence, restart, and session-snapshot implications; and
+- removal of changeset bytes from event schemas and ordinary RPC payloads.
+
+It intentionally excludes:
+
+- redesigning `MergeResultAdvance`, `MergeResultRebase`, or `SyncState`;
+- introducing transition plans, pending deltas, or canonical event pools;
+- moving materializer hashes or provider sync metadata out of event metadata;
+- changing client-only event semantics or pagination; and
+- broader processor publication-order or cross-database atomicity changes.
+
+These are separable follow-up areas. The current merge results may continue to
+contain equivalent event values in multiple fields; changeset correctness must
+simply stop depending on those values sharing mutable metadata.
+
+### Migration outline
+
+1. Define a node-local changeset-store contract around the existing table.
+2. Route leader changeset writes, rollback reads, and deletion through it.
+3. Record session-generated changesets in the session's state database and
+   perform session rollback through the same contract.
+4. Ensure session boot adopts a coherent state-and-changeset snapshot.
+5. Stop reading or writing `meta.sessionChangeset`, then remove that field from
+   event schemas and RPC payloads.
+
+A compatibility period may mirror changesets onto event metadata while all
+consumers move to the store, but correctness must no longer rely on the mirror.
+
+### Validation
+
+Implementation evidence should cover:
+
+- local materialization followed by rollback in both leader and session nodes;
+- accepted local events that are later rebased by the backend;
+- browser-worker and direct in-process adapters behaving identically;
+- session boot from a leader state snapshot followed by rebase;
+- leader restart with rollbackable events;
+- rebase-generation keying, reverse rollback order, and no-op changesets; and
+- missing, duplicate, reclaimed, and transaction-failure cases.
+
+Performance checks should measure changeset-write overhead, rollback lookup
+cost, retained storage, and worker payload size.
+
+## Alternatives Considered
+
+### Keep changesets on canonical event objects
+
+Canonical event references would prevent some lost mutations, but a node-local
+database artifact would still be owned by a cross-node event value. It would
+also introduce event-pool persistence and reclamation without resolving
+changeset lifetime directly.
+
+### Copy changesets between equivalent event values
+
+This can address individual merge branches, but every branch and serialization
+boundary must identify equivalent occurrences correctly. Ownership and
+retention remain implicit.
+
+### Store changesets only for the leader
+
+The leader already persists changesets separately, but sessions also
+materialize and roll back their own SQLite state. A session may adopt
+leader-generated changesets only together with the exact state snapshot they
+describe; using them as ordinary RPC rollback data would conflate distinct
+materialization contexts.
+
+### Redesign merge results at the same time
+
+Explicit transition operations could clarify other sync responsibilities, but
+they are not necessary for changeset lookup by occurrence key. Combining the
+changes would enlarge the migration and make the ownership improvement depend
+on a broader sync redesign.
+
+## Open Questions
+
+1. Is the full composite sequence position a sufficient changeset key across
+   every rebase, or is a separate immutable occurrence identifier required?
+2. What exact signal establishes that a leader or session changeset can no
+   longer be needed for rollback?
+3. Should the changeset store remain part of the state database, and what
+   transaction boundary must join a state write with its changeset record?
+4. How should missing or duplicate changesets be handled: defect, rebuild
+   trigger, or adapter-specific recovery?
+5. Should the web fast path continue deriving the leader head from the
+   changeset table, or should boot metadata have separate ownership?


### PR DESCRIPTION
## Problem

SQLite session changesets describe writes against one node-local state database, but the current event model carries them through mutable event metadata. That makes rollback ownership and lifetime depend on event-object identity, reachability, and serialization behavior.

The rollback failure investigated in #1472 is one example of this broader architectural ambiguity. The intent layer does not currently define how leader and session changesets are owned, retained, recovered, or paired with state snapshots.

## Solution

Add draft RFC 0004 proposing that SQLite changesets are stored separately from event values and owned by the node-local state they describe.

The RFC and linked intent-layer questions cover:

- node-local storage, lookup, retention, and reclamation;
- coherent state-and-changeset snapshots and restart behavior;
- excluding changeset bytes from ordinary sync RPC;
- an ordered, replayable finality checkpoint for safe session reclamation;
- a staged migration away from `meta.sessionChangeset`; and
- open decisions around occurrence keys, concrete checkpoint transport, and recovery.

This proposal deliberately excludes redesigning `SyncState` merge results, transition plans, materializer hashes, and provider sync metadata. It changes no production behavior yet.

## Relationship to #1299

PR #1299 explores the same architectural direction from an implementation-first starting point. It removes changesets from event metadata and introduces explicit `MaterializationJournal` and `StateHead` services, making the required responsibilities and unresolved lifecycle questions concrete.

In particular, #1299 exposes that leader acceptance cannot establish session changeset finality: the event may leave session pending while remaining rollbackable relative to the backend. RFC 0004 now states the corresponding intent requirement. Reclamation must follow an immutable upstream frontier, be ordered and replayable with the transition that established it, and be committed locally only after that transition is applied. The concrete wire representation remains open.

RFC 0004 takes an intent-layer-first starting point: establish ownership, lifetime, snapshot, and transport contracts before selecting the implementation shape. This does not reject the abstractions or complexity in #1299. Explicit Effect services may be appropriate, and some of the complexity may be inherent in making the current implicit contracts explicit.

It remains open whether implementation should continue from #1299, adapt that work after the intent is accepted, or follow another implementation approach. The RFC is intended to provide criteria for that discussion rather than preselect the implementation PR.

## Validation

- `devenv tasks run lint:full:fix`
- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` (8 tests passed)
- `git diff --check`

## Related work

- #1299
- #1472
