### PR TITLE
Compose the quarantine mechanism over effect-utils instead of duplicating it

### DIFF
--- a/.changeset/quarantine-contract-composition.md
+++ b/.changeset/quarantine-contract-composition.md
@@ -1,0 +1,11 @@
+---
+---
+
+No release impact. The only file touched under `packages/` is
+`packages/@livestore/wa-sqlite/flake.nix`, reformatted by `nixfmt` because this change adopts
+effect-utils' `lint-nix` module and `lint:nix:format` became a required check. The vendored
+fork's build is unaffected — formatting only, no expression changes.
+
+The substantive change is CI-side: the test-quarantine mechanism now composes over
+`ci-tools quarantine` (overengineeringstudio/effect-utils#971) instead of reimplementing the
+entry schema, expiry rule, and announcement locally. No published package behavior changes.

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -41,13 +41,19 @@ command column). Two characteristics are deliberate, not drift:
 ## Test Policy
 
 Test targets invoked through `runTestTarget` state an explicit policy
-(LS.SYS.VER.LANE-R04). The mechanism lives in
-`scripts/src/shared/test-policy.ts`; the invocations are in
-`scripts/src/commands/test-commands.ts`. Covered: the unit lane, sync-provider,
-the SQLite substrate, perf, and the DevTools browser cell. The `misc` and
-`todomvc` browser cells and the `mono test integration all` aggregate are not
-covered — see
+(LS.SYS.VER.LANE-R04). The policy decision lives in
+`scripts/src/shared/test-policy.ts` and the invocations in
+`scripts/src/commands/test-commands.ts`; the ledger is
+`genie/quarantine-ledger.ts`. Covered: the unit lane, sync-provider, the SQLite
+substrate, perf, and the DevTools browser cell. The `misc` and `todomvc` browser
+cells and the `mono test integration all` aggregate are not covered — see
 [.delta/DELTA-003-integration-lane-unpoliced.md](./.delta/DELTA-003-integration-lane-unpoliced.md).
+
+What a quarantine *means* is not defined here. `ci-tools quarantine` owns the
+entry schema, the expiry rule, and the announcement, so every repo with a ledger
+gets the same semantics; this repo declares only which targets are quarantined
+(LS.DEL.COMP-R19 and
+[../../../03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md](../../../03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md)).
 
 | Policy | Effect on the job |
 | --- | --- |
@@ -57,7 +63,10 @@ covered — see
 `key` must name an entry in `quarantineLedger`, so a quarantine *on this path*
 cannot be expressed without a checked-in record of its target, reason, tracking
 issue, and expiry date. When the ledger is empty the quarantine constructor is
-uninhabited and the type checker rejects any such attempt.
+uninhabited and the type checker rejects any such attempt. The ledger is
+TypeScript for exactly that reason; `scripts/src/generated/quarantine-ledger.json`
+is generated from it for the CLI, and `lint:check:genie` catches drift between
+the two.
 
 The policy governs whole invocations, not individual tests, and it is opt-in.
 `it.skip`, `test.todo`, an `exclude` glob, piping `Effect.ignore` onto the
@@ -67,13 +76,14 @@ entry, and none are type errors — see
 
 Two properties keep a quarantine from becoming permanent and invisible:
 
-- **Expiry.** `test-policy.test.ts` fails once an entry's `expires` date passes,
-  forcing a renew-or-remove decision in the unit lane, which is a required check.
+- **Expiry.** The `quarantine:check` task fails once an entry's `expires` date
+  passes, forcing a renew-or-remove decision. It is wired into `check` as a
+  required check. A malformed date counts as expired.
 - **Distinguishable signal.** A tolerated failure appends a line to the job
-  summary naming the target, reason, issue, and expiry. That file-based channel is
-  load-bearing; the accompanying `::warning::` annotation is best-effort, because
-  `devenv tasks run` prints a task's stdout only when the task fails and a
-  tolerated failure exits 0.
+  summary naming the target, reason, issue, and expiry, and emits a matching
+  `::warning::` annotation. Failing to announce fails the run: tolerating a
+  failure while losing its signal is the outcome this mechanism exists to
+  prevent.
 
 Test selection is resolved against source-of-truth registries rather than by
 matching test titles — the sync-provider matrix pins a cell with

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -78,8 +78,8 @@ Two properties keep a quarantine from becoming permanent and invisible:
 
 - **Expiry.** The `quarantine:check` task fails once an entry's `expires` date
   passes, forcing a renew-or-remove decision. It runs via `lint:full`, which the
-  `lint` CI job invokes on every pull request, and also via `check` locally. A
-  malformed date counts as expired.
+  `lint` CI job invokes on every pull request, and via `check:quick` /
+  `check:all` locally. A malformed date counts as expired.
 - **Distinguishable signal.** A tolerated failure appends a line to the job
   summary naming the target, reason, issue, and expiry, and emits a matching
   `::warning::` annotation. Failing to announce fails the run: tolerating a

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -9,17 +9,17 @@ Draft.
 
 ## Lane Taxonomy
 
-| Lane | Proves | Home | Runner | Local command | CI job |
-| --- | --- | --- | --- | --- | --- |
-| Unit | Pure semantics per package | `*.test.ts(x)` colocated | Vitest | `mono test unit` | `test-unit` |
-| Package integration | Cross-package engine behavior (materializer, sync processors, client documents) | `tests/package-common/` | Vitest | folded into `mono test unit` | `test-unit` |
-| Repo tooling | `mono` CLI commands (release, docs export, test policy) | `scripts/` | Vitest | folded into `mono test unit` | `test-unit` |
-| Browser integration | Adapter/devtools behavior in real browsers | `tests/integration/` | Playwright | `mono test integration` | `test-integration-playwright` (suite matrix: misc, todomvc, devtools) |
-| Sync-provider conformance | Provider contract (see [../02-conformance/](../02-conformance/spec.md)) | `tests/sync-provider/` | Vitest | `mono test integration sync-provider` | `test-integration-sync-provider` (7-provider matrix) |
-| SQLite substrate | wa-sqlite API, session extension, serialize | `tests/wa-sqlite/` | Vitest | `mono test integration wa-sqlite` | `wa-sqlite-test` |
-| Perf (store) | Measurement collection (see [../03-performance/](../03-performance/spec.md)) | `tests/perf/` | Playwright | `mono test perf` | `perf-test` |
-| Perf (eventlog) | Event-streaming measurements | `tests/perf-eventlog/` | Playwright | package `test` script | — |
-| Examples-as-tests | Examples still build and run | `examples/` | per-example `test` script | `mono examples test` | not a required gate |
+| Lane                      | Proves                                                                          | Home                     | Runner                    | Local command                         | CI job                                                                |
+| ------------------------- | ------------------------------------------------------------------------------- | ------------------------ | ------------------------- | ------------------------------------- | --------------------------------------------------------------------- |
+| Unit                      | Pure semantics per package                                                      | `*.test.ts(x)` colocated | Vitest                    | `mono test unit`                      | `test-unit`                                                           |
+| Package integration       | Cross-package engine behavior (materializer, sync processors, client documents) | `tests/package-common/`  | Vitest                    | folded into `mono test unit`          | `test-unit`                                                           |
+| Repo tooling              | `mono` CLI commands (release, docs export, test policy)                         | `scripts/`               | Vitest                    | folded into `mono test unit`          | `test-unit`                                                           |
+| Browser integration       | Adapter/devtools behavior in real browsers                                      | `tests/integration/`     | Playwright                | `mono test integration`               | `test-integration-playwright` (suite matrix: misc, todomvc, devtools) |
+| Sync-provider conformance | Provider contract (see [../02-conformance/](../02-conformance/spec.md))         | `tests/sync-provider/`   | Vitest                    | `mono test integration sync-provider` | `test-integration-sync-provider` (7-provider matrix)                  |
+| SQLite substrate          | wa-sqlite API, session extension, serialize                                     | `tests/wa-sqlite/`       | Vitest                    | `mono test integration wa-sqlite`     | `wa-sqlite-test`                                                      |
+| Perf (store)              | Measurement collection (see [../03-performance/](../03-performance/spec.md))    | `tests/perf/`            | Playwright                | `mono test perf`                      | `perf-test`                                                           |
+| Perf (eventlog)           | Event-streaming measurements                                                    | `tests/perf-eventlog/`   | Playwright                | package `test` script                 | —                                                                     |
+| Examples-as-tests         | Examples still build and run                                                    | `examples/`              | per-example `test` script | `mono examples test`                  | not a required gate                                                   |
 
 ## Lane / CI Correspondence
 
@@ -44,23 +44,23 @@ Test targets invoked through `runTestTarget` state an explicit policy
 (LS.SYS.VER.LANE-R04). The policy decision lives in
 `scripts/src/shared/test-policy.ts` and the invocations in
 `scripts/src/commands/test-commands.ts`; the ledger is
-`genie/quarantine-ledger.ts`. Covered: the unit lane, sync-provider, the SQLite
+`scripts/src/shared/quarantine-ledger.ts`. Covered: the unit lane, sync-provider, the SQLite
 substrate, perf, and the DevTools browser cell. The `misc` and `todomvc` browser
 cells and the `mono test integration all` aggregate are not covered — see
 [.delta/DELTA-003-integration-lane-unpoliced.md](./.delta/DELTA-003-integration-lane-unpoliced.md).
 
-What a quarantine *means* is not defined here. `ci-tools quarantine` owns the
+What a quarantine _means_ is not defined here. `ci-tools quarantine` owns the
 entry schema, the expiry rule, and the announcement, so every repo with a ledger
 gets the same semantics; this repo declares only which targets are quarantined
 (LS.DEL.COMP-R19 and
 [../../../03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md](../../../03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md)).
 
-| Policy | Effect on the job |
-| --- | --- |
-| `blocking` | Failures fail the job. The default for every target. |
+| Policy             | Effect on the job                                           |
+| ------------------ | ----------------------------------------------------------- |
+| `blocking`         | Failures fail the job. The default for every target.        |
 | `quarantined(key)` | Failures are announced and tolerated, under a ledger entry. |
 
-`key` must name an entry in `quarantineLedger`, so a quarantine *on this path*
+`key` must name an entry in `quarantineLedger`, so a quarantine _on this path_
 cannot be expressed without a checked-in record of its target, reason, tracking
 issue, and expiry date. When the ledger is empty the quarantine constructor is
 uninhabited and the type checker rejects any such attempt. The ledger is

--- a/context/02-system/09-verification/01-lanes/spec.md
+++ b/context/02-system/09-verification/01-lanes/spec.md
@@ -77,8 +77,9 @@ entry, and none are type errors — see
 Two properties keep a quarantine from becoming permanent and invisible:
 
 - **Expiry.** The `quarantine:check` task fails once an entry's `expires` date
-  passes, forcing a renew-or-remove decision. It is wired into `check` as a
-  required check. A malformed date counts as expired.
+  passes, forcing a renew-or-remove decision. It runs via `lint:full`, which the
+  `lint` CI job invokes on every pull request, and also via `check` locally. A
+  malformed date counts as expired.
 - **Distinguishable signal.** A tolerated failure appends a line to the job
   summary naming the target, reason, issue, and expiry, and emits a matching
   `::warning::` annotation. Failing to announce fails the run: tolerating a

--- a/context/03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md
+++ b/context/03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md
@@ -1,0 +1,60 @@
+# Consume shared tooling as Nix-built binaries, not workspace packages
+
+Status: accepted — 2026-07-27, confirmed with the maintainer during the design
+interview that produced this record. Evidence: a clean clone of this branch with
+no `repos/` present ran `pnpm install` (exit 0), `tsgo --build tsconfig.json`
+(exit 0, no errors), and `vitest packages/@livestore/common/src` (19 files, 268
+tests passed).
+
+## Context
+
+`overengineeringstudio/effect-utils` supplies this repo's shared tooling
+(LS.DEL.COMP-A01). When a mechanism belongs upstream — the case that forced this
+decision was the test-quarantine contract, whose entry semantics and CI emit
+channel are not LiveStore's to own — the question is *how* core consumes it.
+
+Three channels exist, and they differ in what they cost a contributor:
+
+| Channel | Reaches core via | Requires materialization to install? |
+| --- | --- | --- |
+| Nix-built binary | `inputs.effect-utils` flake input, pinned by `devenv.lock` | no |
+| Genie helper | `#mr/effect-utils/...`, resolved by Genie's own resolver | only to regenerate |
+| npm workspace package | a `repos/effect-utils/...` entry in `pnpm-workspace.yaml` | **yes** |
+
+The third looks like the obvious way to share TypeScript, and it is the one that
+does real damage. `repos/` is gitignored and every `@overeng/*` package is
+`"private": true`, so a workspace entry would make `pnpm install` fail on a fresh
+clone until `mr apply` had run — for every external contributor of a public repo,
+and for every CI job.
+
+## Decision
+
+Shared tooling reaches core as **Nix-built binaries** from the `effect-utils`
+flake input. `genie`, `effect-tsgo`, `megarepo`, and `ci-tools` already arrive
+this way; new shared mechanisms follow them.
+
+Genie remains the exception, and only at generation time: its sources import
+`#mr/effect-utils/...` and its outputs are committed, so a contributor who does
+not regenerate never needs materialization. That boundary is now stated as
+LS.DEL.COMP-R19 rather than left implicit.
+
+The cost is a process boundary — a consumer invokes a CLI and serializes its
+input rather than importing a function. For the quarantine case that is one
+subprocess per tolerated failure, which is rare by construction.
+
+## Alternatives considered
+
+- **`pnpm-workspace.yaml` entry into `repos/effect-utils`.** In-process, no
+  serialization, and the natural way to share TypeScript. Rejected: it makes
+  installation depend on materialization, which breaks the fresh-clone path for
+  a public repo. Contrib does exactly this for core, but contrib is the
+  downstream repo of that pair — core is the one that must stand alone.
+- **Publish `@overeng/ci-tools` to npm and depend on a version.** Removes the
+  materialization requirement and keeps in-process ergonomics. Rejected for now:
+  it needs a real release process and semver commitment, and it reintroduces a
+  version-skew axis between the two repos that `megarepo.lock` currently
+  eliminates. This is the right answer if the package ever needs consumers
+  outside the megarepo.
+- **Copy the mechanism into core and keep it in sync.** Rejected: it leaves the
+  upstream facts restated here, which is the defect that prompted the decision —
+  a copy of behavior nothing detects going stale.

