### PR TITLE
Repin effect-utils to adopt the mr apply drift postcondition

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1785011204,
-        "narHash": "sha256-D9vZ9tWh+YlDoUJFun//NeI7cD1w5ME4nFAQ3kQg3lM=",
+        "lastModified": 1785095224,
+        "narHash": "sha256-rzEPXZwvDcGd7HDWdsmMH1zONF/17n6AlIRzRevJVcU=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "ba4e4c260a8066a32e74329bbcc0f281af30e6e9",
+        "rev": "02b4b2d3402d38c4bf27e92fc85096df36c7e40d",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1785011204,
-        "narHash": "sha256-D9vZ9tWh+YlDoUJFun//NeI7cD1w5ME4nFAQ3kQg3lM=",
+        "lastModified": 1785095224,
+        "narHash": "sha256-rzEPXZwvDcGd7HDWdsmMH1zONF/17n6AlIRzRevJVcU=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "ba4e4c260a8066a32e74329bbcc0f281af30e6e9",
+        "rev": "02b4b2d3402d38c4bf27e92fc85096df36c7e40d",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "ba4e4c260a8066a32e74329bbcc0f281af30e6e9",
+      "commit": "02b4b2d3402d38c4bf27e92fc85096df36c7e40d",
       "pinned": true,
-      "lockedAt": "2026-07-25T20:29:35.292Z"
+      "lockedAt": "2026-07-27T07:10:30.315Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Problem

livestore pinned effect-utils at `ba4e4c26`, which predates overengineeringstudio/effect-utils#963 — the fix for `mr apply` reporting success while leaving a member drifted from `megarepo.lock`.

That is the root cause behind #1467 and #1168. Contributors were not skipping a step; apply told them it had succeeded while their checkout sat at a different revision. It stayed invisible because `repos/` is gitignored, so `git status` is clean, and `mr:lock-sync-check` compares `devenv.lock` against `megarepo.lock` — lock against lock, never workspace against lock.

The pin also matters more than it did yesterday: since #1470, `devenv.nix` resolves effect-utils **only** from the pinned input, so this is now the single source for the Nix-side helpers.

## Change

Bumps `ba4e4c26` → `02b4b2d3` across all three authority edges — `megarepo.lock` plus both `devenv.lock` inputs (`effect-utils` and `playwright`, which reads `nix/playwright-flake` from the same repo).

## Verification

- New pin exposes `devenvModules.tasks.gh-labels` — the export whose absence produced #1467's opaque evaluation failure.
- `mr apply` materializes all three members cleanly (`effect-utils`, `effect`, `livestore-contrib`).
- `genie --check`: **81 unchanged, 0 updated**. Unlike the previous repin (#1478, which regenerated 5 workflows), #963 touched no generator code.
- `changesets check-pr`: no changeset required, no public package graph files.

## Concerns

- **This does not by itself unblock contributors.** `mr` comes from the nix flake on `PATH`, not from this pin, so the postcondition reaches people on their next toolchain update. This commit only moves the Nix-side helpers.
- Bumping brings in everything between the two revisions, which here is #963 alone.

## Follow-ups

- #1168 should be closeable independently: since #1470, nothing reads `./repos/effect-utils`, so a stale worktree can no longer break evaluation — the same mechanism that closed #1467.

## References

Refs #1467, #1168. Adopts overengineeringstudio/effect-utils#963.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-27-chore-repin-effect-utils |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->