### PR TITLE
Repin effect-utils so CI workflow commands survive devenv task capture

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1785095224,
-        "narHash": "sha256-rzEPXZwvDcGd7HDWdsmMH1zONF/17n6AlIRzRevJVcU=",
+        "lastModified": 1785141032,
+        "narHash": "sha256-wRQxrf3fyCxhJcdd1sESBDVkl2tgvUv8dafau7bvBgc=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "02b4b2d3402d38c4bf27e92fc85096df36c7e40d",
+        "rev": "82ed83e7077af7a4daf2b9a4655de7f9964f39c7",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1785095224,
-        "narHash": "sha256-rzEPXZwvDcGd7HDWdsmMH1zONF/17n6AlIRzRevJVcU=",
+        "lastModified": 1785141032,
+        "narHash": "sha256-wRQxrf3fyCxhJcdd1sESBDVkl2tgvUv8dafau7bvBgc=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "02b4b2d3402d38c4bf27e92fc85096df36c7e40d",
+        "rev": "82ed83e7077af7a4daf2b9a4655de7f9964f39c7",
         "type": "github"
       },
       "original": {

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "02b4b2d3402d38c4bf27e92fc85096df36c7e40d",
+      "commit": "82ed83e7077af7a4daf2b9a4655de7f9964f39c7",
       "pinned": true,
-      "lockedAt": "2026-07-27T07:10:30.315Z"
+      "lockedAt": "2026-07-27T08:31:43.467Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Problem

`devenv` discards a task's stdout. A GitHub workflow command (`::notice::`,
`::group::`, `::endgroup::`) echoed from a shared task module therefore never
reaches the runner — it produces no annotation and no collapsible log group.
The failure is silent: the emit reads as correct and simply does nothing.

Two of the shared modules LiveStore imports were affected:

| Module | Emit | Effect on LiveStore CI |
| --- | --- | --- |
| `pnpm` | `::group::pnpm install failure diagnostics` / `::endgroup::` | Install-failure diagnostics printed flat, never grouped |
| `workflow-report` | `::notice::` for fork PRs and empty comment bodies | Both explanations dropped; the skip looked unexplained |

A third shared module, `context.nix`, has the same `::group::`/`::endgroup::`
pair. It is standalone — no other shared module imports it, and LiveStore does
not import it either — so the table above is complete for this repo.

Root-caused and fixed upstream in overengineeringstudio/effect-utils#969
(tracked here as #968).

## Goal

LiveStore CI picks up the fix: those workflow commands go to stderr, which
devenv does forward, so they become real annotations and log groups.

## Decisions

Lock-only, matching the precedent set by #1496 — the fix itself lives upstream.

Upstream also added `lint:nix:workflow-commands`, a guard that fails when a task
definition writes `::` to stdout. LiveStore does not import `lint-nix`
(`devenv.nix` imports `genie`, `gh-labels`, `megarepo`, `ts`, `check`, `clean`,
`lint-oxc`, `pnpm`, `workflow-report`, `setup`), so that guard protects
effect-utils, not this repo. Nothing to wire up here.

## Verification

All three authority edges agree on the new revision:

```
megarepo:     82ed83e70
effect-utils: 82ed83e70   (devenv.lock input)
playwright:   82ed83e70   (devenv.lock input, dir=nix/playwright-flake)
```

- `mr apply` → exit 0, `repos/effect-utils` materialized at `82ed83e7077a`.
  This also exercises the `mr apply` drift postcondition that #1496 adopted,
  which now fails rather than skipping if the workspace disagrees with the lock.
- `genie --check` → exit 0, 81 files, all `unchanged`.
- The `02b4b2d3..82ed83e70` diff is 6 files — `CHANGELOG.md`, `tasks/README.md`,
  and four `nix/devenv-modules/` files. No generator code, so genie output could
  not have changed; the check confirms it.
- All four upstream emit sites verified redirected at the pinned revision
  (`context.nix:24,41`, `pnpm.nix:391,418`, `workflow-report.nix:118,123`).

## Complexity

None — two lock files, 8 lines each way.

## Concerns

The annotations this restores were never appearing, so CI logs will gain output
that looks new. That is the fix working, not a regression.

Scope limit worth naming: #969 fixes workflow commands emitted from *task
definitions*. It does not change how devenv handles stdout from processes a task
spawns. Anything else in this repo that relies on a task's stdout reaching the
runner is still exposed; I have not audited that surface here.

## Friction & bottlenecks

Committing needed `PREK_ALLOW_NO_CONFIG=1` — the `prek` hook refuses to run in
this repo because there is no `.pre-commit-config.yaml`. Papercut, logged only.

## Follow-ups

- #968 — closed by the upstream merge; this PR is the adoption.
- Audit whether anything else in this repo depends on a devenv task's stdout
  reaching the runner (the scope limit above).

## References

- Closes #968
- Upstream: overengineeringstudio/effect-utils#969
- Prior repin: #1496

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/2026-07-25-1412 |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->