### PR TITLE
fix(docs): repair the docs search sync pipeline

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -965,7 +965,7 @@ jobs:
           bash "$__genie_ci_retry_script" 'devenv tasks run docs:search:sync:prod' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:search:sync:prod'
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
-          MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
+          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/deploy-prod.yml.genie.ts
+++ b/.github/workflows/deploy-prod.yml.genie.ts
@@ -178,7 +178,7 @@ export default githubWorkflow({
           run: runDevenvTasksBefore('docs:search:sync:prod'),
           env: {
             MXBAI_API_KEY: '${{ secrets.MXBAI_API_KEY }}',
-            MXBAI_VECTOR_STORE_ID: '${{ secrets.MXBAI_VECTOR_STORE_ID }}',
+            MXBAI_VECTOR_STORE_ID_PROD: '${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}',
           },
         },
       ]),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1703,7 +1703,7 @@ jobs:
           bash "$__genie_ci_retry_script" 'devenv tasks run docs:search:sync:prod' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:search:sync:prod'
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
-          MXBAI_VECTOR_STORE_ID: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
+          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
       - name: Save pnpm state
         if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -1048,7 +1048,7 @@ fi`,
           run: runDevenvTasksBefore('docs:search:sync:prod'),
           env: {
             MXBAI_API_KEY: '${{ secrets.MXBAI_API_KEY }}',
-            MXBAI_VECTOR_STORE_ID: '${{ secrets.MXBAI_VECTOR_STORE_ID }}',
+            MXBAI_VECTOR_STORE_ID_PROD: '${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}',
           },
         },
       ]),

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,61 +1,387 @@
+# Generated file - DO NOT EDIT
+# Source: sync-docs.yml.genie.ts
+
 name: Sync docs to Mixedbread Vector Store
 
 on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Docs search target to sync'
+        description: Docs search target to sync
         required: true
-        default: 'dev'
+        default: dev
         type: choice
-        options:
-          - dev
-          - prod
+        options: [dev, prod]
   push:
     branches: [main]
-    paths:
-      - docs/src/content/**/*.md
-      - docs/src/content/**/*.mdx
+    paths: [docs/src/content/**/*.md, docs/src/content/**/*.mdx]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true
 
 jobs:
-  sync:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.3.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Sync vector store
+  sync-dev:
+    if: ${{ github.event_name == 'push' || inputs.target == 'dev' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    defaults:
+      run:
         shell: bash
-        working-directory: ./docs
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare CI helper scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts_src='genie/ci-scripts'
+          scripts_dst='${{ runner.temp }}/genie-ci-scripts'
+          if [ ! -d "$scripts_src" ]; then
+            echo "::error::CI helper script directory is missing: $scripts_src"
+            exit 1
+          fi
+          rm -rf "$scripts_dst"
+          mkdir -p "$scripts_dst"
+          cp -R "$scripts_src/." "$scripts_dst/"
+          chmod +x "$scripts_dst"/*.sh
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '\''::error::megarepo.lock missing members["effect-utils"].commit'\''
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf '\''MEGAREPO_STORE=%s\n'\'' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
+          fi
+
+          nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
+        shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ github.workspace }}/.pnpm-store" >> "$GITHUB_ENV"
+          echo "PNPM_CONFIG_STORE_DIR=${{ github.workspace }}/.pnpm-store" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ github.workspace }}/.pnpm-store
+          key: "livestore-pnpm-state-v1-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'Resolve devenv' 'DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '\''::error::devenv.lock missing .nodes.devenv.locked.rev'\''
+            exit 1
+          fi
+
+          resolve_devenv() {
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
+        shell: bash
+      - name: Sync docs search index
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'devenv tasks run docs:search:sync:dev' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:search:sync:dev'
         env:
           MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
           MXBAI_VECTOR_STORE_ID_DEV: ${{ secrets.MXBAI_VECTOR_STORE_ID_DEV }}
-          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
-          MXBAI_VECTOR_STORE_ID_LEGACY: ${{ secrets.MXBAI_VECTOR_STORE_ID }}
-          SYNC_TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'dev' }}
+      - name: Save pnpm state
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ github.workspace }}/.pnpm-store
+          key: "livestore-pnpm-state-v1-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Upload Nix diagnostics artifact
+        if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14
+  sync-prod:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'prod' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - name: Prepare CI helper scripts
+        shell: bash
         run: |
           set -euo pipefail
-          : "${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
-
-          if [ "$SYNC_TARGET" = "prod" ]; then
-            vector_store_id="${MXBAI_VECTOR_STORE_ID_PROD:-}"
-          else
-            vector_store_id="${MXBAI_VECTOR_STORE_ID_DEV:-${MXBAI_VECTOR_STORE_ID_LEGACY:-}}"
+          scripts_src='genie/ci-scripts'
+          scripts_dst='${{ runner.temp }}/genie-ci-scripts'
+          if [ ! -d "$scripts_src" ]; then
+            echo "::error::CI helper script directory is missing: $scripts_src"
+            exit 1
+          fi
+          rm -rf "$scripts_dst"
+          mkdir -p "$scripts_dst"
+          cp -R "$scripts_src/." "$scripts_dst/"
+          chmod +x "$scripts_dst"/*.sh
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://devenv.cachix.org
+            extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            access-tokens = github.com=${{ github.token }}
+            extra-substituters = https://cache.nixos.org
+            extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          summarize: true
+      - name: Provide cachix CLI from nixpkgs
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(nix build --no-link --print-out-paths nixpkgs#cachix)
+          echo "$out/bin" >> "$GITHUB_PATH"
+      - name: Enable Cachix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: livestore
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
+      - name: Restore megarepo store
+        id: restore-megarepo-store
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
+      - name: Sync megarepo dependencies
+        env:
+          MEGAREPO_STORE: '${{ runner.temp }}/megarepo-store'
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'Sync megarepo dependencies' 'EU_REV=$(jq -r '\''.members["effect-utils"].commit'\'' megarepo.lock)
+          if [ -z "$EU_REV" ] || [ "$EU_REV" = "null" ]; then
+            echo '\''::error::megarepo.lock missing members["effect-utils"].commit'\''
+            exit 1
+          fi
+          mkdir -p "$MEGAREPO_STORE"
+          echo "Using job-local megarepo store: $MEGAREPO_STORE"
+          if [ -n "${GITHUB_ENV:-}" ]; then
+            printf '\''MEGAREPO_STORE=%s\n'\'' "$MEGAREPO_STORE" >> "$GITHUB_ENV"
           fi
 
-          : "${vector_store_id:?Missing Mixedbread vector store id for target ${SYNC_TARGET}}"
-          pnpm dlx @mixedbread/cli@2.3.2 store sync "$vector_store_id" "./src/content/**/*.mdx" "./src/content/**/*.md" --yes --strategy fast
+          nix run --no-write-lock-file --override-input flake-utils "https://codeload.github.com/numtide/flake-utils/tar.gz/11707dc2f618dd54ca8739b309ec4fc024de578b" --override-input nixpkgs "https://codeload.github.com/NixOS/nixpkgs/tar.gz/5b63481602d9b0a714d5791c53bebe829d6b1a3c" --override-input tsgo "https://codeload.github.com/Effect-TS/tsgo/tar.gz/8d34c0a2d603a4b963b85ffccd4322c0ef74f472" "https://codeload.github.com/overengineeringstudio/effect-utils/tar.gz/$EU_REV#megarepo" -- apply --all'
+        shell: bash
+      - name: Save megarepo store
+        if: ${{ success() && steps.restore-megarepo-store.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ runner.temp }}/megarepo-store'
+          key: "megarepo-store-v1-${{ runner.os }}-full-${{ hashFiles('megarepo.lock') }}"
+      - name: Use pinned devenv from lock
+        run: |
+          DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '::error::devenv.lock missing .nodes.devenv.locked.rev'
+            exit 1
+          fi
+          echo "DEVENV_REV=$DEVENV_REV" >> "$GITHUB_ENV"
+          echo "Pinned devenv rev: $DEVENV_REV"
+        shell: bash
+      - name: Isolate pnpm state
+        shell: bash
+        run: |
+          echo "PNPM_STORE_DIR=${{ github.workspace }}/.pnpm-store" >> "$GITHUB_ENV"
+          echo "PNPM_CONFIG_STORE_DIR=${{ github.workspace }}/.pnpm-store" >> "$GITHUB_ENV"
+          echo "PNPM_HOME=${{ github.workspace }}/.pnpm-home" >> "$GITHUB_ENV"
+      - id: restore-pnpm-state
+        name: Restore pnpm state
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ github.workspace }}/.pnpm-store
+          key: "livestore-pnpm-state-v1-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Resolve devenv
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'Resolve devenv' 'DEVENV_REV=$(jq -r .nodes.devenv.locked.rev devenv.lock)
+          if [ -z "$DEVENV_REV" ] || [ "$DEVENV_REV" = "null" ]; then
+            echo '\''::error::devenv.lock missing .nodes.devenv.locked.rev'\''
+            exit 1
+          fi
+
+          resolve_devenv() {
+            nix build \
+              --accept-flake-config \
+              --option extra-substituters https://devenv.cachix.org \
+              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+              --no-link \
+              --print-out-paths \
+              "github:cachix/devenv/$DEVENV_REV#devenv"
+          }
+
+          # Temporary: capture diagnostics dir for #272 root-cause analysis.
+          DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
+          mkdir -p "$DIAG_ROOT"
+          echo "NIX_STORE_DIAGNOSTICS_DIR=$DIAG_ROOT" >> "$GITHUB_ENV"
+
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=${RUNNER_NAME:-unknown}"
+            echo "runner_os=${RUNNER_OS:-unknown}"
+            echo "runner_arch=${RUNNER_ARCH:-unknown}"
+            echo "github_job=${GITHUB_JOB:-unknown}"
+            echo "github_run_id=${GITHUB_RUN_ID:-unknown}"
+            echo "nix_user_conf_files=${NIX_USER_CONF_FILES:-}"
+            nix --version || true
+          } > "$DIAG_ROOT/environment.txt" 2>&1
+
+          if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv.log" >&2)); then
+            echo "::error::resolve_devenv failed. Last 30 lines of log:"
+            tail -30 "$DIAG_ROOT/resolve-devenv.log" || true
+            exit 1
+          fi
+          DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+
+          # Fast validity check on the devenv store path (~1-2s vs ~25s for devenv info).
+          if ! nix-store --check-validity "$DEVENV_OUT" 2>/dev/null; then
+            echo "::warning::devenv store path invalid, repairing targeted path..."
+            nix-store --repair-path "$DEVENV_OUT" > "$DIAG_ROOT/nix-store-verify-repair.log" 2>&1 || true
+            rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}"/nix/eval-cache-* ~/.cache/nix/eval-cache-*
+            if ! DEVENV_OUT=$(resolve_devenv 2> >(tee "$DIAG_ROOT/resolve-devenv-post-repair.log" >&2)); then
+              echo "::error::resolve_devenv failed after repair. Last 30 lines of log:"
+              tail -30 "$DIAG_ROOT/resolve-devenv-post-repair.log" || true
+              exit 1
+            fi
+            DEVENV_BIN="$DEVENV_OUT/bin/devenv"
+          fi
+
+          echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
+          "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
+        shell: bash
+      - name: Sync docs search index
+        run: |
+          __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
+          bash "$__genie_ci_retry_script" 'devenv tasks run docs:search:sync:prod' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run docs:search:sync:prod'
+        env:
+          MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}
+          MXBAI_VECTOR_STORE_ID_PROD: ${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}
+      - name: Save pnpm state
+        if: ${{ success() && steps.restore-pnpm-state.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.pnpm-home
+            ${{ github.workspace }}/.pnpm-store
+          key: "livestore-pnpm-state-v1-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}"
+      - name: Upload Nix diagnostics artifact
+        if: failure() && env.NIX_STORE_DIAGNOSTICS_DIR != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'nix-store-diagnostics-${{ github.job }}-${{ runner.os }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}'
+          path: ${{ env.NIX_STORE_DIAGNOSTICS_DIR }}
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/sync-docs.yml.genie.ts
+++ b/.github/workflows/sync-docs.yml.genie.ts
@@ -1,0 +1,92 @@
+/**
+ * Docs search index sync.
+ *
+ * Each docs surface owns its own Mixedbread vector store (LS.DOCS.SEARCH-R03),
+ * so a reader only ever gets hits for pages the surface they are on actually
+ * serves: `dev` tracks `main`, `prod` tracks the published stable release.
+ *
+ * This workflow was the repo's last hand-written one, and drifted for exactly
+ * that reason: it pinned pnpm via `pnpm/action-setup` while `packageManager`
+ * moved to 11.8.0, so every run died at environment setup and the index went
+ * unrefreshed for months. It now uses `livestoreSetupSteps` like every other
+ * workflow, and calls the `docs:search:sync:*` devenv tasks rather than
+ * invoking the Mixedbread CLI inline, so there is one way to run a sync.
+ *
+ * Target selection is two gated jobs rather than a shell branch on an env var.
+ * The previous single-step form silently fell back to a legacy store id when
+ * its target's secret was unset, which is how a prod sync ended up writing the
+ * dev store.
+ */
+import {
+  bashShellDefaults,
+  githubWorkflow,
+  livestoreSetupSteps,
+  nixDiagnosticsArtifactStep,
+  runDevenvTasksBefore,
+  savePnpmStateStep,
+} from '../../genie/repo.ts'
+
+const withNixDiagnosticsOnFailure = (steps: unknown[]) => [
+  ...steps,
+  savePnpmStateStep({ keyPrefix: 'livestore-pnpm-state-v1' }),
+  nixDiagnosticsArtifactStep(),
+]
+
+/** A push to `main` only ever refreshes the dev index; prod is release-gated. */
+const isDevTarget = "github.event_name == 'push' || inputs.target == 'dev'"
+const isProdTarget = "github.event_name == 'workflow_dispatch' && inputs.target == 'prod'"
+
+const syncJob = ({ gate, task, env }: { gate: string; task: string; env: Record<string, string> }) => ({
+  if: `\${{ ${gate} }}`,
+  'runs-on': 'ubuntu-24.04',
+  'timeout-minutes': 20,
+  defaults: bashShellDefaults,
+  steps: withNixDiagnosticsOnFailure([
+    ...livestoreSetupSteps,
+    {
+      name: 'Sync docs search index',
+      run: runDevenvTasksBefore(task),
+      env: {
+        MXBAI_API_KEY: '${{ secrets.MXBAI_API_KEY }}',
+        ...env,
+      },
+    },
+  ]),
+})
+
+export default githubWorkflow({
+  name: 'Sync docs to Mixedbread Vector Store',
+  on: {
+    workflow_dispatch: {
+      inputs: {
+        target: {
+          description: 'Docs search target to sync',
+          required: true,
+          default: 'dev',
+          type: 'choice',
+          options: ['dev', 'prod'],
+        },
+      },
+    },
+    push: {
+      branches: ['main'],
+      paths: ['docs/src/content/**/*.md', 'docs/src/content/**/*.mdx'],
+    },
+  },
+  concurrency: {
+    group: '${{ github.workflow }}-${{ github.ref }}',
+    'cancel-in-progress': true,
+  },
+  jobs: {
+    'sync-dev': syncJob({
+      gate: isDevTarget,
+      task: 'docs:search:sync:dev',
+      env: { MXBAI_VECTOR_STORE_ID_DEV: '${{ secrets.MXBAI_VECTOR_STORE_ID_DEV }}' },
+    }),
+    'sync-prod': syncJob({
+      gate: isProdTarget,
+      task: 'docs:search:sync:prod',
+      env: { MXBAI_VECTOR_STORE_ID_PROD: '${{ secrets.MXBAI_VECTOR_STORE_ID_PROD }}' },
+    }),
+  },
+})

--- a/nix/devenv-modules/tasks/local/mono-wrappers.nix
+++ b/nix/devenv-modules/tasks/local/mono-wrappers.nix
@@ -15,6 +15,21 @@
 }:
 let
   pnpm = "${inputs.effect-utils.lib.mkPnpm { inherit pkgs; }}/bin/pnpm";
+
+  # Each docs surface owns its own Mixedbread vector store, so a surface only
+  # ever searches content it actually serves: `dev` tracks `main`, `prod` tracks
+  # the published stable release. Parameterised by the env var holding the store
+  # id so the two sync tasks cannot drift apart.
+  docsSearchSync = storeIdVar: ''
+    set -euo pipefail
+    : "''${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
+    : "''${${storeIdVar}:?Missing ${storeIdVar} secret}"
+    timeout --signal=TERM --kill-after=1m 10m \
+      pnpm --dir docs exec mxbai store sync "''${${storeIdVar}}" \
+        "./src/content/**/*.mdx" \
+        "./src/content/**/*.md" \
+        --yes --strategy fast
+  '';
 in
 {
   tasks = {
@@ -259,18 +274,15 @@ in
       '';
     };
 
+    "docs:search:sync:dev" = {
+      description = "Sync dev Mixedbread vector store from docs Markdown sources";
+      exec = docsSearchSync "MXBAI_VECTOR_STORE_ID_DEV";
+      after = [ "pnpm:install" ];
+    };
+
     "docs:search:sync:prod" = {
       description = "Sync prod Mixedbread vector store from docs Markdown sources";
-      exec = ''
-        set -euo pipefail
-        : "''${MXBAI_API_KEY:?Missing MXBAI_API_KEY secret}"
-        : "''${MXBAI_VECTOR_STORE_ID:?Missing MXBAI_VECTOR_STORE_ID secret}"
-        timeout --signal=TERM --kill-after=1m 10m \
-          pnpm --dir docs exec mxbai store sync "$MXBAI_VECTOR_STORE_ID" \
-            "./src/content/**/*.mdx" \
-            "./src/content/**/*.md" \
-            --yes --strategy fast
-      '';
+      exec = docsSearchSync "MXBAI_VECTOR_STORE_ID_PROD";
       after = [ "pnpm:install" ];
     };
 


### PR DESCRIPTION
Docs search has been broken in production for roughly three months. This repairs the pipeline; the design rationale and the IaC that declares it live in #1330.

## What was wrong

Two faults, stacked so the second hid the first.

**The `dev`/`prod` split was stillborn.** It was added 2026-04-30 referencing `MXBAI_VECTOR_STORE_ID_DEV` and `MXBAI_VECTOR_STORE_ID_PROD` — **secrets that had never been created**. So `target=prod` hard-failed on its `:?` guard, and `target=dev` silently fell back to the legacy bare store id.

**Then `sync-docs.yml` stopped running at all.** It was the repo's only hand-written workflow, and pinned pnpm `11.3.0` via `pnpm/action-setup` while `packageManager` moved to `11.8.0`. `pnpm/action-setup` hard-errors on that disagreement, so every push run died at `Setup pnpm` before reaching the sync — masking the stillborn split underneath.

Net effect: one vector store existed, named `livestore-docs-dev`, and both docs surfaces read it. Production search served stale, development-named content.

## What this changes

- `sync-docs.yml` now generates from `sync-docs.yml.genie.ts` and uses `livestoreSetupSteps` (devenv/nix) like every other workflow. It was the last hand-written one, which is *why* it drifted — nothing kept its pnpm pin in step.
- Calls the `docs:search:sync:*` devenv tasks instead of invoking `pnpm dlx @mixedbread/cli` inline, so there's one way to run a sync.
- Adds `docs:search:sync:dev`; both tasks are generated from one helper so they can't drift apart, and each **requires its own store id** — a missing secret now fails loudly instead of silently retargeting another store.
- Target selection is two gated jobs rather than a shell branch on an env var. A push to `main` only ever refreshes dev; prod is dispatch-only.
- `deploy-prod.yml` and `release.yml` now pass `MXBAI_VECTOR_STORE_ID_PROD` rather than the bare alias.

## Already applied outside this PR

The missing `MXBAI_VECTOR_STORE_ID_DEV` / `_PROD` secrets have been created, a `livestore-docs-prod` store now exists (populated from `v0.4.0`), the dev store was refreshed from `main`, and each Netlify site points at its own store. `docs.livestore.dev/api/search` returns results from the production store.

**This PR closes a live gap:** production is correct now, but `main` still passes the bare store id to the prod sync, so the next stable release would sync the *wrong* store and leave production search stale against that release.

## Not addressed

The deeper defect is that three months of red runs surfaced to nobody. Detection belongs with the disabled `notify-alignment` job (#1183) rather than a competing mechanism invented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-bolt |
| `agent_session_id` | 05bdf052-d9c2-4930-bfef-1fd90b43680b |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/57hz15fbcg9c3hasm0ny3axd5pg33rh3-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/d9hvhhg1k9n3j20dgcch7sz3sg98l377-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | ls-vrs/docs-search-repair |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@b785b9f |
</details>
<!-- agent-footer:end -->