### PR TITLE
docs(sustainability): record the size-gated source-available licence decision

### DIFF
--- a/context/06-sustainability/.decisions/0001-community-license.md
+++ b/context/06-sustainability/.decisions/0001-community-license.md
@@ -1,0 +1,105 @@
+# 0001 — Adopt a size-gated source-available licence across all packages
+
+Status: accepted (2026-07-27; decided by the project creator after a design
+interview and comparative research across FSL, FCL, ELv2, BUSL and the PolyForm
+family — see Evidence). Licence text is drafted and pending review by counsel;
+that review does not reopen the decision below.
+
+## Context
+
+Every published `@livestore/*` package is Apache-2.0. DevTools is distributed
+under a sponsor licence (LS.SUST-R03, LS.SUST-T01) and gated at runtime by a
+third-party licensing SDK. LS.SUST-DQ1 recorded the licensing model as open and
+blocked on a strategic decision by the project creator.
+
+Two facts settled during investigation:
+
+- **Consent is not a constraint.** A CLA is in place and contributors have
+  agreed, so relicensing existing code is available — not merely the
+  Apache-2.0 §4 "future versions only" path. The CLA is currently not
+  discoverable from the repository, which is itself worth fixing.
+- **Sponsorship alone has not funded the project as stated.** DevTools
+  licensing already operates as a second channel, which LS.SUST-R02 does not
+  describe.
+
+## Options
+
+1. **Stay Apache-2.0 everywhere.** No relicensing event, no fork trigger, no
+   positioning cost. Leaves the engine generating no revenue and sponsorship
+   as the only channel.
+2. **Non-compete family** (FSL, BUSL, PolyForm Perimeter). Defends against a
+   competitor reselling the software as a managed service.
+3. **Size gate across all packages (chosen).** Organisations above a size
+   threshold require a commercial licence; everyone else uses it free.
+
+## Decision
+
+Option 3, with these parameters:
+
+- Free use requires **all three**: fewer than 10 total individuals, under
+  USD 1,000,000 total revenue in the prior tax year, and under USD 1,000,000
+  in aggregate external investment. Figures are fixed, not inflation-indexed.
+  Affiliates under common control aggregate across all three.
+- **Unconditional grants** regardless of the gate: individuals; nonprofit,
+  educational, government and public research organisations; and a 30-day
+  evaluation period.
+- **Each version converts to Apache-2.0** on the second anniversary of its own
+  publication, as a present and irrevocable grant.
+- **No technical enforcement.** Enforcement is contractual.
+- Name: LiveStore Community License 1.0, declared as
+  `LicenseRef-LiveStore-Community-1.0`. Licensor is the project creator
+  personally, with intent to assign to an entity later. The public licence is
+  silent on governing law; the commercial licence is not.
+- `@livestore/wa-sqlite` remains MIT — it is a fork of
+  [`rhashimoto/wa-sqlite`](https://github.com/rhashimoto/wa-sqlite) and its
+  value is upstream's.
+- Prior Apache-2.0 releases are unaffected and remain forkable.
+
+## Rationale
+
+**Why not option 2.** Every restrictive licence in the canon defends one threat
+model: a cloud provider reselling the software as a managed service. LiveStore
+is a client-side library — nobody can host it — and LS.SUST-R04 already commits
+the project to not operating a sync service. FSL's Permitted Purpose explicitly
+enumerates "for your internal use and access", so an enterprise using LiveStore
+internally would be permitted freely and permanently. A non-compete would gate
+nobody the project wants to convert.
+
+**Why no technical enforcement.** Every working licence mechanism in this
+ecosystem is anchored to a rendering surface — a watermark or banner visible in
+the licensee's shipped product. LiveStore renders nothing, so there is nothing
+for a mechanism to attach to. Mapbox GL JS v2 added runtime validation to a
+library and was forked into MapLibre within weeks; RxDB, the closest structural
+analogue, gates at install and advertises that it ships no validation into user
+bundles.
+
+**Why the 2-year conversion.** It answers "what happens if the maintainer
+stops", which a solo project is asked harder than a company. A two-year-old
+build of a fast-moving library has little commercial value, so the concession
+costs little and is the reason this remains eventually-open-source.
+
+## Consequences
+
+- LiveStore becomes commercial software with a free tier rather than open
+  source with a paid tool. `vision.md` requires a pass; that file is
+  human-owned.
+- Revises LS.SUST-R01, LS.SUST-R02, LS.SUST-R03 and LS.SUST-R05; retires
+  LS.SUST-T01. Re-scopes LS.SUST-DQ1.
+- LS-A05 ("no company") is in tension with the intent to assign to an entity.
+- The existing runtime licensing SDK and its `ENFORCE_LICENSE` flag are
+  retired after a grace period covering current activations.
+- **Accepted risk:** competitors are permissively licensed (Zero is
+  Apache-2.0; Yjs and TinyBase are MIT). A non-OSI identifier fails enterprise
+  allowlist checks silently, and lost evaluations are not observable. Two of
+  five canonical relicensings were later reversed (Elastic 2024, Redis 2025),
+  both after ecosystem loss.
+
+## Evidence
+
+Comparative research across FSL-1.1, FCL-1.0, Elastic License 2.0, BUSL-1.1 and
+the PolyForm family, with adoption and outcome data; SPDX list `e4c1f27`
+(`PolyForm-Small-Business-1.0.0` and `FSL-1.1-ALv2` listed, `FCL-1.0-ALv2`
+absent); a codebase authorship census over all 335 non-test source files; and a
+survey of licence-enforcement mechanisms in JavaScript libraries (AG Grid,
+Highcharts, Kendo, FusionCharts, RxDB, Mapbox GL). Tracked in
+[livestorejs/livestore#1511](https://github.com/livestorejs/livestore/issues/1511).

--- a/context/06-sustainability/.reference/licence-draft-commercial-license-notes.md
+++ b/context/06-sustainability/.reference/licence-draft-commercial-license-notes.md
@@ -195,9 +195,11 @@ whole enforcement burden, and should include:
   software above the threshold without a licence can cure by purchasing, at list price,
   for the period of unlicensed use. This is worth having; it converts an awkward
   conversation into a sale and is far cheaper than litigation.
-- Whatever verification right counsel thinks appropriate — see the `{{AUDIT_RIGHTS}}`
-  variant in `LICENSE.md` and §8 of `REVIEW-NOTES.md`. Note that a *paid* agreement can
-  reasonably carry an audit right that a free public licence should not.
+- Whatever verification right counsel thinks appropriate. **The public licence has none
+  at all** — this was settled deliberately (see `REVIEW-NOTES.md` §8), so the commercial
+  agreement is the only place any verification can live. A *paid, signed* agreement can
+  reasonably carry a right that a free public licence should not, but it must not be
+  drafted so as to imply the free licence carried one.
 
 ---
 
@@ -254,8 +256,79 @@ Each of these would contradict a settled requirement:
 
 ---
 
-## 11. Open questions for counsel
+## 11. Governing law and forum — this is where they live
 
+The public licence is **deliberately silent** on governing law and forum, matching
+Apache-2.0, MIT, and every widely used source-available licence. That silence is a
+decision, not an omission (see `REVIEW-NOTES.md` §11).
+
+The commercial agreement is the right home for both, because it is negotiated and
+signed rather than offered to the world.
+
+**Settled: German law, courts of Berlin.**
+
+Points for counsel:
+
+- **Mandatory consumer and small-business protections may override the choice.** German
+  and EU rules on standard terms (AGB, §§305–310 BGB) apply with real force to
+  non-negotiated agreements and can strike clauses that a US-style agreement takes for
+  granted — particularly broad liability exclusions. If the commercial agreement is sold
+  self-serve as standard terms rather than negotiated, expect the AGB regime to apply,
+  and draft the liability section for it rather than importing US wording.
+- **The liability position cannot simply mirror `LICENSE.md`.** German law does not
+  permit excluding liability for intent or gross negligence, or for injury to life, body
+  or health, however the clause is worded. Whatever is chosen for the public licence's
+  `No Liability` section, the commercial agreement needs its own German-law-compliant
+  version. This connects to Q-C7.
+- **A Berlin forum clause is straightforward against business customers** and much less
+  reliable against consumers or very small businesses in other EU states. If any
+  customers might be consumers, the clause should be drafted to yield where mandatory
+  rules require.
+- **Non-EU customers** — particularly US enterprises — routinely resist foreign
+  governing law. Decide in advance whether this is negotiable for larger deals, because
+  it will be asked.
+
+**Question for counsel (Q-C8):** should the agreement be structured as negotiated terms
+or as standard terms (AGB)? The answer changes how much of it survives review, and it is
+better decided before drafting than discovered afterwards.
+
+---
+
+## 12. The licensor is a natural person
+
+`{{LICENSOR}}` resolves to **Johannes Schickling**, an individual, with a stated
+intention to assign the rights to an entity later. Three consequences for the commercial
+agreement:
+
+- **Business and personal liability are mixed.** A natural person signing commercial
+  software agreements carries the obligations personally, with no corporate veil. Given
+  that the agreements will contain warranty and possibly indemnity terms (Q-C6), and
+  that German law limits how far liability can be excluded, this is a real exposure and
+  not a formality. Counsel should advise on whether to form the entity **before** signing
+  any commercial agreements rather than after.
+- **A later assignment means novating or notifying existing customers.** Copyright can be
+  assigned and the assignee takes subject to existing licences, so the *public* licence
+  needs nothing (see `REVIEW-NOTES.md` §12). But signed commercial agreements are
+  contracts, and moving the licensor's side of them to a new entity may require customer
+  consent depending on how they are drafted. **Include an assignment clause permitting
+  assignment to a successor entity without customer consent, in every commercial
+  agreement from the first one.** Retrofitting this across a customer base is painful;
+  including it costs nothing.
+- **Name the licensor consistently.** The public licence identifies the licensor
+  generically and carries the name only in a `Required Notice:` line, precisely so that
+  an assignment does not require re-issuing the licence text. The commercial agreement
+  should name the party explicitly, as contracts must.
+
+**Question for counsel (Q-C9):** should entity formation precede the licence change, or
+can commercial agreements be signed personally in the interim with an assignment clause
+carrying them across later?
+
+---
+
+## 13. Open questions for counsel
+
+- **Q-C0** — Should the agreement restate the two-year Apache-2.0 conversion, or
+  incorporate it by reference to `LICENSE.md`? (§2)
 - **Q-C1** — Organisation definition: repeat verbatim or incorporate by reference? (§4)
 - **Q-C2** — Auto-renewal enforceability and notice requirements. (§5)
 - **Q-C3** — Model A vs Model B. Recommendation is A; confirm. (§6)
@@ -264,11 +337,21 @@ Each of these would contradict a settled requirement:
 - **Q-C5** — If purchase is click-through, what acceptance mechanics are needed for the
   agreement to bind, and does that differ across target jurisdictions? (§8)
 - **Q-C6** — Does a commercial customer need an indemnity from the licensor, and is the
-  project willing to give one? Customers above the size threshold will ask. The answer
+  project willing to give one? Customers who fail any eligibility limb will ask. The answer
   affects pricing and is currently undecided.
 - **Q-C7** — Should the commercial agreement include a warranty and liability position
   different from `LICENSE.md`'s? A paying customer may not accept a bare "as is", and a
-  large one certainly will not.
+  large one certainly will not. Under German law it cannot simply mirror it in any case
+  — see §11.
+- **Q-C8** — Negotiated terms or standard terms (AGB)? The answer determines how much of
+  the agreement survives review under §§305–310 BGB. (§11)
+- **Q-C9** — Should entity formation precede the licence change, or can agreements be
+  signed personally in the interim with an assignment clause? (§12)
+- **Q-C10** — Pricing must be set against the customer's free fallback of running
+  releases more than two years old, not against total denial of access. Is that fallback
+  acceptable commercially, or does it argue for a longer conversion period? Note the
+  two-year period is settled; this question is about whether the *pricing* built on it
+  works, not about reopening it. (§2)
 
 [Application Users]: ./LICENSE.md#application-users
 [Personal Uses]: ./LICENSE.md#personal-uses

--- a/context/06-sustainability/.reference/licence-draft-commercial-license-notes.md
+++ b/context/06-sustainability/.reference/licence-draft-commercial-license-notes.md
@@ -1,0 +1,274 @@
+# Commercial licence — what it must cover
+
+**Draft prepared for legal review. This is not legal advice.** These are notes for
+counsel, not licence text. They describe what the separate commercial agreement has to
+say so that it fits together with `LICENSE.md` without gaps or contradictions.
+
+Nothing here is a settled decision except where it restates a requirement from
+`../licence-requirements.md`. Everything else is a question with a recommendation.
+
+---
+
+## 1. Why this document exists
+
+`LICENSE.md` gates use by organisations that fail any of its three eligibility limbs. It
+does **not** say how such an organisation gets permission — only that they need it. The
+requirements are explicit that this is a shipping blocker:
+
+> A commercial licence must exist before the change ships — price, term, seat or org
+> basis, purchase path. Without it the gate turns organisations into non-users rather
+> than customers, and silently.
+
+So the commercial agreement has to exist and be purchasable on the day the licence
+change lands, not after.
+
+**Settled inputs from the project**, which the agreement must reflect:
+
+- Licence name: **LiveStore Community License 1.0**
+- Licensor: **Johannes Schickling**, a natural person, with stated intent to assign to an
+  entity later (see §12)
+- Governing law and forum for the **commercial** agreement: **German law, courts of
+  Berlin**. The public licence is deliberately silent on both.
+- Every release converts to Apache-2.0 two years after its own publication (see §2)
+- No audit rights anywhere in the public licence — enforcement is pure honour system
+
+---
+
+## 2. What the customer is actually buying — read this before pricing
+
+The two-year conversion changes the product fundamentally, and the pricing model has to
+be built around it rather than bolted on afterwards.
+
+**A customer is buying a time-limited head start, not permanent access.** Every version
+becomes Apache-2.0 on its own second anniversary. An organisation that fails the
+eligibility gate has a standing free alternative: use only releases that are more than
+two years old. That option is always available, always legal, and costs nothing.
+
+So the commercial licence sells exactly one thing: **the right to use recent releases.**
+Everything else is already free or becomes free on a published schedule.
+
+Consequences that should shape the agreement and the price:
+
+- **Nobody will pay enterprise-software prices for this.** The customer's downside if
+  they refuse to buy is running two-year-old software, not being unable to use LiveStore
+  at all. Price against that alternative, not against a total-denial scenario.
+- **It strengthens the Model A recommendation in §6 almost to the point of making the
+  choice obvious.** Granting a perpetual right to versions obtained during the term costs
+  the licensor very little, because those versions convert to Apache-2.0 anyway within
+  two years of their release. Model A is nearly free to offer and removes the customer's
+  single biggest objection.
+- **Renewal pressure comes from wanting current releases**, not from a threat of losing
+  what they have. That is a healthier commercial dynamic and should be how the agreement
+  and the sales material talk about it.
+- **Say the conversion out loud in the agreement.** A customer who discovers it later
+  feels sold-to; a customer who is told up front reads it as unusually fair. It is a
+  genuine differentiator against BUSL-style licences with four-year terms.
+
+**Question for counsel (Q-C0):** should the commercial agreement restate the conversion,
+or incorporate it by reference to `LICENSE.md`? Restating risks the two drifting apart on
+a later revision; silence risks a customer arguing they were not told.
+
+---
+
+## 3. The one structural constraint that cannot be got wrong
+
+LiveStore is a **client-side library that ships inside other people's applications**.
+`LICENSE.md` handles this with the [Application Users] clause: end users of a
+licensee's application get their licences **directly from the licensor**, not by
+sublicence, and those licences survive the licensee's own licences ending.
+
+**The commercial agreement must do the same thing, and must not contradict it.**
+
+Concretely, the commercial agreement must:
+
+- Grant the customer the right to include the software in the customer's own products
+  and distribute those products.
+- Grant, or preserve, the direct-from-licensor licence to the customer's end users, on
+  the same "no separate licence needed" basis.
+- **Not** contain a blanket "no sublicensing, no distribution to third parties" clause
+  of the kind that is standard in commercial software agreements. That clause is
+  correct for a hosted service and wrong here. It would make the paid licence *worse*
+  than the free one, which is the single most damaging drafting error available in this
+  document.
+- Say what happens to already-shipped applications when the agreement ends. See §6.
+
+---
+
+## 4. Seat, organisation, or something else
+
+| Basis | Fits LiveStore? | Notes |
+| --- | --- | --- |
+| **Per developer seat** | Partly | Matches how DevTools is used (a developer's machine). Does not match the engine, which is a build-time dependency touched by everyone on a team and by CI. Creates a counting problem the licensor cannot verify and the customer resents. |
+| **Per organisation (site licence)** | **Recommended** | One price per company (including affiliates, matching the `Your company` definition in `LICENSE.md`), covering unlimited developers and unlimited applications. Simple to sell, simple to comply with, and there is nothing to count. |
+| **Per application / per product** | No | Invites disputes about what counts as one application, and penalises exactly the customers who adopt most deeply. |
+| **Per end user of the customer's app** | No | Directly contradicts [Application Users]. Do not consider. |
+| **Revenue-banded organisation licence** | Possible refinement | Same as per-organisation, with two or three price bands keyed to the same revenue definition already used in `LICENSE.md`. Reuses a definition the customer has already had to apply to know they need a licence at all. |
+
+**Recommendation:** per-organisation, optionally revenue-banded, with the organisation
+defined by reference to the same `Your company` / `Control` definitions as
+`LICENSE.md`, so a customer never has to apply two different tests.
+
+**Question for counsel (Q-C1):** should the definition of the customer's organisation
+be repeated verbatim in the commercial agreement, or incorporated by reference to
+`LICENSE.md`? Incorporation by reference is cleaner but couples the paid agreement to a
+document the licensor can revise unilaterally.
+
+---
+
+## 5. Term and renewal
+
+Recommended shape:
+
+- **Term:** one year, from the date of purchase.
+- **Renewal:** automatic annual renewal unless either side gives notice before the
+  renewal date, with a stated notice period. Alternative: expiry with no auto-renewal,
+  which is friendlier and worse for revenue predictability.
+- **Price at renewal:** state whether the renewal price is the price at purchase or the
+  then-current list price. If the latter, cap the increase.
+- **What the term buys:** see §6 — this is the important part.
+
+**Question for counsel (Q-C2):** whether auto-renewal is enforceable and appropriate
+across the likely customer jurisdictions, and what notice is required.
+
+---
+
+## 6. What happens when the licence lapses — the central decision
+
+Two coherent models. They are genuinely different products and the choice should be
+deliberate.
+
+### Model A — perpetual licence, time-limited updates
+
+The customer buys a **perpetual** right to use the versions released during the term.
+When the term ends they keep those versions forever, and simply stop receiving the
+right to use newer versions.
+
+- Customer risk on lapse: none. Shipped products keep working, legally and technically.
+- Licensor risk: a customer can buy one year and never renew.
+- Prior art: this is how most developer-tool licences of this shape work.
+
+### Model B — subscription, rights end on lapse
+
+The right to use the software ends with the term.
+
+- Customer risk on lapse: severe, and for a library embedded in shipped applications,
+  close to unsellable. A customer whose licence lapses is retroactively infringing in
+  every copy of their application already in users' hands.
+- **This model cannot be reconciled with [Application Users] without a carve-out** that
+  preserves end-user licences for applications already distributed. Without that
+  carve-out, lapse breaks the customer's customers.
+
+**Recommendation: Model A**, and §2 makes this close to unarguable. A perpetual grant
+over versions obtained during the term costs the licensor almost nothing, because those
+versions become Apache-2.0 within two years of their release regardless. Model B asks the
+customer to accept severe lapse risk in exchange for nothing the licensor actually needs.
+Model A is also the only model consistent with the [Application Users] clause.
+
+Whichever is chosen, the agreement must state explicitly:
+
+1. Whether the customer may keep using versions obtained during the term.
+2. Whether applications already distributed remain licensed — this must be **yes**
+   under either model.
+3. Whether the customer may continue to distribute *new copies* of an application built
+   on a version obtained during the term. Recommend **yes** under Model A.
+4. Whether a lapsed customer who later comes back within all three eligibility limbs
+   simply returns to `LICENSE.md`. Recommend **yes**, stated plainly. Note this is now
+   less likely to happen than under a two-limb gate: the investment limb counts
+   cumulatively across the customer's whole history and never resets, so a customer who
+   failed on investment can never become eligible again. Say so rather than implying a
+   route back that does not exist.
+5. That the customer keeps the Apache-2.0 rights that have already vested on versions
+   more than two years old. Nothing in the commercial agreement should appear to take
+   those away, and a customer's lawyer will check.
+
+---
+
+## 7. Enforcement, given there is no technical enforcement
+
+The requirements settle this: enforcement is contractual only, and no licence-key or
+runtime validation mechanism ships. The commercial agreement therefore carries the
+whole enforcement burden, and should include:
+
+- A statement that the customer is responsible for assessing whether it qualifies under
+  `LICENSE.md`, and for notifying the licensor when it stops qualifying.
+- A **retroactive-purchase** term: an organisation that discovers it has been using the
+  software above the threshold without a licence can cure by purchasing, at list price,
+  for the period of unlicensed use. This is worth having; it converts an awkward
+  conversation into a sale and is far cheaper than litigation.
+- Whatever verification right counsel thinks appropriate — see the `{{AUDIT_RIGHTS}}`
+  variant in `LICENSE.md` and §8 of `REVIEW-NOTES.md`. Note that a *paid* agreement can
+  reasonably carry an audit right that a free public licence should not.
+
+---
+
+## 8. Purchase path — must exist at launch
+
+Not a legal question, but the requirements make it a launch blocker. The agreement text
+needs to match whatever the purchase mechanism actually is:
+
+- Self-serve checkout, or invoice, or both.
+- Whether purchase is by click-through acceptance (in which case the agreement must be
+  drafted as a click-through, with the acceptance mechanics counsel requires) or by
+  signature.
+- Whether GitHub Sponsors tiers can grant a commercial licence. There is precedent for
+  this pattern, but a sponsorship tier description is a thin place to hang a licence
+  grant; if used, the tier must point at this agreement rather than restate it.
+
+---
+
+## 9. Migration commitments to honour
+
+From `../licence-requirements.md` §7. These are commitments already made publicly, and
+the commercial agreement or its surrounding policy should say how each is honoured:
+
+1. **Existing sponsors** were promised a DevTools licence as a published benefit. Decide
+   and state the honoured window — indefinitely, or for a stated period.
+2. **Students** receive free licences on request. If the [Personal Uses] clause in
+   `LICENSE.md` is adopted as drafted, this is fully subsumed and no separate student
+   programme is needed. Say so publicly so the promise is visibly kept.
+3. **Existing DevTools activations** under the retired key system persist until the
+   grace period ends. State the grace period end date.
+
+---
+
+## 10. Things this agreement should *not* contain
+
+Each of these would contradict a settled requirement:
+
+- **A non-compete or competing-use restriction.** Deliberately excluded. Nobody can host
+  a client-side SQLite library, and the project has committed not to offer a hosted
+  service.
+- **A source-disclosure obligation.** Not an objective.
+- **Any reference to licence keys, activation, or runtime validation.** The mechanism is
+  being retired; referencing it would reanimate it contractually.
+- **A clause purporting to affect releases that have already converted to Apache-2.0.**
+  This is now a *moving* set, not a fixed one: it includes everything published before
+  `{{FIRST_COVERED_VERSION}}`, plus every covered release more than two years old, and it
+  grows every day. Those grants are perpetual and irrevocable and cannot be clawed back.
+  Draft the agreement so it addresses the customer's rights in *current* releases and is
+  silent on converted ones, rather than trying to enumerate a boundary that moves.
+- **An audit or inspection right that reaches back into the public licence.** The public
+  licence deliberately has none. A verification term in a *paid, signed* agreement is a
+  different matter and is fine (§7), but it must not be drafted so as to imply the free
+  licence carried one.
+
+---
+
+## 11. Open questions for counsel
+
+- **Q-C1** — Organisation definition: repeat verbatim or incorporate by reference? (§4)
+- **Q-C2** — Auto-renewal enforceability and notice requirements. (§5)
+- **Q-C3** — Model A vs Model B. Recommendation is A; confirm. (§6)
+- **Q-C4** — Is the retroactive-purchase cure term enforceable, and does offering it
+  weaken any later claim for the unlicensed period? (§7)
+- **Q-C5** — If purchase is click-through, what acceptance mechanics are needed for the
+  agreement to bind, and does that differ across target jurisdictions? (§8)
+- **Q-C6** — Does a commercial customer need an indemnity from the licensor, and is the
+  project willing to give one? Customers above the size threshold will ask. The answer
+  affects pricing and is currently undecided.
+- **Q-C7** — Should the commercial agreement include a warranty and liability position
+  different from `LICENSE.md`'s? A paying customer may not accept a bare "as is", and a
+  large one certainly will not.
+
+[Application Users]: ./LICENSE.md#application-users
+[Personal Uses]: ./LICENSE.md#personal-uses

--- a/context/06-sustainability/.reference/licence-draft-license.md
+++ b/context/06-sustainability/.reference/licence-draft-license.md
@@ -1,0 +1,292 @@
+# LiveStore Community License 1.0
+
+<{{LICENCE_URL}}>
+
+<!--
+DRAFT PREPARED FOR LEGAL REVIEW. THIS IS NOT LEGAL ADVICE.
+
+Before this text is used:
+  1. Resolve {{LICENCE_URL}} — the only remaining placeholder. It must be a
+     project-hosted URL that resolves before the first covered release.
+  2. Choose option A or B in the "No Liability" Variant block and delete the other.
+     This is the only remaining choice, and it is counsel's, not the project's.
+  3. Delete every HTML comment in this file.
+See REVIEW-NOTES.md for the reasoning behind each clause and the open questions.
+-->
+
+## Who May Use This Software For Free
+
+Individuals, for their own purposes. Nonprofit, educational, government and
+public research organizations. Any organization with fewer than 10 people, under
+1,000,000 US dollars revenue last tax year, and under 1,000,000 US dollars ever
+raised from outside investors — all three. Anyone else may evaluate it for 30
+days, then needs a paid license.
+
+The sections below govern. This summary does not.
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both
+strict obligations and conditions to all your licenses.
+
+This section does not apply to the licenses granted under [Application
+Users](#application-users). The licensor grants those without requiring the
+people who get them to agree to these terms.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything
+you might do with the software that would otherwise infringe the licensor's
+copyright in it for any permitted purpose. However, you may only distribute the
+software according to [Distribution License](#distribution-license) and make
+changes or new works based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of
+the software. Your license to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new
+works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software.
+
+## Notices
+
+If you distribute the software on its own, or in source form, you must ensure
+that anyone who gets a copy of any part of it from you also gets a copy of these
+terms or the URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided with the software.
+For example:
+
+> Required Notice: Copyright Johannes Schickling
+
+If you include the software in your application, and distribute it only as part
+of your application in compiled, bundled, minified, or other processed form, you
+meet this section by including those same notices in the documentation, credits,
+or third-party notices you provide with your application.
+
+## Personal Uses
+
+Use by an individual, for that individual's own purposes, is use for a permitted
+purpose. Personal purposes include study, learning, research, experiment,
+testing, hobby projects, amateur pursuits, private entertainment, religious
+observance, and making or publishing work that shows your own skills, such as a
+portfolio piece or a demonstration.
+
+Work you do for an organization, including your employer or a client, is not
+personal use. Whether that work is permitted depends on [Noncommercial
+Organizations](#noncommercial-organizations), [Eligible
+Organizations](#eligible-organizations), or [Evaluation](#evaluation).
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research
+organization, public safety or health organization, environmental protection
+organization, or government institution is use for a permitted purpose, whatever
+the size of the organization and whatever the source of its funding or the
+obligations that come with that funding.
+
+## Eligible Organizations
+
+Use of the software for the benefit of your company is use for a permitted
+purpose if your company meets all three of these:
+
+- **People.** Fewer than 10 total individuals working as employees and
+  independent contractors.
+- **Revenue.** Less than 1,000,000 US dollars total revenue.
+- **Investment.** Less than 1,000,000 US dollars total external investment.
+
+Your company must meet all three. If it fails any one of them, use for its
+benefit is not a permitted purpose under this section.
+
+The people and revenue figures are measured over your company's prior tax year.
+The investment figure is measured over your company's whole history: money your
+company received in an earlier year still counts, even if your company has since
+spent it.
+
+If your company is new and has no prior tax year, treat the people and revenue
+figures as met until your company passes them during its first tax year. This
+does not apply to the investment figure, which always counts everything your
+company has received to date.
+
+All three figures are counted across your company as defined in
+[Definitions](#definitions), which includes its affiliates.
+
+These figures are fixed amounts. They are not adjusted for inflation. The
+licensor may use different figures in a later version of these terms. That does
+not change the figures in these terms.
+
+## Evaluation
+
+Use to evaluate whether the software suits a particular need or project, for up
+to 30 consecutive calendar days, on behalf of you or your company, is use for a
+permitted purpose. You may evaluate the software for more than one need or
+project, for up to 30 consecutive calendar days each.
+
+Evaluation does not cover distributing your application, or otherwise making it
+available, to anyone outside your company.
+
+## Your Application
+
+Your application is a product of your own that includes the software as a
+component and provides substantial functionality of its own beyond the software.
+Giving someone the software on its own is not giving them your application.
+Neither is giving them a product whose main value is the software itself.
+
+## Application Users
+
+If you were permitted to distribute your application under these terms when you
+distributed it, the licensor grants everyone who receives your application a
+copyright license and a patent license to run, copy, install, host, and deploy
+the software as part of your application, and to pass your application along to
+others, for any purpose.
+
+Those licenses come from the licensor directly, not from you. The people who get
+them do not need to qualify under [Personal Uses](#personal-uses),
+[Noncommercial Organizations](#noncommercial-organizations), [Eligible
+Organizations](#eligible-organizations), or [Evaluation](#evaluation), and need
+no other license from the licensor in order to use your application. Those
+licenses do not end if your own licenses end.
+
+Those licenses cover the software only as part of your application. They do not
+cover using the software apart from your application, or making changes to the
+software. Anyone who wants to do either of those things needs their own licenses
+under these terms.
+
+## Later Apache License
+
+The licensor irrevocably grants you an additional license to use each version of
+the software under the Apache License, Version 2.0, taking effect on the second
+anniversary of the date the licensor first made that version available.
+
+On and after that date, you may use that version under either these terms or the
+Apache License, Version 2.0, whichever you choose. Each version has its own date.
+
+This is a present grant of that additional license, made now. It is not a promise
+to grant it later. The licensor cannot revoke it before it takes effect.
+
+The licensor may include a plain-text line beginning with `Apache Date:` with a
+version of the software, stating the exact date that version's additional license
+takes effect. If it does, that date governs for that version.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do
+not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to
+anyone else, or prevent the licensor from granting licenses to anyone else.
+These terms do not imply any other licenses. [Application
+Users](#application-users) is not an exception to this section: the licenses in
+that section come from the licensor, not from you.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted under
+these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these
+terms, or done anything with the software not covered by your licenses, your
+licenses can nonetheless continue if you come into full compliance with these
+terms, and take practical steps to correct past violations, within 32 days of
+receiving notice. Otherwise, all your licenses end immediately.
+
+If your licenses end, that does not affect the licenses granted under
+[Application Users](#application-users) to people who received your application
+while you were permitted to distribute it, or the licenses granted under [Later
+Apache License](#later-apache-license).
+
+<!-- ===================================================================
+     VARIANT BLOCK: No Liability — THE ONLY REMAINING CHOICE.
+     Choose A or B and delete the other. See REVIEW-NOTES.md §10.
+     This is counsel's call, not the project's: it is the clause most likely
+     to be legally weaker in plain English than in conventional wording.
+     =================================================================== -->
+
+<!-- VARIANT A — plain-English only. -->
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of legal
+claim.***
+
+<!-- VARIANT B — plain English, with implied warranties named. -->
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or
+condition of any kind. This includes any implied warranty of merchantability,
+fitness for a particular purpose, title, or non-infringement, and any warranty
+arising from a course of dealing or from how the software is usually used. As
+far as the law allows, the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any kind
+of legal claim, including direct, indirect, incidental, special, exemplary, and
+consequential damages, and including lost profits and lost or damaged data, even
+if the licensor was told those damages were possible.***
+
+<!-- ===================================================================
+     END VARIANT BLOCK No Liability
+     =================================================================== -->
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the
+**software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
+
+**Total revenue** means all money and other consideration your company received
+or became entitled to receive in the prior tax year, from all sources, before
+deducting any costs. External investment is not revenue. Government grants,
+subsidies and charitable donations are not revenue.
+
+**Total external investment** means all money and other consideration your
+company has ever received from anyone outside your company in exchange for
+shares, for a right to acquire shares, or on terms tied to your company's equity,
+revenue, or growth.
+
+It includes equity investment; convertible notes, SAFEs and similar convertible
+instruments, counted at the amount your company received when it received it,
+not on conversion; venture debt; and revenue-based financing.
+
+It does not include: borrowing from a bank or similar lender on commercial terms
+not tied to your company's equity, revenue, or growth; trade credit; money your
+company earned; government grants, subsidies, research funding and prize money;
+charitable donations; and money put in by your company's own founders or
+employees out of their own funds.
+
+**Your application** has the meaning given in [Your
+Application](#your-application).
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+
+Each figure in [Eligible Organizations](#eligible-organizations) is counted
+across your company, including its affiliates, added together and counted once.

--- a/context/06-sustainability/.reference/licence-draft-license.md
+++ b/context/06-sustainability/.reference/licence-draft-license.md
@@ -119,8 +119,9 @@ figures as met until your company passes them during its first tax year. This
 does not apply to the investment figure, which always counts everything your
 company has received to date.
 
-All three figures are counted across your company as defined in
-[Definitions](#definitions), which includes its affiliates.
+All three figures are counted across your company, which as defined in
+[Definitions](#definitions) includes its affiliates. A subsidiary counts its
+parent's people, revenue and investment, and a parent counts its subsidiaries'.
 
 These figures are fixed amounts. They are not adjusted for inflation. The
 licensor may use different figures in a later version of these terms. That does
@@ -262,8 +263,9 @@ Control can be direct or indirect.
 
 **Total revenue** means all money and other consideration your company received
 or became entitled to receive in the prior tax year, from all sources, before
-deducting any costs. External investment is not revenue. Government grants,
-subsidies and charitable donations are not revenue.
+deducting any costs, added together across your company and counted once.
+External investment is not revenue. Government grants, subsidies and charitable
+donations are not revenue.
 
 **Total external investment** means all money and other consideration your
 company has ever received from anyone outside your company in exchange for
@@ -280,6 +282,9 @@ company earned; government grants, subsidies, research funding and prize money;
 charitable donations; and money put in by your company's own founders or
 employees out of their own funds.
 
+Total external investment is added together across your company and counted
+once, over your company's whole history.
+
 **Your application** has the meaning given in [Your
 Application](#your-application).
 
@@ -287,6 +292,3 @@ Application](#your-application).
 these terms.
 
 **Use** means anything you do with the software requiring one of your licenses.
-
-Each figure in [Eligible Organizations](#eligible-organizations) is counted
-across your company, including its affiliates, added together and counted once.

--- a/context/06-sustainability/.reference/licence-draft-notice-and-packaging.md
+++ b/context/06-sustainability/.reference/licence-draft-notice-and-packaging.md
@@ -306,7 +306,7 @@ date is avoidable fragility. Concretely:
 - Keep `LICENSE-APACHE-2.0` in both repository roots permanently. It is now referenced by
   a live, ongoing mechanism, not just by history.
 
-**Question for counsel (Q-P6):** the conversion runs from "the date the licensor first
+**Question for counsel (Q-P4):** the conversion runs from "the date the licensor first
 made that version available". For an npm package this is unambiguous — the registry
 records it. But a version reachable from a git tag, a GitHub release, or a prerelease
 dist-tag before the npm publish could arguably start the clock earlier. Should the
@@ -345,7 +345,7 @@ Note that `LICENSE.md` does now name Apache-2.0, in `Later Apache License`. That
 forward boundary and it belongs in the operative text, because it is a grant the licence
 itself makes. The backward boundary still does not, and should not, appear there.
 
-**Question for counsel (Q-P4):** should the root `LICENSE` say anything more than the
+**Question for counsel (Q-P5):** should the root `LICENSE` say anything more than the
 paragraph above about the surviving Apache-2.0 grant on pre-`{{FIRST_COVERED_VERSION}}`
 releases? The requirements list this as an open item. The drafting position taken here
 is: state it plainly once, in the repo root and the release notes, and keep it out of
@@ -366,7 +366,7 @@ to fix. Assuming it ships as a Chrome Web Store extension:
 - The Chrome Web Store's own Developer Program Policies apply on top and are not
   displaced by this licence. Counsel may want to check there is no conflict.
 
-**Question for counsel (Q-P5):** does distribution through a third-party store impose
+**Question for counsel (Q-P6):** does distribution through a third-party store impose
 any licence-presentation requirement that `LICENSE.md`'s [Notices] section does not
 already satisfy?
 
@@ -399,23 +399,23 @@ This is documentation, not licence text, and should live in the docs site rather
    block (`No Liability`); delete all HTML comments.
 2. Confirm `LICENSE.md` names neither licence family it was adapted from — see
    `REVIEW-NOTES.md` §2. Grep for both.
-2a. Wire the `Apache Date:` line into the release pipeline and publish the conversion
+3. Wire the `Apache Date:` line into the release pipeline and publish the conversion
    table (§5). This is a recurring release obligation, not a one-off launch task.
-3. Fix the **two** absent `license` fields in the current generation (`devtools-vite`,
+4. Fix the **two** absent `license` fields in the current generation (`devtools-vite`,
    `wa-sqlite`) — do this even if the licence change is deferred.
-4. Decide what to do about the **13** absent `license` fields in the legacy packages
+5. Decide what to do about the **13** absent `license` fields in the legacy packages
    (§3 Group D, Q-P3). Deprecating them on the registry is the recommended minimum.
-5. Decide and record `{{FIRST_COVERED_VERSION}}`.
-6. Re-run the org-endpoint listing immediately before launch and reconcile against
+6. Decide and record `{{FIRST_COVERED_VERSION}}`.
+7. Re-run the org-endpoint listing immediately before launch and reconcile against
    Group A. The scope had grown by 18 packages beyond what the requirements document
    recorded; assume it has moved again.
-7. Add `LICENSE.md` to every Group A package root; add MIT `LICENSE` to `wa-sqlite`.
-8. Update both repository root `LICENSE` files; rename the existing Apache-2.0 text to
+8. Add `LICENSE.md` to every Group A package root; add MIT `LICENSE` to `wa-sqlite`.
+9. Update both repository root `LICENSE` files; rename the existing Apache-2.0 text to
    `LICENSE-APACHE-2.0` in both.
-9. Verify each published tarball actually contains its licence file
+10. Verify each published tarball actually contains its licence file
    (`npm pack --dry-run` per package).
-10. Confirm the commercial licence is purchasable — see `COMMERCIAL-LICENSE-NOTES.md` §7.
-11. Publish `{{LICENCE_URL}}` and confirm it resolves before the first covered release.
+11. Confirm the commercial licence is purchasable — see `COMMERCIAL-LICENSE-NOTES.md` §7.
+12. Publish `{{LICENCE_URL}}` and confirm it resolves before the first covered release.
    Do not rely on any third party's domain for the canonical text; see `REVIEW-NOTES.md`
    §2.
 

--- a/context/06-sustainability/.reference/licence-draft-notice-and-packaging.md
+++ b/context/06-sustainability/.reference/licence-draft-notice-and-packaging.md
@@ -1,0 +1,423 @@
+# Notice and packaging
+
+**Draft prepared for legal review. This is not legal advice.** This document is the
+mechanical companion to `LICENSE.md`: what each `package.json` declares, which `LICENSE`
+file goes where, and how the Apache-2.0 boundary is stated.
+
+The licence is the **LiveStore Community License 1.0**, declared in SPDX as
+`LicenseRef-LiveStore-Community-1.0`. The licensor is **Johannes Schickling**.
+`{{LICENCE_URL}}` is the project-hosted canonical URL and is the only unresolved
+placeholder, apart from `{{FIRST_COVERED_VERSION}}` which the project must choose.
+
+---
+
+## 1. Current published state — verified
+
+Queried 2026-07-27 against the npm registry's org endpoint
+(`https://registry.npmjs.org/-/org/livestore/package`), which is authoritative for scope
+membership, then per-package for the `latest` dist-tag. **The org publishes 39 packages
+under `@livestore/*`** — considerably more than the requirements document implies.
+
+Do not build the relicensing checklist from `npm search`: it returns 38 and silently
+omits at least `@livestore/devtools-react`. Use the org endpoint.
+
+### Current generation — 25 packages, all at 0.4.0, published 2026-06-02
+
+| Package | `license` field |
+| --- | --- |
+| `@livestore/livestore` | `Apache-2.0` |
+| `@livestore/common` | `Apache-2.0` |
+| `@livestore/common-cf` | `Apache-2.0` |
+| `@livestore/utils` | `Apache-2.0` |
+| `@livestore/utils-dev` | `Apache-2.0` |
+| `@livestore/peer-deps` | `Apache-2.0` |
+| `@livestore/webmesh` | `Apache-2.0` |
+| `@livestore/sqlite-wasm` | `Apache-2.0` |
+| `@livestore/framework-toolkit` | `Apache-2.0` |
+| `@livestore/adapter-web` | `Apache-2.0` |
+| `@livestore/adapter-node` | `Apache-2.0` |
+| `@livestore/adapter-expo` | `Apache-2.0` |
+| `@livestore/adapter-cloudflare` | `Apache-2.0` |
+| `@livestore/react` | `Apache-2.0` |
+| `@livestore/solid` | `Apache-2.0` |
+| `@livestore/svelte` | `Apache-2.0` |
+| `@livestore/graphql` | `Apache-2.0` |
+| `@livestore/cli` | `Apache-2.0` |
+| `@livestore/sync-cf` | `Apache-2.0` |
+| `@livestore/sync-electric` | `Apache-2.0` |
+| `@livestore/sync-s2` | `Apache-2.0` |
+| `@livestore/devtools-expo` | `Apache-2.0` |
+| `@livestore/devtools-web-common` | `Apache-2.0` |
+| **`@livestore/devtools-vite`** | **absent** |
+| **`@livestore/wa-sqlite`** | **absent** |
+
+### Legacy and dormant — 14 packages, last published 2024-02 to 2025-12
+
+| Package | Latest | Last published | `license` field |
+| --- | --- | --- | --- |
+| `@livestore/web` | 0.2.0 | 2024-11-22 | absent |
+| `@livestore/node` | 0.3.0-dev.4 | 2025-01-27 | absent |
+| `@livestore/expo` | 0.2.0 | 2024-11-22 | absent |
+| `@livestore/tauri` | 0.0.57 | 2024-09-06 | absent |
+| `@livestore/cf-sync` | 0.0.57 | 2024-09-06 | absent |
+| `@livestore/db-schema` | 0.2.0 | 2024-11-22 | absent |
+| `@livestore/sql-queries` | 0.0.41 | 2024-02-18 | absent |
+| `@livestore/fractional-index` | 0.0.46-dev.4 | 2024-03-17 | absent |
+| `@livestore/effect-playwright` | `0.0.0-snapshot-…` | 2024-11-04 | absent |
+| `@livestore/devtools-react` | 0.2.0 | 2024-11-22 | absent, **deprecated** |
+| `@livestore/devtools-expo-bridge` | 0.0.56 | 2024-08-19 | absent |
+| `@livestore/devtools-expo-common` | 0.2.0 | 2024-11-22 | absent |
+| `@livestore/devtools-node-common` | 0.3.0-dev.4 | 2025-01-27 | absent |
+| `@livestore/sync-http` | `0.0.0-snapshot-…` | 2025-12-14 | `Apache-2.0` |
+
+Not published to npm at all: **`@livestore/devtools-chrome`**. See §6.
+
+### Three corrections to the requirements document
+
+1. It calls the engine package `livestore`. **No package of that bare name exists on
+   npm** (404). It is `@livestore/livestore`. A checklist keyed to the bare name misses
+   the single most important package.
+2. It lists `devtools-chrome` among packages to relicense. It is **not on npm**, so it
+   has no `package.json` `license` field to change. Different mechanism — §6.
+3. It treats `devtools-react` as a current DevTools package. It was **last published
+   2024-11-22 at 0.2.0 and is deprecated on the registry**. It is not part of the 0.4.0
+   generation. The current DevTools surface on npm is `devtools-vite`, `devtools-expo`
+   and `devtools-web-common`. Relicensing `devtools-react` would be relicensing a
+   dead package; fixing its absent `license` field is still worthwhile (§3, Group D).
+
+### The absent `license` fields
+
+**15 of 39 packages publish with no `license` field** — 2 in the current generation
+(`devtools-vite`, `wa-sqlite`) and 13 legacy. This is the material defect and it is
+five times larger than the requirements document records.
+
+A reader of `@livestore/devtools-vite@0.4.0` finds no package-level licence, follows the
+repository link, finds an Apache-2.0 root `LICENSE`, and reasonably concludes Apache-2.0
+applies. That inference actively undercuts the commercial position. **Fix all 15
+regardless of whether the licence change proceeds** — this is hygiene, not strategy, and
+it is independently worth doing.
+
+---
+
+## 2. The `package.json` `license` field
+
+A bespoke licence has no SPDX-listed identifier. SPDX's own mechanism for this is the
+`LicenseRef-` form, which is valid SPDX expression syntax and is what npm's own
+documentation points to for non-standard licences.
+
+**Every package moving to the new licence declares:**
+
+```json
+"license": "LicenseRef-LiveStore-Community-1.0"
+```
+
+This is the settled identifier. Counsel should confirm it is one the project is content
+to have appear in every downstream SBOM and licence report, since it is effectively
+permanent once published.
+
+Rules:
+
+- **Do not** use a bare string such as `"LiveStore-Community-1.0"`. It is not valid
+  SPDX and tooling will classify it as unknown or, worse, silently ignore it.
+- **Do not** use `"SEE LICENSE IN LICENSE.md"`. It is accepted by npm but conveys
+  nothing to an SBOM scanner and will be reported as an unidentified licence.
+- **Do not** leave the field absent. That is the current defect.
+- Add `"files"` coverage so the `LICENSE.md` is actually included in the published
+  tarball. npm includes a file named `LICENSE` or `LICENSE.md` at the package root
+  automatically, but confirm this per package rather than assuming it.
+
+Expected downstream behaviour, which should be communicated in the announcement: SBOM
+and licence-scanning tools will report `LicenseRef-LiveStore-Community-1.0` as a
+non-OSI-approved, unrecognised licence requiring manual review. This is correct and
+unavoidable for any bespoke licence. It is a friction point for enterprise adopters and
+should be anticipated, not discovered.
+
+---
+
+## 3. Which package gets which licence
+
+### Group A — new licence, `LicenseRef-LiveStore-Community-1.0`
+
+The **24 current-generation packages** from §1, excluding `wa-sqlite` (Group B):
+
+`@livestore/livestore`, `common`, `common-cf`, `utils`, `utils-dev`, `peer-deps`,
+`webmesh`, `sqlite-wasm`, `framework-toolkit`, `adapter-web`, `adapter-node`,
+`adapter-expo`, `adapter-cloudflare`, `react`, `solid`, `svelte`, `graphql`, `cli`,
+`sync-cf`, `sync-electric`, `sync-s2`, `devtools-expo`, `devtools-web-common`,
+`devtools-vite`.
+
+Each gets:
+- `"license": "LicenseRef-LiveStore-Community-1.0"` in `package.json`
+- a `LICENSE.md` at the package root containing the full new licence text, with all
+  placeholders resolved
+
+**Question for counsel (Q-P1):** `utils`, `utils-dev`, `peer-deps` and
+`framework-toolkit` are internal or build-time packages rather than parts of the
+shipped library surface. Relicensing them is the conservative default and is what
+"all published `@livestore/*` packages" in the requirements says. But `utils-dev` in
+particular is plausibly a build dependency of *contributors*, not of licensees, and
+gating it may create friction with no commercial upside. Worth a deliberate decision
+rather than inheriting one from a wildcard.
+
+### Group B — stays MIT
+
+**`@livestore/wa-sqlite`.** A fork of [`rhashimoto/wa-sqlite`], MIT © 2023 Roy T.
+Hashimoto. MIT permits sublicensing under different terms provided the notice is
+preserved, but the value in that package is upstream's, and anyone gated by the new
+licence could simply use upstream directly. Relicensing it buys nothing and costs
+goodwill.
+
+- `"license": "MIT"` — this is a **fix to a current defect**, not a change; the package
+  publishes with no `license` field today and must declare MIT regardless of whether the
+  wider licence change proceeds.
+- `LICENSE` at package root: the upstream MIT text with Roy T. Hashimoto's copyright
+  notice intact, plus a second copyright line for the fork's own changes if the project
+  asserts one.
+
+**Question for counsel (Q-P2):** does the fork contain enough original authorship to
+warrant a second copyright line, and if so in whose name?
+
+### Group C — not published to npm
+
+**`@livestore/devtools-chrome`.** See §6.
+
+### Group D — legacy and dormant, 14 packages
+
+The packages in §1's second table. None has been published since 2025-12 and most since
+2024. **Recommendation: do not relicense them.** Reasons:
+
+- A new release of a dead package purely to change its licence signals nothing useful and
+  invites the reading that the project is retroactively narrowing rights, which is
+  exactly the impression to avoid.
+- Their existing published versions stay under whatever terms they carried, which nothing
+  can change (see §5).
+- Several are superseded by current-generation equivalents (`web` → `adapter-web`, `node`
+  → `adapter-node`, `expo` → `adapter-expo`, `cf-sync` → `sync-cf`).
+
+**But do two things:**
+
+1. **Deprecate them on the registry** with a message pointing at the successor package,
+   as has already been done for `devtools-react`. This is the honest signal, it costs
+   nothing, and it stops new adopters landing on an unlicensed package.
+2. **If any is republished for any reason**, it must carry a `license` field at that
+   point — either `Apache-2.0` if it stays legacy, or `LicenseRef-LiveStore-Community-1.0` if it
+   is revived into the current generation.
+
+**Question for counsel (Q-P3):** 13 of these 14 packages have published for years with
+**no `license` field at all**. What terms, if any, govern a user who installed one of
+them? The absence of a licence grant is ordinarily "all rights reserved", which is a
+worse position for those users than Apache-2.0, and is unlikely to be what was intended
+given the repository root was Apache-2.0 throughout. Is a clarifying public statement
+that those versions were and remain available under Apache-2.0 advisable, and does
+making it carry any risk?
+
+---
+
+## 4. Repository root `LICENSE` files
+
+There are **two** repositories, and both roots are currently Apache-2.0. Both must be
+updated; changing only one leaves a contradictory record.
+
+- `livestorejs/livestore` — root `LICENSE` is Apache-2.0
+- `livestorejs/livestore-contrib` — root `LICENSE` is Apache-2.0, and its nine
+  `packages/@livestore/*` packages all declare `Apache-2.0`
+
+Each root `LICENSE` must state three things: what it covers, what it does not, and the
+version boundary. Suggested wording for both roots, adjusted per repo:
+
+```
+# Licensing
+
+Except as stated below, the contents of this repository are licensed under the
+LiveStore Community License 1.0. The full text is in LICENSE.md in this directory
+and at {{LICENCE_URL}}. Copyright Johannes Schickling.
+
+## Subtrees under different terms
+
+- packages/@livestore/wa-sqlite is licensed under the MIT License. It is a fork of
+  https://github.com/rhashimoto/wa-sqlite, Copyright (c) 2023 Roy T. Hashimoto. See
+  the LICENSE file in that directory.
+
+## Earlier releases
+
+Versions of the LiveStore packages published before {{FIRST_COVERED_VERSION}} were
+released under the Apache License, Version 2.0. That licence is perpetual and
+irrevocable for those versions. It is unaffected by this change, and those versions
+remain available under it.
+
+## Every release becomes Apache-2.0 after two years
+
+Each version released under the LiveStore Community License 1.0 also becomes
+available under the Apache License, Version 2.0 on the second anniversary of the
+date it was first made available. Each version has its own date. See the "Later
+Apache License" section of LICENSE.md.
+
+A copy of the Apache License, Version 2.0 is kept in LICENSE-APACHE-2.0 in this
+directory, for both of the purposes above.
+
+This licensing information is provided for convenience. The operative terms are those
+in the licence texts themselves.
+```
+
+Notes on that wording:
+
+- The existing Apache-2.0 text is **kept in the repository**, renamed to
+  `LICENSE-APACHE-2.0`, rather than deleted. Deleting it makes it harder for a user of a
+  prior version to find the terms that still govern them, and reads as an attempt to
+  obscure the earlier grant.
+- `{{FIRST_COVERED_VERSION}}` should be a concrete version number decided before
+  launch — for example `0.5.0`. State the number, not a date. Users reason about
+  versions; git history and release dates are ambiguous.
+- The root `LICENSE` should be renamed to `LICENSE.md` if it now contains Markdown, or
+  the block above should be plain text. Do not leave a Markdown document in a file named
+  `LICENSE` that tooling will try to match against known licence texts.
+
+---
+
+## 5. The two Apache-2.0 boundaries — how they are stated, and where
+
+There are now **two** distinct relationships to Apache-2.0, and conflating them in
+communications will confuse everyone:
+
+- **Backward:** releases before `{{FIRST_COVERED_VERSION}}` were published under
+  Apache-2.0 and stay there permanently. A fixed, closed set.
+- **Forward:** every release from `{{FIRST_COVERED_VERSION}}` onward *becomes*
+  Apache-2.0 two years after its own publication. A rolling, open set that grows
+  continuously.
+
+The practical upshot for a reader is simple and should be stated that way: **every
+version of LiveStore is Apache-2.0, either already or within two years.** The community
+licence governs a two-year window on each release, and nothing more.
+
+### The per-version conversion date must be recorded
+
+The licence lets the licensor ship an `Apache Date:` plain-text line stating a version's
+exact conversion date. **Use it.** Without it, a licensee has to establish "the date the
+licensor first made that version available" from the registry, and while npm's `time`
+field is authoritative and public, relying on a third party's metadata to fix a licence
+date is avoidable fragility. Concretely:
+
+- Add a line to each package's shipped notices at release time:
+  `Apache Date: YYYY-MM-DD` — the publication date plus two years.
+- Generate it from the release pipeline, not by hand. A wrong date is a wrong licence.
+- **Publish a conversion table** on the docs site: version, publication date, Apache-2.0
+  date. This is the single most useful artefact for an enterprise adopter evaluating the
+  licence, and it costs nothing to maintain from release metadata.
+- Keep `LICENSE-APACHE-2.0` in both repository roots permanently. It is now referenced by
+  a live, ongoing mechanism, not just by history.
+
+**Question for counsel (Q-P6):** the conversion runs from "the date the licensor first
+made that version available". For an npm package this is unambiguous — the registry
+records it. But a version reachable from a git tag, a GitHub release, or a prerelease
+dist-tag before the npm publish could arguably start the clock earlier. Should the
+licence define availability by reference to the npm publication specifically, or is the
+`Apache Date:` line sufficient to remove the ambiguity in practice?
+
+### Where each boundary is stated
+
+The backward boundary is stated in **four** places, deliberately redundantly, because
+each audience reaches for a different one:
+
+1. **Repository root `LICENSE`** — the "Earlier releases" paragraph in §4. For someone
+   browsing the repo.
+2. **`package.json` of each new release** — the `license` field changes to
+   `LicenseRef-LiveStore-Community-1.0` at `{{FIRST_COVERED_VERSION}}` and stays `Apache-2.0` in
+   every already-published version. Already-published `package.json` files are immutable
+   on npm; **do not** attempt to amend them, and do not unpublish. The registry record is
+   the strongest evidence of what was granted, and it is correct as it stands.
+3. **Release notes for `{{FIRST_COVERED_VERSION}}`** — a plain statement that this
+   release and later ones are under the new licence, that earlier releases remain under
+   Apache-2.0, and that the Apache-2.0 grant on those is irrevocable.
+4. **A `Required Notice:` line shipped with the software**, if the project uses that
+   mechanism from `LICENSE.md`:
+
+   ```
+   Required Notice: Copyright Johannes Schickling
+   ```
+
+The operative fact that must not be muddied anywhere: **Apache-2.0 §2 grants are
+perpetual and irrevocable.** Versions already published cannot be withdrawn and remain
+forkable. Any communication implying otherwise is both wrong and damaging. Nothing in
+the new licence purports to affect them; the backward boundary is drawn by *which text
+ships with which version*, not by a clause describing its own scope.
+
+Note that `LICENSE.md` does now name Apache-2.0, in `Later Apache License`. That is the
+forward boundary and it belongs in the operative text, because it is a grant the licence
+itself makes. The backward boundary still does not, and should not, appear there.
+
+**Question for counsel (Q-P4):** should the root `LICENSE` say anything more than the
+paragraph above about the surviving Apache-2.0 grant on pre-`{{FIRST_COVERED_VERSION}}`
+releases? The requirements list this as an open item. The drafting position taken here
+is: state it plainly once, in the repo root and the release notes, and keep it out of
+the operative licence text.
+
+---
+
+## 6. `@livestore/devtools-chrome`
+
+Not published to npm, so there is no `package.json` `license` field in a registry record
+to fix. Assuming it ships as a Chrome Web Store extension:
+
+- The extension's `manifest.json` has no licence field. Chrome Web Store listings carry a
+  developer-supplied terms-of-use / privacy URL instead. Point it at `{{LICENCE_URL}}`.
+- Ship `LICENSE.md` inside the extension package, at its root.
+- If the extension source lives in a public repository, that repository's root `LICENSE`
+  must carry the same statement as §4.
+- The Chrome Web Store's own Developer Program Policies apply on top and are not
+  displaced by this licence. Counsel may want to check there is no conflict.
+
+**Question for counsel (Q-P5):** does distribution through a third-party store impose
+any licence-presentation requirement that `LICENSE.md`'s [Notices] section does not
+already satisfy?
+
+---
+
+## 7. Third-party notices produced by licensees
+
+`LICENSE.md`'s [Notices] section lets a licensee who ships the software only as part of
+a bundled application satisfy the notice obligation through a third-party-notices file
+rather than by shipping the licence text as a separate file. This is deliberate — see
+`REVIEW-NOTES.md` §4b — because the alternative reading puts every licensee shipping a
+minified web bundle in technical breach.
+
+To make that easy in practice, the project should publish a short, copy-pasteable
+attribution block for licensees to include, for example:
+
+```
+This product includes LiveStore ({{LICENCE_URL}}).
+Copyright Johannes Schickling. Licensed under the LiveStore Community License 1.0.
+```
+
+This is documentation, not licence text, and should live in the docs site rather than in
+`LICENSE.md`.
+
+---
+
+## 8. Pre-launch checklist
+
+1. Resolve `{{LICENCE_URL}}` in `LICENSE.md`; choose A or B in the one remaining Variant
+   block (`No Liability`); delete all HTML comments.
+2. Confirm `LICENSE.md` names neither licence family it was adapted from — see
+   `REVIEW-NOTES.md` §2. Grep for both.
+2a. Wire the `Apache Date:` line into the release pipeline and publish the conversion
+   table (§5). This is a recurring release obligation, not a one-off launch task.
+3. Fix the **two** absent `license` fields in the current generation (`devtools-vite`,
+   `wa-sqlite`) — do this even if the licence change is deferred.
+4. Decide what to do about the **13** absent `license` fields in the legacy packages
+   (§3 Group D, Q-P3). Deprecating them on the registry is the recommended minimum.
+5. Decide and record `{{FIRST_COVERED_VERSION}}`.
+6. Re-run the org-endpoint listing immediately before launch and reconcile against
+   Group A. The scope had grown by 18 packages beyond what the requirements document
+   recorded; assume it has moved again.
+7. Add `LICENSE.md` to every Group A package root; add MIT `LICENSE` to `wa-sqlite`.
+8. Update both repository root `LICENSE` files; rename the existing Apache-2.0 text to
+   `LICENSE-APACHE-2.0` in both.
+9. Verify each published tarball actually contains its licence file
+   (`npm pack --dry-run` per package).
+10. Confirm the commercial licence is purchasable — see `COMMERCIAL-LICENSE-NOTES.md` §7.
+11. Publish `{{LICENCE_URL}}` and confirm it resolves before the first covered release.
+   Do not rely on any third party's domain for the canonical text; see `REVIEW-NOTES.md`
+   §2.
+
+[`rhashimoto/wa-sqlite`]: https://github.com/rhashimoto/wa-sqlite
+[Notices]: ./LICENSE.md#notices

--- a/context/06-sustainability/.reference/licence-draft-review-notes.md
+++ b/context/06-sustainability/.reference/licence-draft-review-notes.md
@@ -1,0 +1,644 @@
+# Review notes for counsel
+
+**This is a draft prepared for legal review. It is not legal advice, and it was not
+prepared by a lawyer.** Every clause below is offered as a starting point for your
+review, not as a settled position.
+
+Purpose of this document: to save you the work of reverse-engineering intent. It records
+what each clause is for, where the draft departs from its source and why, what is
+unverified, and what I could not resolve. §12 is the numbered list of open questions.
+§13 states what I am least confident in.
+
+**Read §2 first.** It corrects a factual premise I was given, and it constrains the
+licence text.
+
+---
+
+## 1. What the licence has to achieve
+
+From the settled requirements (`../licence-requirements.md`), which I treated as fixed:
+
+- Free use if **fewer than 10 individuals AND less than USD 1,000,000 revenue** in the
+  prior tax year. Conjunctive, deliberately. Fixed figure, **not** inflation-indexed.
+  Affiliates aggregate.
+- Unconditional grants regardless of that gate for: individuals, noncommercial and public
+  organisations, and a ~30-day evaluation.
+- Modification and redistribution as part of the licensee's own application permitted.
+- **Downstream recipients of a licensee's application must not need their own licence.**
+- No non-compete. No source-disclosure obligation. No technical enforcement.
+- Future releases only; prior releases stay Apache-2.0 irrevocably.
+- `@livestore/wa-sqlite` excluded, stays MIT.
+
+The context that makes several of these load-bearing: **LiveStore is a client-side
+library that ships inside other people's applications.** Most source-available licences
+were drafted for server software, and several of their standard clauses misbehave in this
+setting. §3 and §4 are the two places that bites.
+
+---
+
+## 2. Provenance and the licence of the source texts — correcting the brief
+
+The draft is adapted from three licences in the same plain-English family: a
+small-business-gated licence, a noncommercial licence, and a free-trial licence, each at
+version 1.0.0. I took canonical text from the publisher's release tags in their source
+repository rather than from their website — see the note on availability below.
+
+**I was told these texts are licensed CC-BY-4.0 and that the derived licence must carry
+attribution. That is incorrect, and the correct position points the opposite way.**
+
+The publisher's own repository states the terms, identically at all three refs I checked
+(`master`, the `1.0.0` branch, and the `Polyform-Small-Business-1.0.0` release tag):
+
+> Each contributor licenses you to do everything with PolyForm licenses that would
+> otherwise infringe that contributor's copyright in it.
+>
+> If you make changes to a PolyForm license, you must remove all mention of "PolyForm"
+> and polyformproject.org, as well.
+
+So: a bare permissive copyright grant with **no attribution requirement**, and a
+**de-branding requirement** attached to modified texts. The publisher also holds a US
+trademark application for the mark (serial 88400646), which is consistent with reading
+the de-branding condition as a trademark-protective term rather than a copyright one.
+
+I traced the CC-BY-4.0 claim to its likely source: ScanCode LicenseDB's pages for these
+licences carry a footer stating that *the database* is licensed CC-BY-4.0. That footer
+describes ScanCode's own catalogue, not the licence texts.
+
+**Consequences, which I have acted on:**
+
+1. `LICENSE.md` contains **zero** occurrences of the family name or the publisher's
+   domain. I verified this with a grep; it returns nothing. Please re-verify after you
+   edit.
+2. **I did not copy the precedent's provenance header.** The closest precedent for this
+   exact adaptation — Statiq's "Statiq Public License 1.0.0", which combines the same
+   three source licences and modifies the same two thresholds — opens with a paragraph
+   naming the family three times and linking the publisher's domain three times. On the
+   reading above, that header is the one thing Statiq got wrong. I took their **clause
+   composition**, which is sound and is direct precedent for what we are doing, and
+   discarded their header.
+3. The licence needs a **project-hosted canonical URL**. The `Notices` clause obliges
+   recipients to get "these terms or the URL for them above"; with the publisher's URL
+   removed there must be one of our own. I added a placeholder the brief did not list:
+   **`{{LICENCE_URL}}`**. It must resolve before the first covered release.
+
+**My interpretation, flagged as mine:** I read the de-branding condition as binding the
+*modified licence text*, not as barring a separate memo that discusses derivation. That
+is why this document names the family freely and `LICENSE.md` does not. If you read the
+condition more broadly, this document would need sanitising too. **See Q1.**
+
+**Availability note, relevant to (3):** the publisher's website is currently returning
+404 for every subpage — `/licenses`, `/about`, and each individual licence URL — while
+the domain root serves. It was live in the Internet Archive's 2026-07-17 snapshot and is
+broken as of 2026-07-27, most likely from a site push on 2026-07-12. This does not affect
+the draft, since I took text from release tags, but it is a concrete reason not to
+depend on a third party's domain for canonical licence text. It also means any licensee
+following a URL in the unmodified upstream licences right now reaches a 404.
+
+---
+
+## 2a. Placeholder inventory — including three the brief did not list
+
+The brief specified `{{LICENCE_NAME}}`, `{{LICENSOR}}`, `{{GOVERNING_LAW}}`,
+`{{SUNSET}}`, `{{AUDIT_RIGHTS}}`, `{{REVENUE_DEFINITION}}` and
+`{{INDIVIDUALS_DEFINITION}}`. All appear in the draft. I added **three more**, each
+because the text is unusable without it. Flagged here rather than slipped in:
+
+| Placeholder | Why it exists |
+| --- | --- |
+| **`{{LICENCE_URL}}`** | The `Notices` clause obliges recipients to get the terms *or the URL for them*. Removing the source publisher's URL under the de-branding condition (§2) leaves nothing there. A project-hosted canonical URL must exist and resolve before the first covered release. |
+| **`{{LICENSOR_URL}}`** | Appears only in the `Required Notice:` example line, mirroring the source licences' own example format. Cosmetic; can be dropped with the example if the `Required Notice:` mechanism is not used. |
+| **`{{VENUE}}`** | Only inside the optional `Governing Law` section. Governing law and forum are separate choices and conflating them into one placeholder would hide that. Disappears entirely if §11's recommendation to omit that section is accepted. |
+
+Two further placeholders, `{{SUNSET_PERIOD}}` and `{{SUNSET_LICENCE}}`, sit inside the
+`{{SUNSET}}` variant block and are needed only if that variant is chosen. `LICENSE.md`
+also references `{{LICENCE_ID}}` indirectly through `NOTICE-AND-PACKAGING.md`, which is
+the SPDX `LicenseRef-` identifier and is not part of the licence text itself.
+
+I invented no substantive figures, names, periods or jurisdictions anywhere. The only
+concrete numbers in the operative text are those the requirements fix (10 individuals,
+USD 1,000,000), the 32-day cure period inherited unchanged from the source, and the
+30-day evaluation and certification-response periods discussed at §3 and §8.
+
+---
+
+## 3. The individual-grant defect, and how the draft fixes it
+
+The small-business licence's only permitted purpose is *"use of the software for the
+benefit of your company"*. It therefore grants **nothing** to an individual acting for
+themselves — no hobbyist, no student, no one building a portfolio piece. The drafter has
+confirmed this and his suggested remedy is to dual-licence with the noncommercial
+licence. For a library that most people first meet through a weekend project, shipping
+that defect would be fatal.
+
+The draft fixes it by composing sections rather than dual-licensing, giving four
+independent permitted purposes. **A user needs to satisfy only one.** That structure is
+the essential design decision and is worth confirming reads that way to you.
+
+### `Personal Uses` — deviation from source, deliberate
+
+The source noncommercial licence reads:
+
+> Personal use for research, experiment, and testing for the benefit of public
+> knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or
+> religious observance, **without any anticipated commercial application**, is use for a
+> permitted purpose.
+
+I made two changes:
+
+- **Removed "without any anticipated commercial application".** The requirements
+  explicitly include *portfolio work*. A portfolio piece is built precisely in
+  anticipation of commercial benefit — getting hired. The qualifier would exclude the
+  single case the requirement names. It would also make the grant turn on a developer's
+  private future intentions, which is unknowable and therefore unadministrable.
+- **Added portfolio work by name**, and added an explicit negative boundary: work for an
+  organisation, including an employer or a client, is not personal use, and falls to the
+  other sections.
+
+**Trade-off you should weigh:** without the "no anticipated commercial application"
+qualifier, `Personal Uses` is broader than its source. A sole developer could argue that
+solo commercial work is "an individual's own purposes". I have relied on the negative
+boundary sentence plus the `Your company` definition to close this — see §5 — but the
+seam is real and it is the widest one in the draft. **See Q2.**
+
+### `Noncommercial Organizations` — near-verbatim
+
+Taken from the source noncommercial licence essentially unchanged, with "whatever the
+size of the organization" added to satisfy the requirement's "regardless of size or
+funding source". The source already covered funding source; size was implicit and is now
+explicit.
+
+### `Evaluation` — deviation from source, deliberate
+
+Three changes from the source free-trial licence:
+
+- **30 days rather than 32.** The requirement says ~30 days. The source's 32 is a
+  drafting convenience (it guarantees a full calendar month has elapsed regardless of
+  month length). 30 is what a reader expects and what the requirement says. If you prefer
+  32 for that reason, say so — I have no attachment to 30.
+- **Added an explicit carve-out of external distribution.** The source free-trial licence
+  forbids distribution outright. Ours cannot, because the same document grants
+  distribution elsewhere. Without the carve-out, "evaluation" would let an
+  above-threshold organisation ship a production application free for 30 days, and
+  arguably keep re-starting the clock for each "project". The carve-out limits evaluation
+  to internal use.
+- **Retained multiple concurrent evaluations** for different needs or projects, matching
+  the source and the publisher's later working draft.
+
+---
+
+## 4. The two library-specific problems, and the clauses that fix them
+
+These are the parts of the draft with **no counterpart in any source text**. They are
+where I would most want your attention.
+
+### 4a. `Your Application` + `Application Users` — the downstream grant
+
+**The problem.** Under the unmodified source structure, distribution is permitted, but
+every recipient must accept the terms themselves and must have their own permitted
+purpose, and `No Other Rights` bars the licensee from sublicensing. So: a qualifying
+five-person startup ships a web application containing the library. A 5,000-person
+enterprise uses that application. The enterprise's browsers download and copy the
+library; the enterprise has no permitted purpose and cannot get one from the startup.
+Result: the startup's customers are infringing, and the startup cannot fix it. For a
+library that ships inside other people's products, that is a product-breaking defect,
+and the requirements identify it as such.
+
+**The fix.** Two new sections:
+
+- **`Your Application`** defines the unit of redistribution: a product of the licensee's
+  own that includes the software as a component and adds substantial functionality of its
+  own. Bare redistribution of the software, and products whose main value is the software
+  itself, are excluded.
+- **`Application Users`** grants recipients of that application copyright and patent
+  licences **directly from the licensor** to run, copy, install, host, deploy, and pass
+  along the software as part of the application, for any purpose, regardless of their
+  size or purpose, with no other licence needed.
+
+**Five drafting choices inside this, each deliberate:**
+
+1. **Direct grant, not sublicence.** This is what makes it consistent with
+   `No Other Rights`. I also added a cross-reference in `No Other Rights` pointing at
+   `Application Users`, so the two do not read as contradicting each other.
+2. **Carved out of `Acceptance`.** `Acceptance` conditions every licence on the
+   recipient agreeing to the terms, and `you` is defined as the person agreeing.
+   Application Users recipients by construction never see the terms and never agree, so
+   without a carve-out `Acceptance` would deny them the very licence `Application Users`
+   grants — the document would defeat itself before you reached the question of whether
+   the construction works at all. `Acceptance` now states that it does not apply to
+   those licences and that the licensor grants them without requiring agreement. This is
+   the same cross-reference pattern used in `No Other Rights`. **This was a real defect
+   in an earlier version of the draft; flagged so you know it was found rather than
+   never present.**
+3. **Verb list covers hosting and deployment, not just running.** An early draft said
+   only "run and make copies", which arguably fails the case where a recipient
+   *self-hosts* the licensee's application on its own infrastructure — a normal
+   enterprise-software pattern. "Install, host, and deploy" closes that.
+4. **Conditioned on the distribution having been permitted when made**, so an
+   unqualified distributor cannot manufacture free rights for others.
+5. **Survives the licensee's licences ending**, stated both in `Application Users` and
+   again in `Violations`. Without this, a licensee's later breach retroactively
+   infringes on every copy already in end users' hands — commercially intolerable and
+   the main reason `COMMERCIAL-LICENSE-NOTES.md` §5 recommends a perpetual model.
+
+**A consequence you should decide on, not a defect.** `Patent Defense` terminates the
+patent licence on a written infringement claim by "you" or "your company". Application
+Users recipients are deliberately **not** "you" — that is correct and consistent
+throughout the clause, and it is what makes the direct grant work. But it follows that an
+above-threshold enterprise using a licensee's application holds a patent licence from the
+licensor with **no defensive-termination hook attached to it**. If that is not wanted,
+`Application Users` needs its own defensive-termination sentence. I have not added one,
+because doing so would partly undo the "no other licence needed, nothing to agree to"
+property that the clause exists to create. **See Q3.**
+
+**Known weakness.** "Substantial functionality of its own beyond the software" and
+"a product whose main value is the software itself" are the anti-circumvention test, and
+they are vague. A determined enterprise could route around the gate through a thin
+wrapper published by a hobbyist. I do not think more words fix this — every formulation I
+tried either failed to exclude the wrapper or accidentally excluded a legitimate thin
+integration library. It is a judgement call about how much to tighten and I have left it
+deliberately loose rather than risk the false negative. **See Q4.**
+
+### 4b. `Notices` — deviation from source, deliberate
+
+**The problem.** The source clause obliges the licensee to ensure that anyone who gets a
+copy of **any part** of the software also gets the terms or the URL. End users of a
+minified web bundle *do* receive a copy of parts of the software, and never see a licence
+file. Read literally, **every licensee shipping a web application is in breach**.
+
+**The fix.** The obligation is split. Distributing the software on its own or in source
+form keeps the full obligation. Distributing it only as part of an application, in
+compiled/bundled/minified/processed form, is satisfied by including the same notices in
+the application's documentation, credits, or third-party-notices — the conventional
+practice the whole ecosystem already follows.
+
+This is a real narrowing of the licensor's notice rights, chosen because the alternative
+is a clause nobody can comply with. `NOTICE-AND-PACKAGING.md` §7 recommends publishing a
+copy-pasteable attribution block to make compliance trivial. **See Q5.**
+
+**A second, related narrowing, which I noticed and left in place.** `Application Users`
+lets recipients "pass your application along to others". Those recipients are not "you",
+and are carved out of `Acceptance`, so **no notice obligation attaches to them at all**.
+The notice chain therefore terminates at the first downstream hop: the licensee must
+carry notices into their application, but a reseller or redistributor of that application
+need not carry them further.
+
+I believe this is unavoidable rather than a defect. Obligations cannot sensibly attach to
+people who never agreed to anything, and making the downstream grant conditional on
+compliance would reintroduce exactly the "downstream recipients need their own licence"
+problem the clause exists to solve. But it is a deliberate choice and it does reduce
+attribution reach, so it should be a decision rather than a discovery. If you want notices
+to propagate further, the mechanism would have to be an obligation on the *licensee* to
+require it of their own redistributors — which is enforceable against someone who did
+agree, and is how this is usually solved.
+
+---
+
+## 5. The size gate
+
+Drafted from the small-business licence's `Small Business` clause with these changes:
+
+- **Thresholds:** 100 → **10** individuals; 1,000,000 USD retained but its meaning
+  changed, see next point.
+- **CPI indexing removed entirely.** The source says `1,000,000 USD (2019)` followed by a
+  sentence directing the reader to adjust for inflation via the US BLS CPI-U index. The
+  requirements reject indexing: it obliges every prospective licensee to perform an
+  index lookup before knowing whether they may use the software. I removed **both** the
+  adjustment sentence **and** the `(2019)` parenthetical — the parenthetical is
+  meaningless without the mechanism and would read as a drafting error. In its place the
+  draft states affirmatively that the figures are fixed and not adjusted for inflation,
+  and that a later version using different figures does not change these ones.
+
+  *This is a live trap.* The Statiq precedent modified the numbers but kept both the
+  `(2019)` marker and the full CPI sentence. Anyone adapting from Statiq by swapping
+  figures will silently reimport exactly what the requirements reject.
+- **Conjunctive test made explicit.** The source's "and" is easy to skim past, so the
+  draft adds "Your company must meet both of these. If it meets only one, use for its
+  benefit is not a permitted purpose under this section." The requirements are emphatic
+  that a five-person company at USD 3M revenue is meant to be gated.
+- **New-company case added.** The source has no rule for a company with no prior tax
+  year, which is undefined for a large share of the target audience — the gate simply
+  has no answer for them. The draft permits use during the first tax year until either
+  figure is passed. This is not in the requirements, but the gate is incomplete without
+  it, so I trace it to the gate requirement rather than treating it as an addition. The
+  publisher's own later working draft adopts the same approach, which I take as
+  confirmation it is the conventional fix. **Confirm this is wanted — see Q6.**
+- **Affiliate roll-up** comes free from the source's `Your company` / `Control`
+  definitions, which the draft keeps essentially verbatim. Nothing was added.
+
+### An open item from the requirements that I believe is now answered
+
+Requirements open item 5 asks whether the individual grant should extend to sole traders
+and single-person companies. **I think the definitions already settle it and it does not
+need to go to you as an open question.** The `Your company` definition expressly includes
+"sole proprietorship", and `Personal Uses` expressly excludes work for an organization
+including a client. So a sole trader doing client work falls to `Small Business` — where,
+being one person under USD 1,000,000, they pass anyway. The outcome the requirement
+wanted is reached without a special rule. Flagged here so you can disagree rather than
+rediscover it.
+
+---
+
+## 6. `{{REVENUE_DEFINITION}}` — variants in the draft
+
+Requirements open item 4. Left as a labelled variant block in the Definitions section
+because it materially changes who is gated.
+
+- **Variant A — undefined.** What the source licences do. Relies on ordinary meaning.
+  Shortest, and consistent with the register, but leaves genuine ambiguity for grant-
+  funded organisations and for pre-revenue funded startups.
+- **Variant B — defined.** Gross (before costs), consolidated across the company and its
+  affiliates and counted once, excluding equity investment, borrowing, grants and
+  donations.
+
+**Recommendation: Variant B.** The pre-revenue-funded-startup case is common in this
+audience and Variant A gives no answer. Excluding investment means a seed-funded
+five-person company with no product revenue qualifies, which I read as the intended
+outcome given the requirement's stated rationale of ability to pay. Excluding grants
+avoids double-gating organisations that `Noncommercial Organizations` already covers.
+**Confirm the investment carve-out is intended — see Q7.**
+
+---
+
+## 7. `{{INDIVIDUALS_DEFINITION}}` — variants in the draft
+
+Requirements open item 3. Three labelled variants:
+
+- **A — undefined.** Source behaviour.
+- **B — headcount, part-time counted in full.** Every individual counted once regardless
+  of hours; agency workers count if they worked mainly for the company.
+- **C — full-time equivalents.** Averaged FTE across the prior tax year.
+
+**Recommendation: Variant B.** At a threshold of 10, FTE arithmetic is disproportionate
+and creates a self-assessment burden bigger than the decision it informs. B is
+conservative — it counts more people, so it gates more organisations — and is trivial to
+apply. The agency sentence in B is the part I am least sure of: "worked mainly for your
+company" is a soft test, and offshore agency arrangements are exactly where a licensee
+would push. **See Q8.**
+
+---
+
+## 8. `{{AUDIT_RIGHTS}}` — variants in the draft
+
+Requirements §5 asks counsel to advise. Two labelled variants:
+
+- **A — nothing.** Rely on `Violations` and on the commercial agreement.
+- **B — self-certification on request.** On written request the licensee confirms in
+  writing, within 30 days, whether its use is permitted and under which section. Capped
+  at one request per 12 months. No financial records. Never applies to `Personal Uses`.
+
+**Recommendation: Variant B, but this is the clause I would most readily drop.** A
+records-inspection audit right of the kind found in enterprise agreements is
+disproportionate in a public licence for a client-side library and would be read as
+hostile by exactly the developer audience the project depends on. Variant B is the
+minimum that gives the licensor a documented request-and-response record. The
+`Personal Uses` carve-out is there so an individual can never receive a compliance
+letter. A *paid* agreement can reasonably carry more; see `COMMERCIAL-LICENSE-NOTES.md`
+§6. **See Q9.**
+
+---
+
+## 9. `{{SUNSET}}` — variants in the draft
+
+Being decided separately, so it is a labelled variant with placeholders left open.
+
+- **A — none.** The terms apply indefinitely.
+- **B — delayed permissive grant.** After `{{SUNSET_PERIOD}}`, each version also becomes
+  available under `{{SUNSET_LICENCE}}`, with an optional `Change Date:` plain-text line
+  to state the date exactly for a given release.
+
+Drafting notes on B, which apply whichever period is chosen:
+
+- The grant is **additive** — the licensee may then choose either set of terms. It does
+  not replace the original grant, so nobody's existing rights shrink.
+- It runs **per version, from first availability of that version**, matching the
+  established convention for this pattern.
+- It cascades to earlier versions ("that version, and every earlier version"), so a
+  licensee never has to track more than one date.
+- The `Change Date:` mechanism lets the project state an exact date per release rather
+  than obliging every licensee to compute one. Recommended if B is chosen.
+
+**Interaction worth noting:** if `{{SUNSET_LICENCE}}` is Apache-2.0, the project ends up
+with Apache-2.0 on prior releases, the new licence on covered releases, and Apache-2.0
+again after the sunset period. That is coherent, and probably reassuring to enterprise
+adopters, but the announcement must be very clear or it will read as confusing. **See Q10.**
+
+---
+
+## 10. Warranty and liability — where plain English may be legally weaker
+
+**This is the clause where I am least comfortable, and I have not chosen for you.**
+
+The draft offers two labelled variants of `No Liability`:
+
+- **Variant A** — the source licences' single bold sentence, verbatim: *"As far as the
+  law allows, the software comes as is, without any warranty or condition, and the
+  licensor will not be liable to you for any damages arising out of these terms or the
+  use or nature of the software, under any kind of legal claim."*
+- **Variant B** — the same plain-English register, but naming merchantability, fitness
+  for a particular purpose, title, non-infringement, course of dealing and usage of
+  trade, and naming the excluded damage categories including consequential and lost
+  profits.
+
+**The concern.** Under UCC §2-316(2) an exclusion of the implied warranty of
+merchantability must *mention merchantability*, and an exclusion of fitness must be in
+writing and conspicuous. Variant A mentions neither by name. It is possible that "without
+any warranty or condition" plus "as far as the law allows" is read as sufficient, and the
+drafters of the source licences are experienced practitioners who presumably considered
+this — that is real evidence for A. But Variant A is untested in litigation as far as I
+can determine, and the downside of being wrong is asymmetric: the licensor bears it
+entirely. Similar concerns apply to excluding consequential damages without naming them,
+and to jurisdictions outside the US with their own conspicuousness or
+incorporation requirements.
+
+Both variants are already bolded and italicised, which is the conventional way of meeting
+a conspicuousness requirement in a Markdown document, and I have preserved that from the
+source in both.
+
+**I have deliberately not picked.** The choice is between fidelity to a plain-English
+register that the whole document depends on, and defensive drafting. That is your call,
+not mine. **See Q11.**
+
+---
+
+## 11. `{{GOVERNING_LAW}}` — included as optional, and I would leave it out
+
+The source licences have **no** governing-law or venue clause at all, and no
+public source-available licence in wide use has one. The draft includes a short optional
+section so it is available if wanted.
+
+**My view: omit it.** A public licence offered to the world is not a negotiated contract;
+naming a forum invites the argument that it is one, and a venue clause is unlikely to
+survive against a consumer or small business in an unfavourable jurisdiction anyway. It
+also breaks register — it is the one section that reads like conventional contract
+boilerplate. The place for governing law and venue is the **commercial agreement**, which
+is negotiated and signed. **See Q12.**
+
+---
+
+## 12. Open questions — numbered
+
+1. **De-branding scope.** I read the source publisher's condition ("remove all mention
+   of [the family name] and [their domain]") as binding the modified licence text only,
+   so `LICENSE.md` is clean but these notes discuss derivation freely. Is that right? If
+   you read it more broadly, this document needs sanitising too. Related: is the
+   condition a copyright term, a trademark term, or both, and does that change the
+   answer? (§2)
+2. **Breadth of `Personal Uses`.** I removed "without any anticipated commercial
+   application" to admit portfolio work. Does the negative boundary sentence plus the
+   `Your company` definition adequately stop a solo commercial developer relying on
+   `Personal Uses` instead of `Small Business`? (§3)
+3. **Patent defence and Application Users.** Application Users recipients get a patent
+   licence with no defensive-termination hook, because `Patent Defense` binds only "you"
+   and "your company". Is that acceptable, or should `Application Users` carry its own
+   defensive-termination sentence at the cost of some of its no-agreement-needed
+   simplicity? (§4a)
+4. **Anti-circumvention in `Your Application`.** Is "substantial functionality of its own
+   beyond the software" / "a product whose main value is the software itself" a
+   workable test, and can it be tightened without excluding legitimate thin integration
+   libraries? (§4a)
+5. **Narrowed `Notices`.** Is accepting a third-party-notices file as compliance for
+   bundled distribution acceptable, and does it weaken any later claim? (§4b)
+6. **New-company rule.** Is permitting a company with no prior tax year to use the
+   software during its first tax year, until it passes either figure, wanted? It is not
+   in the requirements but the gate is undefined without it. (§5)
+7. **Revenue definition.** Variant A or B; and if B, confirm that excluding equity
+   investment and borrowing is intended, so a well-funded pre-revenue startup qualifies.
+   (§6)
+8. **Individuals definition.** Variant A, B, or C; and if B, is "worked mainly for your
+   company" adequate for offshore agency arrangements? (§7)
+9. **Audit rights.** Variant A or B, and is even the light self-certification in B
+   appropriate in a public licence for a client-side library? (§8)
+10. **Sunset.** If Variant B is chosen: what period, what target licence, and is the
+    additive per-version cascading structure right? (§9)
+11. **Warranty and liability.** Variant A or B. This is the clause most likely to be
+    legally weaker in plain English than in conventional wording. (§10)
+12. **Governing law.** Include or omit? Recommendation is omit from the public licence
+    and put it in the commercial agreement. (§11)
+13. **Enforceability of self-assessment.** Requirements open item 1, which I could not
+    address in drafting. If a licensee self-assesses incorrectly in good faith, is the
+    gate enforceable against them, and does the absence of any technical enforcement
+    weaken the licensor's position? This affects whether Q9 should be answered A or B.
+14. **Interaction with the surviving Apache-2.0 grant.** Requirements open item 6. My
+    drafting position: state it plainly in the repo root `LICENSE` and the release notes,
+    and keep it out of the operative licence entirely — the boundary is drawn by which
+    text ships with which version. Confirm. (`NOTICE-AND-PACKAGING.md` §5)
+15. **`wa-sqlite` fork copyright.** Does the fork contain enough original authorship for
+    a second copyright line, and in whose name? (`NOTICE-AND-PACKAGING.md` §3)
+16. **Acceptance mechanics.** `Acceptance` makes agreement both a strict obligation and a
+    condition of the licences. For software installed by a package manager with no
+    click-through, is that sufficient to bind, and does anything need to change now that
+    a *paid* alternative exists behind the same gate? Note this is separate from the
+    Application Users carve-out described at §4a(2), which fixes an internal
+    contradiction rather than the general binding question. Not raised in the
+    requirements; it occurred to me while drafting.
+17. **Legacy packages published with no `license` field.** 13 packages have published for
+    years with no licence grant at all, which is ordinarily "all rights reserved" and
+    almost certainly not what was intended. Is a clarifying statement that those versions
+    were and remain available under Apache-2.0 advisable, and does making it carry risk?
+    (`NOTICE-AND-PACKAGING.md` §3, Q-P3)
+18. **Scope of Group A.** Should internal and build-time packages (`utils`, `utils-dev`,
+    `peer-deps`, `framework-toolkit`) be relicensed along with the shipped library
+    surface? The requirements' "all published `@livestore/*` packages" says yes by
+    default. (`NOTICE-AND-PACKAGING.md` §3, Q-P1)
+19. **Commercial agreement questions.** `COMMERCIAL-LICENSE-NOTES.md` §10 carries seven
+    further questions (Q-C1 to Q-C7), including indemnity and warranty position for
+    paying customers, which is currently undecided and will affect pricing.
+
+---
+
+## 13. What I am least confident in
+
+Ordered by how much damage an error would do.
+
+1. **`Application Users` (§4a).** It is the most important clause in the document — the
+   requirements say getting it wrong "breaks the product" — and it is the one with no
+   precedent to copy. The direct-grant construction is sound in principle, but I cannot
+   tell you whether a court would treat a grant to an unidentified class of future
+   recipients, made through a document those recipients never see, as effective. It may
+   need to be restructured as an express third-party-beneficiary provision, or as an
+   irrevocable offer that recipients accept by use. That is beyond what I can judge.
+2. **`No Liability` (§10).** Explained above. Untested plain-English wording against a
+   statutory requirement that names specific words.
+3. **The anti-circumvention test in `Your Application` (§4a).** Deliberately loose. I
+   know it is loose. I could not find a formulation that was both tight and did not
+   catch legitimate cases.
+4. **Whether the four independent permitted purposes read as independent.** They are
+   separate sections each ending "is use for a permitted purpose", which is the source
+   licences' own pattern for exactly this. But a reader who arrives at `Small Business`
+   and stops might conclude the gate is universal. If you think that risk is real, a
+   short orienting sentence before the four sections would fix it — I left it out to
+   protect the register, which may have been the wrong trade.
+5. **Length.** With one option chosen per variant block the operative text lands around
+   1,200 words against the source's ~550. The extra is almost entirely the three added
+   permitted purposes and the two library-specific clauses, all of which trace to
+   requirements. Length is a defect in this genre and I would welcome cuts, but I could
+   not find any that did not drop a required grant.
+
+---
+
+## 14. Sources
+
+Licence texts, taken from release tags in the publisher's source repository rather than
+their website, which is currently 404ing (§2):
+
+- `https://raw.githubusercontent.com/polyformproject/polyform-licenses/Polyform-Small-Business-1.0.0/Polyform-Small-Business.md`
+- `https://raw.githubusercontent.com/polyformproject/polyform-licenses/Polyform-Noncommercial-1.0.0/Polyform-Noncommercial.md`
+- `https://raw.githubusercontent.com/polyformproject/polyform-licenses/Polyform-Free-Trial-1.0.0/Polyform-Free-Trial.md`
+
+Terms on which those texts are themselves licensed — checked at three refs, identical at
+each (§2):
+
+- `https://raw.githubusercontent.com/polyformproject/polyform-licenses/1.0.0/README.md`
+- `https://raw.githubusercontent.com/polyformproject/polyform-licenses/Polyform-Small-Business-1.0.0/README.md`
+- `https://raw.githubusercontent.com/polyformproject/polyform-licenses/master/README.md`
+
+Precedent for this exact adaptation:
+
+- `https://github.com/statiqdev/Statiq/blob/main/LICENSE.md` — Statiq Public License
+  1.0.0, combining the same three sources with modified thresholds (10 individuals /
+  USD 100,000)
+
+The publisher's current working draft, consulted for the new-company rule (§5), the
+30-day trial period, and current wording directions:
+
+- `https://raw.githubusercontent.com/polyformproject/license-development/main/template.erb.md`
+- `https://raw.githubusercontent.com/polyformproject/license-development/main/licenses.yml`
+
+Origin of the CC-BY-4.0 claim (§2):
+
+- `https://scancode-licensedb.aboutcode.org/polyform-noncommercial-1.0.0.html` — footer
+  licences the ScanCode database, not the licence texts
+
+Website availability (§2):
+
+- `https://polyformproject.org/` — 200; `/licenses`, `/about`, and each licence URL — 404
+  as of 2026-07-27
+- `http://web.archive.org/web/20260717100234/https://polyformproject.org/licenses` — live
+  in the 2026-07-17 snapshot
+
+Trademark (§2):
+
+- `https://tsdr.uspto.gov/#caseNumber=88400646&caseType=SERIAL_NO&searchType=statusSearch`
+
+Package inventory (`NOTICE-AND-PACKAGING.md` §1) — npm registry, queried 2026-07-27:
+
+- `https://registry.npmjs.org/-/org/livestore/package` — authoritative scope membership,
+  **39 packages**
+- `https://registry.npmjs.org/<pkg>` per package, for the `latest` dist-tag, its
+  `license` field, publish date and deprecation status
+
+A note on method, because it changed the answer. My first pass used `npm search`, which
+returned 38 names and silently omitted `@livestore/devtools-react` — a package I already
+knew existed. Anything built on that listing would have left packages unrelicensed
+without any error. The org endpoint is the one to use, and
+`NOTICE-AND-PACKAGING.md` §8 step 6 says to re-run it immediately before launch. The
+scope had grown by 18 packages beyond what the requirements document records, so it
+should be assumed to move again.
+
+Upstream of the excluded package:
+
+- `https://github.com/rhashimoto/wa-sqlite` — MIT © 2023 Roy T. Hashimoto
+
+Individual-grant defect, as recorded in the requirements:
+
+- `https://github.com/polyformproject/polyform-licenses/issues/58`

--- a/context/06-sustainability/.reference/licence-draft-review-notes.md
+++ b/context/06-sustainability/.reference/licence-draft-review-notes.md
@@ -9,6 +9,11 @@ what each clause is for, where the draft departs from its source and why, what i
 unverified, and what I could not resolve. §12 is the numbered list of open questions.
 §13 states what I am least confident in.
 
+All business decisions are settled. `LICENSE.md` has **one** unresolved placeholder
+(`{{LICENCE_URL}}`) and **one** remaining choice (`No Liability`, A or B) — and that
+choice is yours, not the project's, because it is a question about legal effect rather
+than commercial intent. See §10.
+
 **Read §2 first.** It corrects a factual premise I was given, and it constrains the
 licence text.
 
@@ -18,15 +23,19 @@ licence text.
 
 From the settled requirements (`../licence-requirements.md`), which I treated as fixed:
 
-- Free use if **fewer than 10 individuals AND less than USD 1,000,000 revenue** in the
-  prior tax year. Conjunctive, deliberately. Fixed figure, **not** inflation-indexed.
-  Affiliates aggregate.
+- Free use requires **all three** of: fewer than 10 individuals; less than USD 1,000,000
+  revenue in the prior tax year; less than USD 1,000,000 in aggregate external
+  investment. Conjunctive, deliberately. Fixed figures, **not** inflation-indexed.
+  Affiliates aggregate across all three.
 - Unconditional grants regardless of that gate for: individuals, noncommercial and public
   organisations, and a ~30-day evaluation.
 - Modification and redistribution as part of the licensee's own application permitted.
 - **Downstream recipients of a licensee's application must not need their own licence.**
-- No non-compete. No source-disclosure obligation. No technical enforcement.
+- Every release converts to Apache-2.0 two years after its own publication.
+- No non-compete. No source-disclosure obligation. No technical enforcement. **No audit
+  rights.** No governing-law clause in the public licence.
 - Future releases only; prior releases stay Apache-2.0 irrevocably.
+- Licence name: LiveStore Community License 1.0. Licensor: Johannes Schickling.
 - `@livestore/wa-sqlite` excluded, stays MIT.
 
 The context that makes several of these load-bearing: **LiveStore is a client-side
@@ -96,28 +105,35 @@ following a URL in the unmodified upstream licences right now reaches a 404.
 
 ---
 
-## 2a. Placeholder inventory — including three the brief did not list
+## 2a. Placeholder inventory — all but one now resolved
 
-The brief specified `{{LICENCE_NAME}}`, `{{LICENSOR}}`, `{{GOVERNING_LAW}}`,
-`{{SUNSET}}`, `{{AUDIT_RIGHTS}}`, `{{REVENUE_DEFINITION}}` and
-`{{INDIVIDUALS_DEFINITION}}`. All appear in the draft. I added **three more**, each
-because the text is unusable without it. Flagged here rather than slipped in:
+Every placeholder from the brief has been resolved into the text: `{{LICENCE_NAME}}` →
+LiveStore Community License 1.0; `{{LICENSOR}}` → Johannes Schickling (see §11 for how it
+is carried); `{{GOVERNING_LAW}}` → section deleted (§9); `{{SUNSET}}` → two-year
+per-version Apache-2.0 conversion (§7); `{{AUDIT_RIGHTS}}` → section deleted (§8);
+`{{REVENUE_DEFINITION}}` and `{{INDIVIDUALS_DEFINITION}}` → resolved in §6, plus the new
+investment limb in §5.
 
-| Placeholder | Why it exists |
+I had added three placeholders of my own. Two are now gone, one remains:
+
+| Placeholder | Status |
 | --- | --- |
-| **`{{LICENCE_URL}}`** | The `Notices` clause obliges recipients to get the terms *or the URL for them*. Removing the source publisher's URL under the de-branding condition (§2) leaves nothing there. A project-hosted canonical URL must exist and resolve before the first covered release. |
-| **`{{LICENSOR_URL}}`** | Appears only in the `Required Notice:` example line, mirroring the source licences' own example format. Cosmetic; can be dropped with the example if the `Required Notice:` mechanism is not used. |
-| **`{{VENUE}}`** | Only inside the optional `Governing Law` section. Governing law and forum are separate choices and conflating them into one placeholder would hide that. Disappears entirely if §11's recommendation to omit that section is accepted. |
+| **`{{LICENCE_URL}}`** | **Still open — the only one.** The `Notices` clause obliges recipients to get the terms *or the URL for them*. Removing the source publisher's URL under the de-branding condition (§2) leaves nothing there. A project-hosted canonical URL must exist and resolve before the first covered release. |
+| `{{LICENSOR_URL}}` | Gone. The `Required Notice:` example now reads simply `Copyright Johannes Schickling`, with no URL, so nothing needs inventing. |
+| `{{VENUE}}` | Gone with the `Governing Law` section (§9). |
 
-Two further placeholders, `{{SUNSET_PERIOD}}` and `{{SUNSET_LICENCE}}`, sit inside the
-`{{SUNSET}}` variant block and are needed only if that variant is chosen. `LICENSE.md`
-also references `{{LICENCE_ID}}` indirectly through `NOTICE-AND-PACKAGING.md`, which is
-the SPDX `LicenseRef-` identifier and is not part of the licence text itself.
+`{{SUNSET_PERIOD}}` and `{{SUNSET_LICENCE}}` are also gone, resolved into the text as two
+years and Apache-2.0 respectively (§7).
+
+`NOTICE-AND-PACKAGING.md` carries one further placeholder of its own,
+`{{FIRST_COVERED_VERSION}}` — the version number at which the new licence takes effect.
+That is a project decision, not a legal one, but it must be fixed before launch because
+three separate documents refer to it.
 
 I invented no substantive figures, names, periods or jurisdictions anywhere. The only
-concrete numbers in the operative text are those the requirements fix (10 individuals,
-USD 1,000,000), the 32-day cure period inherited unchanged from the source, and the
-30-day evaluation and certification-response periods discussed at §3 and §8.
+concrete numbers in the operative text are those the project fixed (10 individuals, USD
+1,000,000 revenue, USD 1,000,000 investment, two-year conversion), the 32-day cure period
+inherited unchanged from the source, and the 30-day evaluation period discussed at §3.
 
 ---
 
@@ -183,6 +199,21 @@ Three changes from the source free-trial licence:
   to internal use.
 - **Retained multiple concurrent evaluations** for different needs or projects, matching
   the source and the publisher's later working draft.
+
+**A problem with the narrow form, which I have left as drafted but want to flag.** The
+carve-out means an ineligible organisation may trial the software only internally. For a
+*server* library that is a complete evaluation. For a client-side library whose entire
+purpose is shipping inside an application that reaches end users, it is not: the
+organisation cannot build anything it can put in front of a real user, which is exactly
+what evaluating this library means. So `Evaluation`, as drafted, offers less than it
+appears to, and the signpost's "may evaluate it for 30 days" slightly oversells it.
+
+I left the narrow form because widening it re-opens the hole it was added to close — an
+ineligible organisation shipping production software free under a rolling "evaluation".
+But there are middle positions: permit distribution to a small number of named pilot
+users, or to non-production deployments, or permit external distribution during the 30
+days on condition it stops at the end. Each needs care to avoid becoming a loophole.
+**See Q23.**
 
 ---
 
@@ -293,12 +324,17 @@ agree, and is how this is usually solved.
 
 ---
 
-## 5. The size gate
+## 5. The eligibility gate — three limbs
 
-Drafted from the small-business licence's `Small Business` clause with these changes:
+Drafted from the small-business licence's `Small Business` clause, with the third limb
+having no precedent anywhere. Changes from the source:
 
-- **Thresholds:** 100 → **10** individuals; 1,000,000 USD retained but its meaning
-  changed, see next point.
+- **Section renamed** from `Small Business` to `Eligible Organizations`. The source name
+  is no longer accurate: a three-person company that raised USD 1.5M is unambiguously a
+  small business and is unambiguously gated. Leaving the heading as "Small Business"
+  while the test excludes obvious small businesses would be actively misleading.
+- **Thresholds:** 100 → **10** individuals; USD 1,000,000 revenue retained; **USD
+  1,000,000 external investment added as a third limb.**
 - **CPI indexing removed entirely.** The source says `1,000,000 USD (2019)` followed by a
   sentence directing the reader to adjust for inflation via the US BLS CPI-U index. The
   requirements reject indexing: it obliges every prospective licensee to perform an
@@ -311,116 +347,241 @@ Drafted from the small-business licence's `Small Business` clause with these cha
   *This is a live trap.* The Statiq precedent modified the numbers but kept both the
   `(2019)` marker and the full CPI sentence. Anyone adapting from Statiq by swapping
   figures will silently reimport exactly what the requirements reject.
-- **Conjunctive test made explicit.** The source's "and" is easy to skim past, so the
-  draft adds "Your company must meet both of these. If it meets only one, use for its
-  benefit is not a permitted purpose under this section." The requirements are emphatic
-  that a five-person company at USD 3M revenue is meant to be gated.
-- **New-company case added.** The source has no rule for a company with no prior tax
-  year, which is undefined for a large share of the target audience — the gate simply
-  has no answer for them. The draft permits use during the first tax year until either
-  figure is passed. This is not in the requirements, but the gate is incomplete without
-  it, so I trace it to the gate requirement rather than treating it as an addition. The
-  publisher's own later working draft adopts the same approach, which I take as
-  confirmation it is the conventional fix. **Confirm this is wanted — see Q6.**
+- **Conjunctive test made explicit.** "Your company must meet all three. If it fails any
+  one of them, use for its benefit is not a permitted purpose under this section." The
+  three limbs are also set out as a labelled list rather than a run-on sentence, because
+  at three conditions the prose form becomes genuinely hard to parse.
+- **Different measurement periods, stated explicitly.** People and revenue are measured
+  over the prior tax year; investment is measured over the company's whole history. Two
+  different frames in one test is a real comprehension hazard, so the draft states it in
+  its own paragraph rather than leaving a reader to infer it from the definitions.
+- **New-company case added, and scoped.** The source has no rule for a company with no
+  prior tax year, which is undefined for a large share of the target audience. The draft
+  permits use during the first tax year until either the people or revenue figure is
+  passed — and **expressly does not extend to the investment limb**, so a newly
+  incorporated company that has just raised USD 5M is gated from day one. Without that
+  scoping the new-company rule would swallow the investment limb entirely for exactly the
+  companies it targets. **Confirm — see Q6.**
 - **Affiliate roll-up** comes free from the source's `Your company` / `Control`
-  definitions, which the draft keeps essentially verbatim. Nothing was added.
+  definitions, which the draft keeps verbatim. The draft adds one closing sentence in
+  Definitions making explicit that it applies to all three figures, and the gate section
+  cross-references it. For investment this means a group's historical raises aggregate:
+  a subsidiary of a well-funded parent is gated by the parent's fundraising.
+
+### The investment limb — my least-precedented clause
+
+**This is the single clause in the document with no precedent I could find anywhere.**
+Not in the PolyForm family, not in FSL, BUSL, SSPL or Elastic, not in Statiq. Every
+existing size-gated licence gates on headcount and revenue. I could find none that gates
+on capital raised. Treat the drafting as a first attempt rather than an adaptation of
+something tested, and please give it disproportionate attention.
+
+What the definition does:
+
+| Counts | Does not count |
+| --- | --- |
+| Equity investment | Bank borrowing on ordinary commercial terms |
+| Convertible notes, SAFEs and similar, **at the amount received when received, not on conversion** | Trade credit |
+| Venture debt | Money the company earned |
+| Revenue-based financing | Government grants, subsidies, research funding, prize money |
+| | Charitable donations |
+| | Money put in by the company's own founders or employees from their own funds |
+
+Reasoning for each of the contested calls, so you can overrule them individually:
+
+- **Convertible instruments counted on receipt, not conversion.** A SAFE is not equity
+  until it converts, so a definition keyed to shares alone would let a company hold USD
+  5M on SAFEs and remain eligible indefinitely. Counting at receipt closes that, and it
+  is also the figure the company actually knows.
+- **Venture debt and revenue-based financing count; ordinary bank borrowing does not.**
+  The line drawn is whether the terms are tied to the company's equity, revenue or
+  growth. This is the softest boundary in the definition and the place a well-advised
+  licensee would push. A structured facility deliberately dressed as commercial lending
+  is a foreseeable workaround and the current wording may not catch it.
+- **Grants and subsidies do not count.** They are not investment; nobody took a stake.
+  But this creates a visible gap against the limb's own rationale: a company sitting on a
+  EUR 2M research grant plainly has ability to pay and remains eligible. If the intent is
+  "ability to pay" rather than "has investors", grants should count and the definition
+  needs changing. **See Q7.**
+- **Founder capital does not count.** "External" investment naturally excludes the
+  founders' own money. But a founder who puts USD 2M of personal wealth in is
+  indistinguishable, in ability-to-pay terms, from one who raised it. Same tension as
+  grants, same question.
+
+**The consequence you should be most sure about is permanence.** Because investment is
+cumulative to date and never resets:
+
+> A company that raised USD 1.2M in 2019, spent it, failed, and is now three people with
+> no revenue and no investors is **permanently ineligible**, with no route back, forever.
+
+That is the harshest edge in the document by a wide margin. It is a direct consequence of
+"cumulative-to-date", which the project chose deliberately and which I have drafted
+faithfully and unambiguously rather than softening. But it is not what the word
+"Community" in the licence name leads a reader to expect, and it will produce at least
+one bad story. **See Q8**, which offers three ways to soften it if wanted.
+
+I have deliberately **not** editorialised about any of this in the licence text itself,
+per instruction. The text states the rule plainly and leaves it there.
 
 ### An open item from the requirements that I believe is now answered
 
 Requirements open item 5 asks whether the individual grant should extend to sole traders
-and single-person companies. **I think the definitions already settle it and it does not
-need to go to you as an open question.** The `Your company` definition expressly includes
-"sole proprietorship", and `Personal Uses` expressly excludes work for an organization
-including a client. So a sole trader doing client work falls to `Small Business` — where,
-being one person under USD 1,000,000, they pass anyway. The outcome the requirement
-wanted is reached without a special rule. Flagged here so you can disagree rather than
-rediscover it.
+and single-person companies. **I think the definitions already settle it.** The
+`Your company` definition expressly includes "sole proprietorship", and `Personal Uses`
+expressly excludes work for an organization including a client. So a sole trader doing
+client work falls to `Eligible Organizations` — where, being one person with no outside
+investment and under USD 1,000,000, they pass. Flagged here so you can disagree rather
+than rediscover it.
 
 ---
 
-## 6. `{{REVENUE_DEFINITION}}` — variants in the draft
+## 6. Revenue and headcount definitions — both resolved
 
-Requirements open item 4. Left as a labelled variant block in the Definitions section
-because it materially changes who is gated.
+**Headcount: the source wording, unchanged.** "Fewer than 10 total individuals working as
+employees and independent contractors." No definition added — bodies, not
+full-time-equivalents, on any working basis. I had offered an FTE variant and a
+count-everyone variant; the project chose to add neither, which is the right call at a
+threshold of 10, where arithmetic costs more than it clarifies. The consequence is that
+"total individuals" carries its ordinary meaning, and the offshore-agency edge I
+previously flagged is left unaddressed on purpose rather than by oversight. A company
+using a 30-person agency team through a single contract is, on the plain words, not
+employing 30 individuals. **See Q9** if you think that needs closing.
 
-- **Variant A — undefined.** What the source licences do. Relies on ordinary meaning.
-  Shortest, and consistent with the register, but leaves genuine ambiguity for grant-
-  funded organisations and for pre-revenue funded startups.
-- **Variant B — defined.** Gross (before costs), consolidated across the company and its
-  affiliates and counted once, excluding equity investment, borrowing, grants and
-  donations.
+**Revenue: defined, and the definition now does double duty.** Gross, before costs,
+across the company and its affiliates, counted once. It expressly excludes external
+investment, grants, subsidies and donations.
 
-**Recommendation: Variant B.** The pre-revenue-funded-startup case is common in this
-audience and Variant A gives no answer. Excluding investment means a seed-funded
-five-person company with no product revenue qualifies, which I read as the intended
-outcome given the requirement's stated rationale of ability to pay. Excluding grants
-avoids double-gating organisations that `Noncommercial Organizations` already covers.
-**Confirm the investment carve-out is intended — see Q7.**
-
----
-
-## 7. `{{INDIVIDUALS_DEFINITION}}` — variants in the draft
-
-Requirements open item 3. Three labelled variants:
-
-- **A — undefined.** Source behaviour.
-- **B — headcount, part-time counted in full.** Every individual counted once regardless
-  of hours; agency workers count if they worked mainly for the company.
-- **C — full-time equivalents.** Averaged FTE across the prior tax year.
-
-**Recommendation: Variant B.** At a threshold of 10, FTE arithmetic is disproportionate
-and creates a self-assessment burden bigger than the decision it informs. B is
-conservative — it counts more people, so it gates more organisations — and is trivial to
-apply. The agency sentence in B is the part I am least sure of: "worked mainly for your
-company" is a soft test, and offshore agency arrangements are exactly where a licensee
-would push. **See Q8.**
+The investment carve-out is no longer merely a clarification — it is now **structurally
+required**. With investment gated as its own limb, counting the same money as revenue too
+would double-count it and make the revenue limb unpredictable. The two definitions have
+to be read together and are drafted to be mutually exclusive. If you change one, check
+the other.
 
 ---
 
-## 8. `{{AUDIT_RIGHTS}}` — variants in the draft
+## 7. The two-year conversion — mechanism chosen and why
 
-Requirements §5 asks counsel to advise. Two labelled variants:
+Settled: each version converts to Apache-2.0 on the second anniversary of **its own**
+publication. I was asked to compare two mechanisms and pick.
 
-- **A — nothing.** Rely on `Violations` and on the commercial agreement.
-- **B — self-certification on request.** On written request the licensee confirms in
-  writing, within 30 days, whether its use is permitted and under which section. Capped
-  at one request per 12 months. No financial records. Never applies to `Personal Uses`.
+### The candidates
 
-**Recommendation: Variant B, but this is the clause I would most readily drop.** A
-records-inspection audit right of the kind found in enterprise agreements is
-disproportionate in a public licence for a client-side library and would be read as
-hostile by exactly the developer audience the project depends on. Variant B is the
-minimum that gives the licensor a documented request-and-response record. The
-`Personal Uses` carve-out is there so an individual can never receive a compliance
-letter. A *paid* agreement can reasonably carry more; see `COMMERCIAL-LICENSE-NOTES.md`
-§6. **See Q9.**
+**PolyForm Countdown 1.0.0** is a *separate document*, shipped alongside each release,
+with an explicit ISO-8601 start date filled in per release and the full target licence
+text copied into it. Its virtues are precision and, especially, its framing:
+
+> Legally, this is a present grant of a license on the date of release, not a contract
+> promise to grant the license later.
+>
+> No contributor can revoke the new license before it starts.
+
+**FSL's Grant of Future License** is an *inline clause* in the licence itself:
+
+> We hereby irrevocably grant you an additional license to use the Software under the
+> Apache License, Version 2.0 that is effective on the second anniversary of the date we
+> make the Software available.
+
+### What I chose, and why
+
+**FSL's structure, with Countdown's framing sentences imported into it.**
+
+The deciding factor is operational, and it is decisive at this project's scale.
+Countdown's defining feature is that it is a per-release artefact. LiveStore publishes
+24 packages in lockstep; adopting Countdown means generating and shipping a second
+licence document, carrying a correct computed date, with every release, forever. A
+missing file or a wrong date in one package silently breaks or muddies that package's
+conversion, and nothing in the build would catch it. FSL's clause cannot be omitted,
+because it is part of the licence text that already has to ship.
+
+Two further points against Countdown as a document:
+
+- It requires the target licence text to be copied in wholesale, which would roughly
+  double the licence's length for a project already carrying more sections than the
+  source.
+- Its canonical URL is currently dead (§2), and its repository describes it as working
+  drafts. FSL's wording, by contrast, is in production at Sentry, Codecov, Convex,
+  GitButler, PowerSync, NativeLink and CodeCrafters.
+
+**But Countdown's legal framing is better than FSL's, and I took it.** FSL relies on
+"hereby irrevocably grant" to do the work implicitly. Countdown says the quiet part out
+loud: this is a present grant, not a promise. That distinction matters, because a bare
+promise to grant a licence in future, unsupported by consideration, is the obvious line
+of attack on this kind of clause. The draft therefore adds two sentences FSL does not
+have:
+
+> This is a present grant of that additional license, made now. It is not a promise to
+> grant it later. The licensor cannot revoke it before it takes effect.
+
+### Deviations from both sources
+
+- **No cascade.** My earlier draft had each version's conversion also release all earlier
+  versions, so a licensee tracked only one date. The project specified per-version
+  conversion from each version's own publication, so I removed it. Consequence: a
+  licensee wanting to rely on the Apache-2.0 grant must check the date for each version
+  they use. `NOTICE-AND-PACKAGING.md` §5 addresses this with a published conversion table.
+- **`Apache Date:` line retained** from my earlier draft, renamed from `Change Date:` to
+  avoid confusion with BUSL's differently-behaving term of art. It lets the project pin
+  an exact date per release rather than obliging each licensee to compute one. Strongly
+  recommend using it; see Q10.
+- **Added to `Violations`,** so that a licensee whose licences end does not lose
+  Apache-2.0 rights that had already vested. Without this, breach would retroactively
+  strip rights the licence says are irrevocable — an internal contradiction.
+
+### Reuse position on FSL's wording
+
+FSL imposes the same de-branding condition as the PolyForm family — its FAQ says that a
+variant with a different conversion licence must "call it something other than FSL". The
+draft complies with both by construction: it is the LiveStore Community License and names
+neither family.
+
+But unlike PolyForm, **FSL publishes no express grant covering reuse of its text.**
+PolyForm states one plainly in its repository; I could find no equivalent for FSL, only
+the renaming condition. So the copyright position on the ~40 borrowed words is unstated
+rather than permissive. In practice short functional legal wording of this kind is
+routinely adapted across licences, and the project has complied with the one condition
+FSL does state — but I am flagging the asymmetry rather than assuming it away. **See Q17.**
 
 ---
 
-## 9. `{{SUNSET}}` — variants in the draft
+## 8. Audit rights — none, as instructed
 
-Being decided separately, so it is a labelled variant with placeholders left open.
+Settled: no audit clause, no inspection right, no obligation to confirm eligibility on
+request. Pure honour system. The `Confirming You Qualify` variant I had drafted is
+deleted, not commented out.
 
-- **A — none.** The terms apply indefinitely.
-- **B — delayed permissive grant.** After `{{SUNSET_PERIOD}}`, each version also becomes
-  available under `{{SUNSET_LICENCE}}`, with an optional `Change Date:` plain-text line
-  to state the date exactly for a given release.
+This is the right call for a public licence aimed at developers, and it matches the
+requirements' position that enforcement is contractual rather than technical. Two things
+follow that counsel should be aware of rather than surprised by:
 
-Drafting notes on B, which apply whichever period is chosen:
+- **The licensor has no contractual route to information.** Combined with no technical
+  enforcement, the only mechanism against a non-compliant organisation is the `Violations`
+  clause, which requires the licensor to already know about the violation. In practice
+  the gate is enforced by licensees choosing to comply.
+- **This raises the stakes on the self-assessment question.** With three limbs — one of
+  which requires a company to total its fundraising across its entire history and its
+  affiliates — good-faith misassessment is likely, not hypothetical. **See Q12.**
 
-- The grant is **additive** — the licensee may then choose either set of terms. It does
-  not replace the original grant, so nobody's existing rights shrink.
-- It runs **per version, from first availability of that version**, matching the
-  established convention for this pattern.
-- It cascades to earlier versions ("that version, and every earlier version"), so a
-  licensee never has to track more than one date.
-- The `Change Date:` mechanism lets the project state an exact date per release rather
-  than obliging every licensee to compute one. Recommended if B is chosen.
+A *paid, signed* agreement can reasonably carry a verification term that a free public
+licence should not; see `COMMERCIAL-LICENSE-NOTES.md` §7.
 
-**Interaction worth noting:** if `{{SUNSET_LICENCE}}` is Apache-2.0, the project ends up
-with Apache-2.0 on prior releases, the new licence on covered releases, and Apache-2.0
-again after the sunset period. That is coherent, and probably reassuring to enterprise
-adopters, but the announcement must be very clear or it will read as confusing. **See Q10.**
+---
+
+## 9. Governing law — omitted, as instructed
+
+Settled: the public licence is silent on governing law and forum. The optional
+`Governing Law` section and the `{{VENUE}}` placeholder are deleted.
+
+This matches Apache-2.0, MIT, the PolyForm family and FSL — none carries a governing-law
+clause. It was also my recommendation before the decision was made, for the reason given
+in the earlier draft: a public licence offered to the world is not a negotiated contract,
+and naming a forum invites the argument that it is one, while being unlikely to survive
+against a consumer or small business in an unfavourable jurisdiction.
+
+Governing law and forum for the **commercial** agreement are settled as German law,
+courts of Berlin. That is covered in `COMMERCIAL-LICENSE-NOTES.md` §11, together with the
+German-law points that follow from it — in particular that the AGB regime (§§305–310 BGB)
+may apply to self-serve standard terms and constrains liability exclusion far more than
+US drafting assumes.
 
 ---
 
@@ -454,95 +615,202 @@ Both variants are already bolded and italicised, which is the conventional way o
 a conspicuousness requirement in a Markdown document, and I have preserved that from the
 source in both.
 
-**I have deliberately not picked.** The choice is between fidelity to a plain-English
-register that the whole document depends on, and defensive drafting. That is your call,
-not mine. **See Q11.**
+**I have deliberately not picked, and this is now the only unmade choice in the
+document.** The project told me every placeholder was resolved and nothing further was
+open. I read that as addressing the `{{PLACEHOLDER}}` items, which were business
+decisions. This one was never a placeholder — it was flagged for counsel from the start,
+and it is a question about legal effect rather than commercial intent. I have therefore
+left it as a live A/B choice rather than picking silently. If the project intended to
+close it too, say so and I will resolve it.
+
+**One further point, new since the governing-law decision.** The commercial agreement is
+now to be governed by German law (`COMMERCIAL-LICENSE-NOTES.md` §11), and German law does
+not permit excluding liability for intent or gross negligence, or for injury to life,
+body or health, however drafted. The `No Liability` analysis above is US-centric because
+the source wording is. If German or EU law is likely to govern disputes under the
+**public** licence too — which is plausible given the licensor is resident there, even
+with no forum clause — then neither variant is calibrated for it and a third, German-law
+variant may be needed. **See Q15.** **See Q11** for the original US-law question.
 
 ---
 
-## 11. `{{GOVERNING_LAW}}` — included as optional, and I would leave it out
+## 11. Licence name and licensor — two drafting consequences
 
-The source licences have **no** governing-law or venue clause at all, and no
-public source-available licence in wide use has one. The draft includes a short optional
-section so it is available if wanted.
+### The name
 
-**My view: omit it.** A public licence offered to the world is not a negotiated contract;
-naming a forum invites the argument that it is one, and a venue clause is unlikely to
-survive against a consumer or small business in an unfavourable jurisdiction anyway. It
-also breaks register — it is the one section that reads like conventional contract
-boilerplate. The place for governing law and venue is the **commercial agreement**, which
-is negotiated and signed. **See Q12.**
+Settled: **LiveStore Community License 1.0**, SPDX `LicenseRef-LiveStore-Community-1.0`.
+
+Two things I did in response, and one risk I could not draft away.
+
+**Prominence.** The name leads with "Community" while the gate is genuinely tight — a
+three-person company that has ever raised USD 1.5M is excluded. A reader who meets the
+name first and the conditions late will feel the name oversold it. The draft therefore
+opens with a **`Who May Use This Software For Free`** section, before `Acceptance`, that
+states all three limbs in plain words in under sixty. It names the investment limb
+explicitly rather than saying "small teams use it free", because a signpost that omits
+the least expected condition is worse than no signpost.
+
+**The summary-versus-operative risk this creates.** A summary in an operative document
+invites the argument that the summary governs where the two diverge, and short plain
+wording will inevitably be less precise than the sections it summarises. The draft
+closes this with an express deferral — "The sections below govern. This summary does not."
+I believe that is sufficient, but it is a construction risk that did not exist before and
+you should confirm the deferral wording is strong enough. The alternative is to move the
+summary out of `LICENSE.md` into the docs site, which removes the risk entirely at the
+cost of the prominence the project asked for. **See Q13.**
+
+**Naming collision risk I could not resolve.** "Community License" is well-trodden:
+Confluent Community License, Elastic, MongoDB and Redis have all used "Community" or
+"Source Available" branding for source-available licences. Nothing prevents reusing the
+word, but a reader familiar with those may assume LiveStore's terms match one of them,
+and they do not. Worth a trademark search before launch. **See Q14.**
+
+### The licensor as a natural person
+
+Settled: **Johannes Schickling**, an individual, intending to assign to an entity later.
+
+**I changed the drafting in response, and it removes the need for an assignment clause.**
+An earlier draft defined the licensor as the named person: "The **licensor** is
+{{LICENSOR}}". Hard-coding a natural person into the Definitions section is exactly the
+wrong shape when assignment is planned — after an assignment the operative text would
+still name the individual, and every package would need its licence text re-issued.
+
+The draft now restores the source licences' generic definition — "The **licensor** is the
+individual or entity offering these terms" — and carries the name only in the
+`Required Notice:` line and the repository-root `LICENSE`. The licensor is then whoever
+is offering the terms at the time, which is the assignee after an assignment.
+
+**On whether an express assignment clause is needed: I do not think so, and silence is
+better than a clause.** Copyright is assignable, and an assignee takes subject to
+licences already granted, so existing licensees are unaffected and the assignee steps
+into the licensor's position automatically. `No Other Rights` restricts the *licensee*
+from transferring their licences; it says nothing about the licensor and does not need
+to. Adding an express assignment right would be the only clause in the document
+addressing the licensor's own dealings, which reads oddly and invites the question of
+what else is reserved. **See Q16.**
+
+**The commercial side is different and does need a clause.** Signed agreements are
+contracts, and moving the licensor's side to a new entity may need customer consent
+depending on drafting. `COMMERCIAL-LICENSE-NOTES.md` §12 recommends including an
+assignment-to-successor clause in every commercial agreement from the first one, and
+flags that a natural person signing commercial agreements carries the obligations
+personally with no corporate veil — which, combined with German law's limits on excluding
+liability, is a real exposure. Counsel may want to advise forming the entity before
+signing anything.
 
 ---
 
 ## 12. Open questions — numbered
 
-1. **De-branding scope.** I read the source publisher's condition ("remove all mention
-   of [the family name] and [their domain]") as binding the modified licence text only,
-   so `LICENSE.md` is clean but these notes discuss derivation freely. Is that right? If
-   you read it more broadly, this document needs sanitising too. Related: is the
-   condition a copyright term, a trademark term, or both, and does that change the
-   answer? (§2)
+All business decisions are settled; these are legal questions. **Q3, Q7, Q8 and Q11 are
+the ones I would most want answered.**
+
+1. **De-branding scope.** I read the source publishers' conditions (PolyForm: "remove all
+   mention of PolyForm and polyformproject.org"; FSL: "call it something other than FSL")
+   as binding the modified licence text only, so `LICENSE.md` names neither family but
+   these notes discuss derivation freely. Is that right? Related: is PolyForm's condition
+   a copyright term, a trademark term, or both, and does that change the answer? (§2)
 2. **Breadth of `Personal Uses`.** I removed "without any anticipated commercial
    application" to admit portfolio work. Does the negative boundary sentence plus the
    `Your company` definition adequately stop a solo commercial developer relying on
-   `Personal Uses` instead of `Small Business`? (§3)
+   `Personal Uses` instead of `Eligible Organizations`? (§3)
 3. **Patent defence and Application Users.** Application Users recipients get a patent
    licence with no defensive-termination hook, because `Patent Defense` binds only "you"
-   and "your company". Is that acceptable, or should `Application Users` carry its own
-   defensive-termination sentence at the cost of some of its no-agreement-needed
-   simplicity? (§4a)
+   and "your company". Acceptable, or should `Application Users` carry its own? (§4a)
 4. **Anti-circumvention in `Your Application`.** Is "substantial functionality of its own
-   beyond the software" / "a product whose main value is the software itself" a
-   workable test, and can it be tightened without excluding legitimate thin integration
+   beyond the software" / "a product whose main value is the software itself" a workable
+   test, and can it be tightened without excluding legitimate thin integration
    libraries? (§4a)
 5. **Narrowed `Notices`.** Is accepting a third-party-notices file as compliance for
-   bundled distribution acceptable, and does it weaken any later claim? (§4b)
-6. **New-company rule.** Is permitting a company with no prior tax year to use the
-   software during its first tax year, until it passes either figure, wanted? It is not
-   in the requirements but the gate is undefined without it. (§5)
-7. **Revenue definition.** Variant A or B; and if B, confirm that excluding equity
-   investment and borrowing is intended, so a well-funded pre-revenue startup qualifies.
-   (§6)
-8. **Individuals definition.** Variant A, B, or C; and if B, is "worked mainly for your
-   company" adequate for offshore agency arrangements? (§7)
-9. **Audit rights.** Variant A or B, and is even the light self-certification in B
-   appropriate in a public licence for a client-side library? (§8)
-10. **Sunset.** If Variant B is chosen: what period, what target licence, and is the
-    additive per-version cascading structure right? (§9)
-11. **Warranty and liability.** Variant A or B. This is the clause most likely to be
-    legally weaker in plain English than in conventional wording. (§10)
-12. **Governing law.** Include or omit? Recommendation is omit from the public licence
-    and put it in the commercial agreement. (§11)
-13. **Enforceability of self-assessment.** Requirements open item 1, which I could not
-    address in drafting. If a licensee self-assesses incorrectly in good faith, is the
-    gate enforceable against them, and does the absence of any technical enforcement
-    weaken the licensor's position? This affects whether Q9 should be answered A or B.
-14. **Interaction with the surviving Apache-2.0 grant.** Requirements open item 6. My
-    drafting position: state it plainly in the repo root `LICENSE` and the release notes,
-    and keep it out of the operative licence entirely — the boundary is drawn by which
-    text ships with which version. Confirm. (`NOTICE-AND-PACKAGING.md` §5)
-15. **`wa-sqlite` fork copyright.** Does the fork contain enough original authorship for
-    a second copyright line, and in whose name? (`NOTICE-AND-PACKAGING.md` §3)
-16. **Acceptance mechanics.** `Acceptance` makes agreement both a strict obligation and a
+   bundled distribution acceptable, and does it weaken any later claim? Note also that the
+   notice chain terminates at the first downstream hop, for the reason given at §4b. (§4b)
+6. **New-company rule, and its scoping.** A company with no prior tax year is treated as
+   meeting the people and revenue figures during its first tax year, but **not** the
+   investment figure. Is that the right split? Without it the rule would exempt exactly
+   the newly-incorporated well-funded startups the investment limb targets. (§5)
+7. **The investment limb — definitional boundaries.** This is my least-precedented
+   clause and it needs line-by-line review. Specifically: (a) are convertible instruments
+   correctly counted at receipt rather than conversion? (b) is "tied to your company's
+   equity, revenue, or growth" a workable line between venture debt and ordinary
+   borrowing, and does it catch a facility deliberately structured to look like
+   commercial lending? (c) should government grants count, given a grant-funded company
+   plainly has ability to pay? (d) should founder capital count, for the same reason?
+   (§5)
+8. **The permanence of the investment limb.** Because it is cumulative to date and never
+   resets, a company that raised USD 1.2M in 2019, spent it, and is now three people with
+   no revenue is permanently ineligible with no route back. This is deliberate and I have
+   drafted it faithfully. If it is ever to be softened, the three mechanisms are: measure
+   over a trailing window (e.g. the last five years); allow the investment limb to be
+   disregarded where revenue and headcount are both far under; or add a discretionary
+   reinstatement the licensor can grant. Each has costs. Do any warrant adding? (§5)
+9. **Headcount left undefined.** The source wording is kept unchanged, so "total
+   individuals working as employees and independent contractors" carries its ordinary
+   meaning. That leaves the offshore-agency case open: a company using a 30-person agency
+   team through one contract is, on the plain words, not employing 30 individuals. Leave
+   it, or close it? (§6)
+10. **The conversion mechanism.** Is the present-grant framing ("This is a present grant
+    of that additional license, made now. It is not a promise to grant it later.")
+    sufficient to defeat the argument that a future grant unsupported by consideration is
+    unenforceable? And is "the date the licensor first made that version available"
+    adequately certain, or should it be tied to npm publication specifically? (§7,
+    `NOTICE-AND-PACKAGING.md` Q-P4)
+11. **Warranty and liability.** Variant A or B — the only remaining choice in the
+    licence, and the clause most likely to be legally weaker in plain English than in
+    conventional wording. (§10)
+12. **Enforceability of self-assessment, now with no audit rights.** With three limbs —
+    one requiring a company to total its fundraising across its whole history and its
+    affiliates — good-faith misassessment is likely rather than hypothetical, and the
+    licence now has no mechanism to ask. Is the gate enforceable against a licensee who
+    self-assesses wrongly in good faith? (§8)
+13. **The summary section.** `Who May Use This Software For Free` sits before
+    `Acceptance` and expressly defers to the sections below. Is the deferral wording
+    strong enough to prevent the summary being read as operative where it is less precise
+    than the clauses it summarises? (§11)
+14. **Licence name.** "Community License" is used by Confluent, Elastic, MongoDB and
+    Redis for source-available licences with materially different terms. Worth a
+    trademark search, and is there a confusion risk with those? (§11)
+15. **German law and the public licence.** The commercial agreement will be governed by
+    German law. The public licence has no governing-law clause, but the licensor is
+    resident in Germany, so German or EU law may govern disputes under it regardless.
+    Neither `No Liability` variant is calibrated for a legal system that forbids
+    excluding liability for gross negligence. Is a third variant needed? (§10)
+16. **Licensor assignment.** I concluded that silence suffices for the public licence —
+    copyright is assignable and an assignee takes subject to existing licences — and that
+    an express assignment clause would read oddly as the only provision addressing the
+    licensor's own dealings. Confirm. The commercial side does need a clause; see
+    `COMMERCIAL-LICENSE-NOTES.md` §12. (§11)
+17. **Reuse of FSL's wording.** FSL publishes no express grant covering reuse of its
+    text, unlike PolyForm. The draft complies with the one condition FSL does state
+    (renaming), but the copyright position on the borrowed ~40 words is unstated rather
+    than permissive. Is that a real exposure? (§7)
+18. **Interaction with the surviving Apache-2.0 grant.** My drafting position: state the
+    backward boundary plainly in the repo root and release notes and keep it out of the
+    operative licence; the forward boundary belongs in the licence because it is a grant
+    the licence makes. Confirm. (`NOTICE-AND-PACKAGING.md` §5)
+19. **`wa-sqlite` fork copyright.** Does the fork contain enough original authorship for
+    a second copyright line, and in whose name? (`NOTICE-AND-PACKAGING.md` §3, Q-P2)
+20. **Acceptance mechanics.** `Acceptance` makes agreement both a strict obligation and a
     condition of the licences. For software installed by a package manager with no
-    click-through, is that sufficient to bind, and does anything need to change now that
-    a *paid* alternative exists behind the same gate? Note this is separate from the
-    Application Users carve-out described at §4a(2), which fixes an internal
-    contradiction rather than the general binding question. Not raised in the
-    requirements; it occurred to me while drafting.
-17. **Legacy packages published with no `license` field.** 13 packages have published for
+    click-through, is that sufficient to bind? Separate from the Application Users
+    carve-out at §4a(2), which fixes an internal contradiction rather than the general
+    binding question. (§4a)
+21. **Legacy packages published with no `license` field.** 13 packages have published for
     years with no licence grant at all, which is ordinarily "all rights reserved" and
-    almost certainly not what was intended. Is a clarifying statement that those versions
-    were and remain available under Apache-2.0 advisable, and does making it carry risk?
-    (`NOTICE-AND-PACKAGING.md` §3, Q-P3)
-18. **Scope of Group A.** Should internal and build-time packages (`utils`, `utils-dev`,
+    almost certainly not intended. Is a clarifying statement advisable, and does making it
+    carry risk? (`NOTICE-AND-PACKAGING.md` §3, Q-P3)
+22. **Scope of Group A.** Should internal and build-time packages (`utils`, `utils-dev`,
     `peer-deps`, `framework-toolkit`) be relicensed along with the shipped library
-    surface? The requirements' "all published `@livestore/*` packages" says yes by
-    default. (`NOTICE-AND-PACKAGING.md` §3, Q-P1)
-19. **Commercial agreement questions.** `COMMERCIAL-LICENSE-NOTES.md` §10 carries seven
-    further questions (Q-C1 to Q-C7), including indemnity and warranty position for
-    paying customers, which is currently undecided and will affect pricing.
+    surface? (`NOTICE-AND-PACKAGING.md` §3, Q-P1)
+23. **Scope of `Evaluation`.** As drafted it permits internal trial only, which for a
+    client-side library may not constitute a meaningful evaluation at all (§3). Should it
+    permit limited external distribution — named pilot users, non-production deployments,
+    or unrestricted distribution that must cease at day 30 — and can that be drafted
+    without becoming a route to indefinite free production use? (§3)
+24. **Commercial agreement questions.** `COMMERCIAL-LICENSE-NOTES.md` §13 carries eleven
+    further questions (Q-C0 to Q-C10), including whether entity formation should precede
+    signing anything (Q-C9), whether the agreement is standard terms subject to the AGB
+    regime (Q-C8), and whether pricing works against the customer's free fallback of
+    running two-year-old releases (Q-C10).
 
 ---
 
@@ -557,22 +825,34 @@ Ordered by how much damage an error would do.
    recipients, made through a document those recipients never see, as effective. It may
    need to be restructured as an express third-party-beneficiary provision, or as an
    irrevocable offer that recipients accept by use. That is beyond what I can judge.
-2. **`No Liability` (§10).** Explained above. Untested plain-English wording against a
-   statutory requirement that names specific words.
+2. **`No Liability` (§10).** Untested plain-English wording against a statutory
+   requirement that names specific words — and now with a second, German-law dimension
+   that neither variant addresses.
 3. **The anti-circumvention test in `Your Application` (§4a).** Deliberately loose. I
    know it is loose. I could not find a formulation that was both tight and did not
    catch legitimate cases.
-4. **Whether the four independent permitted purposes read as independent.** They are
+3. **The investment limb (§5).** Moved up from where it would otherwise sit, because it
+   has **no precedent anywhere** — not in the PolyForm family, FSL, BUSL, SSPL, Elastic
+   or Statiq. Every existing size-gated licence gates on headcount and revenue; I found
+   none gating on capital raised. The venture-debt-versus-ordinary-borrowing line is the
+   softest boundary, and the permanence of the cumulative measure is the harshest
+   consequence. Both are deliberate, and both are first attempts rather than adaptations.
+4. **The anti-circumvention test in `Your Application` (§4a).** Deliberately loose. I
+   know it is loose. I could not find a formulation that was both tight and did not
+   catch legitimate cases.
+5. **Whether the four independent permitted purposes read as independent.** They are
    separate sections each ending "is use for a permitted purpose", which is the source
-   licences' own pattern for exactly this. But a reader who arrives at `Small Business`
-   and stops might conclude the gate is universal. If you think that risk is real, a
-   short orienting sentence before the four sections would fix it — I left it out to
-   protect the register, which may have been the wrong trade.
-5. **Length.** With one option chosen per variant block the operative text lands around
-   1,200 words against the source's ~550. The extra is almost entirely the three added
-   permitted purposes and the two library-specific clauses, all of which trace to
-   requirements. Length is a defect in this genre and I would welcome cuts, but I could
-   not find any that did not drop a required grant.
+   licences' own pattern for exactly this. But a reader who arrives at `Eligible
+   Organizations` and stops might conclude the gate is universal. The new
+   `Who May Use This Software For Free` signpost substantially mitigates this — it was
+   added for prominence but it also fixes this — at the cost of the summary-versus-
+   operative risk discussed at §11.
+6. **Length.** With one option chosen the operative text lands around 1,850 words against
+   the source's ~550. Roughly 400 of the increase is the three-limb gate and the
+   investment definition; the rest is the added permitted purposes, the two
+   library-specific clauses, and the conversion. Every part traces to a requirement.
+   Length is a defect in this genre and I would welcome cuts, but I could not find any
+   that did not drop something the project asked for.
 
 ---
 
@@ -591,6 +871,15 @@ each (§2):
 - `https://raw.githubusercontent.com/polyformproject/polyform-licenses/1.0.0/README.md`
 - `https://raw.githubusercontent.com/polyformproject/polyform-licenses/Polyform-Small-Business-1.0.0/README.md`
 - `https://raw.githubusercontent.com/polyformproject/polyform-licenses/master/README.md`
+
+Conversion mechanism, both candidates compared at §7:
+
+- `https://raw.githubusercontent.com/polyformproject/polyform-countdown/v1.0.0/form.md`
+  — PolyForm Countdown License Grant 1.0.0, the per-release-document mechanism (not
+  adopted; its framing sentences were)
+- `https://raw.githubusercontent.com/getsentry/fsl.software/main/FSL-1.1-ALv2.template.md`
+  — FSL 1.1, "Grant of Future License" (structure adopted)
+- `https://fsl.software/` — FSL FAQ, source of the renaming condition discussed at §7
 
 Precedent for this exact adaptation:
 

--- a/context/06-sustainability/requirements.md
+++ b/context/06-sustainability/requirements.md
@@ -6,33 +6,51 @@ surfaces.
 
 ## Context
 
-Builds on the root [requirements.md](../requirements.md). Grounded in
-`LICENSE`, `.github/FUNDING.yml`, and
+Builds on the root [requirements.md](../requirements.md). Grounded in the
+repository `LICENSE` files (per-package since 2026-07-27; the root file states
+which subtrees it does not cover), `.github/FUNDING.yml`, and
 `docs/src/content/docs/sustainable-open-source/sponsoring.mdx` (derived
 surface per LS-R15).
 
 ## Acceptable Tradeoffs
 
-- **LS.SUST-T01 Sponsorware devtools:** Distributing devtools under a
-  sponsor license (rather than fully open) is accepted as a funding
-  mechanism. Opening much of the devtools UI as a component kit is roadmap
-  (root [roadmap.md](../roadmap.md)).
+- **LS.SUST-T01 Source-available system:** Distributing the whole system
+  under a size-gated source-available license (rather than an OSI-approved
+  one) is accepted as a funding mechanism. Retires the earlier
+  sponsorware-devtools tradeoff. The accepted cost is that competitors are
+  permissively licensed and a non-OSI identifier can fail enterprise
+  allowlist checks silently. Adopted 2026-07-27 —
+  [decision 0001](./.decisions/0001-community-license.md).
 
 ## Requirements
 
-- **LS.SUST-R01 Open-source core:** The core repository (engine, primary
-  adapters, sync provider, docs, examples) is licensed Apache-2.0.
-- **LS.SUST-R02 Sponsor funding:** The project is funded through
-  sponsorship (GitHub Sponsors, partner sponsors) — not venture capital and
-  not a first-party hosting service. `refines: LS-A05`
-- **LS.SUST-R03 Devtools as sponsor benefit:** Devtools licenses are granted
-  through sponsorship; free licenses are available to students on request.
+- **LS.SUST-R01 Size-gated source-available:** All published packages are
+  licensed under the LiveStore Community License: free for individuals,
+  nonprofit/educational/government organizations, and organizations under all
+  of 10 people, USD 1M revenue and USD 1M raised; a commercial license is
+  required above that. Each version converts to Apache-2.0 on the second
+  anniversary of its publication. `@livestore/wa-sqlite` remains MIT
+  (upstream fork). Releases published before adoption remain Apache-2.0
+  irrevocably. Revised 2026-07-27 —
+  [decision 0001](./.decisions/0001-community-license.md).
+- **LS.SUST-R02 Sponsorship and commercial licensing:** The project is
+  funded through sponsorship (GitHub Sponsors, partner sponsors) **and**
+  commercial licenses sold to organizations above the LS.SUST-R01 threshold —
+  not venture capital and not a first-party hosting service. `refines: LS-A05`
+- **LS.SUST-R03 Entitlement follows the license, not sponsorship:** Use is
+  governed solely by LS.SUST-R01. Devtools are no longer a sponsor benefit and
+  no runtime entitlement check is shipped; students and other individuals are
+  covered by the license's unconditional individual grant rather than by
+  request. Existing sponsor and student grants are honored through a stated
+  migration window. Revised 2026-07-27 —
+  [decision 0001](./.decisions/0001-community-license.md).
 - **LS.SUST-R04 No hosting lock-in:** Sync is served via partner services
   and self-hosting; the project does not operate a first-party hosted sync
   service. `refines: LS-R08`
 - **LS.SUST-R05 Published benefits:** Sponsor benefits are published and
-  honored via the sponsor dashboard (devtools license, sponsor-only Discord,
-  office hours, prioritized fixes/requests).
+  honored via the sponsor dashboard (sponsor-only Discord, office hours,
+  prioritized fixes/requests). The devtools license left this list on
+  2026-07-27; commercial licenses are sold separately from sponsorship.
 - **LS.SUST-R06 Brand stewardship:** The LiveStore name and logo are
   stewarded by the project creator; use by forks and contrib packages is
   good-faith and informal (no formal trademark policy exists). Adopted

--- a/context/06-sustainability/spec.md
+++ b/context/06-sustainability/spec.md
@@ -11,9 +11,14 @@ Draft.
 
 | Surface | License |
 | --- | --- |
-| `livestorejs/livestore` (this repo) | Apache-2.0 |
-| `livestorejs/livestore-contrib` | Apache-2.0 (same product identity) |
-| Devtools | Sponsor license, delivered via the sponsor dashboard |
+| All published `@livestore/*` packages | LiveStore Community License 1.0 (`LicenseRef-LiveStore-Community-1.0`) |
+| `@livestore/wa-sqlite` | MIT (fork of `rhashimoto/wa-sqlite`, © Roy T. Hashimoto) |
+| Releases published before 2026-07-27 | Apache-2.0, irrevocably |
+| Every version, from its second anniversary | Apache-2.0, by present grant |
+
+Licensing is per package, not per repository: `livestorejs/livestore` and
+`livestorejs/livestore-contrib` both carry per-package `LICENSE` files, and each
+repository root states which subtrees it does not cover.
 
 ## Funding Channels (LS.SUST-R02)
 
@@ -43,28 +48,17 @@ feature requests. Student devtools licenses via Discord request.
 
 ## Open Design Questions
 
-- **LS.SUST-DQ1 Licensing model.** Whether LiveStore keeps its current model
-  (permissive open-source core, Apache-2.0, plus closed sponsor-licensed
-  devtools — LS.SUST-R01/R03, LS.SUST-T01) or moves to a source-available model
-  that better funds maintenance. **Leading direction (2026-07-17, interview —
-  not yet decided):** a single time-delayed license over the *whole* system
-  (FSL or similar — source-available now, converting to a permissive license
-  after a rolling window), which would also open the devtools source. Candidate
-  families in
-  [.reference/license-model-options.md](./.reference/license-model-options.md).
-  Implications, none settled until the decision is made:
-  - **Identity / vision.** A whole-product time-delayed license means the core
-    is not OSI "open source" *now* (it becomes "eventually open source" / fair
-    source). This changes what LiveStore *is*, needs a `vision.md` pass
-    (human-only), and would revise LS.SUST-R01 (core Apache-2.0) plus
-    LS.SUST-R03/T01 (devtools would become source-available, not sponsorware).
-  - **Positioning wording.** The sponsoring page's "fully open source" line
-    (today it sits directly above the devtools-license line it contradicts) is
-    rewritten to match the chosen model.
-  - **Mechanics** (tiers, per-seat vs per-org, lapse, enforcement) and the
-    **UI-component-kit** boundary are subsumed / moot until the model is chosen.
-  Blocked on: a strategic decision by the project creator (+ legal review).
-  Reframed 2026-07-17 (interview) from a narrower "wording + mechanics"
-  question.
+- **LS.SUST-DQ1 Licensing model.** **Resolved 2026-07-27** —
+  [decision 0001](./.decisions/0001-community-license.md) adopts a size-gated
+  source-available license across all packages with a two-year per-version
+  conversion to Apache-2.0. What remains open is not the model but its
+  execution: the licence text is drafted and pending review by counsel; the
+  commercial licence (price, term, seat-vs-org basis, purchase path) does not
+  yet exist and must before the change ships; and `vision.md` still describes
+  the project as community-owned open source sustained through sponsorship
+  alone, which this decision makes inaccurate. `LS-A05 "No company"` is also in
+  tension with the intent to assign the licensor role to an entity.
+
+
 - **LS.SUST-DQ2 Scaling maintainership.** The stated goal of funding
   additional maintainers has no defined thresholds or mechanics.


### PR DESCRIPTION
Records the licensing decision from #1511 in the intent layer, and files the drafted licence for review.

**This does not change any licence.** No `LICENSE` file, no `package.json`, no published artifact is touched. It records a decision and files a draft.

## What's here

- **`context/06-sustainability/.decisions/0001-community-license.md`** — the decision, its rejected alternatives, and the reasoning
- **`requirements.md`** — revises `LS.SUST-R01` (Apache-2.0 → size-gated source-available), `LS.SUST-R02` (commercial licensing becomes a real funding channel), `LS.SUST-R03` (entitlement follows the licence, not sponsorship), `LS.SUST-R05` (devtools leaves the sponsor-benefit list); retires `LS.SUST-T01`
- **`spec.md`** — rewrites the License Inventory per-package rather than per-repo; resolves `LS.SUST-DQ1` on the model while naming what is still open in execution
- **`.reference/licence-draft-*`** — the drafted licence, review notes, packaging instructions and commercial-licence notes

## The decision in one paragraph

All published `@livestore/*` packages move to the **LiveStore Community License 1.0**: free for individuals, for nonprofit/educational/government organisations, and for organisations under **all** of 10 people, USD 1M revenue and USD 1M raised. Each version converts to Apache-2.0 on the second anniversary of its own publication. `@livestore/wa-sqlite` stays MIT. Releases published before adoption remain Apache-2.0 irrevocably. Enforcement is contractual — no runtime check ships.

## Why not a non-compete licence

Every restrictive licence in the canon (BUSL, SSPL, ELv2, FSL) defends one threat: a cloud provider reselling the software as a managed service. LiveStore is a client-side library — nobody can host it — and `LS.SUST-R04` already commits to not operating a sync service. FSL's Permitted Purpose explicitly enumerates *"for your internal use and access"*, so an enterprise using LiveStore internally would be permitted freely and permanently.

## Why no technical enforcement

Every working licence mechanism in this ecosystem is anchored to a rendering surface — a watermark or banner in the licensee's shipped product. LiveStore renders nothing. Mapbox GL JS v2 added runtime validation to a library and was forked into MapLibre within weeks; RxDB gates at install and advertises that it ships no validation into user bundles.

## Review notes

- **The licence text is a draft for counsel**, not a finished document. `.reference/licence-draft-review-notes.md` lists 19 open questions ordered by confidence. The `Application Users` clause is the one with no precedent in any source text and the one the drafter is least sure of — PolyForm's structure genuinely breaks for a library, since recipients would need their own permitted purpose and sublicensing is barred.
- **The draft deliberately contains no mention of PolyForm.** Their repository requires that adaptations *remove* all mention of PolyForm and their domain — a de-branding condition, not attribution.
- `vision.md` is **not** touched. It still describes the project as community-owned open source sustained through sponsorship alone, which this decision makes inaccurate. That file is human-owned and needs a separate pass.
- `LS-A05 "No company"` is in tension with the intent to assign the licensor role to an entity. Flagged in the decision record, not resolved.
- Core's intent-layer suite needs a full workspace install, which I didn't run in a fresh worktree. I verified the mechanical invariants directly instead: zero broken relative links across `context/`, decision-record filename and `Status:` shape valid, no committed `.proposed/`.

Refs #1511

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | cl1-reef |
| `agent_session_id` | f54dccb2-7cbf-4ab6-af33-c23c984cc1a3 |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_model` | claude-opus-5 |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling-assistant/2026-07-27-2026-07-27-licensing-vrs |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->