--- a/context/03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md
+++ b/context/03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md
@@ -11,15 +11,15 @@ tests passed).
 `overengineeringstudio/effect-utils` supplies this repo's shared tooling
 (LS.DEL.COMP-A01). When a mechanism belongs upstream — the case that forced this
 decision was the test-quarantine contract, whose entry semantics and CI emit
-channel are not LiveStore's to own — the question is *how* core consumes it.
+channel are not LiveStore's to own — the question is _how_ core consumes it.
 
 Three channels exist, and they differ in what they cost a contributor:
 
-| Channel | Reaches core via | Requires materialization to install? |
-| --- | --- | --- |
-| Nix-built binary | `inputs.effect-utils` flake input, pinned by `devenv.lock` | no |
-| Genie helper | `#mr/effect-utils/...`, resolved by Genie's own resolver | only to regenerate |
-| npm workspace package | a `repos/effect-utils/...` entry in `pnpm-workspace.yaml` | **yes** |
+| Channel               | Reaches core via                                           | Requires materialization to install? |
+| --------------------- | ---------------------------------------------------------- | ------------------------------------ |
+| Nix-built binary      | `inputs.effect-utils` flake input, pinned by `devenv.lock` | no                                   |
+| Genie helper          | `#mr/effect-utils/...`, resolved by Genie's own resolver   | only to regenerate                   |
+| npm workspace package | a `repos/effect-utils/...` entry in `pnpm-workspace.yaml`  | **yes**                              |
 
 The third looks like the obvious way to share TypeScript, and it is the one that
 does real damage. `repos/` is gitignored and every `@overeng/*` package is

--- a/context/03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md
+++ b/context/03-delivery/01-composition/.decisions/0001-shared-tooling-consumption-channel.md
@@ -1,10 +1,14 @@
-# Consume shared tooling as Nix-built binaries, not workspace packages
+# 0001 — Consume shared tooling as Nix-built binaries, not workspace packages
 
-Status: accepted — 2026-07-27, confirmed with the maintainer during the design
-interview that produced this record. Evidence: a clean clone of this branch with
+Status: accepted (2026-07-27, confirmed with the maintainer during the design
+interview that produced this record). Evidence: a clean clone of this branch with
 no `repos/` present ran `pnpm install` (exit 0), `tsgo --build tsconfig.json`
-(exit 0, no errors), and `vitest packages/@livestore/common/src` (19 files, 268
-tests passed).
+(exit 0, no errors), and one unit-lane project,
+`vitest packages/@livestore/common/src` (19 files, 268 tests passed). The
+structural basis is independent of that sample: `scripts/tsconfig.json` excludes
+`**/*.genie.ts`, so the only `#mr/effect-utils/...` import is outside the
+typecheck graph, and neither root nor `scripts/` declares an `@overeng/*`
+dependency or an `imports` map.
 
 ## Context
 

--- a/context/03-delivery/01-composition/requirements.md
+++ b/context/03-delivery/01-composition/requirements.md
@@ -120,7 +120,7 @@ Interacts with `../../04-docs/`.
 
 - **LS.DEL.COMP-R19 Core installs and tests without materialization:** A fresh
   clone of core installs dependencies, typechecks, and runs its test lanes
-  without `mr apply`. Materialization is required to *regenerate* — Genie
+  without `mr apply`. Materialization is required to _regenerate_ — Genie
   sources import `#mr/effect-utils/...`, which resolves through `repos/` or the
   megarepo store — but generated outputs are committed, so building and testing
   never need it. Shared tooling therefore reaches core as Nix-built binaries

--- a/context/03-delivery/01-composition/requirements.md
+++ b/context/03-delivery/01-composition/requirements.md
@@ -108,6 +108,7 @@ Interacts with `../../04-docs/`.
   preserve relevant pre-move commit history through filtered history import.
 - **LS.DEL.COMP-R17 Source commit traceability:** The history import records
   the source core commit used to establish contrib ownership.
+
 ### Must Keep The Development Shell Diagnostic
 
 - **LS.DEL.COMP-R18 Readiness before validation:** Entering the supported

--- a/context/03-delivery/01-composition/requirements.md
+++ b/context/03-delivery/01-composition/requirements.md
@@ -108,7 +108,6 @@ Interacts with `../../04-docs/`.
   preserve relevant pre-move commit history through filtered history import.
 - **LS.DEL.COMP-R17 Source commit traceability:** The history import records
   the source core commit used to establish contrib ownership.
-
 ### Must Keep The Development Shell Diagnostic
 
 - **LS.DEL.COMP-R18 Readiness before validation:** Entering the supported
@@ -116,3 +115,16 @@ Interacts with `../../04-docs/`.
   without requiring full source validation. TypeScript build and check tasks
   remain explicit developer and CI gates. Refined by
   [01-developer-environment](./01-developer-environment/requirements.md).
+
+### Must Stay Usable Without Materialization
+
+- **LS.DEL.COMP-R19 Core installs and tests without materialization:** A fresh
+  clone of core installs dependencies, typechecks, and runs its test lanes
+  without `mr apply`. Materialization is required to *regenerate* — Genie
+  sources import `#mr/effect-utils/...`, which resolves through `repos/` or the
+  megarepo store — but generated outputs are committed, so building and testing
+  never need it. Shared tooling therefore reaches core as Nix-built binaries
+  from the `effect-utils` flake input (LS.DEL.COMP-A01) rather than as
+  workspace packages under `repos/`, which would make `pnpm install` depend on
+  materialization for every external contributor. Adopted 2026-07-27; see
+  [.decisions/0001-shared-tooling-consumption-channel.md](./.decisions/0001-shared-tooling-consumption-channel.md).

--- a/context/03-delivery/01-composition/spec.md
+++ b/context/03-delivery/01-composition/spec.md
@@ -43,31 +43,31 @@ bump core's unpinned contrib reference. This satisfies LS.DEL.COMP-R04–R06.
 
 ## Package Ownership
 
-| Package               | Owner   | Reason                                                    |
-| --------------------- | ------- | --------------------------------------------------------- |
-| `livestore`           | core    | Engine root                                               |
-| `common`              | core    | Engine internals                                          |
-| `common-cf`           | core    | Cloudflare engine internals                               |
-| `utils`               | core    | Shared utility surface                                    |
-| `utils-dev`           | core    | Shared test infrastructure                                |
-| `peer-deps`           | core    | Catalog management                                        |
-| `react`               | core    | Primary framework integration                             |
-| `adapter-web`         | core    | Primary browser adapter                                   |
-| `adapter-cloudflare`  | core    | Primary production adapter                                |
-| `sync-cf`             | core    | Primary sync provider                                     |
-| `sqlite-wasm`         | core    | SQLite browser surface                                    |
-| `wa-sqlite`           | core    | Vendored SQLite                                           |
-| `webmesh`             | core    | Cross-worker mesh primitive                               |
-| `framework-toolkit`   | core    | Shared primitive imported by React and contrib frameworks |
-| `svelte`              | contrib | Framework integration                                     |
-| `solid`               | contrib | Framework integration                                     |
-| `adapter-node`        | contrib | Node platform adapter                                     |
-| `adapter-expo`        | contrib | Expo platform adapter                                     |
-| `devtools-expo`       | contrib | Expo devtools surface                                     |
-| `sync-electric`       | contrib | Additional sync provider                                  |
-| `sync-s2`             | contrib | Additional sync provider                                  |
-| `graphql`             | contrib | Optional integration                                      |
-| `cli`                 | contrib | Scaffolding and MCP server                                |
+| Package              | Owner   | Reason                                                    |
+| -------------------- | ------- | --------------------------------------------------------- |
+| `livestore`          | core    | Engine root                                               |
+| `common`             | core    | Engine internals                                          |
+| `common-cf`          | core    | Cloudflare engine internals                               |
+| `utils`              | core    | Shared utility surface                                    |
+| `utils-dev`          | core    | Shared test infrastructure                                |
+| `peer-deps`          | core    | Catalog management                                        |
+| `react`              | core    | Primary framework integration                             |
+| `adapter-web`        | core    | Primary browser adapter                                   |
+| `adapter-cloudflare` | core    | Primary production adapter                                |
+| `sync-cf`            | core    | Primary sync provider                                     |
+| `sqlite-wasm`        | core    | SQLite browser surface                                    |
+| `wa-sqlite`          | core    | Vendored SQLite                                           |
+| `webmesh`            | core    | Cross-worker mesh primitive                               |
+| `framework-toolkit`  | core    | Shared primitive imported by React and contrib frameworks |
+| `svelte`             | contrib | Framework integration                                     |
+| `solid`              | contrib | Framework integration                                     |
+| `adapter-node`       | contrib | Node platform adapter                                     |
+| `adapter-expo`       | contrib | Expo platform adapter                                     |
+| `devtools-expo`      | contrib | Expo devtools surface                                     |
+| `sync-electric`      | contrib | Additional sync provider                                  |
+| `sync-s2`            | contrib | Additional sync provider                                  |
+| `graphql`            | contrib | Optional integration                                      |
+| `cli`                | contrib | Scaffolding and MCP server                                |
 
 `@livestore/effect-playwright` is not part of either repository's final
 LiveStore package set; it belongs in `overengineeringstudio/effect-utils`.
@@ -122,10 +122,10 @@ Publish-time rewriting of `workspace:*` to exact versions is
 Core consumes effect-utils through two channels, and which one a mechanism uses
 is a contract, not a convenience (LS.DEL.COMP-R19, [decision 0001](./.decisions/0001-shared-tooling-consumption-channel.md)):
 
-| Channel | Reaches core via | Examples |
-| --- | --- | --- |
-| Nix-built binary | `inputs.effect-utils`, pinned by `devenv.lock` | `genie`, `effect-tsgo`, `megarepo`, `ci-tools` |
-| Genie helper | `#mr/effect-utils/...`, Genie's own resolver | `oxlint-base`, `oxfmt-base`, `ci-workflow`, `jsonArtifact` |
+| Channel          | Reaches core via                               | Examples                                                   |
+| ---------------- | ---------------------------------------------- | ---------------------------------------------------------- |
+| Nix-built binary | `inputs.effect-utils`, pinned by `devenv.lock` | `genie`, `effect-tsgo`, `megarepo`, `ci-tools`             |
+| Genie helper     | `#mr/effect-utils/...`, Genie's own resolver   | `oxlint-base`, `oxfmt-base`, `ci-workflow`, `jsonArtifact` |
 
 Core has no npm dependency on `@overeng/*`. A `repos/effect-utils/...` entry in
 `pnpm-workspace.yaml` would make `pnpm install` require `mr apply`, which is why
@@ -139,15 +139,15 @@ but contrib owns its package and example membership locally. Core exports
 core package metadata and reusable generator helpers; it does not carry the
 final contrib package manifest.
 
-| Surface           | Source of truth                                                        |
-| ----------------- | ---------------------------------------------------------------------- |
-| devenv            | effect-utils modules, imported by contrib                              |
-| pnpm workspace    | contrib-local package/example manifest plus core/effect-utils helpers  |
-| package manifests | contrib-local package manifest plus core/effect-utils helpers          |
-| tsconfig          | contrib-local workspace shape plus core/effect-utils helpers           |
-| oxlint/oxfmt      | effect-utils base config plus contrib-local ignores                    |
-| labels/settings   | effect-utils catalog plus contrib-local labels                         |
-| CI workflow       | effect-utils workflow builders plus core re-exported setup atoms       |
+| Surface           | Source of truth                                                       |
+| ----------------- | --------------------------------------------------------------------- |
+| devenv            | effect-utils modules, imported by contrib                             |
+| pnpm workspace    | contrib-local package/example manifest plus core/effect-utils helpers |
+| package manifests | contrib-local package manifest plus core/effect-utils helpers         |
+| tsconfig          | contrib-local workspace shape plus core/effect-utils helpers          |
+| oxlint/oxfmt      | effect-utils base config plus contrib-local ignores                   |
+| labels/settings   | effect-utils catalog plus contrib-local labels                        |
+| CI workflow       | effect-utils workflow builders plus core re-exported setup atoms      |
 
 Contrib's `genie/repo.ts` imports core helpers by relative path:
 
@@ -208,13 +208,13 @@ package-specific docs into contrib without changing the public docs URL.
 
 ## Issue And Pull-Request Routing
 
