### PR TITLE
Fix warm setup probes by preserving traced cache exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           DEFAULT_REFS_JSON: '{}'
           VERIFY_REACHABLE: '1'
           NORMALIZE_GIT_BRANCH_REFS: '1'
+          ALLOW_LEGACY_MEMBER_COMMIT_REFS: '0'
         run: |
           nix shell nixpkgs#nodejs_24 -c node <<'NODE'
           const fs = require('node:fs')
@@ -64,6 +65,7 @@ jobs:
           const defaultRef = process.env.DEFAULT_REF || 'main'
           const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
           const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const allowLegacyMemberCommitRefs = process.env.ALLOW_LEGACY_MEMBER_COMMIT_REFS === '1'
           const violations = []
 
           const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
@@ -71,6 +73,12 @@ jobs:
           const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
           const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
           const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+          const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i
+          const isAllowedLegacyMemberRef = ({ memberName, ref }) =>
+            allowLegacyMemberCommitRefs &&
+            typeof memberName === 'string' &&
+            memberName.endsWith('-legacy') &&
+            immutableCommitRef.test(ref)
 
           const githubRepoFromUrl = (url) => {
             const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
@@ -125,6 +133,7 @@ jobs:
             const expectedRef = expectedRefFor(repo)
             const normalizedRef = normalizeRef(ref)
             if (normalizedRef === expectedRef) return
+            if (isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })) return
             violations.push({
               type: 'ref',
               file,
@@ -350,6 +359,12 @@ jobs:
             for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
               const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
               if (!repo || !isFirstParty(repo)) continue
+              if (
+                typeof member.ref === 'string' &&
+                isAllowedLegacyMemberRef({ memberName, ref: normalizeRef(member.ref) })
+              ) {
+                continue
+              }
               const expectedRef = expectedRefFor(repo)
               const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
               const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
@@ -509,15 +524,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -554,6 +561,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -692,15 +708,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -737,6 +745,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -870,15 +887,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -915,6 +924,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1055,15 +1073,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1100,6 +1110,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1232,15 +1251,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1277,6 +1288,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1419,15 +1439,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1464,6 +1476,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1612,15 +1633,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1657,6 +1670,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1818,15 +1840,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1863,6 +1877,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -2009,15 +2032,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2054,6 +2069,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -2209,15 +2233,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2254,6 +2270,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -2429,15 +2454,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2474,6 +2491,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -2637,15 +2663,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2682,6 +2700,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,7 +524,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -708,7 +708,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -887,7 +887,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1073,7 +1073,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1251,7 +1251,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1439,7 +1439,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1633,7 +1633,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1840,7 +1840,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2032,7 +2032,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2233,7 +2233,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2454,7 +2454,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -2663,7 +2663,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -517,7 +517,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -734,7 +734,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -927,7 +927,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -53,6 +53,7 @@ jobs:
           DEFAULT_REFS_JSON: '{}'
           VERIFY_REACHABLE: '1'
           NORMALIZE_GIT_BRANCH_REFS: '1'
+          ALLOW_LEGACY_MEMBER_COMMIT_REFS: '0'
         run: |
           nix shell nixpkgs#nodejs_24 -c node <<'NODE'
           const fs = require('node:fs')
@@ -65,6 +66,7 @@ jobs:
           const defaultRef = process.env.DEFAULT_REF || 'main'
           const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
           const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const allowLegacyMemberCommitRefs = process.env.ALLOW_LEGACY_MEMBER_COMMIT_REFS === '1'
           const violations = []
 
           const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
@@ -72,6 +74,12 @@ jobs:
           const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
           const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
           const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+          const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i
+          const isAllowedLegacyMemberRef = ({ memberName, ref }) =>
+            allowLegacyMemberCommitRefs &&
+            typeof memberName === 'string' &&
+            memberName.endsWith('-legacy') &&
+            immutableCommitRef.test(ref)
 
           const githubRepoFromUrl = (url) => {
             const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
@@ -126,6 +134,7 @@ jobs:
             const expectedRef = expectedRefFor(repo)
             const normalizedRef = normalizeRef(ref)
             if (normalizedRef === expectedRef) return
+            if (isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })) return
             violations.push({
               type: 'ref',
               file,
@@ -351,6 +360,12 @@ jobs:
             for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
               const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
               if (!repo || !isFirstParty(repo)) continue
+              if (
+                typeof member.ref === 'string' &&
+                isAllowedLegacyMemberRef({ memberName, ref: normalizeRef(member.ref) })
+              ) {
+                continue
+              }
               const expectedRef = expectedRefFor(repo)
               const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
               const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
@@ -502,15 +517,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -547,6 +554,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -718,15 +734,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -763,6 +771,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -910,15 +927,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -955,6 +964,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -89,6 +89,7 @@ jobs:
           DEFAULT_REFS_JSON: '{}'
           VERIFY_REACHABLE: '1'
           NORMALIZE_GIT_BRANCH_REFS: '1'
+          ALLOW_LEGACY_MEMBER_COMMIT_REFS: '0'
         run: |
           nix shell nixpkgs#nodejs_24 -c node <<'NODE'
           const fs = require('node:fs')
@@ -101,6 +102,7 @@ jobs:
           const defaultRef = process.env.DEFAULT_REF || 'main'
           const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
           const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const allowLegacyMemberCommitRefs = process.env.ALLOW_LEGACY_MEMBER_COMMIT_REFS === '1'
           const violations = []
 
           const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
@@ -108,6 +110,12 @@ jobs:
           const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
           const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
           const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+          const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i
+          const isAllowedLegacyMemberRef = ({ memberName, ref }) =>
+            allowLegacyMemberCommitRefs &&
+            typeof memberName === 'string' &&
+            memberName.endsWith('-legacy') &&
+            immutableCommitRef.test(ref)
 
           const githubRepoFromUrl = (url) => {
             const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
@@ -162,6 +170,7 @@ jobs:
             const expectedRef = expectedRefFor(repo)
             const normalizedRef = normalizeRef(ref)
             if (normalizedRef === expectedRef) return
+            if (isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })) return
             violations.push({
               type: 'ref',
               file,
@@ -387,6 +396,12 @@ jobs:
             for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
               const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
               if (!repo || !isFirstParty(repo)) continue
+              if (
+                typeof member.ref === 'string' &&
+                isAllowedLegacyMemberRef({ memberName, ref: normalizeRef(member.ref) })
+              ) {
+                continue
+              }
               const expectedRef = expectedRefFor(repo)
               const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
               const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
@@ -536,15 +551,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -581,6 +588,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -551,7 +551,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -125,15 +125,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -170,6 +162,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -125,7 +125,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
           DEFAULT_REFS_JSON: '{}'
           VERIFY_REACHABLE: '1'
           NORMALIZE_GIT_BRANCH_REFS: '1'
+          ALLOW_LEGACY_MEMBER_COMMIT_REFS: '0'
         run: |
           nix shell nixpkgs#nodejs_24 -c node <<'NODE'
           const fs = require('node:fs')
@@ -110,6 +111,7 @@ jobs:
           const defaultRef = process.env.DEFAULT_REF || 'main'
           const defaultRefs = new Map(Object.entries(JSON.parse(process.env.DEFAULT_REFS_JSON || '{}')).map(([repo, ref]) => [repo.toLowerCase(), ref]))
           const verifyReachable = process.env.VERIFY_REACHABLE === '1'
+          const allowLegacyMemberCommitRefs = process.env.ALLOW_LEGACY_MEMBER_COMMIT_REFS === '1'
           const violations = []
 
           const repoKey = (repo) => repo.owner.toLowerCase() + '/' + repo.repo.toLowerCase()
@@ -117,6 +119,12 @@ jobs:
           const normalizeGitBranchRefs = process.env.NORMALIZE_GIT_BRANCH_REFS === '1'
           const normalizeRef = (ref) => normalizeGitBranchRefs && ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
           const expectedRefFor = (repo) => normalizeRef(defaultRefs.get(repoKey(repo)) || defaultRef)
+          const immutableCommitRef = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i
+          const isAllowedLegacyMemberRef = ({ memberName, ref }) =>
+            allowLegacyMemberCommitRefs &&
+            typeof memberName === 'string' &&
+            memberName.endsWith('-legacy') &&
+            immutableCommitRef.test(ref)
 
           const githubRepoFromUrl = (url) => {
             const match = url.match(/github\.com[/:]([^/]+)\/([^/#?]+?)(?:\.git)?(?:[#?].*)?$/)
@@ -171,6 +179,7 @@ jobs:
             const expectedRef = expectedRefFor(repo)
             const normalizedRef = normalizeRef(ref)
             if (normalizedRef === expectedRef) return
+            if (isAllowedLegacyMemberRef({ memberName, ref: normalizedRef })) return
             violations.push({
               type: 'ref',
               file,
@@ -396,6 +405,12 @@ jobs:
             for (const [memberName, member] of Object.entries((lock && lock.members) || {})) {
               const repo = typeof member.url === 'string' ? githubRepoFromUrl(member.url) : undefined
               if (!repo || !isFirstParty(repo)) continue
+              if (
+                typeof member.ref === 'string' &&
+                isAllowedLegacyMemberRef({ memberName, ref: normalizeRef(member.ref) })
+              ) {
+                continue
+              }
               const expectedRef = expectedRefFor(repo)
               const remote = 'https://github.com/' + repo.owner + '/' + repo.repo + '.git'
               const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'default-ref-policy-'))
@@ -1054,15 +1069,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1099,6 +1106,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1296,15 +1312,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1341,6 +1349,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1545,15 +1562,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1590,6 +1599,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -1837,15 +1855,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1882,6 +1892,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1069,7 +1069,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1312,7 +1312,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1562,7 +1562,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -1855,7 +1855,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -137,7 +137,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -322,7 +322,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -137,15 +137,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -182,6 +174,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -321,15 +322,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -366,6 +359,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -131,15 +131,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -176,6 +168,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'
@@ -313,15 +314,7 @@ jobs:
             exit 1
           fi
 
-          resolve_devenv() {
-            nix build \
-              --accept-flake-config \
-              --option extra-substituters https://devenv.cachix.org \
-              --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
-              --no-link \
-              --print-out-paths \
-              "github:cachix/devenv/$DEVENV_REV#devenv"
-          }
+          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -358,6 +351,15 @@ jobs:
             fi
             DEVENV_BIN="$DEVENV_OUT/bin/devenv"
           fi
+
+          # resolve_devenv_once uses this out-link directly, so Nix registers the GC
+          # root before a successful build returns. RUNNER_TEMP cleanup removes it after
+          # the job; the run/attempt/job namespace prevents cross-job replacement.
+          if [ ! -L "$DEVENV_GC_ROOT" ] || [ ! "$DEVENV_GC_ROOT" -ef "$DEVENV_OUT" ]; then
+            echo "::error::devenv resolution did not publish the expected job-scoped GC root: $DEVENV_GC_ROOT"
+            exit 1
+          fi
+          echo "DEVENV_GC_ROOT=$DEVENV_GC_ROOT" >> "$GITHUB_ENV"
 
           echo "DEVENV_BIN=$DEVENV_BIN" >> "$GITHUB_ENV"
           "$DEVENV_BIN" version | tee "$DIAG_ROOT/devenv-version.txt"'

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -131,7 +131,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"
@@ -314,7 +314,7 @@ jobs:
             exit 1
           fi
 
-          . '\''${{ runner.temp }}/genie-ci-scripts/resolve-devenv.sh'\''
+          . '\''${{ runner.temp }}/genie-ci-scripts/nix-gc-race-retry.sh'\''
 
           # Temporary: capture diagnostics dir for #272 root-cause analysis.
           DIAG_ROOT="${RUNNER_TEMP:-/tmp}/nix-store-diagnostics-${GITHUB_JOB:-job}-${RUNNER_OS:-unknown}-${GITHUB_RUN_ATTEMPT:-0}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ For maintainers and contributors:
   devenv tracing and `otelite`; `otel:verify:setup` gates the connected trace
   shape without a repository-local orchestration module
   ([#1402](https://github.com/livestorejs/livestore/issues/1402)).
+- **Tooling:** Warm shell setup now receives the shared setup-fingerprint
+  verdict across the traced task boundary. Genie uses its bounded generated-file
+  check while pnpm retains projection-integrity validation
+  ([#1500](https://github.com/livestorejs/livestore/issues/1500),
+  [effect-utils#1030](https://github.com/overengineeringstudio/effect-utils/pull/1030)).
 - **Tooling:** Unit-test failures now block merges. The `test-unit` job ran
   `packages/@livestore/webmesh` and `tests/package-common` through
   `Effect.ignore` on CI, so their failures produced a passing required check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ For maintainers and contributors:
   ([#1402](https://github.com/livestorejs/livestore/issues/1402)).
 - **Tooling:** Warm shell setup now receives the shared setup-fingerprint
   verdict across the traced task boundary. Genie uses its bounded generated-file
-  check while pnpm retains projection-integrity validation
+  check while pnpm retains projection-integrity validation. The shared CI
+  runtime also composes devenv resolution into the support artifact already
+  materialized by consumers
   ([#1500](https://github.com/livestorejs/livestore/issues/1500),
   [effect-utils#1030](https://github.com/overengineeringstudio/effect-utils/pull/1030)).
 - **Tooling:** Unit-test failures now block merges. The `test-unit` job ran

--- a/context/03-delivery/01-composition/01-developer-environment/.experiments/0002-traced-task-export-propagation.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.experiments/0002-traced-task-export-propagation.md
@@ -1,0 +1,131 @@
+# 0002 — Traced task-export propagation and warm status probes
+
+Date: 2026-07-29
+
+## Question
+
+Why do warm shell entries still repeat the expensive pnpm and Genie status
+paths after the shared setup fingerprint reports a hit, and can the floor be
+reduced without weakening stale-state detection?
+
+## Revisions
+
+- LiveStore baseline: `6fff977115465f096e4e04f4b80da622ea693a5f`
+- Effect-utils baseline:
+  `99c8c7764359de121e59577e4270c1c290d6e236`
+- Effect-utils implementation:
+  `fc7121f40f5be934e217bc8e5fab44edb808e5c4`
+  ([effect-utils#1030](https://github.com/overengineeringstudio/effect-utils/pull/1030))
+
+## Method
+
+- Used an isolated LiveStore worktree on one Linux host.
+- Warmed the dependency, generator, Nix evaluation, and setup-fingerprint
+  caches before measuring.
+- Captured `setup:strict` through the shared `otel:profile:setup` task. Otelite
+  normalized native devenv OTLP/gRPC spans and Effect-utils OTLP/HTTP task spans
+  into one trace.
+- Inspected devenv's task database and generated task wrapper to determine
+  which `setup:gate` exports reached the downstream tasks.
+- Invoked the exact generated pnpm and Genie status programs for negative
+  checks, then restored each changed path and required a hit.
+- Recorded host load with the timing samples. Samples taken while the shared
+  host was oversubscribed are structural trace evidence only, not a speedup
+  claim.
+
+## Root cause
+
+`setup:gate` declared devenv task exports, but `trace.exec` ran the task body
+under `otel-span -> bash -c`. The body exported the fingerprint and cache
+verdict in that child process. Devenv's generated export epilogue ran later in
+the parent wrapper, where those variables did not exist. Only an already
+inherited `TRACEPARENT` appeared in the task output.
+
+The consequence was a false cold status path on every warm run:
+
+- Genie recomputed its source and generated-file content hash.
+- pnpm recomputed workspace state in addition to the required projection
+  integrity digest.
+
+The shared Effect-utils fix adds `trace.execWithExports`, which writes the
+declared values to `DEVENV_TASK_EXPORTS_FILE` from inside the traced child.
+`setup:gate` composes that helper and preserves an existing trace context.
+LiveStore only consumes the shared fix by pinning Effect-utils.
+
+## Structural trace evidence
+
+The baseline connected trace
+`df66e0bfb88bbfe567f35a72b448bbea` contained 24 spans, one trace, and no error
+spans. Its cached status children were:
+
+| Task | Baseline status span |
+| --- | ---: |
+| `genie:run` | 906.855ms |
+| `pnpm:install` | 559.899ms |
+
+After the fix, the real task output included
+`DEVENV_SETUP_OUTER_CACHE_HIT=1`, `DEVENV_SETUP_FINGERPRINT`,
+`DEVENV_SETUP_GIT_HASH`, `TRACEPARENT`, and `OTEL_SHELL_ENTRY_NS`.
+
+The fixed connected trace
+`18c21e580a4b1a224c378a8e953239b6` again contained 24 spans in one connected
+tree and no error spans. Genie selected its bounded warm path:
+
+| Task | Fixed status span | Interpretation |
+| --- | ---: | --- |
+| `genie:run` | 5.950ms | Warm verdict reached the output-existence check. |
+| `pnpm:install` | 1572.926ms | Projection integrity scan retained. Timing contaminated by host load. |
+
+The fixed capture was taken at load average `53.09 / 56.91 / 41.83` on a
+32-core host with swap fully consumed. It is not comparable to the baseline
+timing capture. The span shape and selected code path are still valid.
+
+## Integrity negatives
+
+| Mutation | Expected | Observed |
+| --- | --- | --- |
+| Move `node_modules/typescript` projection away | pnpm warm status misses | exit 1 |
+| Move generated `.github/workflows/auto-review.yml` away | Genie warm status misses | exit 1 |
+| Add an uncommitted `pnpm-lock.yaml` change | outer fingerprint misses | `DEVENV_SETUP_OUTER_CACHE_HIT=0` |
+| Restore each path | both task statuses hit | exit 0 |
+
+The Effect-utils module suite also exercises foreign and broken nested
+dependency edges, missing projection metadata, and disappearing projected
+symlinks on the outer-cache path.
+
+## Benchmark
+
+Seven same-worktree pairs invoked the exact generated status programs with the
+pre-fix verdict (`DEVENV_SETUP_OUTER_CACHE_HIT=0`) and the fixed verdict
+(`DEVENV_SETUP_OUTER_CACHE_HIT=1`). Pair order alternated to reduce monotonic
+host-drift bias:
+
+| Pair | Genie before | Genie after | pnpm before | pnpm after |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 | 1088ms | 26ms | 5113ms | 1294ms |
+| 2 | 682ms | 15ms | 658ms | 746ms |
+| 3 | 759ms | 8ms | 1274ms | 508ms |
+| 4 | 297ms | 5ms | 520ms | 408ms |
+| 5 | 255ms | 4ms | 509ms | 516ms |
+| 6 | 424ms | 4ms | 528ms | 454ms |
+| 7 | 389ms | 6ms | 739ms | 444ms |
+| Median | 424ms | 6ms | 658ms | 508ms |
+
+The observed medians are 98.6% lower for Genie and 22.8% lower for pnpm.
+However, the host load average was `64.24 / 43.60 / 39.44` at the start and
+`61.62 / 44.12 / 39.68` at the end on 32 cores. The paired, alternating design
+supports the direction and mechanism of the result, while the absolute values
+and percentages remain low-confidence under the active oversubscription
+incident. They must not become CI thresholds.
+
+## Conclusion
+
+The warm Genie floor was not inherent filesystem work. It was a task-export
+propagation bug introduced at the tracing process boundary. Persisting exports
+inside that boundary restores the intended shared composition and removes the
+full Genie hash without duplicating LiveStore task wrappers.
+
+pnpm's remaining floor is principled integrity work over the realized
+dependency projection. Reducing it further requires a reusable integrity
+primitive with equivalent negative-case coverage, not a LiveStore-only cache
+bypass.

--- a/context/03-delivery/01-composition/01-developer-environment/spec.md
+++ b/context/03-delivery/01-composition/01-developer-environment/spec.md
@@ -22,6 +22,13 @@ developer and CI workflows, so source errors cannot delay or block access to
 the diagnostic environment
 ([decision 0001](./.decisions/0001-separate-readiness-from-validation.md)).
 
+The shared setup gate computes one repository-input fingerprint and exports its
+cache verdict to every downstream status probe. Instrumentation must preserve
+those task exports across its process boundary. A warm verdict only selects the
+bounded pnpm projection and generated-output existence checks; it does not
+bypass them. Dirty lockfiles, missing or broken dependency projections, and
+missing generated outputs remain cache misses.
+
 ## Setup Observability
 
 `otel:profile:setup` is the canonical setup diagnostic. The shared Effect-utils
@@ -45,7 +52,8 @@ the native root and task spans, and the native `setup:gate` to Effect-utils
 `devenv.task.exec` parent relationship. It does not enforce absolute duration.
 Benchmark timings remain experiment evidence because host and cache state are
 material inputs
-([experiment 0001](./.experiments/0001-worktree-setup-and-trace.md)).
+([experiment 0001](./.experiments/0001-worktree-setup-and-trace.md),
+[experiment 0002](./.experiments/0002-traced-task-export-propagation.md)).
 
 Setup captures are local diagnostic artifacts under the ignored `tmp/` tree.
 They are not uploaded automatically. This keeps machine-local paths and command

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1785183265,
-        "narHash": "sha256-vBz9Hp/p6eh2rSOyHDyXxkaksV30ddbUdYfTT9NGpTk=",
+        "lastModified": 1785309423,
+        "narHash": "sha256-0NNljNVAa9I//eCnG7kl8bpg8lE/S+M9xpdDe1AwzTQ=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "99c8c7764359de121e59577e4270c1c290d6e236",
+        "rev": "fc7121f40f5be934e217bc8e5fab44edb808e5c4",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1785183265,
-        "narHash": "sha256-vBz9Hp/p6eh2rSOyHDyXxkaksV30ddbUdYfTT9NGpTk=",
+        "lastModified": 1785309423,
+        "narHash": "sha256-0NNljNVAa9I//eCnG7kl8bpg8lE/S+M9xpdDe1AwzTQ=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "99c8c7764359de121e59577e4270c1c290d6e236",
+        "rev": "fc7121f40f5be934e217bc8e5fab44edb808e5c4",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1785315044,
-        "narHash": "sha256-s065827dnjZzOE5CCa3dNf2CteHwUenyR4FgG/EXM6s=",
+        "lastModified": 1785315813,
+        "narHash": "sha256-YgDRYo5K5PnYBEnUsk713iNid/fJXF8h+jjbFCL4SX4=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "f59e064f202792e925157d7110fc8b915c520559",
+        "rev": "4c46064bfb5aa69461fbfe57e202055737114b05",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1785315044,
-        "narHash": "sha256-s065827dnjZzOE5CCa3dNf2CteHwUenyR4FgG/EXM6s=",
+        "lastModified": 1785315813,
+        "narHash": "sha256-YgDRYo5K5PnYBEnUsk713iNid/fJXF8h+jjbFCL4SX4=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "f59e064f202792e925157d7110fc8b915c520559",
+        "rev": "4c46064bfb5aa69461fbfe57e202055737114b05",
         "type": "github"
       },
       "original": {

--- a/devenv.lock
+++ b/devenv.lock
@@ -24,11 +24,11 @@
         "tsgo": "tsgo"
       },
       "locked": {
-        "lastModified": 1785309423,
-        "narHash": "sha256-0NNljNVAa9I//eCnG7kl8bpg8lE/S+M9xpdDe1AwzTQ=",
+        "lastModified": 1785315044,
+        "narHash": "sha256-s065827dnjZzOE5CCa3dNf2CteHwUenyR4FgG/EXM6s=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "fc7121f40f5be934e217bc8e5fab44edb808e5c4",
+        "rev": "f59e064f202792e925157d7110fc8b915c520559",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
       },
       "locked": {
         "dir": "nix/playwright-flake",
-        "lastModified": 1785309423,
-        "narHash": "sha256-0NNljNVAa9I//eCnG7kl8bpg8lE/S+M9xpdDe1AwzTQ=",
+        "lastModified": 1785315044,
+        "narHash": "sha256-s065827dnjZzOE5CCa3dNf2CteHwUenyR4FgG/EXM6s=",
         "owner": "overengineeringstudio",
         "repo": "effect-utils",
-        "rev": "fc7121f40f5be934e217bc8e5fab44edb808e5c4",
+        "rev": "f59e064f202792e925157d7110fc8b915c520559",
         "type": "github"
       },
       "original": {

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -7,6 +7,7 @@ run_nix_gc_race_retry() {
   local task="$1"
   local max="${NIX_GC_RACE_MAX_RETRIES:-10}"
   local heartbeat="${CI_PROGRESS_HEARTBEAT_SECONDS:-60}"
+  local daemon_socket_retry_delay="${NIX_DAEMON_SOCKET_RETRY_DELAY_SECONDS:-2}"
   local attempt=1
   local log log_dir stdout_pipe stderr_pipe rc path start now elapsed hb_pid stdout_tee_pid stderr_tee_pid flattened saw_invalid_path saw_cachix_signature saw_fetch_signature saw_github_archive_503 saw_daemon_socket_failure had_errexit
 
@@ -23,36 +24,6 @@ run_nix_gc_race_retry() {
       echo "- Attempts: $attempt/$max"
       [ -z "${2:-}" ] || echo "- Note: $2"
     } >> "$GITHUB_STEP_SUMMARY"
-  }
-
-  repair_nix_daemon() {
-    if [ "${NIX_GC_RACE_SKIP_DAEMON_REPAIR:-0}" = 1 ]; then
-      echo "::warning::Nix daemon repair skipped by NIX_GC_RACE_SKIP_DAEMON_REPAIR=1"
-      return 0
-    fi
-
-    echo "::warning::Nix daemon socket is unavailable; attempting daemon restart before retry"
-
-    if command -v launchctl >/dev/null 2>&1; then
-      sudo launchctl kickstart -k system/org.nixos.nix-daemon >/dev/null 2>&1 || true
-    fi
-
-    if command -v systemctl >/dev/null 2>&1; then
-      sudo systemctl restart nix-daemon.socket >/dev/null 2>&1 || true
-      sudo systemctl restart nix-daemon.service >/dev/null 2>&1 || true
-      sudo systemctl restart nix-daemon >/dev/null 2>&1 || true
-    fi
-
-    if [ ! -S /nix/var/nix/daemon-socket/socket ] && [ -x /nix/var/nix/profiles/default/bin/nix-daemon ]; then
-      sudo /nix/var/nix/profiles/default/bin/nix-daemon --daemon >/tmp/nix-daemon-restart.log 2>&1 || true
-    fi
-
-    for _ in 1 2 3 4 5; do
-      [ -S /nix/var/nix/daemon-socket/socket ] && return 0
-      sleep 1
-    done
-
-    return 0
   }
 
   while [ "$attempt" -le "$max" ]; do
@@ -132,8 +103,7 @@ run_nix_gc_race_retry() {
     fi
 
     if [ "$saw_daemon_socket_failure" = true ]; then
-      repair_nix_daemon
-      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); retrying after daemon repair"
+      echo "::warning::Nix daemon socket failure detected for $task (attempt $attempt/$max); waiting $daemon_socket_retry_delay s for host supervision before retrying without mutating the host daemon"
     elif [ "$saw_github_archive_503" = true ]; then
       github_archive_delay_base="${NIX_GITHUB_ARCHIVE_503_BASE_DELAY_SECONDS:-15}"
       github_archive_delay=$((github_archive_delay_base * attempt + RANDOM % github_archive_delay_base))
@@ -151,6 +121,9 @@ run_nix_gc_race_retry() {
 
     [ -z "$path" ] || nix-store --realise "$path" 2>/dev/null || true
     rm -rf ~/.cache/nix/eval-cache-*
+    if [ "$saw_daemon_socket_failure" = true ] && [ "$attempt" -lt "$max" ]; then
+      sleep "$daemon_socket_retry_delay"
+    fi
     attempt=$((attempt + 1))
   done
 

--- a/genie/ci-scripts/nix-gc-race-retry.sh
+++ b/genie/ci-scripts/nix-gc-race-retry.sh
@@ -133,3 +133,53 @@ run_nix_gc_race_retry() {
   write_summary failure "Transient Nix retry exhausted"
   return 1
 }
+
+DEVENV_GC_ROOT_DIR="${RUNNER_TEMP:-/tmp}/genie-nix-gc-roots"
+DEVENV_GC_ROOT_ID=$(printf '%s' "${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}-${GITHUB_JOB:-job}" | tr -c 'A-Za-z0-9._-' '_')
+DEVENV_GC_ROOT="$DEVENV_GC_ROOT_DIR/devenv-$DEVENV_GC_ROOT_ID"
+
+resolve_devenv_once() {
+  mkdir -p "$DEVENV_GC_ROOT_DIR"
+  nix build \
+    --accept-flake-config \
+    --option extra-substituters https://devenv.cachix.org \
+    --option extra-trusted-public-keys devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= \
+    --out-link "$DEVENV_GC_ROOT" \
+    --print-out-paths \
+    "github:cachix/devenv/$DEVENV_REV#devenv"
+}
+
+resolve_devenv() {
+  local invalid_path
+  local log
+  local rc
+
+  log=$(mktemp)
+  if resolve_devenv_once 2>"$log"; then
+    cat "$log" >&2
+    rm -f "$log"
+    return 0
+  else
+    rc=$?
+  fi
+  cat "$log" >&2
+  invalid_path=$(grep -o "error:[[:space:]]*path '/nix/store/[^']*'[[:space:]]*is not valid" "$log" |
+    head -1 | grep -o "/nix/store/[^']*" || true)
+  rm -f "$log"
+  [ -n "$invalid_path" ] || return "$rc"
+
+  echo "::warning::devenv resolution hit an invalid Nix store path; clearing the client eval cache and retrying once: $invalid_path" >&2
+  rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/nix/eval-cache-"* ~/.cache/nix/eval-cache-*
+  nix-store --repair-path "$invalid_path" >/dev/null 2>&1 ||
+    nix-store --realise "$invalid_path" >/dev/null 2>&1 || true
+  if resolve_devenv_once; then
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      echo '### Recovered Nix store lifecycle incident' >> "$GITHUB_STEP_SUMMARY"
+      echo "- Invalid path: $invalid_path" >> "$GITHUB_STEP_SUMMARY"
+      echo '- Attempts: 2/2' >> "$GITHUB_STEP_SUMMARY"
+    fi
+    return 0
+  else
+    return $?
+  fi
+}

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "99c8c7764359de121e59577e4270c1c290d6e236",
+      "commit": "fc7121f40f5be934e217bc8e5fab44edb808e5c4",
       "pinned": true,
-      "lockedAt": "2026-07-27T20:15:32.646Z"
+      "lockedAt": "2026-07-29T07:19:06.911Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "f59e064f202792e925157d7110fc8b915c520559",
+      "commit": "4c46064bfb5aa69461fbfe57e202055737114b05",
       "pinned": true,
-      "lockedAt": "2026-07-29T08:53:15.956Z"
+      "lockedAt": "2026-07-29T09:04:23.845Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",

--- a/megarepo.lock
+++ b/megarepo.lock
@@ -4,9 +4,9 @@
     "effect-utils": {
       "url": "https://github.com/overengineeringstudio/effect-utils",
       "ref": "main",
-      "commit": "fc7121f40f5be934e217bc8e5fab44edb808e5c4",
+      "commit": "f59e064f202792e925157d7110fc8b915c520559",
       "pinned": true,
-      "lockedAt": "2026-07-29T07:19:06.911Z"
+      "lockedAt": "2026-07-29T08:53:15.956Z"
     },
     "effect": {
       "url": "https://github.com/effect-ts/effect",


### PR DESCRIPTION
## Problem

Warm `devenv shell` entry still paid the full pnpm and Genie status-probe floor
even when `setup:gate` had a valid outer fingerprint hit. The traced gate
declared devenv task exports, but `trace.exec` ran its body in a child
`bash -c`; devenv's parent wrapper could not observe values created there.
Downstream tasks therefore never saw `DEVENV_SETUP_OUTER_CACHE_HIT=1`.

The generated CI runtime also sourced a new shared `resolve-devenv.sh` helper
that source-linked consumers did not materialize, so every CI lane failed before
reaching its task.

Both shared defects are fixed in
[effect-utils#1030](https://github.com/overengineeringstudio/effect-utils/pull/1030);
this PR consumes that stack and records the LiveStore contract and evidence.

## Solution

- Pin effect-utils/playwright to
  `4c46064bfb5aa69461fbfe57e202055737114b05`.
- Consume `trace.execWithExports`, which persists named values from inside the
  traced child while preserving body and persistence failures.
- Preserve existing `TRACEPARENT` and `OTEL_SHELL_ENTRY_NS` values so shell
  entry, native task, and Effect child spans remain connected.
- Keep warm-hit validation bounded but integrity preserving:
  - stale lock/fingerprint => outer cache miss
  - missing/corrupt pnpm projection => pnpm status failure
  - missing/out-of-date generated output => Genie status failure
- Consume the store-owned imported OTEL E2E task, which now runs from a foreign
  consumer cwd without ambient tools on `PATH`.
- Compose devenv resolution into the existing CI support artifact every
  LiveStore workflow already materializes.
- Add the accepted developer-environment contract and reproducible experiment
  report.

The remaining pnpm warm floor is intentionally retained: it validates the
installed projection (about 9.7k symlinks / 3.1 GB here). Skipping it would
weaken the integrity contract without an equivalent primitive.

## Validation

- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check check:quick --refresh-task-cache`
- `devenv tasks run test:unit` (all unit projects passed)
- `vitest run tests/package-common/src/intent-layer` (8/8)
- `devenv tasks run otel:test:devenv-e2e` (real otelite capture from the
  imported task)
- `devenv tasks run otel:test:trace-structure` (8/8)
- `devenv tasks run otel:verify:setup`
- `devenv tasks run mr:lock-sync-check mr:source-policy-check`
- Generated workflow invariant: no `resolve-devenv.sh` references remain; all
  lanes source `nix-gc-race-retry.sh`, which contains both resolver functions.
- Negative probes:
  - removed `node_modules/typescript`: pnpm status failed, then passed after
    restore
  - removed `.github/workflows/auto-review.yml`: Genie status failed, then
    passed after restore
  - changed `pnpm-lock.yaml`: next gate exported
    `DEVENV_SETUP_OUTER_CACHE_HIT=0`

The repository instructions name `devenv tasks run test:run`, but that task
does not exist; this is captured as Axe feedback FB-306.

### Trace shape

Native devenv tasks are siblings under `running tasks`; each Effect status span
is a child of its own native task:

```text
devenv
`- running tasks
   |- setup:gate (native)
   |  `- devenv.task.exec [setup:gate]
   |- genie:run (native)
   |  `- devenv.task.status [genie:run] 906.855 ms -> 5.950 ms
   `- pnpm:install (native)
      `- devenv.task.status [pnpm:install]
```

Connected baseline trace: `df66e0bfb88bbfe567f35a72b448bbea`.
Connected fixed trace: `18c21e580a4b1a224c378a8e953239b6`.

Seven alternating same-worktree status pairs:

| Probe | pre-fix median (`outer=0`) | fixed median (`outer=1`) | Delta |
| --- | ---: | ---: | ---: |
| Genie | 424 ms | 6 ms | -98.6% |
| pnpm | 658 ms | 508 ms | -22.8% |

The host was heavily oversubscribed (load about 62-64 on 32 cores), so these
numbers are directional, not CI thresholds. The causal evidence is the exported
task state, connected span hierarchy, negative integrity probes, and alternating
paired selection.

## Trade-offs and follow-up

- effect-utils#1030 is a required stacked dependency and remains draft.
- #1504 overlaps only in its older effect-utils lock pin. It is not superseded
  as a whole; whichever lands second must rebase/repin.
- Axe FB-294 records that `genie:run` did not invalidate when the shared
  generator changed; `lint:check:genie` caught the stale outputs.
- Shared-host contention is tracked by the active dev3 CPU incident; no
  uncontended wall-clock speedup is claimed.

## Related issues

- Fixes #1500
- Follow-up to #1402
- Depends on overengineeringstudio/effect-utils#1030

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | co3-nova |
| `agent_session_id` | fabbecde-5efe-4752-b82d-3bde982ab17f |
| `agent_tool` | Codex CLI |
| `agent_tool_version` | 0.145.0 |
| `agent_runtime` | Codex CLI 0.145.0 |
| `agent_model` | unknown |
| `runtime_profile` | /nix/store/g65ryv9zcr8acxxjlpgcrynh8d7s7qwn-coding-agent-runtime-profile/share/coding-agents/profile.json |
| `skills_manifest` | /nix/store/hiw5ggfjp9mr78vbrq30i77ypfyixv32-agent-skills-corpus/share/agent-skills/manifest.json |
| `worktree` | livestore/schickling/perf/setup-probes |
| `machine` | dev3 |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->