### PR TITLE
refactor: add SQLite savepoint helper

### DIFF
--- a/.changeset/empty-sqlite-savepoint-helpers.md
+++ b/.changeset/empty-sqlite-savepoint-helpers.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Adds an internal SQLite savepoint helper for later materialization rollback refactors.

--- a/packages/@livestore/common/src/sqlite-db-helper.ts
+++ b/packages/@livestore/common/src/sqlite-db-helper.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@livestore/utils/effect'
+import { Effect, Exit, Function, Schema } from '@livestore/utils/effect'
 
 import { type SqliteDb, SqliteError } from './adapter-types.ts'
 import { getResultSchema, isQueryBuilder } from './schema/state/sqlite/query-builder/mod.ts'
@@ -39,6 +39,68 @@ export const makeSelect = <T>(
     }
   }
 }
+
+/**
+ * Runs an Effect inside an SQLite savepoint.
+ *
+ * @remarks
+ *
+ * This starts a savepoint before running `effect`, releases the savepoint on
+ * success, and rolls back to the savepoint before re-emitting the original
+ * failure on failure.
+ *
+ * Use this for atomic DB updates that need to compose with callers that may
+ * already have an open transaction.
+ *
+ * @see {@link https://sqlite.org/lang_savepoint.html | SQLite savepoint documentation}
+ * @see {@link https://sqlite.org/lang_transaction.html | SQLite transaction documentation}
+ */
+export const withSavepoint: {
+  (db: SqliteDb): <A, E, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A, E | SqliteError, R>
+  <A, E, R>(self: Effect.Effect<A, E, R>, db: SqliteDb): Effect.Effect<A, E | SqliteError, R>
+} = Function.dual(
+  2,
+  <A, E, R>(self: Effect.Effect<A, E, R>, db: SqliteDb): Effect.Effect<A, E | SqliteError, R> =>
+    Effect.uninterruptibleMask((restore) =>
+      Effect.sync(generateSavepointName).pipe(
+        Effect.flatMap((savepointName) => {
+          const savepointSql = `SAVEPOINT ${savepointName}`
+          const releaseSql = `RELEASE SAVEPOINT ${savepointName}`
+
+          return executeSavepointSql(db, savepointSql).pipe(
+            // Cleanup is installed only after SQLite successfully creates the savepoint.
+            Effect.andThen(
+              restore(self).pipe(
+                Effect.exit,
+                Effect.flatMap((exit) => {
+                  const cleanup =
+                    Exit.isSuccess(exit) === true
+                      ? executeSavepointSql(db, releaseSql)
+                      : executeSavepointSql(db, `ROLLBACK TO SAVEPOINT ${savepointName}`).pipe(
+                          Effect.andThen(executeSavepointSql(db, releaseSql)),
+                        )
+
+                  // Cleanup failures supersede the wrapped exit because the connection state is uncertain.
+                  return cleanup.pipe(Effect.andThen(exit))
+                }),
+              ),
+            ),
+          )
+        }),
+      ),
+    ),
+)
+
+let nextSavepointId = 0
+
+/** Uses a reserved prefix and process-local counter to avoid caller-controlled or reused identifiers. */
+const generateSavepointName = () => `livestore_savepoint_${nextSavepointId++}`
+
+const executeSavepointSql = (db: SqliteDb, sql: string): Effect.Effect<void, SqliteError> =>
+  Effect.try({
+    try: () => db.execute(sql),
+    catch: (cause) => new SqliteError({ cause, query: { sql, bindValues: [] } }),
+  })
 
 export const validateSnapshot = (snapshot: Uint8Array) => {
   const headerBytes = new TextDecoder().decode(snapshot.slice(0, 16))

--- a/tests/package-common/src/sqlite-db-helper.test.ts
+++ b/tests/package-common/src/sqlite-db-helper.test.ts
@@ -1,0 +1,199 @@
+import { expect } from 'vitest'
+
+import { SqliteDbHelper, SqliteError } from '@livestore/common'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Deferred, Effect, Fiber } from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+const setup = Effect.gen(function* () {
+  const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+  const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+  const db = yield* makeSqliteDb({ _tag: 'in-memory' })
+
+  db.execute('CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)')
+
+  return { db, sqlite3 }
+})
+
+Vitest.describe('withSavepoint', () => {
+  Vitest.live('rolls back failed effects', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+
+      const exit = yield* SqliteDbHelper.withSavepoint(
+        Effect.gen(function* () {
+          db.execute("INSERT INTO test (id, value) VALUES (1, 'rolled-back')")
+          return yield* Effect.fail('rollback')
+        }),
+        db,
+      ).pipe(Effect.exit)
+
+      expect(exit._tag).toEqual('Failure')
+
+      const rows = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rows).toEqual([])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('returns SqliteError without cleanup when savepoint acquisition fails', (test) =>
+    Effect.gen(function* () {
+      const { db, sqlite3 } = yield* setup
+      const savepointOperations: string[] = []
+      let effectRan = false
+
+      const SQLITE_OK = 0
+      const SQLITE_DENY = 1
+      const SQLITE_SAVEPOINT = 32
+      sqlite3.set_authorizer(
+        db.metadata.dbPointer,
+        (_userData, actionCode, operation) => {
+          if (actionCode === SQLITE_SAVEPOINT) {
+            savepointOperations.push(operation ?? '')
+            return SQLITE_DENY
+          }
+
+          return SQLITE_OK
+        },
+        undefined,
+      )
+
+      const error = yield* Effect.sync(() => {
+        effectRan = true
+      }).pipe(SqliteDbHelper.withSavepoint(db), Effect.flip)
+
+      expect(error).toBeInstanceOf(SqliteError)
+      expect(error.query?.sql).toMatch(/^SAVEPOINT livestore_savepoint_\d+$/)
+      expect(effectRan).toBe(false)
+      expect(savepointOperations).toEqual(['BEGIN'])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('returns SqliteError when releasing the savepoint fails', (test) =>
+    Effect.gen(function* () {
+      const { db, sqlite3 } = yield* setup
+
+      const SQLITE_OK = 0
+      const SQLITE_DENY = 1
+      const SQLITE_SAVEPOINT = 32
+      sqlite3.set_authorizer(
+        db.metadata.dbPointer,
+        (_userData, actionCode, operation) =>
+          actionCode === SQLITE_SAVEPOINT && operation === 'RELEASE' ? SQLITE_DENY : SQLITE_OK,
+        undefined,
+      )
+
+      const error = yield* Effect.void.pipe(SqliteDbHelper.withSavepoint(db), Effect.flip)
+
+      expect(error).toBeInstanceOf(SqliteError)
+      expect(error.query?.sql).toMatch(/^RELEASE SAVEPOINT livestore_savepoint_\d+$/)
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('returns SqliteError when rolling back to the savepoint fails', (test) =>
+    Effect.gen(function* () {
+      const { db, sqlite3 } = yield* setup
+
+      const SQLITE_OK = 0
+      const SQLITE_DENY = 1
+      const SQLITE_SAVEPOINT = 32
+      sqlite3.set_authorizer(
+        db.metadata.dbPointer,
+        (_userData, actionCode, operation) =>
+          actionCode === SQLITE_SAVEPOINT && operation === 'ROLLBACK' ? SQLITE_DENY : SQLITE_OK,
+        undefined,
+      )
+
+      const error = yield* Effect.fail('wrapped failure').pipe(SqliteDbHelper.withSavepoint(db), Effect.flip)
+
+      expect(error).toBeInstanceOf(SqliteError)
+      if (error instanceof SqliteError) {
+        expect(error.query?.sql).toMatch(/^ROLLBACK TO SAVEPOINT livestore_savepoint_\d+$/)
+      }
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('composes inside an outer transaction', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+
+      db.execute('BEGIN TRANSACTION')
+
+      db.execute("INSERT INTO test (id, value) VALUES (1, 'outer')")
+
+      yield* Effect.sync(() => {
+        db.execute("INSERT INTO test (id, value) VALUES (2, 'inner')")
+      }).pipe(SqliteDbHelper.withSavepoint(db))
+
+      yield* Effect.sync(() => {
+        db.execute("INSERT INTO test (id, value) VALUES (3, 'rolled-back')")
+      }).pipe(Effect.andThen(Effect.fail('rollback inner')), SqliteDbHelper.withSavepoint(db), Effect.ignore)
+
+      db.execute('COMMIT')
+
+      const rows = db.select<{ id: number; value: string }>('SELECT id, value FROM test ORDER BY id ASC')
+      expect(rows).toEqual([
+        { id: 1, value: 'outer' },
+        { id: 2, value: 'inner' },
+      ])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('rolls back and releases on interruption', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+      const started = yield* Deferred.make<void>()
+
+      const fiber = yield* Effect.gen(function* () {
+        db.execute("INSERT INTO test (id, value) VALUES (1, 'interrupted')")
+        yield* Deferred.succeed(started, undefined)
+        return yield* Effect.never
+      }).pipe(SqliteDbHelper.withSavepoint(db), Effect.forkScoped)
+
+      yield* Deferred.await(started)
+      yield* Fiber.interrupt(fiber)
+
+      const rows = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rows).toEqual([])
+
+      db.execute("INSERT INTO test (id, value) VALUES (2, 'after-interrupt')")
+      const rowsAfterInterrupt = db.select<{ value: string }>('SELECT value FROM test')
+      expect(rowsAfterInterrupt).toEqual([{ value: 'after-interrupt' }])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('runs nested success and rollback branches synchronously', (test) =>
+    Effect.gen(function* () {
+      const { db } = yield* setup
+      const context = yield* Effect.context()
+
+      const result = yield* Effect.sync(() =>
+        Effect.runSyncWith(context)(
+          Effect.sync(() => {
+            db.execute("INSERT INTO test (id, value) VALUES (1, 'outer-before')")
+          }).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                db.execute("INSERT INTO test (id, value) VALUES (2, 'inner-rolled-back')")
+              }).pipe(Effect.andThen(Effect.fail('rollback inner')), SqliteDbHelper.withSavepoint(db), Effect.ignore),
+            ),
+            Effect.andThen(
+              Effect.sync(() => {
+                db.execute("INSERT INTO test (id, value) VALUES (3, 'outer-after')")
+              }),
+            ),
+            SqliteDbHelper.withSavepoint(db),
+            Effect.as('result'),
+          ),
+        ),
+      )
+
+      expect(result).toEqual('result')
+      expect(db.select<{ id: number; value: string }>('SELECT id, value FROM test ORDER BY id ASC')).toEqual([
+        { id: 1, value: 'outer-before' },
+        { id: 3, value: 'outer-after' },
+      ])
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+})


### PR DESCRIPTION
## Problem

LiveStore needs atomic SQLite writes that compose with an existing transaction. SQLite `BEGIN` transactions do not nest, and incorrect savepoint cleanup can leave partial writes or an active savepoint after failure or interruption. Savepoint names also cannot be bound as query parameters.

## Solution

Add `SqliteDbHelper.withSavepoint`, an Effect combinator that:

- supports pipeable and data-first usage
- generates savepoint names internally
- releases on success and rolls back then releases on failure, defect, or interruption
- maps acquisition and cleanup SQL failures to query-aware `SqliteError` values
- masks interruption during setup and cleanup while keeping the wrapped Effect interruptible
- composes with outer transactions and preserves synchronous execution

Focused tests cover acquisition and cleanup SQL errors, typed failure rollback, outer transaction composition, interruption cleanup, and nested synchronous success and rollback. This PR adds the primitive without runtime call sites; an empty changeset records no release-note impact.

## Validation

- `devenv shell -- vitest run tests/package-common/src/sqlite-db-helper.test.ts` — 7 tests passed
- `devenv tasks run test:unit`
- `devenv tasks run ts:check`
- `devenv tasks run lint:full:fix`
- `devenv tasks run lint:full`
- commit hook: `check-quick`

## Trade-offs

- Savepoints are connection-scoped, so callers must serialize access to `db` for the wrapped Effect's lifetime.
- If cleanup SQL fails, that typed failure supersedes the wrapped Effect's exit because the connection state may be uncertain.