-| Concern                                                                  | Repository                                                           |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| Core engine, React, web adapter, Cloudflare adapter, Cloudflare sync     | `livestorejs/livestore`                                              |
-| Svelte, Solid, Node, Expo, Electric, S2, GraphQL, CLI, contrib devtools  | `livestorejs/livestore-contrib`                                      |
-| Docs site infrastructure                                                 | `livestorejs/livestore`                                              |
-| Package-specific docs content                                            | owning package repository once docs source ownership is implemented  |
-| Cross-repo release/version coordination                                  | `livestorejs/livestore` coordination issue                           |
+| Concern                                                                 | Repository                                                          |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Core engine, React, web adapter, Cloudflare adapter, Cloudflare sync    | `livestorejs/livestore`                                             |
+| Svelte, Solid, Node, Expo, Electric, S2, GraphQL, CLI, contrib devtools | `livestorejs/livestore-contrib`                                     |
+| Docs site infrastructure                                                | `livestorejs/livestore`                                             |
+| Package-specific docs content                                           | owning package repository once docs source ownership is implemented |
+| Cross-repo release/version coordination                                 | `livestorejs/livestore` coordination issue                          |
 
 The package ownership table is the routing source of truth
 (LS.DEL.COMP-R03).

--- a/context/03-delivery/01-composition/spec.md
+++ b/context/03-delivery/01-composition/spec.md
@@ -117,6 +117,21 @@ host-user pnpm Store Cache defined by effect-utils' storage authority.
 Publish-time rewriting of `workspace:*` to exact versions is
 [../02-release/](../02-release/spec.md)'s contract.
 
+## Shared Tooling Consumption
+
+Core consumes effect-utils through two channels, and which one a mechanism uses
+is a contract, not a convenience (LS.DEL.COMP-R19, [decision 0001](./.decisions/0001-shared-tooling-consumption-channel.md)):
+
+| Channel | Reaches core via | Examples |
+| --- | --- | --- |
+| Nix-built binary | `inputs.effect-utils`, pinned by `devenv.lock` | `genie`, `effect-tsgo`, `megarepo`, `ci-tools` |
+| Genie helper | `#mr/effect-utils/...`, Genie's own resolver | `oxlint-base`, `oxfmt-base`, `ci-workflow`, `jsonArtifact` |
+
+Core has no npm dependency on `@overeng/*`. A `repos/effect-utils/...` entry in
+`pnpm-workspace.yaml` would make `pnpm install` require `mr apply`, which is why
+a fresh clone installs and tests without materialization while regeneration
+still needs it.
+
 ## Tooling Composition
 
 Contrib's generated files are composed from the same helper stack as core,

--- a/devenv.nix
+++ b/devenv.nix
@@ -331,13 +331,22 @@ in
     })
     (taskModules.check {
       hasTests = false;
+      # `hasNixCheck` gates the nix-cli build tasks (nix:check:quick / nix:flake:check), which
+      # this repo does not use. Nix *linting* is separate and wired in via extraChecks below.
       hasNixCheck = false;
+      extraChecks = [
+        "lint:nix"
+        "quarantine:check"
+      ];
     })
     (taskModules.clean {
       packages = pnpmPackages;
       extraDirs = [ ".astro" ];
     })
     # Lint tasks via lint-oxc plus local aggregate wrappers.
+    # Nix linting: nixfmt + deadnix, plus lint:nix:workflow-commands, which fails when a task
+    # definition writes a GitHub workflow command to stdout (devenv discards it there).
+    (taskModules.lint-nix { })
     (taskModules.lint-oxc {
       lintPaths = [
         "packages"
@@ -391,6 +400,7 @@ in
     # Local task: mono command wrappers for uniform dt interface
     ./nix/devenv-modules/tasks/local/mono-wrappers.nix
     ./nix/devenv-modules/tasks/local/github-rulesets.nix
+    ./nix/devenv-modules/tasks/local/quarantine.nix
   ];
 
   # Non-`.genie.ts` generator inputs (source-of-truth modules that the `.genie.ts`
@@ -412,6 +422,9 @@ in
   ]
   ++ [
     effectUtilsPackages.genie
+    # `mono test` shells out to `ci-tools quarantine announce` when a target's failure is
+    # tolerated, and `quarantine:check` validates the ledger.
+    effectUtilsPackages.ci-tools
     effectUtils.packages.${pkgs.system}.megarepo
     pkgs.jq
     pkgs.unzip

--- a/devenv.nix
+++ b/devenv.nix
@@ -344,8 +344,8 @@ in
       extraDirs = [ ".astro" ];
     })
     # Lint tasks via lint-oxc plus local aggregate wrappers.
-    # Nix linting: nixfmt + deadnix, plus lint:nix:workflow-commands, which fails when a task
-    # definition writes a GitHub workflow command to stdout (devenv discards it there).
+    # nixfmt formatting and deadnix dead-code checks over this repo's tracked `.nix` files.
+    # Gated through `extraChecks` above rather than run standalone.
     (taskModules.lint-nix { })
     (taskModules.lint-oxc {
       lintPaths = [

--- a/devenv.nix
+++ b/devenv.nix
@@ -99,200 +99,200 @@ let
   '';
 
   devtoolsArtifactCertifyLivenessExec = ''
-    set -euo pipefail
-    cd "$DEVENV_ROOT"
+        set -euo pipefail
+        cd "$DEVENV_ROOT"
 
-    : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
+        : "''${LIVESTORE_RELEASE_VERSION:?Set LIVESTORE_RELEASE_VERSION to the LiveStore release-group version}"
 
-    out_dir="''${LIVESTORE_DEVTOOLS_OUT_DIR:-$(mktemp -d)}"
-    mkdir -p "$out_dir"
-    export LIVESTORE_DEVTOOLS_OUT_DIR="$out_dir"
+        out_dir="''${LIVESTORE_DEVTOOLS_OUT_DIR:-$(mktemp -d)}"
+        mkdir -p "$out_dir"
+        export LIVESTORE_DEVTOOLS_OUT_DIR="$out_dir"
 
-    export LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK=1
-    ${devtoolsArtifactRepackExec "--dry-run"}
-    unset LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK
+        export LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK=1
+        ${devtoolsArtifactRepackExec "--dry-run"}
+        unset LIVESTORE_DEVTOOLS_ALLOW_UNCERTIFIED_REPACK
 
-    repacked_tarball="$out_dir/livestore-devtools-vite-$LIVESTORE_RELEASE_VERSION.tgz"
-    if [ ! -f "$repacked_tarball" ]; then
-      echo "Expected repacked DevTools tarball not found: $repacked_tarball" >&2
-      exit 1
-    fi
-
-    backup_dir="$(mktemp -d)"
-    package_links=(
-      "tests/integration/node_modules/@livestore/devtools-vite"
-    )
-
-    for index in "''${!package_links[@]}"; do
-      package_link="''${package_links[$index]}"
-      if [ ! -e "$package_link" ]; then
-        echo "Expected installed @livestore/devtools-vite package link not found: $package_link" >&2
-        exit 1
-      fi
-      cp -a "$package_link" "$backup_dir/devtools-vite-$index"
-    done
-
-    restore_node_modules() {
-      for index in "''${!package_links[@]}"; do
-        package_link="''${package_links[$index]}"
-        rm -rf "$package_link"
-        cp -a "$backup_dir/devtools-vite-$index" "$package_link"
-      done
-      rm -rf "$backup_dir"
-    }
-
-    dev_server_pid=""
-    dev_server_log=""
-    stop_dev_server() {
-      if [ -n "$dev_server_pid" ]; then
-        kill "$dev_server_pid" 2>/dev/null || true
-        wait "$dev_server_pid" 2>/dev/null || true
-      fi
-      if [ -n "$dev_server_log" ]; then
-        rm -f "$dev_server_log"
-      fi
-    }
-    cleanup_certification() {
-      stop_dev_server
-      restore_node_modules
-    }
-    trap cleanup_certification EXIT
-
-    unpack_dir="$(mktemp -d)"
-    tar -xzf "$repacked_tarball" -C "$unpack_dir"
-    hydrate_devtools_package() {
-      package_dir="$1"
-      installed_devtools_package="$(readlink -f tests/integration/node_modules/@livestore/devtools-vite)"
-      mkdir -p "$package_dir/node_modules/@livestore"
-
-      dependencies=(
-        "@livestore/adapter-web"
-        "@livestore/utils"
-        "vite"
-      )
-
-      for dependency in "''${dependencies[@]}"; do
-        source_path="tests/integration/node_modules/$dependency"
-        target_path="$package_dir/node_modules/$dependency"
-        if [ ! -e "$source_path" ]; then
-          echo "Expected installed dependency for exact DevTools artifact not found: $source_path" >&2
+        repacked_tarball="$out_dir/livestore-devtools-vite-$LIVESTORE_RELEASE_VERSION.tgz"
+        if [ ! -f "$repacked_tarball" ]; then
+          echo "Expected repacked DevTools tarball not found: $repacked_tarball" >&2
           exit 1
         fi
-        rm -rf "$target_path"
-        mkdir -p "$(dirname "$target_path")"
-        ln -s "$(readlink -f "$source_path")" "$target_path"
-      done
 
-      parcel_watcher_path="$(
-        bun --eval '
-          const { createRequire } = require("node:module")
-          const path = require("node:path")
-          const requireFromDevtools = createRequire(path.resolve(process.argv[1], "package.json"))
-          console.log(path.dirname(requireFromDevtools.resolve("@parcel/watcher/package.json")))
-        ' "$installed_devtools_package"
-      )"
-      parcel_watcher_target="$package_dir/node_modules/@parcel/watcher"
-      rm -rf "$parcel_watcher_target"
-      mkdir -p "$(dirname "$parcel_watcher_target")"
-      cp -a "$parcel_watcher_path" "$parcel_watcher_target"
+        backup_dir="$(mktemp -d)"
+        package_links=(
+          "tests/integration/node_modules/@livestore/devtools-vite"
+        )
 
-      parcel_watcher_platform_packages="$(
-        bun --eval '
-          const { createRequire } = require("node:module")
-          const path = require("node:path")
-          const watcherPackageJson = path.resolve(process.argv[1], "package.json")
-          const requireFromWatcher = createRequire(watcherPackageJson)
-          for (const dependency of Object.keys(require(watcherPackageJson).optionalDependencies ?? {})) {
-            try {
-              console.log(dependency + "\t" + path.dirname(requireFromWatcher.resolve(dependency + "/package.json")))
-            } catch {}
-          }
-        ' "$parcel_watcher_path"
-      )"
-      mkdir -p "$package_dir/node_modules/@parcel"
-      while IFS="$(printf '\t')" read -r dependency dependency_path; do
-        if [ -z "$dependency" ] || [ -z "$dependency_path" ]; then
-          continue
+        for index in "''${!package_links[@]}"; do
+          package_link="''${package_links[$index]}"
+          if [ ! -e "$package_link" ]; then
+            echo "Expected installed @livestore/devtools-vite package link not found: $package_link" >&2
+            exit 1
+          fi
+          cp -a "$package_link" "$backup_dir/devtools-vite-$index"
+        done
+
+        restore_node_modules() {
+          for index in "''${!package_links[@]}"; do
+            package_link="''${package_links[$index]}"
+            rm -rf "$package_link"
+            cp -a "$backup_dir/devtools-vite-$index" "$package_link"
+          done
+          rm -rf "$backup_dir"
+        }
+
+        dev_server_pid=""
+        dev_server_log=""
+        stop_dev_server() {
+          if [ -n "$dev_server_pid" ]; then
+            kill "$dev_server_pid" 2>/dev/null || true
+            wait "$dev_server_pid" 2>/dev/null || true
+          fi
+          if [ -n "$dev_server_log" ]; then
+            rm -f "$dev_server_log"
+          fi
+        }
+        cleanup_certification() {
+          stop_dev_server
+          restore_node_modules
+        }
+        trap cleanup_certification EXIT
+
+        unpack_dir="$(mktemp -d)"
+        tar -xzf "$repacked_tarball" -C "$unpack_dir"
+        hydrate_devtools_package() {
+          package_dir="$1"
+          installed_devtools_package="$(readlink -f tests/integration/node_modules/@livestore/devtools-vite)"
+          mkdir -p "$package_dir/node_modules/@livestore"
+
+          dependencies=(
+            "@livestore/adapter-web"
+            "@livestore/utils"
+            "vite"
+          )
+
+          for dependency in "''${dependencies[@]}"; do
+            source_path="tests/integration/node_modules/$dependency"
+            target_path="$package_dir/node_modules/$dependency"
+            if [ ! -e "$source_path" ]; then
+              echo "Expected installed dependency for exact DevTools artifact not found: $source_path" >&2
+              exit 1
+            fi
+            rm -rf "$target_path"
+            mkdir -p "$(dirname "$target_path")"
+            ln -s "$(readlink -f "$source_path")" "$target_path"
+          done
+
+          parcel_watcher_path="$(
+            bun --eval '
+              const { createRequire } = require("node:module")
+              const path = require("node:path")
+              const requireFromDevtools = createRequire(path.resolve(process.argv[1], "package.json"))
+              console.log(path.dirname(requireFromDevtools.resolve("@parcel/watcher/package.json")))
+            ' "$installed_devtools_package"
+          )"
+          parcel_watcher_target="$package_dir/node_modules/@parcel/watcher"
+          rm -rf "$parcel_watcher_target"
+          mkdir -p "$(dirname "$parcel_watcher_target")"
+          cp -a "$parcel_watcher_path" "$parcel_watcher_target"
+
+          parcel_watcher_platform_packages="$(
+            bun --eval '
+              const { createRequire } = require("node:module")
+              const path = require("node:path")
+              const watcherPackageJson = path.resolve(process.argv[1], "package.json")
+              const requireFromWatcher = createRequire(watcherPackageJson)
+              for (const dependency of Object.keys(require(watcherPackageJson).optionalDependencies ?? {})) {
+                try {
+                  console.log(dependency + "\t" + path.dirname(requireFromWatcher.resolve(dependency + "/package.json")))
+                } catch {}
+              }
+            ' "$parcel_watcher_path"
+          )"
+          mkdir -p "$package_dir/node_modules/@parcel"
+          while IFS="$(printf '\t')" read -r dependency dependency_path; do
+            if [ -z "$dependency" ] || [ -z "$dependency_path" ]; then
+              continue
+            fi
+            platform_target="$package_dir/node_modules/$dependency"
+            rm -rf "$platform_target"
+            mkdir -p "$(dirname "$platform_target")"
+            ln -s "$dependency_path" "$platform_target"
+          done <<EOF
+    $parcel_watcher_platform_packages
+    EOF
+        }
+        hydrate_devtools_package "$unpack_dir/package"
+        for package_link in "''${package_links[@]}"; do
+          rm -rf "$package_link"
+          cp -a "$unpack_dir/package" "$package_link"
+        done
+        rm -rf "$unpack_dir"
+
+        for package_link in "''${package_links[@]}"; do
+          package_version="$(bun -e "console.log(require('./$package_link/package.json').version)")"
+          if [ "$package_version" != "$LIVESTORE_RELEASE_VERSION" ]; then
+            echo "Expected $package_link to contain exact DevTools artifact version $LIVESTORE_RELEASE_VERSION, found $package_version" >&2
+            exit 1
+          fi
+        done
+
+        (
+          cd tests/integration
+          dev_server_port="''${LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT:-4444}"
+          dev_server_log="$(mktemp)"
+          TEST_LIVESTORE_SCHEMA_PATH_JSON='"./devtools/todomvc/livestore/schema.ts"' \
+            LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false \
+            VITE_OTEL_EXPORTER_OTLP_ENDPOINT= \
+            ./node_modules/.bin/vite \
+              --config src/tests/playwright/fixtures/vite.config.ts \
+              dev \
+              --port "$dev_server_port" \
+              --strictPort \
+              >"$dev_server_log" 2>&1 &
+          dev_server_pid="$!"
+          trap stop_dev_server EXIT
+
+          if ! LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT="$dev_server_port" \
+            LIVESTORE_DEV_SERVER_PID="$dev_server_pid" \
+            bun --eval '
+              const port = process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT ?? "4444"
+              const pid = Number(process.env.LIVESTORE_DEV_SERVER_PID ?? "0")
+              const deadline = Date.now() + 60_000
+              const paths = ["/devtools/todomvc", "/_livestore/web"]
+              while (Date.now() < deadline) {
+                try {
+                  if (pid > 0) process.kill(pid, 0)
+                } catch {
+                  throw new Error("Vite dev server exited before accepting connections")
+                }
+                try {
+                  const responses = await Promise.all(paths.map((path) => fetch("http://localhost:" + port + path)))
+                  if (responses.every((response) => response.status < 500)) process.exit(0)
+                } catch {}
+                await new Promise((resolve) => setTimeout(resolve, 250))
+              }
+              throw new Error("Timed out waiting for exact DevTools artifact routes on localhost:" + port)
+            '; then
+            echo "Vite dev server log:" >&2
+            sed -n '1,200p' "$dev_server_log" >&2
+            exit 1
+          fi
+        )
+
+        certification_path="''${LIVESTORE_DEVTOOLS_CERTIFICATION:-release/devtools-artifact.certification.json}"
+        evidence="DevTools exact-artifact Vite route liveness passed for $LIVESTORE_RELEASE_VERSION"
+        if [[ -n "''${GITHUB_SERVER_URL:-}" && -n "''${GITHUB_REPOSITORY:-}" && -n "''${GITHUB_RUN_ID:-}" ]]; then
+          evidence="$evidence in $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         fi
-        platform_target="$package_dir/node_modules/$dependency"
-        rm -rf "$platform_target"
-        mkdir -p "$(dirname "$platform_target")"
-        ln -s "$dependency_path" "$platform_target"
-      done <<EOF
-$parcel_watcher_platform_packages
-EOF
-    }
-    hydrate_devtools_package "$unpack_dir/package"
-    for package_link in "''${package_links[@]}"; do
-      rm -rf "$package_link"
-      cp -a "$unpack_dir/package" "$package_link"
-    done
-    rm -rf "$unpack_dir"
-
-    for package_link in "''${package_links[@]}"; do
-      package_version="$(bun -e "console.log(require('./$package_link/package.json').version)")"
-      if [ "$package_version" != "$LIVESTORE_RELEASE_VERSION" ]; then
-        echo "Expected $package_link to contain exact DevTools artifact version $LIVESTORE_RELEASE_VERSION, found $package_version" >&2
-        exit 1
-      fi
-    done
-
-    (
-      cd tests/integration
-      dev_server_port="''${LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT:-4444}"
-      dev_server_log="$(mktemp)"
-      TEST_LIVESTORE_SCHEMA_PATH_JSON='"./devtools/todomvc/livestore/schema.ts"' \
-        LIVESTORE_DEVTOOLS_ENFORCE_LICENSE=false \
-        VITE_OTEL_EXPORTER_OTLP_ENDPOINT= \
-        ./node_modules/.bin/vite \
-          --config src/tests/playwright/fixtures/vite.config.ts \
-          dev \
-          --port "$dev_server_port" \
-          --strictPort \
-          >"$dev_server_log" 2>&1 &
-      dev_server_pid="$!"
-      trap stop_dev_server EXIT
-
-      if ! LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT="$dev_server_port" \
-        LIVESTORE_DEV_SERVER_PID="$dev_server_pid" \
-        bun --eval '
-          const port = process.env.LIVESTORE_PLAYWRIGHT_DEV_SERVER_PORT ?? "4444"
-          const pid = Number(process.env.LIVESTORE_DEV_SERVER_PID ?? "0")
-          const deadline = Date.now() + 60_000
-          const paths = ["/devtools/todomvc", "/_livestore/web"]
-          while (Date.now() < deadline) {
-            try {
-              if (pid > 0) process.kill(pid, 0)
-            } catch {
-              throw new Error("Vite dev server exited before accepting connections")
-            }
-            try {
-              const responses = await Promise.all(paths.map((path) => fetch("http://localhost:" + port + path)))
-              if (responses.every((response) => response.status < 500)) process.exit(0)
-            } catch {}
-            await new Promise((resolve) => setTimeout(resolve, 250))
-          }
-          throw new Error("Timed out waiting for exact DevTools artifact routes on localhost:" + port)
-        '; then
-        echo "Vite dev server log:" >&2
-        sed -n '1,200p' "$dev_server_log" >&2
-        exit 1
-      fi
-    )
-
-    certification_path="''${LIVESTORE_DEVTOOLS_CERTIFICATION:-release/devtools-artifact.certification.json}"
-    evidence="DevTools exact-artifact Vite route liveness passed for $LIVESTORE_RELEASE_VERSION"
-    if [[ -n "''${GITHUB_SERVER_URL:-}" && -n "''${GITHUB_REPOSITORY:-}" && -n "''${GITHUB_RUN_ID:-}" ]]; then
-      evidence="$evidence in $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-    fi
-    bun scripts/src/commands/devtools-artifact.ts certify \
-      --manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}" \
-      --version "$LIVESTORE_RELEASE_VERSION" \
-      --out "$certification_path" \
-      --evidence "$evidence"
-    if [[ -n "''${GITHUB_ENV:-}" ]]; then
-      echo "LIVESTORE_DEVTOOLS_CERTIFICATION=$certification_path" >> "$GITHUB_ENV"
-    fi
+        bun scripts/src/commands/devtools-artifact.ts certify \
+          --manifest "''${LIVESTORE_DEVTOOLS_MANIFEST:-release/devtools-artifact.json}" \
+          --version "$LIVESTORE_RELEASE_VERSION" \
+          --out "$certification_path" \
+          --evidence "$evidence"
+        if [[ -n "''${GITHUB_ENV:-}" ]]; then
+          echo "LIVESTORE_DEVTOOLS_CERTIFICATION=$certification_path" >> "$GITHUB_ENV"
+        fi
   '';
 
   devtoolsArtifactRepackTask =

