### PR TITLE
docs(contributing): point the before-push gate at real test tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Use GitHub issues or an issue checklist for non-trivial work.
 
 ### Development Workflow
 
-- Run the full test suite before pushing: `devenv tasks run test:run`
+- Run the test suites before pushing (there is no single `test:run` task): `devenv tasks run test:unit`, plus the relevant `test:integration:*` and `test:perf` tasks (all `test:*` tasks are defined in `nix/devenv-modules/tasks/local/mono-wrappers.nix`)
 - Ensure TypeScript compilation passes: `devenv tasks run ts:check`
 - Use `devenv tasks run lint:full:fix` to automatically fix formatting issues
 

--- a/context/05-contributing/01-collaboration/requirements.md
+++ b/context/05-contributing/01-collaboration/requirements.md
@@ -16,8 +16,10 @@ conventions (`CLAUDE.md`/`AGENTS.md`) and
   `<username>/<kind>/<short-desc>` in kebab-case (e.g.
   `jane/fix/memory-leak`).
 - **LS.CONTRIB.COLLAB-R02 Green gates before commit:** Changes pass lint and
-  type checks before commit (`dt lint:full:fix`, `dt ts:check`); the full
-  test suite passes before push (`dt test:run`).
+  type checks before commit (`dt lint:full:fix`, `dt ts:check`); the test
+  suites pass before push (`dt test:unit` plus the relevant
+  `dt test:integration:*` / `dt test:perf` tasks; there is no single
+  `dt test:run` task).
 - **LS.CONTRIB.COLLAB-R03 Changelog discipline:** Every user-facing change
   lands in the upcoming section of `CHANGELOG.md`; each user-facing bullet
   links at least one GitHub issue or PR; no placeholder links.

--- a/context/05-contributing/01-collaboration/spec.md
+++ b/context/05-contributing/01-collaboration/spec.md
@@ -16,8 +16,9 @@ branch ──► changes + changeset ──► lint/type gates ──► PR (pro
 
 - Branch per LS.CONTRIB.COLLAB-R01; changeset per LS.CONTRIB-R05
   (`pnpm exec changeset`, `--empty` when no release-note impact).
-- Gates: `dt lint:full:fix` then `dt ts:check` before commit; `dt test:run`
-  before push (LS.CONTRIB.COLLAB-R02).
+- Gates: `dt lint:full:fix` then `dt ts:check` before commit; the relevant
+  `dt test:*` suites (`test:unit`, `test:integration:*`, `test:perf`) before
+  push (LS.CONTRIB.COLLAB-R02).
 - PR body follows the repo template: problem, solution, validation,
   trade-offs, linked issues; evidence (logs, screenshots, diagrams)
   encouraged.


### PR DESCRIPTION
## Problem

The contributor docs tell contributors (and agents) to run the full test suite before pushing via `devenv tasks run test:run` / `dt test:run` (CLAUDE.md, and the `LS.CONTRIB.COLLAB-R02` requirement/spec). There is no `test:run` task defined, so the documented before-push gate fails and, as #1506 notes, wastes agent runs.

## Solution

Point the before-push gate at the tasks that actually exist. The test tasks defined in `nix/devenv-modules/tasks/local/mono-wrappers.nix` are `test:unit`, `test:perf`, and the `test:integration:*` suites (there is no single full-suite task), so the three references now name those instead of the nonexistent `test:run`:

- `CLAUDE.md` (Development Workflow)
- `context/05-contributing/01-collaboration/requirements.md` (LS.CONTRIB.COLLAB-R02)
- `context/05-contributing/01-collaboration/spec.md` (Gates)

**Open question from the issue:** you flagged that the alternative is to *add* a `test:run` alias that runs the full suite. I went with the docs fix because there is no obvious canonical composition for a full-suite task (unit + all integration suites + perf, and whether perf/playwright belong in a before-push gate is a judgment call). If you'd rather I add a `test:run` alias in `mono-wrappers.nix` instead of (or in addition to) this docs change, say so and I'll switch — happy to do either.

## Validation

Docs-only. Verified against the repo that `test:run` does not exist and that `test:unit` / `test:perf` / `test:integration:*` do (`nix/devenv-modules/tasks/local/mono-wrappers.nix`). No `test:run` references remain except the two that explicitly state the task does not exist.

## Trade-offs

The gate now names several tasks rather than one command. Adding a `test:run` alias (the alternative above) would keep it a single command; this PR keeps the change to documentation only.

Per `.changeset/README.md`, documentation changes that do not touch public package files do not need a changeset, so none is included.

Closes #1506.

Disclosure: prepared with AI assistance; I reviewed the change and verified the task names against the source.
