### PR TITLE
refactor: remove unused `withChangeset` option

### DIFF
--- a/.changeset/empty-unconditional-session-changesets.md
+++ b/.changeset/empty-unconditional-session-changesets.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Remove the unused `withChangeset` materialization option and always capture session changesets for rebase rollback.

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -57,7 +57,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   clientSession: ClientSession
   materializeEvent: (
     eventEncoded: LiveStoreEvent.Client.EncodedWithMeta,
-    options: { withChangeset: boolean; materializerHashLeader: Option.Option<number> },
+    options: { materializerHashLeader: Option.Option<number> },
   ) => Effect.Effect<
     {
       writeTables: Set<string>
@@ -302,7 +302,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
               sessionChangeset,
               materializerHash,
             } = yield* materializeEvent(event, {
-              withChangeset: true,
               materializerHashLeader: event.meta.materializerHashLeader,
             })
             for (const table of newWriteTables) {
@@ -405,7 +404,6 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         sessionChangeset,
         materializerHash,
       } = yield* materializeEvent(event, {
-        withChangeset: true,
         materializerHashLeader: Option.none(),
       })
       for (const table of newWriteTables) {

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -212,7 +212,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
       schema,
       clientSession,
       materializeEvent: Effect.fn('client-session-sync-processor:materialize-event')(
-        (eventEncoded, { withChangeset, materializerHashLeader }) =>
+        (eventEncoded, { materializerHashLeader }) =>
           // We need to use `Effect.gen` (even though we're using `Effect.fn`) so that we can pass `this` to the function
           Effect.gen({ self: this }, function* () {
             const resolution = yield* resolveEventDef(schema, {
@@ -287,15 +287,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
               }
             }
 
-            let sessionChangeset:
-              | { _tag: 'sessionChangeset'; data: Uint8Array<ArrayBuffer>; debug: any }
-              | { _tag: 'no-op' }
-              | { _tag: 'unset' } = { _tag: 'unset' }
-            if (withChangeset === true) {
-              sessionChangeset = this[StoreInternalsSymbol].sqliteDbWrapper.withChangeset(exec).changeset
-            } else {
-              exec()
-            }
+            const sessionChangeset = this[StoreInternalsSymbol].sqliteDbWrapper.withChangeset(exec).changeset
 
             return { writeTables: writeTablesForEvent, sessionChangeset, materializerHash }
           }).pipe(Effect.mapError((cause) => MaterializeError.make({ cause }))),

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -1120,10 +1120,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       })
 
       const materializeEvent = Effect.fn('test:materialize-event')(
-        (
-          event: LiveStoreEvent.Client.EncodedWithMeta,
-          _options: { withChangeset: boolean; materializerHashLeader: Option.Option<number> },
-        ) =>
+        (event: LiveStoreEvent.Client.EncodedWithMeta, _options: { materializerHashLeader: Option.Option<number> }) =>
           Effect.gen(function* () {
             materializedEvents.push(event)
             return {


### PR DESCRIPTION
## Problem

The client-session materialization callback accepted a `withChangeset` boolean even though every caller passed `true`. The unreachable `false` branch obscured the sync invariant that session materializations must retain SQLite changesets for rebase rollback.

## Solution

- Remove `withChangeset` from the materialization callback options and both call sites.
- Capture the session changeset unconditionally after executing a known event materializer.
- Update the affected test callback type.
- Add an empty release changeset because this is an internal, behavior-preserving public-package refactor.

Unknown events continue to return a no-op changeset, and known events continue to capture either changeset bytes or a no-op result.

## Validation

- `pnpm exec vitest run tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts --testNamePattern "unknown upstream events still invoke materializeEvent"`
- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check` (via `check:all`)
- `devenv tasks run test:unit`
- `git diff --check`

`devenv tasks run check:all` completed 15 checks successfully but remains non-green because the unrelated `otel:verify:setup` self-test exits 1 after its child `setup:gate` succeeds and emits one span. Re-running that verifier alone reproduces the same environment-level failure.

## Trade-offs and follow-up

No runtime behavior or public API changes. The SQLite wrapper method remains named `withChangeset`; this PR removes only the unused materialization option. No related GitHub issue was found.