--- a/devenv.nix
+++ b/devenv.nix
@@ -411,6 +411,9 @@ in
   # by the module; the glob overlap with genie/**/*.genie.ts is harmless.
   effectUtils.genie.extraInputGlobs = [
     ":(glob)genie/**/*.ts"
+    # The quarantine ledger lives under scripts/ (it is imported by runtime code, so it must
+    # sit inside that project's rootDir) while still being a generator input.
+    ":(glob)scripts/src/shared/quarantine-ledger.ts"
   ];
 
   packages = [

--- a/genie/quarantine-ledger.ts
+++ b/genie/quarantine-ledger.ts
@@ -1,0 +1,39 @@
+/**
+ * Every currently-tolerated test failure in this repository.
+ *
+ * Empty is the intended steady state: it means no required check is lying. Entries are
+ * expected to be rare and short-lived — `ci-tools quarantine validate` fails once an entry's
+ * `expires` date passes, so a forgotten quarantine reds a required check instead of silently
+ * becoming permanent.
+ *
+ * This module is the source of truth. It stays free of imports so it can be read by a Genie
+ * generator source (which must stay out of the runtime dependency closure) and by
+ * `scripts/src/shared/test-policy.ts`, which needs the literal type: `QuarantineKey` is
+ * uninhabited while the ledger is empty, so `TestPolicy.quarantined(...)` cannot be written
+ * without a checked-in entry. `scripts/src/generated/quarantine-ledger.json` is generated from
+ * here for the CLI, which cannot read TypeScript.
+ */
+
+/** A tolerated test failure, and the record that justifies tolerating it. */
+export type QuarantineEntry = {
+  /** What is quarantined — a package path, provider key, or suite name. */
+  readonly target: string
+  /** Why its failures are currently tolerated. */
+  readonly reason: string
+  /** Issue tracking the underlying problem. */
+  readonly issue: string
+  /** `YYYY-MM-DD`. Past this date the ledger check fails, forcing a renew-or-remove decision. */
+  readonly expires: string
+}
+
+export const quarantineLedger = {
+  'devtools-suite': {
+    target: 'tests/integration:devtools',
+    reason:
+      'Every test in the suite fails (0/15). All browser-extension tests die at "No devtools page found"; the rest time out on locators. Pre-existing — the suite was silently suppressed from 2025-05-10 until #1404.',
+    issue: 'https://github.com/livestorejs/livestore/issues/1489',
+    expires: '2026-09-30',
+  },
+} as const satisfies Record<string, QuarantineEntry>
+
+export type QuarantineKey = keyof typeof quarantineLedger

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -604,11 +604,15 @@ in
     };
 
     "lint:full" = {
-      description = "Run full lint checks (lint:check + madge + markdown import guard)";
+      description = "Run full lint checks (lint:check + madge + markdown import guard + quarantine ledger)";
       after = [
         "lint:check"
         "lint:check:madge"
         "lint:check:md-imports"
+        # Expiry is only a real gate if it runs on every PR. CI invokes
+        # `lint:full:with-megarepo-check`, never `check:quick`/`check:all`, so hanging the
+        # ledger check off `check` alone would let an expired quarantine stay green forever.
+        "quarantine:check"
       ];
     };
 

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -604,14 +604,17 @@ in
     };
 
     "lint:full" = {
-      description = "Run full lint checks (lint:check + madge + markdown import guard + quarantine ledger)";
+      description = "Run full lint checks (lint:check + madge + markdown imports + nix + quarantine ledger)";
+      # CI invokes `lint:full:with-megarepo-check` and never `check:quick`/`check:all`, so a
+      # check reachable only through the `check` aggregate does not actually gate anything.
+      # Both entries below are here for that reason, not just for grouping.
       after = [
         "lint:check"
         "lint:check:madge"
         "lint:check:md-imports"
-        # Expiry is only a real gate if it runs on every PR. CI invokes
-        # `lint:full:with-megarepo-check`, never `check:quick`/`check:all`, so hanging the
-        # ledger check off `check` alone would let an expired quarantine stay green forever.
+        # nixfmt + deadnix. Without this the repo's Nix formatting has no CI gate.
+        "lint:nix"
+        # An expired quarantine would otherwise stay green indefinitely.
         "quarantine:check"
       ];
     };
@@ -626,10 +629,16 @@ in
 
     "lint:full:fix" = {
       description = "Fix lint issues, then run full lint checks";
+      # CONTRIBUTING/CLAUDE.md point contributors at this task before committing, so it has to
+      # cover what `lint:full` gates in CI — otherwise the documented pre-commit command passes
+      # while CI fails. Nix formatting gets the fixing variant; the rest are check-only.
       after = [
         "lint:fix"
         "lint:check:madge"
         "lint:check:md-imports"
+        "lint:nix:fix:format"
+        "lint:nix:deadcode"
+        "quarantine:check"
       ];
     };
   };

--- a/nix/devenv-modules/tasks/local/quarantine.nix
+++ b/nix/devenv-modules/tasks/local/quarantine.nix
@@ -1,0 +1,14 @@
+{ ... }:
+{
+  # Fails once a quarantine entry's `expires` date passes, forcing a renew-or-remove decision
+  # rather than letting a tolerated failure quietly become permanent. Runs against the generated
+  # JSON — `genie/quarantine-ledger.ts` is the source of truth, and `lint:check:genie` catches
+  # drift between the two.
+  #
+  # The expiry rule itself lives in `ci-tools` (effect-utils#971), so every repo with a ledger
+  # gets the same semantics, including treating a malformed date as expired.
+  tasks."quarantine:check" = {
+    description = "Check the quarantine ledger for expired or malformed entries";
+    exec = "ci-tools quarantine validate --ledger scripts/src/generated/quarantine-ledger.json";
+  };
+}

--- a/nix/devenv-modules/tasks/local/quarantine.nix
+++ b/nix/devenv-modules/tasks/local/quarantine.nix
@@ -2,7 +2,7 @@
 {
   # Fails once a quarantine entry's `expires` date passes, forcing a renew-or-remove decision
   # rather than letting a tolerated failure quietly become permanent. Runs against the generated
-  # JSON — `genie/quarantine-ledger.ts` is the source of truth, and `lint:check:genie` catches
+  # JSON — `scripts/src/shared/quarantine-ledger.ts` is the source of truth, and `lint:check:genie` catches
   # drift between the two.
   #
   # The expiry rule itself lives in `ci-tools` (effect-utils#971), so every repo with a ledger

--- a/nix/devenv-modules/tasks/local/quarantine.nix
+++ b/nix/devenv-modules/tasks/local/quarantine.nix
@@ -1,9 +1,9 @@
 { ... }:
 {
   # Fails once a quarantine entry's `expires` date passes, forcing a renew-or-remove decision
-  # rather than letting a tolerated failure quietly become permanent. Runs against the generated
-  # JSON — `scripts/src/shared/quarantine-ledger.ts` is the source of truth, and `lint:check:genie` catches
-  # drift between the two.
+  # rather than letting a tolerated failure quietly become permanent. Runs against the
+  # generated JSON; `scripts/src/shared/quarantine-ledger.ts` is the source of truth, and
+  # `lint:check:genie` catches drift between the two.
   #
   # The expiry rule itself lives in `ci-tools` (effect-utils#971), so every repo with a ledger
   # gets the same semantics, including treating a malformed date as expired.

--- a/packages/@livestore/wa-sqlite/flake.nix
+++ b/packages/@livestore/wa-sqlite/flake.nix
@@ -5,8 +5,15 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
 
@@ -72,7 +79,7 @@
 
             mkdir -p ${pname}
             cd ${pname}
-            
+
             # Unpack the SQLite source to sqlite-src
             unpackFile ${sqliteSrc}
 
@@ -88,177 +95,177 @@
           '';
 
           configurePhase = ''
-            runHook preConfigure
+                        runHook preConfigure
 
-            echo "Emscripten version:"
-            emcc --version
+                        echo "Emscripten version:"
+                        emcc --version
 
-            pwd
-            ls -la
+                        pwd
+                        ls -la
 
-            mkdir -p cache/version-${version}
-            cp -r ./sqlite-src/* ./cache/version-${version}
+                        mkdir -p cache/version-${version}
+                        cp -r ./sqlite-src/* ./cache/version-${version}
 
-            extensionFunctionsSha3="$(openssl dgst -sha3-256 -r ./src/extension-functions.c | sed -e 's/\s.*//')"
-            expectedExtensionFunctionsSha3="$(sed -n 's/^EXTENSION_FUNCTIONS_SHA3 = //p' Makefile)"
-            if [ "$extensionFunctionsSha3" != "$expectedExtensionFunctionsSha3" ]; then
-              echo "src/extension-functions.c does not match Makefile EXTENSION_FUNCTIONS_SHA3" >&2
-              echo "got:      $extensionFunctionsSha3" >&2
-              echo "expected: $expectedExtensionFunctionsSha3" >&2
-              exit 1
-            fi
-            cp ./src/extension-functions.c ./cache/extension-functions.c
+                        extensionFunctionsSha3="$(openssl dgst -sha3-256 -r ./src/extension-functions.c | sed -e 's/\s.*//')"
+                        expectedExtensionFunctionsSha3="$(sed -n 's/^EXTENSION_FUNCTIONS_SHA3 = //p' Makefile)"
+                        if [ "$extensionFunctionsSha3" != "$expectedExtensionFunctionsSha3" ]; then
+                          echo "src/extension-functions.c does not match Makefile EXTENSION_FUNCTIONS_SHA3" >&2
+                          echo "got:      $extensionFunctionsSha3" >&2
+                          echo "expected: $expectedExtensionFunctionsSha3" >&2
+                          exit 1
+                        fi
+                        cp ./src/extension-functions.c ./cache/extension-functions.c
 
-            # Since we provide the source code via Nix, we don't need to download it
-            # comment out all `curl` commands in `Makefile` of wa-sqlite
-            chmod u+w Makefile # Ensure we have write permissions for the Makefile
-            sed -i 's/curl/#curl/g' Makefile
-            
-            # Update the SQLITE_VERSION in the Makefile to match our version
-            sed -i 's/SQLITE_VERSION = version-.*/SQLITE_VERSION = version-${version}/g' Makefile
+                        # Since we provide the source code via Nix, we don't need to download it
+                        # comment out all `curl` commands in `Makefile` of wa-sqlite
+                        chmod u+w Makefile # Ensure we have write permissions for the Makefile
+                        sed -i 's/curl/#curl/g' Makefile
+                        
+                        # Update the SQLITE_VERSION in the Makefile to match our version
+                        sed -i 's/SQLITE_VERSION = version-.*/SQLITE_VERSION = version-${version}/g' Makefile
 
-            # Add `dist/wa-sqlite.node.mjs` to end of `Makefile` of wa-sqlite
-            # Note: We use EMFLAGS_DIST to ensure memory growth is enabled (via EMFLAGS_COMMON)
-            # This allows the WASM heap to grow dynamically at runtime, preventing "Cannot enlarge memory arrays" errors
-            # when working with databases larger than the initial 16MB allocation
-            cat >> Makefile <<'EOF'
-dist/wa-sqlite.node.mjs: $(OBJ_FILES_DIST) $(JSFILES) $(EXPORTED_FUNCTIONS) $(EXPORTED_RUNTIME_METHODS)
-	mkdir -p dist
-	$(EMCC) $(EMFLAGS_DIST) $(EMFLAGS_INTERFACES) $(EMFLAGS_LIBRARIES) -s ENVIRONMENT=node $(OBJ_FILES_DIST) -o $@
-EOF
+                        # Add `dist/wa-sqlite.node.mjs` to end of `Makefile` of wa-sqlite
+                        # Note: We use EMFLAGS_DIST to ensure memory growth is enabled (via EMFLAGS_COMMON)
+                        # This allows the WASM heap to grow dynamically at runtime, preventing "Cannot enlarge memory arrays" errors
+                        # when working with databases larger than the initial 16MB allocation
+                        cat >> Makefile <<'EOF'
+            dist/wa-sqlite.node.mjs: $(OBJ_FILES_DIST) $(JSFILES) $(EXPORTED_FUNCTIONS) $(EXPORTED_RUNTIME_METHODS)
+            	mkdir -p dist
+            	$(EMCC) $(EMFLAGS_DIST) $(EMFLAGS_INTERFACES) $(EMFLAGS_LIBRARIES) -s ENVIRONMENT=node $(OBJ_FILES_DIST) -o $@
+            EOF
 
-            cat Makefile
+                        cat Makefile
 
-            runHook postConfigure
+                        runHook postConfigure
           '';
 
           buildPhase = ''
-            runHook preBuild
+                      runHook preBuild
 
-            # Needed for `make`
-            export DESTDIR="$PWD"
-            export HOME="$PWD"
+                      # Needed for `make`
+                      export DESTDIR="$PWD"
+                      export HOME="$PWD"
 
-            mkdir -p cache/emscripten
-            export EM_CACHE="$PWD/cache/emscripten"
+                      mkdir -p cache/emscripten
+                      export EM_CACHE="$PWD/cache/emscripten"
 
-            # Ensure dist directory exists and has correct permissions
-            mkdir -p dist
-            chmod 755 dist
+                      # Ensure dist directory exists and has correct permissions
+                      mkdir -p dist
+                      chmod 755 dist
 
-            # Extra build with FTS5
-            make dist/wa-sqlite.mjs dist/wa-sqlite.node.mjs WASQLITE_EXTRA_DEFINES="-DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK -DSQLITE_ENABLE_FTS5"
-            mkdir -p dist-fts5
-            mv dist/wa-sqlite* dist-fts5
+                      # Extra build with FTS5
+                      make dist/wa-sqlite.mjs dist/wa-sqlite.node.mjs WASQLITE_EXTRA_DEFINES="-DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK -DSQLITE_ENABLE_FTS5"
+                      mkdir -p dist-fts5
+                      mv dist/wa-sqlite* dist-fts5
 
-            # Make dist files writable before cleaning
-            chmod -R u+w dist/ || true
+                      # Make dist files writable before cleaning
+                      chmod -R u+w dist/ || true
 
-            make clean
+                      make clean
 
-            # Add SQLite flags to `ext/wasm/api/sqlite3-wasm.c` (bytecode, session (incl. preupdate))
-            make dist/wa-sqlite.mjs dist/wa-sqlite.node.mjs WASQLITE_EXTRA_DEFINES="-DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK"
+                      # Add SQLite flags to `ext/wasm/api/sqlite3-wasm.c` (bytecode, session (incl. preupdate))
+                      make dist/wa-sqlite.mjs dist/wa-sqlite.node.mjs WASQLITE_EXTRA_DEFINES="-DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK"
 
-            # Build async and jspi variants for standard build (before organizing FTS5)
-            make dist/wa-sqlite-async.mjs dist/wa-sqlite-jspi.mjs WASQLITE_EXTRA_DEFINES="-DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK"
+                      # Build async and jspi variants for standard build (before organizing FTS5)
+                      make dist/wa-sqlite-async.mjs dist/wa-sqlite-jspi.mjs WASQLITE_EXTRA_DEFINES="-DSQLITE_ENABLE_BYTECODE_VTAB -DSQLITE_ENABLE_SESSION -DSQLITE_ENABLE_PREUPDATE_HOOK"
 
-            # Organize FTS5 variant (only move web and node variants)
-            mkdir -p dist/fts5
-            mv dist-fts5/wa-sqlite.mjs dist/fts5/wa-sqlite.mjs
-            mv dist-fts5/wa-sqlite.wasm dist/fts5/wa-sqlite.wasm  
-            mv dist-fts5/wa-sqlite.node.mjs dist/fts5/wa-sqlite.node.mjs
-            mv dist-fts5/wa-sqlite.node.wasm dist/fts5/wa-sqlite.node.wasm
-            rm -rf dist-fts5
+                      # Organize FTS5 variant (only move web and node variants)
+                      mkdir -p dist/fts5
+                      mv dist-fts5/wa-sqlite.mjs dist/fts5/wa-sqlite.mjs
+                      mv dist-fts5/wa-sqlite.wasm dist/fts5/wa-sqlite.wasm  
+                      mv dist-fts5/wa-sqlite.node.mjs dist/fts5/wa-sqlite.node.mjs
+                      mv dist-fts5/wa-sqlite.node.wasm dist/fts5/wa-sqlite.node.wasm
+                      rm -rf dist-fts5
 
-            # Adjust `mayCreate` code in all .mjs dist files
-            for file in dist/*.mjs dist/fts5/*.mjs; do
-              sed -i '
-                /mayCreate(dir, name) {/,/FS.lookupNode(dir, name);/ c\
-  mayCreate(dir, name) {\
-      var node\
-      try {\
-        node = FS.lookupNode(dir, name);
-        ' "$file"
-            done
+                      # Adjust `mayCreate` code in all .mjs dist files
+                      for file in dist/*.mjs dist/fts5/*.mjs; do
+                        sed -i '
+                          /mayCreate(dir, name) {/,/FS.lookupNode(dir, name);/ c\
+            mayCreate(dir, name) {\
+                var node\
+                try {\
+                  node = FS.lookupNode(dir, name);
+                  ' "$file"
+                      done
 
-            # Adjust `mayCreate` in minified dist files
-            for file in dist/*.mjs dist/fts5/*.mjs; do
-              sed -i 's/mayCreate(dir,name){try{var node=FS.lookupNode(dir,name)/mayCreate(dir,name){var node;try{node=FS.lookupNode(dir,name)/g' "$file"
-            done
+                      # Adjust `mayCreate` in minified dist files
+                      for file in dist/*.mjs dist/fts5/*.mjs; do
+                        sed -i 's/mayCreate(dir,name){try{var node=FS.lookupNode(dir,name)/mayCreate(dir,name){var node;try{node=FS.lookupNode(dir,name)/g' "$file"
+                      done
 
-            # Generate README with build information
-            {
-              echo "# wa-sqlite Build Information"
-              echo ""
-              echo "This dist directory was built with the following configuration:"
-              echo ""
-              echo "## Build Environment"
-              echo "- **Built on:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-              echo "- **Emscripten:** $(emcc --version | head -1)"
-              echo "- **SQLite Version:** ${version}"
-              echo "- **SQLite Commit:** ${sqliteCommit}"
-              echo ""
-              echo "## SQLite Features Enabled"
-              echo "- Session extension (changesets/sync)"
-              echo "- Preupdate hooks"  
-              echo "- Bytecode virtual table"
-              echo "- FTS5 full-text search (in fts5/ variant)"
-              echo ""
-              echo "## Build Variants"
-              echo ""
-              echo "### Standard Builds"
-              echo "- **wa-sqlite.mjs + .wasm**: Web/Worker build with all features"
-              echo "- **wa-sqlite-async.mjs + .wasm**: Async build for Promise-based usage"
-              echo "- **wa-sqlite-jspi.mjs + .wasm**: JSPI build for JavaScript Promise Integration"
-              echo "- **wa-sqlite.node.mjs + .wasm**: Node.js build"
-              echo ""
-              echo "### FTS5 Builds"
-              echo "- **fts5/wa-sqlite.mjs + .wasm**: Web build with FTS5 full-text search"
-              echo "- **fts5/wa-sqlite.node.mjs + .wasm**: Node.js build with FTS5"
-              echo ""
-              echo "## Session/Changeset API Available"
-              echo "The following session functions are exported and available:"
-              echo "- \`sqlite3session_create\` - Create session objects"
-              echo "- \`sqlite3session_attach\` - Attach tables to sessions"
-              echo "- \`sqlite3session_enable\` - Enable session recording"
-              echo "- \`sqlite3session_changeset\` - Generate changesets"
-              echo "- \`sqlite3session_delete\` - Clean up sessions"
-              echo "- \`sqlite3changeset_start\` - Process changesets"
-              echo "- \`sqlite3changeset_finalize\` - Finalize changeset processing"
-              echo "- \`sqlite3changeset_invert\` - Invert changesets"
-              echo "- \`sqlite3changeset_apply\` - Apply changesets"
-              echo ""
-              echo "## Build Script"
-              echo "Generated via: \`nix build .#wa-sqlite-livestore\`"
-              echo ""
-              echo "## File Sizes"
-              echo ""
-              echo "### Standard Build Sizes"
-              for f in dist/*.{mjs,wasm}; do
-                if [ -f "$f" ]; then
-                  size=$(ls -lah "$f" | awk '{print $5}')
-                  gzip_size=$(gzip -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
-                  brotli_size=$(brotli -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
-                  echo "- **$(basename "$f")**: $size (gzip: $gzip_size, brotli: $brotli_size)"
-                fi
-              done
-              echo ""
-              echo "### FTS5 Variant Sizes"
-              for f in dist/fts5/*.{mjs,wasm}; do
-                if [ -f "$f" ]; then
-                  size=$(ls -lah "$f" | awk '{print $5}')
-                  gzip_size=$(gzip -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
-                  brotli_size=$(brotli -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
-                  echo "- **fts5/$(basename "$f")**: $size (gzip: $gzip_size, brotli: $brotli_size)"
-                fi
-              done
-              echo ""
-              echo "## Notes"
-              echo "- All builds include session extension for data synchronization"
-              echo "- mayCreate fixes applied to prevent filesystem errors"
-            } > dist/README.md
+                      # Generate README with build information
+                      {
+                        echo "# wa-sqlite Build Information"
+                        echo ""
+                        echo "This dist directory was built with the following configuration:"
+                        echo ""
+                        echo "## Build Environment"
+                        echo "- **Built on:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+                        echo "- **Emscripten:** $(emcc --version | head -1)"
+                        echo "- **SQLite Version:** ${version}"
+                        echo "- **SQLite Commit:** ${sqliteCommit}"
+                        echo ""
+                        echo "## SQLite Features Enabled"
+                        echo "- Session extension (changesets/sync)"
+                        echo "- Preupdate hooks"  
+                        echo "- Bytecode virtual table"
+                        echo "- FTS5 full-text search (in fts5/ variant)"
+                        echo ""
+                        echo "## Build Variants"
+                        echo ""
+                        echo "### Standard Builds"
+                        echo "- **wa-sqlite.mjs + .wasm**: Web/Worker build with all features"
+                        echo "- **wa-sqlite-async.mjs + .wasm**: Async build for Promise-based usage"
+                        echo "- **wa-sqlite-jspi.mjs + .wasm**: JSPI build for JavaScript Promise Integration"
+                        echo "- **wa-sqlite.node.mjs + .wasm**: Node.js build"
+                        echo ""
+                        echo "### FTS5 Builds"
+                        echo "- **fts5/wa-sqlite.mjs + .wasm**: Web build with FTS5 full-text search"
+                        echo "- **fts5/wa-sqlite.node.mjs + .wasm**: Node.js build with FTS5"
+                        echo ""
+                        echo "## Session/Changeset API Available"
+                        echo "The following session functions are exported and available:"
+                        echo "- \`sqlite3session_create\` - Create session objects"
+                        echo "- \`sqlite3session_attach\` - Attach tables to sessions"
+                        echo "- \`sqlite3session_enable\` - Enable session recording"
+                        echo "- \`sqlite3session_changeset\` - Generate changesets"
+                        echo "- \`sqlite3session_delete\` - Clean up sessions"
+                        echo "- \`sqlite3changeset_start\` - Process changesets"
+                        echo "- \`sqlite3changeset_finalize\` - Finalize changeset processing"
+                        echo "- \`sqlite3changeset_invert\` - Invert changesets"
+                        echo "- \`sqlite3changeset_apply\` - Apply changesets"
+                        echo ""
+                        echo "## Build Script"
+                        echo "Generated via: \`nix build .#wa-sqlite-livestore\`"
+                        echo ""
+                        echo "## File Sizes"
+                        echo ""
+                        echo "### Standard Build Sizes"
+                        for f in dist/*.{mjs,wasm}; do
+                          if [ -f "$f" ]; then
+                            size=$(ls -lah "$f" | awk '{print $5}')
+                            gzip_size=$(gzip -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
+                            brotli_size=$(brotli -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
+                            echo "- **$(basename "$f")**: $size (gzip: $gzip_size, brotli: $brotli_size)"
+                          fi
+                        done
+                        echo ""
+                        echo "### FTS5 Variant Sizes"
+                        for f in dist/fts5/*.{mjs,wasm}; do
+                          if [ -f "$f" ]; then
+                            size=$(ls -lah "$f" | awk '{print $5}')
+                            gzip_size=$(gzip -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
+                            brotli_size=$(brotli -c "$f" | wc -c | awk '{printf "%.1fK", $1/1024}')
+                            echo "- **fts5/$(basename "$f")**: $size (gzip: $gzip_size, brotli: $brotli_size)"
+                          fi
+                        done
+                        echo ""
+                        echo "## Notes"
+                        echo "- All builds include session extension for data synchronization"
+                        echo "- mayCreate fixes applied to prevent filesystem errors"
+                      } > dist/README.md
 
-            runHook postBuild
+                      runHook postBuild
           '';
 
           installPhase = ''
@@ -286,32 +293,34 @@ EOF
         # Convenience app to build and update dist directory
         apps.build = {
           type = "app";
-          program = toString (pkgs.writeShellScript "copy-dist" ''
-            set -euo pipefail
-            
-            echo "Building wa-sqlite with session support and FTS5 variant..."
-            
-            # Build the derivation
-            RESULT=$(nix build --no-link --print-out-paths)
-            
-            # Copy dist directory to current working directory
-            if [ -d "$RESULT/dist" ]; then
-              # Remove old dist with proper permissions handling
-              if [ -d "./dist" ]; then
+          program = toString (
+            pkgs.writeShellScript "copy-dist" ''
+              set -euo pipefail
+
+              echo "Building wa-sqlite with session support and FTS5 variant..."
+
+              # Build the derivation
+              RESULT=$(nix build --no-link --print-out-paths)
+
+              # Copy dist directory to current working directory
+              if [ -d "$RESULT/dist" ]; then
+                # Remove old dist with proper permissions handling
+                if [ -d "./dist" ]; then
+                  chmod -R u+w ./dist
+                  rm -rf ./dist
+                fi
+                cp -r "$RESULT/dist" ./
                 chmod -R u+w ./dist
-                rm -rf ./dist
+                echo "✓ Build complete - dist directory regenerated with session support and FTS5 variant"
+              else
+                echo "ERROR: No dist directory found in build result"
+                exit 1
               fi
-              cp -r "$RESULT/dist" ./
-              chmod -R u+w ./dist
-              echo "✓ Build complete - dist directory regenerated with session support and FTS5 variant"
-            else
-              echo "ERROR: No dist directory found in build result"
-              exit 1
-            fi
-          '');
+            ''
+          );
         };
 
-        # Default app for convenience  
+        # Default app for convenience
         apps.default = self.apps.${system}.build;
 
         # Development shell

--- a/scripts/src/generated/quarantine-ledger.json
+++ b/scripts/src/generated/quarantine-ledger.json
@@ -1,0 +1,8 @@
+{
+  "devtools-suite": {
+    "target": "tests/integration:devtools",
+    "reason": "Every test in the suite fails (0/15). All browser-extension tests die at \"No devtools page found\"; the rest time out on locators. Pre-existing — the suite was silently suppressed from 2025-05-10 until #1404.",
+    "issue": "https://github.com/livestorejs/livestore/issues/1489",
+    "expires": "2026-09-30"
+  }
+}

--- a/scripts/src/generated/quarantine-ledger.json.genie.ts
+++ b/scripts/src/generated/quarantine-ledger.json.genie.ts
@@ -1,5 +1,5 @@
 import { jsonArtifact } from '#mr/effect-utils/packages/@overeng/genie/src/runtime/json-artifact/mod.ts'
 
-import { quarantineLedger } from '../../../genie/quarantine-ledger.ts'
+import { quarantineLedger } from '../shared/quarantine-ledger.ts'
 
 export default jsonArtifact({ data: quarantineLedger })

--- a/scripts/src/generated/quarantine-ledger.json.genie.ts
+++ b/scripts/src/generated/quarantine-ledger.json.genie.ts
@@ -1,0 +1,5 @@
+import { jsonArtifact } from '#mr/effect-utils/packages/@overeng/genie/src/runtime/json-artifact/mod.ts'
+
+import { quarantineLedger } from '../../../genie/quarantine-ledger.ts'
+
+export default jsonArtifact({ data: quarantineLedger })

--- a/scripts/src/shared/quarantine-ledger.ts
+++ b/scripts/src/shared/quarantine-ledger.ts
@@ -8,7 +8,7 @@
  *
  * This module is the source of truth. It stays free of imports so it can be read by a Genie
  * generator source (which must stay out of the runtime dependency closure) and by
- * `scripts/src/shared/test-policy.ts`, which needs the literal type: `QuarantineKey` is
+ * `test-policy.ts`, which needs the literal type: `QuarantineKey` is
  * uninhabited while the ledger is empty, so `TestPolicy.quarantined(...)` cannot be written
  * without a checked-in entry. `scripts/src/generated/quarantine-ledger.json` is generated from
  * here for the CLI, which cannot read TypeScript.

--- a/scripts/src/shared/test-policy.test.ts
+++ b/scripts/src/shared/test-policy.test.ts
@@ -1,65 +1,44 @@
-import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
-import { Effect, Exit, Schema } from '@livestore/utils/effect'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { blocking, expiredEntries, QuarantineEntry, quarantineLedger, runTestTarget } from './test-policy.ts'
+import { Effect, Exit } from '@livestore/utils/effect'
+
+import {
+  blocking,
+  type QuarantineKey,
+  quarantineLedger,
+  quarantineLedgerJsonPath,
+  quarantined,
+  runTestTarget,
+} from './test-policy.ts'
 
 const isoDate = /^\d{4}-\d{2}-\d{2}$/
 
-const today = (): string => new Date().toISOString().slice(0, 10)
-
-const decodeEntry = Schema.decodeUnknownExit(QuarantineEntry)
-
 describe('quarantine ledger', () => {
-  it('has no expired entries', () => {
-    // A quarantine past its expiry reds `test-unit` rather than quietly becoming permanent.
-    // Renew it with a new date and a fresh justification, or delete it.
-    expect(expiredEntries(quarantineLedger, today())).toEqual([])
-  })
-
-  it('flags a lapsed entry and leaves a live one alone', () => {
-    const lapsed = new QuarantineEntry({
-      target: 'packages/@livestore/example',
-      reason: 'demonstrates the expiry rule',
-      issue: 'https://github.com/livestorejs/livestore/issues/1404',
-      expires: '2020-01-01',
-    })
-    const live = new QuarantineEntry({ ...lapsed, expires: '2999-01-01' })
-
-    expect(expiredEntries({ lapsed, live }, today()).map(([key]) => key)).toEqual(['lapsed'])
-  })
-
-  it('treats a malformed expiry as expired rather than never-expiring', () => {
-    // Lexicographic comparison would sort 'someday' above every real date, so a typo would
-    // otherwise create a permanent quarantine.
-    const malformed = new QuarantineEntry({
-      target: 'packages/@livestore/example',
-      reason: 'typo in the expiry',
-      issue: 'https://github.com/livestorejs/livestore/issues/1404',
-      expires: 'someday',
-    })
-
-    expect(expiredEntries({ malformed }, today()).map(([key]) => key)).toEqual(['malformed'])
-  })
-
-  it('rejects a malformed entry', () => {
-    // Exercises the decode used by the shape check above, which otherwise never runs while
-    // the ledger is empty — an unexercised assertion is the failure mode this PR exists to stop.
-    expect(Exit.isSuccess(decodeEntry({ target: 'x', reason: 'y', issue: 'z', expires: '2999-01-01' }))).toBe(true)
-    expect(Exit.isSuccess(decodeEntry({ target: 'x', reason: 'y', issue: 'z' }))).toBe(false)
-  })
-
   it('records a target, reason, issue and a well-formed expiry for every entry', () => {
-    for (const [key, entry] of Object.entries(quarantineLedger as Record<string, QuarantineEntry>)) {
-      expect(Exit.isSuccess(decodeEntry(entry)), `${key} shape`).toBe(true)
-      expect(entry.issue, `${key} issue`).toMatch(/^https:\/\/github\.com\//)
-      expect(entry.expires, `${key} expires`).toMatch(isoDate)
-      expect(entry.reason.length, `${key} reason`).toBeGreaterThan(0)
+    // `ci-tools quarantine validate` enforces this in CI against the generated JSON. Asserting
+    // it here too keeps a malformed entry from reaching that check as a confusing failure.
+    for (const [key, entry] of Object.entries(quarantineLedger)) {
+      expect(entry.target, `${key}.target`).not.toBe('')
+      expect(entry.reason, `${key}.reason`).not.toBe('')
+      expect(entry.issue, `${key}.issue`).toMatch(/^https:\/\/github\.com\//)
+      expect(entry.expires, `${key}.expires`).toMatch(isoDate)
     }
+  })
+
+  it('stays in sync with the generated JSON the CLI reads', () => {
+    // The TS module is the source of truth and the JSON is generated from it, so a drifted
+    // artifact would quarantine one set of targets in the type system and another in CI.
+    expect(JSON.parse(fs.readFileSync(quarantineLedgerJsonPath, 'utf8'))).toEqual(quarantineLedger)
   })
 })
 
 describe('runTestTarget', () => {
+  afterEach(() => restorePath())
+
   it('propagates failure under the blocking policy', async () => {
     const exit = await Effect.runPromiseExit(
       runTestTarget({ label: 'demo', policy: blocking, run: Effect.fail('boom' as const) }),
@@ -69,43 +48,89 @@ describe('runTestTarget', () => {
   })
 
   it('passes success through under the blocking policy', async () => {
-    const exit = await Effect.runPromiseExit(
-      runTestTarget({ label: 'demo', policy: blocking, run: Effect.succeed('ok' as const) }),
-    )
+    const exit = await Effect.runPromiseExit(runTestTarget({ label: 'demo', policy: blocking, run: Effect.succeed(1) }))
 
     expect(Exit.isSuccess(exit)).toBe(true)
   })
 
-  it('refuses a quarantine key with no ledger entry', () => {
-    // The type checker rejects this statically; a cast or a JS caller can still reach it, and
-    // treating an unknown quarantine as "suppress everything" is the failure mode to avoid.
-    expect(() =>
-      runTestTarget({ label: 'packages/@livestore/unrelated', policy: fakePolicy(), run: Effect.void }),
-    ).toThrow(/has no entry in the ledger/)
-  })
-
-  it('refuses a real quarantine applied to a target it does not declare', () => {
-    const [key, entry] = Object.entries(quarantineLedger as Record<string, QuarantineEntry>)[0] ?? []
-    if (key === undefined || entry === undefined) return
-
-    expect(() =>
-      runTestTarget({ label: `${entry.target}-but-not-really`, policy: fakePolicy(key), run: Effect.void }),
-    ).toThrow(/declares target/)
-  })
-
-  it('swallows a failure for a correctly declared quarantine', async () => {
-    // The mechanism's whole point. Without this, dropping the `Effect.ignore` would pass the suite.
-    const [key, entry] = Object.entries(quarantineLedger as Record<string, QuarantineEntry>)[0] ?? []
-    if (key === undefined || entry === undefined) return
+  it('swallows a declared quarantine failure, and announces it with the ledger entry', async () => {
+    // The mechanism's whole point. The stub stands in for the real `ci-tools` so the wiring —
+    // argv, ledger path, key, label — is exercised without depending on the binary being built.
+    const { key, entry } = firstLedgerEntry()
+    const calls = stubCiTools({ exitCode: 0 })
 
     const exit = await Effect.runPromiseExit(
-      runTestTarget({ label: entry.target, policy: fakePolicy(key), run: Effect.fail('boom' as const) }),
+      runTestTarget({ label: entry.target, policy: quarantined(key), run: Effect.fail('boom' as const) }),
     )
 
     expect(Exit.isSuccess(exit)).toBe(true)
+    expect(calls()).toEqual([
+      ['quarantine', 'announce', '--ledger', quarantineLedgerJsonPath, '--key', key, '--label', entry.target],
+    ])
+  })
+
+  it('fails when the announcement does, rather than tolerating a failure with no signal', async () => {
+    // Losing the signal while still suppressing the failure is the outcome the whole mechanism
+    // exists to prevent, so a broken announcer must be loud.
+    const { key, entry } = firstLedgerEntry()
+    stubCiTools({ exitCode: 1 })
+
+    const exit = await Effect.runPromiseExit(
+      runTestTarget({ label: entry.target, policy: quarantined(key), run: Effect.fail('boom' as const) }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  it('does not reach the announcer for a blocking target', () => {
+    const calls = stubCiTools({ exitCode: 0 })
+
+    Effect.runSyncExit(runTestTarget({ label: 'demo', policy: blocking, run: Effect.fail('boom' as const) }))
+
+    expect(calls()).toEqual([])
   })
 })
 
-/** A quarantine policy the type checker would reject, to reach the runtime guards. */
-const fakePolicy = (key = 'demo-entry'): Parameters<typeof runTestTarget>[0]['policy'] =>
-  ({ _tag: 'quarantined', key }) as unknown as Parameters<typeof runTestTarget>[0]['policy']
+let originalPath: string | undefined
+
+/** The ledger is non-empty by construction; a quarantine test with nothing to test is a bug. */
+const firstLedgerEntry = () => {
+  const key = (Object.keys(quarantineLedger) as QuarantineKey[])[0]
+  if (key === undefined) throw new Error('quarantineLedger is empty; these tests need an entry to exercise.')
+  return { key, entry: quarantineLedger[key] }
+}
+
+/**
+ * Puts a fake `ci-tools` on `PATH` that records its argv, so the announce path can be tested
+ * without the real binary. Returns a reader for the recorded invocations.
+ */
+const stubCiTools = ({ exitCode }: { readonly exitCode: number }): (() => readonly string[][]) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-tools-stub-'))
+  const log = path.join(dir, 'calls.tsv')
+  const bin = path.join(dir, 'ci-tools')
+
+  fs.writeFileSync(
+    bin,
+    `#!/usr/bin/env bash\nprintf '%s\\t' "$@" >> '${log}'\nprintf '\\n' >> '${log}'\nexit ${exitCode}\n`,
+    {
+      mode: 0o755,
+    },
+  )
+
+  originalPath = process.env.PATH
+  process.env.PATH = `${dir}${path.delimiter}${originalPath ?? ''}`
+
+  return () =>
+    fs.existsSync(log) === true
+      ? fs
+          .readFileSync(log, 'utf8')
+          .split('\n')
+          .filter((line) => line.length > 0)
+          .map((line) => line.split('\t').filter((arg) => arg.length > 0))
+      : []
+}
+
+const restorePath = (): void => {
+  if (originalPath !== undefined) process.env.PATH = originalPath
+  originalPath = undefined
+}

--- a/scripts/src/shared/test-policy.test.ts
+++ b/scripts/src/shared/test-policy.test.ts
@@ -73,12 +73,17 @@ describe('runTestTarget', () => {
     // Losing the signal while still suppressing the failure is the outcome the whole mechanism
     // exists to prevent, so a broken announcer must be loud.
     const { key, entry } = firstLedgerEntry()
-    stubCiTools({ exitCode: 1 })
+    const calls = stubCiTools({ exitCode: 1 })
 
     const exit = await Effect.runPromiseExit(
       runTestTarget({ label: entry.target, policy: quarantined(key), run: Effect.fail('boom' as const) }),
     )
 
+    // Asserting the stub actually ran matters: `ci-tools` is absent from a bare checkout, so
+    // without this the test would also pass on a spawn ENOENT — including if `Effect.ignore`
+    // were deleted outright. It has to prove "non-zero announcer exit ⇒ fatal", not merely
+    // "announcing didn't succeed ⇒ fatal".
+    expect(calls()).toHaveLength(1)
     expect(Exit.isFailure(exit)).toBe(true)
   })
 
@@ -117,8 +122,9 @@ const stubCiTools = ({ exitCode }: { readonly exitCode: number }): (() => readon
     },
   )
 
-  originalPath = process.env.PATH
-  process.env.PATH = `${dir}${path.delimiter}${originalPath ?? ''}`
+  if (originalPath !== undefined) throw new Error('stubCiTools called twice; the first stub would leak onto PATH.')
+  originalPath = process.env.PATH ?? ''
+  process.env.PATH = `${dir}${path.delimiter}${originalPath}`
 
   return () =>
     fs.existsSync(log) === true

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -1,6 +1,9 @@
-import fs from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
-import { Effect, Schema } from '@livestore/utils/effect'
+import { Effect } from '@livestore/utils/effect'
+
+import type { QuarantineKey } from '../../../genie/quarantine-ledger.ts'
 
 /**
  * How a test target's failures reach the job's exit code.
@@ -8,8 +11,9 @@ import { Effect, Schema } from '@livestore/utils/effect'
  * Test targets invoked through {@link runTestTarget} state their policy explicitly, so
  * weakening one is a deliberate, reviewable act rather than a `.pipe(Effect.ignore)` or a
  * `|| true` buried in a task wrapper. Quarantining is reachable only through
- * {@link quarantined}, which accepts a key of {@link quarantineLedger} — so a quarantine here
- * cannot exist without a checked-in entry carrying a reason, tracking issue, and expiry date.
+ * {@link quarantined}, which accepts a key of `quarantineLedger` — so a quarantine here cannot
+ * exist without a checked-in entry carrying a reason, tracking issue, and expiry date. The
+ * ledger lives in `genie/quarantine-ledger.ts`; `ci-tools quarantine` owns what an entry means.
  *
  * What this is NOT: a chokepoint. It governs whole invocations, not individual tests, and it
  * is opt-in — `it.skip`, `test.todo`, an `exclude` glob, piping `Effect.ignore` onto the
@@ -25,43 +29,21 @@ export const blocking: TestPolicy = { _tag: 'blocking' }
 /** Failures are reported but do not fail the job, under a declared, expiring ledger entry. */
 export const quarantined = (key: QuarantineKey): TestPolicy => ({ _tag: 'quarantined', key })
 
-export class QuarantineEntry extends Schema.Class<QuarantineEntry>('QuarantineEntry')({
-  /** What is quarantined — a package path, provider key, or suite name. */
-  target: Schema.String,
-  /** Why its failures are currently tolerated. */
-  reason: Schema.String,
-  /** Issue tracking the underlying problem. */
-  issue: Schema.String,
-  /** `YYYY-MM-DD`. Past this date the ledger check fails, forcing a renew-or-remove decision. */
-  expires: Schema.String,
-}) {}
+export { type QuarantineEntry, type QuarantineKey, quarantineLedger } from '../../../genie/quarantine-ledger.ts'
 
-/**
- * Every currently-tolerated test failure in the repository.
- *
- * Empty is the intended steady state: it means no required check is lying. Entries are
- * expected to be rare and short-lived — `expires` is enforced by
- * `test-policy.test.ts`, so a forgotten quarantine reds `test-unit` instead of
- * silently becoming permanent.
- */
-export const quarantineLedger = {
-  'devtools-suite': new QuarantineEntry({
-    target: 'tests/integration:devtools',
-    reason:
-      'Every test in the suite fails (0/15). All browser-extension tests die at "No devtools page found"; the rest time out on locators. Pre-existing — the suite was silently suppressed from 2025-05-10 until #1404.',
-    issue: 'https://github.com/livestorejs/livestore/issues/1489',
-    expires: '2026-09-30',
-  }),
-} as const satisfies Record<string, QuarantineEntry>
-
-export type QuarantineKey = keyof typeof quarantineLedger
+/** Generated from {@link quarantineLedger}; the CLI reads JSON, not TypeScript. */
+export const quarantineLedgerJsonPath = fileURLToPath(new URL('../generated/quarantine-ledger.json', import.meta.url))
 
 /**
  * Runs a test target under its stated policy.
  *
- * A quarantined failure is announced on its own line and in the job summary, so a suppressed
- * failure is distinguishable from a genuine pass — the property the previous `::warning::`
- * wrappers lacked, being indistinguishable from unrelated Actions warnings.
+ * A quarantined failure is announced by `ci-tools quarantine announce`, which owns what a
+ * quarantine means: it resolves the key against the ledger, refuses an entry applied to a
+ * target it does not declare, writes the job-summary line, and emits the `::warning::`
+ * annotation. A failure to announce is fatal rather than ignored — tolerating a
+ * failure *and* losing its signal is the exact outcome this mechanism exists to prevent.
+ *
+ * Contract: effect-utils `context/ci-tools/01-quarantine/`.
  */
 export const runTestTarget = <A, E, R>({
   label,
@@ -74,66 +56,25 @@ export const runTestTarget = <A, E, R>({
 }): Effect.Effect<void, E, R> => {
   if (policy._tag === 'blocking') return run.pipe(Effect.asVoid)
 
-  const entry = (quarantineLedger as Record<string, QuarantineEntry>)[policy.key]
-
-  // The type checker rejects an unknown key, but a cast or a JS caller can still get here, and
-  // silently treating an unknown quarantine as "suppress everything" is the failure this whole
-  // mechanism exists to prevent.
-  if (entry === undefined) {
-    throw new Error(`Quarantine '${String(policy.key)}' has no entry in the ledger.`)
-  }
-
-  // The ledger's `target` is the declaration of what is suppressed, so it has to be enforced
-  // rather than decorative: without this, one entry's key could silently suppress an unrelated
-  // target under another target's reason, issue, and expiry.
-  if (entry.target !== label) {
-    throw new Error(
-      `Quarantine '${String(policy.key)}' declares target ${JSON.stringify(entry.target)} but was applied to ${JSON.stringify(label)}.`,
-    )
-  }
-
   return run.pipe(
     Effect.asVoid,
-    Effect.tapError(() => Effect.sync(() => announceQuarantinedFailure(label, entry))),
+    Effect.tapError(() => Effect.sync(() => announceQuarantinedFailure(label, policy.key))),
     Effect.ignore,
   )
 }
 
-/**
- * Entries whose expiry has passed, relative to `today` (`YYYY-MM-DD`).
- *
- * Takes the ledger as an argument so the expiry rule stays testable while the real ledger is
- * empty — otherwise the check that keeps quarantines from becoming permanent would itself be
- * unverified.
- */
-export const expiredEntries = (
-  ledger: Record<string, QuarantineEntry>,
-  today: string,
-): readonly (readonly [string, QuarantineEntry])[] =>
-  Object.entries(ledger).filter(([, entry]) => isExpired(entry.expires, today))
+const announceQuarantinedFailure = (label: string, key: QuarantineKey): void => {
+  const result = spawnSync(
+    'ci-tools',
+    ['quarantine', 'announce', '--ledger', quarantineLedgerJsonPath, '--key', key, '--label', label],
+    { stdio: 'inherit' },
+  )
 
-const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/
-
-/**
- * A malformed `expires` counts as expired.
- *
- * Comparison is lexicographic, so any free-form string (`'someday'`) sorts above every real
- * date and would otherwise never expire — turning a typo into a permanent quarantine, which
- * is the outcome the expiry rule exists to prevent.
- */
-const isExpired = (expires: string, today: string): boolean => isoDatePattern.test(expires) === false || expires < today
-
-const announceQuarantinedFailure = (label: string, entry: QuarantineEntry): void => {
-  const summary = `Quarantined failure: ${label} — ${entry.reason} Tracking ${entry.issue}, expires ${entry.expires}.`
-
-  // The job summary is the load-bearing channel. The annotation below is best-effort: a
-  // tolerated failure exits 0, and `devenv tasks run` prints a task's stdout only when the
-  // task fails, so this line is discarded whenever the run happens under devenv — the same
-  // trap that made the old `|| echo "::warning::"` wrappers invisible for over a year.
-  const summaryPath = process.env.GITHUB_STEP_SUMMARY
-  if (summaryPath !== undefined && summaryPath !== '') {
-    fs.appendFileSync(summaryPath, `- ${summary}\n`)
+  if (result.error !== undefined) {
+    throw new Error(`Could not announce quarantined failure for ${label}: ${result.error.message}`)
   }
 
-  console.log(`::warning title=Quarantined test failure::${summary}`)
+  if (result.status !== 0) {
+    throw new Error(`Announcing the quarantined failure for ${label} failed with exit code ${result.status}.`)
+  }
 }

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 
 import { Effect } from '@livestore/utils/effect'
 
-import type { QuarantineKey } from '../../../genie/quarantine-ledger.ts'
+import type { QuarantineKey } from './quarantine-ledger.ts'
 
 /**
  * How a test target's failures reach the job's exit code.
@@ -13,7 +13,7 @@ import type { QuarantineKey } from '../../../genie/quarantine-ledger.ts'
  * `|| true` buried in a task wrapper. Quarantining is reachable only through
  * {@link quarantined}, which accepts a key of `quarantineLedger` — so a quarantine here cannot
  * exist without a checked-in entry carrying a reason, tracking issue, and expiry date. The
- * ledger lives in `genie/quarantine-ledger.ts`; `ci-tools quarantine` owns what an entry means.
+ * ledger lives in `scripts/src/shared/quarantine-ledger.ts`; `ci-tools quarantine` owns what an entry means.
  *
  * What this is NOT: a chokepoint. It governs whole invocations, not individual tests, and it
  * is opt-in — `it.skip`, `test.todo`, an `exclude` glob, piping `Effect.ignore` onto the
@@ -29,7 +29,7 @@ export const blocking: TestPolicy = { _tag: 'blocking' }
 /** Failures are reported but do not fail the job, under a declared, expiring ledger entry. */
 export const quarantined = (key: QuarantineKey): TestPolicy => ({ _tag: 'quarantined', key })
 
-export { type QuarantineEntry, type QuarantineKey, quarantineLedger } from '../../../genie/quarantine-ledger.ts'
+export { type QuarantineEntry, type QuarantineKey, quarantineLedger } from './quarantine-ledger.ts'
 
 /** Generated from {@link quarantineLedger}; the CLI reads JSON, not TypeScript. */
 export const quarantineLedgerJsonPath = fileURLToPath(new URL('../generated/quarantine-ledger.json', import.meta.url))

--- a/scripts/src/shared/test-policy.ts
+++ b/scripts/src/shared/test-policy.ts
@@ -10,10 +10,12 @@ import type { QuarantineKey } from './quarantine-ledger.ts'
  *
  * Test targets invoked through {@link runTestTarget} state their policy explicitly, so
  * weakening one is a deliberate, reviewable act rather than a `.pipe(Effect.ignore)` or a
- * `|| true` buried in a task wrapper. Quarantining is reachable only through
- * {@link quarantined}, which accepts a key of `quarantineLedger` — so a quarantine here cannot
- * exist without a checked-in entry carrying a reason, tracking issue, and expiry date. The
- * ledger lives in `scripts/src/shared/quarantine-ledger.ts`; `ci-tools quarantine` owns what an entry means.
+ * `|| true` buried in a task wrapper. A quarantine names a key of `quarantineLedger`, so it
+ * cannot exist without a checked-in entry carrying a reason, tracking issue, and expiry date —
+ * when the ledger is empty `QuarantineKey` is `never` and no quarantine can be written at all.
+ * (`TestPolicy` is a plain union, so a caller can spell the object literal instead of using
+ * {@link quarantined}; the ledger constraint binds either way.) The ledger lives in
+ * `scripts/src/shared/quarantine-ledger.ts`; `ci-tools quarantine` owns what an entry means.
  *
  * What this is NOT: a chokepoint. It governs whole invocations, not individual tests, and it
  * is opt-in — `it.skip`, `test.todo`, an `exclude` glob, piping `Effect.ignore` onto the
@@ -26,7 +28,11 @@ export type TestPolicy = { readonly _tag: 'blocking' } | { readonly _tag: 'quara
 /** Failures fail the job. The default for every target. */
 export const blocking: TestPolicy = { _tag: 'blocking' }
 
-/** Failures are reported but do not fail the job, under a declared, expiring ledger entry. */
+/**
+ * Expected failures are reported but do not fail the job, under a declared, expiring ledger
+ * entry. Only the `Fail` channel is tolerated: a defect or an interruption still fails the job,
+ * and is not announced.
+ */
 export const quarantined = (key: QuarantineKey): TestPolicy => ({ _tag: 'quarantined', key })
 
 export { type QuarantineEntry, type QuarantineKey, quarantineLedger } from './quarantine-ledger.ts'
@@ -58,23 +64,30 @@ export const runTestTarget = <A, E, R>({
 
   return run.pipe(
     Effect.asVoid,
-    Effect.tapError(() => Effect.sync(() => announceQuarantinedFailure(label, policy.key))),
+    Effect.tapError((cause) => Effect.sync(() => announceQuarantinedFailure(label, policy.key, cause))),
     Effect.ignore,
   )
 }
 
-const announceQuarantinedFailure = (label: string, key: QuarantineKey): void => {
+const announceQuarantinedFailure = (label: string, key: QuarantineKey, cause: unknown): void => {
   const result = spawnSync(
     'ci-tools',
     ['quarantine', 'announce', '--ledger', quarantineLedgerJsonPath, '--key', key, '--label', label],
     { stdio: 'inherit' },
   )
 
+  // The original failure is carried into the message: this path discards the quarantined
+  // error to surface the announcer's, and without it the red job would say only that
+  // announcing broke, never what actually failed.
   if (result.error !== undefined) {
-    throw new Error(`Could not announce quarantined failure for ${label}: ${result.error.message}`)
+    throw new Error(
+      `Could not announce quarantined failure for ${label}: ${result.error.message}. Original failure: ${String(cause)}`,
+    )
   }
 
   if (result.status !== 0) {
-    throw new Error(`Announcing the quarantined failure for ${label} failed with exit code ${result.status}.`)
+    throw new Error(
+      `Announcing the quarantined failure for ${label} failed with exit code ${result.status}. Original failure: ${String(cause)}`,
+    )
   }
 }


### PR DESCRIPTION
## Problem

The quarantine mechanism from #1494 carried what a quarantine *means* — the entry schema, the
expiry rule, the announcement — inside this repo, where none of it is this repo's to own. A
second repo adopting the pattern would have copied ~130 lines of generic logic, and the
semantics could drift between them with nothing detecting it.

## Goal

This repo declares *which* targets are quarantined, and nothing about what a quarantine is or
how CI is told about one.

## Decisions

**The mechanism moved to `ci-tools quarantine`** (overengineeringstudio/effect-utils#971,
merged). It owns the entry schema, the expiry rule including its fail-closed handling of
malformed dates, the two resolution guards, and the announcement. Contract stated in that
repo's `context/ci-tools/01-quarantine/`.

**Consumed as a Nix-built binary, not a workspace package.** This repo already gets `genie`,
`effect-tsgo`, `megarepo`, and `ci-tools` from the `effect-utils` flake input pinned by
`devenv.lock`. A `repos/effect-utils/...` entry in `pnpm-workspace.yaml` would instead make
`pnpm install` require `mr apply` — for every external contributor of a public repo, and every
CI job. That boundary was real but written down nowhere, so it is now **LS.DEL.COMP-R19**, with
`.decisions/0001-shared-tooling-consumption-channel.md` recording the rejected alternatives.

**The ledger stays TypeScript.** `genie/quarantine-ledger.ts` is the source of truth, so
`QuarantineKey` is uninhabited while the ledger is empty and `quarantined(...)` cannot be
written without a checked-in entry — the strongest property the design has. Genie emits the
JSON the CLI reads, and `lint:check:genie` catches drift.

**A failed announcement is fatal.** Tolerating a failure *and* losing its signal is precisely
what the mechanism exists to prevent.

**`runTestTarget` stays here**, because the blocking-vs-tolerated decision is about this repo's
lanes and its Effect-shaped orchestration.

**Adopts `lint-nix`**, bringing nixfmt and deadnix to this repo's four tracked `.nix` files.
(`hasNixCheck = false` gates the nix-cli *build* tasks and is unrelated; it stays.)

## Verification

Against the pinned `ci-tools` binary (`99c8c7764`, which `main` already pins — the repin this
branch originally carried is now redundant and was dropped in the rebase):

```
quarantine validate                    → exit 0
quarantine validate --today 2026-10-01 → exit 1
runTestTarget, quarantined failure     → tolerated
    stdout: ::warning title=Quarantined test failure::Quarantined failure: … expires 2026-09-30.
    $GITHUB_STEP_SUMMARY: - Quarantined failure: … expires 2026-09-30.
```

```
vitest test-policy + intent-layer  → 15 passed
tsgo --build tsconfig.json         → exit 0
genie --check                      → 83 files, all unchanged
nixfmt --check / deadnix           → clean
oxfmt --check (changed files)      → clean
```

Unit tests stub `ci-tools` on `PATH` and assert the exact argv, so the announce wiring is
covered without depending on the binary; the blocking path is asserted never to reach it.

**LS.DEL.COMP-R19**, verified on a clean clone with no `repos/` and no `mr apply`:
`pnpm install` exit 0, `tsgo --build` exit 0, `vitest packages/@livestore/common/src` 19 files /
268 tests passed.

## Complexity

One data module, one generated artifact, one 12-line devenv task. `test-policy.ts` gets
*smaller*: the schema, expiry rule, and announcement all leave.

## Concerns

**A subprocess per tolerated failure**, and the ledger crosses as JSON. That is the price of
not coupling `pnpm install` to megarepo materialization. Tolerated failures are rare by
construction.

**`ci-tools` must be on `PATH`** — it is, via `devenv.nix`. Outside devenv a quarantined failure
now errors instead of being silently tolerated. Deliberate, per the fatal-announcement decision.

**The `style(nix)` commit is pure reformatting**, including `packages/@livestore/wa-sqlite/flake.nix`,
a vendored fork that `genieCoverageExcludes` deliberately leaves unmanaged. Adopting `lint-nix`
makes `lint:nix:format` a required check and the module has no ignore mechanism, so it was that
or an upstream change. Kept as its own commit so it can be skipped in review.

## Note on scope

Earlier revisions of this branch also carried a stderr workaround, on the belief that devenv
discards a task's stdout so workflow commands never reached the runner. That was wrong — it came
from a local measurement taken inside a coding agent, where devenv's implicit quiet mode applies.
A [CI probe](https://github.com/schickling-repros/2026-07-devenv-task-stdout-discarded/actions/runs/30297762510)
shows a task's stdout becomes an annotation on a GitHub runner with no opt-in. All of that is
removed here and upstream (#971, effect-utils#974); the announcement uses stdout, which is what
GitHub documents.

## Follow-ups

- `LS.SYS.VER.LANE-R04` stays "not met": its open items are DELTA-003 and DELTA-004, neither
  addressed here.

## References

- Closes #968
- Refs #1494, #1489
- Upstream: overengineeringstudio/effect-utils#971, #974

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-iris |
| `agent_session_id` | f0a25af9-c1ee-48a5-add1-5ea39125b283 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-27-fix-quarantine-annotation |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->