### PR TITLE
Retain the scenario contract in core while moving its realization to contrib

### DIFF
--- a/.changeset/mock-sync-broadcast-observation.md
+++ b/.changeset/mock-sync-broadcast-observation.md
@@ -1,0 +1,7 @@
+---
+'@livestore/common': patch
+---
+
+Make each mock Sync backend connection receive the full live Event stream
+instead of load-balancing Events through one shared queue. Expose read-only
+Eventlog and connectivity observations for verification and diagnostics.

--- a/context/02-system/09-verification/06-scenarios/.decisions/0001-declarative-scenario-verification.md
+++ b/context/02-system/09-verification/06-scenarios/.decisions/0001-declarative-scenario-verification.md
@@ -1,0 +1,46 @@
+# 0001 — Declarative, production-shaped Scenario verification
+
+Status: accepted (maintainer migration direction, 2026-07-29; tracked in
+livestorejs/livestore#1517)
+
+## Context
+
+Focused unit, integration, conformance, determinism, and performance tests do
+not provide one reproducible way to exercise the complete sync system across
+multiple Clients and sessions, changing topology, faults, Recovery,
+materialization, and runtime boundaries. Scenario verification must produce
+portable correctness evidence without replacing the components it verifies.
+
+## Options
+
+- **Declarative typed Scenarios with a versioned serializable AST (chosen).**
+  Effect Schema-backed TypeScript constructors preserve inference while making
+  control, time, randomness, faults, and oracles inspectable. Arbitrary
+  orchestration callbacks cannot be validated or visualized uniformly.
+- **Production-shaped profiles behind capability contracts (chosen).** A
+  profile claiming composed evidence runs real Stores, processors,
+  materializers, and selected runtime/State boundaries. A pure merge model is
+  useful subordinate evidence but not a substitute.
+- **Headless authority behind a normalized trace (chosen).** Oracles, artifacts,
+  live visualization, and replay consume the same semantic trace. Execution
+  does not depend on a dashboard.
+
+## Decision
+
+Adopt the three constraints above as the core Scenario contract. Runner,
+Participant-host, backend, and viewer realizations may evolve independently
+only while preserving Scenario semantics and the serializable control, trace,
+and artifact boundaries.
+
+Evidence: the implementation history behind
+[RFC review #1442](https://github.com/livestorejs/livestore/pull/1442) and the
+maintainer's 2026-07-29 direction to retain the mechanism-independent contract
+while migrating its realization to `livestore-contrib`.
+
+## Consequences
+
+- Product packages never depend on a Scenario realization.
+- Exact realization APIs, profiles, fault seams, trace retention, and viewer
+  interaction belong to contrib implementation intent.
+- Core subsystem changes require independent product justification and the
+  smallest generalized testing seam.

--- a/context/02-system/09-verification/06-scenarios/.decisions/0002-observed-state-and-event-identity.md
+++ b/context/02-system/09-verification/06-scenarios/.decisions/0002-observed-state-and-event-identity.md
@@ -1,0 +1,34 @@
+# 0002 — Project observed State with run-local Event identity
+
+Status: accepted (maintainer implementation review, 2026-07-20)
+
+## Context
+
+A replay projection must show how backend, Client, Leader-role, and session
+State appeared at a selected trace boundary. A distributed run has no
+atomically observable global State, and Event sequence numbers identify
+Eventlog positions that can change through rebasing. Event fields and current
+position therefore cannot always correlate one Event across components.
+
+The trace must remain grounded in actual LiveStore behavior. State inferred
+from runner instructions could diverge from the Stores, processors, Eventlogs,
+and backend that the Scenario is intended to verify.
+
+## Decision
+
+- Scrubbing selects a monotonic observation index and reconstructs the complete
+  accumulated trace prefix. It does not claim an atomic distributed snapshot.
+- A profile claiming exact Event lineage assigns a run-local reference over
+  actual encoded Event facts and carries it through explicit transition
+  mappings. Event fields, positions, and timing alone do not establish lineage.
+- Participant hosts observe product transitions. When existing surfaces cannot
+  expose a portable fact, the profile advertises that capability limit unless
+  the owning subsystem independently justifies a generalized observation seam.
+
+## Consequences
+
+- Component-scoped observations remain separate.
+- Correlation without lineage capability is diagnostic, not oracle or causal
+  evidence.
+- Full projection checkpoints may accelerate seeking but are derived caches.
+- Scenario needs alone do not justify a new product Event field.

--- a/context/02-system/09-verification/06-scenarios/.decisions/0003-contrib-runner-viewer-realization.md
+++ b/context/02-system/09-verification/06-scenarios/.decisions/0003-contrib-runner-viewer-realization.md
@@ -1,0 +1,47 @@
+# 0003 — Host the Scenario runner/viewer realization in contrib
+
+Status: accepted (maintainer migration direction, 2026-07-29; tracked in
+livestorejs/livestore#1517)
+
+## Context
+
+The Scenario contract constrains LiveStore verification across repositories,
+while the runner, Participant hosts, backend profiles, corpus, artifacts, and
+viewer form one fast-evolving private realization. Keeping that realization in
+core would require root workspace, TypeScript, Vitest, browser, and lockfile
+wiring that exists only for contributor tooling.
+
+The product already uses a two-repository contract/realization pattern:
+canonical `LS.*` contracts and registries live in core; contrib implementation
+intent uses its own `LSC.*` IDs and cites the core requirements.
+
+## Options
+
+- **Keep contract and realization together in core (rejected).** This couples
+  product package delivery to private Scenario tooling and its browser/runtime
+  dependencies.
+- **Move both contract and realization to contrib (rejected).** This makes
+  cross-system evidence semantics subordinate to one implementation.
+- **Keep the contract in core and host the realization plus implementation
+  intent in contrib (chosen).**
+
+## Decision
+
+Core owns `context/02-system/09-verification/06-scenarios/`,
+`LS.SYS.VER.SCEN-*`, canonical terminology, and generalized package seams.
+`livestore-contrib` owns the runner/viewer realization at
+`context/verification/scenarios/`, including profiles, backend realizations,
+corpus, artifacts, UI decisions, and implementation deltas.
+
+Core lists that realization in [realizations.md](../realizations.md). Contrib
+cites the core requirement IDs and pins a merged core revision containing the
+contract and any consumed seams.
+
+## Consequences
+
+- No Scenario workspace, artifact, viewer, or Scenario-only root wiring is
+  registered in core.
+- Implementation gaps and realization-specific decisions are not duplicated as
+  core deltas.
+- Contrib cannot pin this draft PR's fork commit as a durable dependency; it
+  repins to the eventual upstream merge commit before integration.

--- a/context/02-system/09-verification/06-scenarios/.decisions/0004-causal-order-and-calibrated-time.md
+++ b/context/02-system/09-verification/06-scenarios/.decisions/0004-causal-order-and-calibrated-time.md
@@ -1,0 +1,37 @@
+# 0004 — Separate causal order from calibrated elapsed time
+
+Status: accepted (maintainer implementation review, 2026-07-21)
+
+## Context
+
+Observation order can serialize independent propagation branches, while a
+causal-stage view can conceal operational delay. Contributors need both the
+dependency structure and elapsed-time offsets without introducing timestamps
+into LiveStore synchronization semantics.
+
+## Decision
+
+The canonical Scenario trace represents a causal partial order, not a global
+total order. Participant-local sequence and explicit instruction,
+acknowledgement, boundary-transition, dependency, and causation records are the
+ordering evidence. Correlation associates records but creates no edge.
+
+Profiles comparing cross-process time record Participant-local monotonic time
+and calibration evidence sufficient to estimate a shared Scenario-time
+interval with explicit uncertainty. Timestamp proximity, Event-field equality,
+and Observation-capture membership never create causal edges.
+
+Visualization provides causal-flow and elapsed-time projections over the same
+immutable records. Flow may align sibling propagation branches while retaining
+latency evidence. Elapsed-time layout uses calibrated intervals and does not
+force overlapping intervals into a total order.
+
+## Consequences
+
+- A Scenario observation capture is useful for grouping and scrubbing but is
+  never presented as an atomic moment.
+- The same causal stage does not mean simultaneous.
+- Exact receive/apply latency is available only when both transitions are
+  instrumented.
+- Timing that contradicts a known causal edge beyond its uncertainty is an
+  instrumentation defect.

--- a/context/02-system/09-verification/06-scenarios/.decisions/0005-operation-evidence-and-property-boundaries.md
+++ b/context/02-system/09-verification/06-scenarios/.decisions/0005-operation-evidence-and-property-boundaries.md
@@ -1,0 +1,33 @@
+# 0005 — Preserve Operation, Settlement, and property evidence boundaries
+
+Status: accepted (maintainer implementation reviews, 2026-07-22 to 2026-07-28)
+
+## Context
+
+Instructions, host responses, sampled observations, Recovery, Settlement, and
+property verdicts answer different questions. Collapsing them into one success
+signal would hide indefinite outcomes, make Fault removal look like Recovery,
+or let a later oracle rewrite whether the system reached a stable barrier.
+
+## Decision
+
+- Every runner-invoked Scenario operation has stable identity across
+  instruction, response, observation, and outcome evidence. Outcome certainty
+  is independent from Participant-host failure category.
+- A Settlement barrier establishes bounded Quiescence and Convergence for a
+  declared group. It does not prove Eventlog contents, State equality, or a
+  later Scenario property.
+- Scenario oracles evaluate explicit properties from retained evidence and emit
+  separate verdicts. Rebase preservation and bounded liveness are compositional
+  claims over Operation, Recovery, Settlement, Eventlog, and State evidence.
+- A failed execution preserves the available trace prefix in a failed artifact
+  once the run has begun.
+
+## Consequences
+
+- A timeout or lost response may produce an indefinite outcome even when the
+  requested effect occurred.
+- Fault removal precedes independently observed Recovery.
+- Matching heads are insufficient for Eventlog-convergence success.
+- Trace-history oracles declare their sampling and coverage limits.
+- A failed property may fail a settled run without rewriting Settlement.

--- a/context/02-system/09-verification/06-scenarios/intuition.md
+++ b/context/02-system/09-verification/06-scenarios/intuition.md
@@ -1,0 +1,67 @@
+# Scenario-Based Sync Verification — Intuition
+
+*For: contributors investigating sync correctness · Assumes:
+[../intuition.md](../intuition.md) · Covers: why reproducible Scenarios are a
+separate verification evidence shape*
+
+## Focused tests prove parts; Scenarios prove compositions
+
+Unit and conformance tests remain the fastest way to prove a local invariant.
+They do not show how Stores, session and Leader processors, materialization,
+queues, retries, topology changes, faults, and Recovery behave together over a
+long run. A Scenario makes that composition reviewable and reproducible without
+reimplementing LiveStore as a second behavioral model.
+
+```text
+typed Scenario source → serializable Scenario AST → runner
+                                                   │
+                                                   ▼
+Scenario oracle ← Scenario trace ← real LiveStore components
+       │
+       └── verdict + reproducible run artifact
+```
+
+The Scenario runner is a correctness falsifier and reproducer, not a proof that
+LiveStore is correct for every workload, schedule, fault, or Execution
+configuration. A passing run means no declared Scenario property was violated
+by the recorded inputs and observations; it does not rule out a counterexample
+elsewhere.
+
+## Control is not observation
+
+“Disconnect Client A” is an instruction. “Client A reported offline” is an
+observation. Scenario traces keep instructions, Control acknowledgements,
+Operation outcomes, observations, and Scenario verdicts distinct. Correlation
+groups evidence about the same operation; only explicit dependency/causation
+edges and participant-local sequence order it.
+
+A timeout deserves particular care. A child process or browser may apply a
+request and then lose its response. That is an indefinite Operation outcome,
+not evidence that the operation did not happen.
+
+## Fast evidence and faithful evidence answer different questions
+
+A controlled profile asks whether the composed sync system is correct under a
+particular workload, schedule, topology, and fault sequence. Platform-realized
+profiles add evidence about persistence, transport, leadership, and lifecycle
+boundaries. Results are scoped to their profile; cross-profile comparison is
+useful when explicitly requested, not an implied equivalence guarantee.
+
+## Convergence is an explicit claim
+
+Open streams, future polling, and telemetry mean “nothing is running” is not a
+useful definition of completion. A settle phase instead names the participants
+expected to converge, the faults whose injection must stop, the work that must
+become quiescent, the barrier that confirms stable Convergence, and the timeout
+that bounds the claim. Fault removal is followed by separately observed
+Recovery; it does not prove it.
+
+Settlement answers whether the declared convergence barrier completed. After
+that, Scenario oracles evaluate Scenario properties and emit verdicts. A
+property can fail a settled run without rewriting the convergence evidence.
+
+Head alignment alone is not proof of Eventlog convergence. Two participants can
+report the same backend head while one has lost, duplicated, reordered, or
+replaced an Event behind that head. Eventlog convergence and State convergence
+are also different evidence: a profile may exercise a concrete State
+realization while the Scenario language keeps sync semantics independent of it.

--- a/context/02-system/09-verification/06-scenarios/realizations.md
+++ b/context/02-system/09-verification/06-scenarios/realizations.md
@@ -1,0 +1,13 @@
+# Scenario Verification Realizations — Registry
+
+All realizations of the Scenario verification contract
+([spec.md](./spec.md)). The referencing mechanism follows
+[root decision 0003](../../../.decisions/0003-contrib-referencing.md).
+
+| Realization | Home | Contract status |
+| --- | --- | --- |
+| Headless runner and live/replay viewer | [`livestore-contrib`](https://github.com/livestorejs/livestore-contrib) · implementation intent: contrib `context/verification/scenarios/` | migration in progress; must refine `LS.SYS.VER.SCEN-*` |
+
+Core owns no in-repository Scenario realization. Profile, backend, corpus,
+artifact, UI, and implementation-gap detail belongs to the contrib intent node;
+only reusable LiveStore package seams and their focused tests remain here.

--- a/context/02-system/09-verification/06-scenarios/requirements.md
+++ b/context/02-system/09-verification/06-scenarios/requirements.md
@@ -1,0 +1,140 @@
+# Scenario-Based Sync Verification — Requirements
+
+Role: owns the mechanism-independent contract for reproducible, system-wide
+verification scenarios spanning Clients, Client sessions, Sync backends,
+workloads, faults, Recovery, State, and runtime boundaries.
+
+## Context
+
+Builds on [../requirements.md](../requirements.md). Product behavior remains
+owned by sync, runtime, State, Store, and observability nodes; this node owns
+the evidence architecture that composes those behaviors. Runner, host, backend,
+artifact, and viewer implementation intent live in `livestore-contrib` per
+[decision 0003](./.decisions/0003-contrib-runner-viewer-realization.md).
+
+## Requirements
+
+- **LS.SYS.VER.SCEN-R01 Declarative scenario model:** Contributors author
+  typed TypeScript Scenario specifications through Effect Schema-backed
+  declarative constructors that normalize to a versioned, serializable AST.
+  Control flow, time, randomness, faults, and assertions are explicit data,
+  not arbitrary orchestration callbacks. Stable names, schema validation, and
+  canonical serialization keep human- and agent-authored scenarios reviewable.
+  `refines: LS-R11, LS.SYS-R02`
+- **LS.SYS.VER.SCEN-R02 Application definition:** An Application definition
+  wraps the actual `LiveStoreSchema` and reuses its Event types, Store type,
+  and materializers. Named actions and State inspectors cross a host boundary
+  by stable name and schema-encoded values; Scenario specifications never
+  redeclare or invoke materializers. `refines: LS-R11`
+- **LS.SYS.VER.SCEN-R03 Topology and lifecycle:** The Scenario model represents
+  a Sync backend separately from one or more Clients. A Client is the stable
+  top-level participant containing one active Leader role and one or more
+  Client-session participants. Plans may create Clients, add Client sessions,
+  and stop or restart supported session or Client runtimes while preserving
+  their Scenario identities. `refines: LS.SYS-R04`
+- **LS.SYS.VER.SCEN-R04 Explicit plans and workloads:** Plans declaratively
+  compose application actions, participant lifecycle, connectivity and faults,
+  workloads, scheduling, observed conditions, phases, and Settlement. Reusable
+  Workload patterns expand deterministically, and every emitted application
+  action appears in the Scenario trace.
+- **LS.SYS.VER.SCEN-R05 Participant-host boundary:** The Scenario runner
+  controls Clients and Client sessions only through a transport-neutral
+  Participant-host contract. Scenario operations, Control acknowledgements,
+  capability descriptions, application actions, Operation outcomes, and trace
+  records crossing that boundary are serializable. An acknowledgement proves
+  only completion of host handling at its advertised boundary, never Sync
+  backend acceptance or propagation; the runner never holds participant
+  Stores, processors, adapters, or databases.
+- **LS.SYS.VER.SCEN-R06 Capability-based execution:** An Execution
+  configuration composes a Participant execution profile, Sync-backend
+  realization, and optional State capabilities. Profiles advertise supported
+  controls and fault semantics before execution, and the runner rejects a
+  Scenario whose required capabilities are unavailable. The contract does not
+  require every profile/backend combination.
+- **LS.SYS.VER.SCEN-R07 Production-shaped evidence:** A profile claiming
+  composed-system correctness uses real Stores, session and Leader sync
+  processors, materializers, and the selected State realization behind
+  controlled boundaries. A processor-only model or runner-side simulation of
+  product state cannot satisfy that claim. `refines: LS-R03, LS-R05, LS-R06`
+- **LS.SYS.VER.SCEN-R08 Profile conformance and evidence scope:** Every
+  Participant execution profile passes one shared host-conformance suite for
+  its claimed capabilities. Compatible Scenarios remain unchanged across
+  profiles, but each result makes claims only about its selected profile.
+  Cross-profile comparison is optional and declares the properties compared.
+- **LS.SYS.VER.SCEN-R09 Reproduction:** Every profile records a seed governing
+  generated inputs and requested choices. Seeded reproduction never claims to
+  reproduce internal delivery ordering. A profile may advertise recorded
+  boundary replay only when it names and controls those boundaries, records
+  their decisions, and reports the first replay divergence.
+- **LS.SYS.VER.SCEN-R10 Time semantics:** Logical time orders Scenario-owned
+  plan and trace facts and governs explicitly advertised runner-owned
+  scheduling controls; performance evidence uses wall-clock time. Logical time
+  is never reported as performance evidence or as proof of internal sync order.
+- **LS.SYS.VER.SCEN-R11 Valid fault semantics:** Fault injection occurs at the
+  highest boundary that still exercises the behavior under test and respects
+  the selected realization's guarantees. Impossible corruption, duplication,
+  or reordering requires an explicitly adversarial realization or capability.
+  Fault removal ends the injected condition but does not itself prove Recovery;
+  Recovery and Convergence require separate observation.
+- **LS.SYS.VER.SCEN-R12 Sync/State separation:** Eventlog safety and
+  Convergence are independently verifiable from State convergence and
+  rematerialization. A State realization may be required by a full-stack
+  profile without becoming part of Scenario-level sync semantics.
+  `refines: LS-R05, LS-R06, LS-R10`
+- **LS.SYS.VER.SCEN-R13 Scenario trace protocol:** Every run emits a versioned
+  Scenario trace with a stable run descriptor, runner-receipt-ordered semantic
+  records, distinct causal partial-order evidence, participant and boundary
+  identities, correlation, explicit dependency/causation edges, and typed
+  payloads. Correlation associates evidence but never establishes ordering or
+  causation. Namespaced implementation diagnostics may extend the trace, but
+  portable consumers ignore unknown diagnostics and do not depend on them.
+- **LS.SYS.VER.SCEN-R14 Scenario properties and oracles:** Safety, ordering,
+  Convergence, pending resolution, rebase preservation, State,
+  rematerialization, liveness, and optional resource/performance claims are
+  explicit Scenario properties. Scenario oracles evaluate them and produce
+  bounded Scenario verdicts with evidence references. `refines: LS-R03, LS-R05`
+- **LS.SYS.VER.SCEN-R15 Settlement:** A settle phase stops new work, removes
+  its named faults, identifies the expected Convergence group, and evaluates
+  an explicit profile-appropriate Settlement barrier and timeout. Unresolved
+  pending Events or unacknowledged control work prevent successful Settlement;
+  there is no hidden global meaning of “eventually.” Oracle evaluation follows
+  Settlement and cannot retroactively change whether its barrier completed.
+- **LS.SYS.VER.SCEN-R16 Reproducible artifacts:** A Scenario run artifact
+  contains the normalized Scenario specification, Application and source
+  identity, Execution configuration, component versions, seed, controlled
+  decisions when present, Scenario trace, verdicts, and relevant snapshots
+  needed to explain or replay the run.
+- **LS.SYS.VER.SCEN-R17 Headless authority:** Headless execution is the
+  authoritative local and CI mode. Live and replay visualization consume the
+  Scenario trace or run artifact and may issue controls only through an
+  explicit runner API; visualizers never mutate or inspect participants
+  directly. `refines: LS-R13`
+- **LS.SYS.VER.SCEN-R18 Cross-repository realization boundary:** Core owns
+  this contract, its terminology, and generalized product testing seams.
+  Scenario orchestration, hosts, backend realizations, traces, oracles,
+  artifacts, corpus, and visualization are one contrib-owned realization and
+  implementation-intent node. That realization may depend on core packages;
+  core product packages never depend on it.
+- **LS.SYS.VER.SCEN-R19 Causal and temporal evidence:** A Scenario trace
+  preserves participant-local sequence, explicit control and boundary
+  causation, runner receipt order, Observation-capture membership, and
+  calibrated monotonic elapsed-time evidence as distinct facts. Cross-process
+  time carries calibration uncertainty and never creates a causal edge or
+  affects LiveStore sync behavior. Records distinguish an instrumented
+  transition from a fact first observed by later sampling.
+- **LS.SYS.VER.SCEN-R20 Truth-preserving trace projections:** Visualization
+  offers causal-flow and elapsed-time projections over the same immutable
+  trace. Flow layout exposes partial-order structure without claiming sibling
+  transitions were simultaneous; elapsed-time layout exposes stalls and
+  uncertainty without claiming timestamp order is causality. Aggregation,
+  visibility filters, and derived playback navigation never remove access to
+  raw records or change observation-index cursor semantics.
+  `refines: LS.SYS.VER.SCEN-R13, LS.SYS.VER.SCEN-R17`
+- **LS.SYS.VER.SCEN-R21 Operation outcomes and history:** Runner-invoked
+  Scenario operations preserve stable identity and classify their outcome as
+  success, definite failure, or indefinite whenever the execution boundary
+  supplies that knowledge. Timeouts and lost responses never imply that an
+  operation did not occur. Participant-host failure category is independent
+  from outcome certainty. A Scenario operation history advertises which
+  operation families and concurrency boundaries it covers; the full Scenario
+  trace remains the authoritative evidence envelope.

--- a/context/02-system/09-verification/06-scenarios/spec.md
+++ b/context/02-system/09-verification/06-scenarios/spec.md
@@ -1,0 +1,306 @@
+# Scenario-Based Sync Verification — Spec
+
+This document specifies reproducible system-wide verification Scenarios. It
+builds on [requirements.md](./requirements.md); rationale lives in
+[intuition.md](./intuition.md).
+
+## Status
+
+Draft.
+
+## Scope and Ownership
+
+This node owns Scenario semantics, plans, participant-host control, capability
+and evidence boundaries, fault and time semantics, reproduction, Settlement,
+Scenario traces, Scenario oracles, run artifacts, profile conformance, and
+truth-preserving visualization.
+
+Sync, runtime, State, Store, and observability nodes own the product behavior
+being exercised. Scenario code may request the smallest generalized
+observation or control seam from those owners, using an explicit internal
+testing export when the seam is not product API. Scenario-specific product
+instrumentation is not assumed by this contract.
+
+The runner/viewer and its implementation intent are contrib-owned. Core records
+that realization in [realizations.md](./realizations.md) and owns no Scenario
+workspace, artifacts, or implementation delta. See
+[decision 0003](./.decisions/0003-contrib-runner-viewer-realization.md).
+
+## Architecture
+
+```text
+typed Scenario source
+        │
+        ▼
+validation + normalization
+        │
+        ▼
+versioned Scenario AST ──▶ Scenario runner ──▶ Participant hosts
+                                  │                  + backend realization
+                                  ▼
+                            Scenario trace
+                                  │
+                 ┌────────────────┼─────────────────────┐
+                 ▼                ▼                     ▼
+       Operation history    Scenario oracles     live/replay viewer
+                                  │                     │
+                                  └──────▶ run artifact ◀┘
+```
+
+Scenario semantics, runner control, trace protocol, oracles, and consumers are
+separate contracts. Headless execution is authoritative; visualization is a
+consumer of the same evidence.
+
+## Scenario Semantic Model (LS.SYS.VER.SCEN-R01, R02)
+
+The authoring surface is typed TypeScript using Effect Schema-backed
+declarative constructors. It normalizes to a versioned, serializable AST. JSON
+may encode that AST in artifacts or across transports, but arbitrary
+TypeScript/Effect programs are not portable Scenario control.
+
+The AST carries stable Scenario and Application identity, seed, Execution
+configuration, topology, lifecycle, Workload patterns, schedule, faults,
+completion, selected properties/oracles, and capture policy. All run-specific
+control is represented by normalized data.
+
+An Application definition wraps the actual `LiveStoreSchema`; it does not
+redeclare Event definitions or materializers. Named application actions with
+schema-encoded inputs are the portable mutation boundary. Optional State
+inspectors read already-materialized State and return normalized encoded
+values. Rematerialization uses the Application's normal schema and materializers
+rather than a Scenario-side substitute.
+
+## Topology and Plans (LS.SYS.VER.SCEN-R03, R04)
+
+The topology reflects LiveStore's product boundaries:
+
+```text
+Sync backend
+    ▲
+    │ provider boundary
+Client
+  ├─ Leader role
+  └─ Client session(s) ── leader-proxy boundary ──▶ Leader role
+```
+
+A Client is the stable top-level Scenario participant and owns shared local
+data, one active Leader role, and one or more Client-session participants. The
+Leader is an observable role within its Client, not a separate participant.
+The Sync backend is a separate topology component.
+
+Plans may sequence or compose:
+
+| Family | Meaning |
+| --- | --- |
+| Application | Invoke a named Application action |
+| Lifecycle | Create a Client; add, stop, or restart a supported runtime |
+| Connectivity/fault | Inject or remove a supported adverse condition |
+| Workload | Expand a named, parameterized, seeded pattern |
+| Scheduling | Sequence, bounded parallelism, logical timing, repetition, condition wait |
+| Settlement | Stop work, remove named faults, establish a Convergence group, evaluate a barrier |
+
+Creation, lifecycle, connectivity, and deletion are distinct semantics.
+Stopping a session does not delete its Client's local data; disconnecting a
+Client does not stop its runtime. Any control that terminates a Client, deletes
+persistence, revokes access, or excludes a participant from Convergence must
+name that meaning directly.
+
+Instructions and observations are distinct. A Control acknowledgement proves
+only Participant-host handling at its advertised boundary. A timeout or lost
+transport can leave an Operation outcome indefinite.
+
+## Execution Configuration (LS.SYS.VER.SCEN-R05…R08)
+
+An Execution configuration composes:
+
+```text
+Participant execution profile
+        +
+Sync-backend realization
+        +
+optional State profile/capabilities
+```
+
+The runner derives required capabilities from topology, operations,
+observations, and selected oracles, then validates them before creating a
+participant. Unsupported configurations fail preflight. Profiles describe real
+guarantees and need not implement every Cartesian combination.
+
+Every profile realizes a transport-neutral Participant-host contract that can
+create and control participants, dispatch serialized named actions, advertise
+capabilities, classify host failures, and emit stable Scenario trace records
+without exposing Participant objects to the runner.
+
+A profile claiming production-shaped composed-system evidence uses the actual
+Stores, processors, materializers, adapters, and selected State realization at
+the boundaries under test. A pure merge model or runner-side state simulation
+may be useful subordinate evidence but cannot make that claim.
+
+Every implemented host passes one shared conformance suite for the capabilities
+it advertises. A result is evidence only about its selected profile. Optional
+cross-profile comparison names the semantic properties compared rather than
+assuming byte-identical traces or one-to-one outcomes.
+
+## Time, Scheduling, and Reproduction (LS.SYS.VER.SCEN-R09, R10, R19)
+
+Logical time orders Scenario-owned plan and trace facts and may control
+explicitly advertised runner-owned scheduling. Participant-local monotonic
+time and calibrated Scenario time describe observed elapsed time. Wall-clock
+time supplies externally comparable performance evidence. None participates
+in LiveStore synchronization.
+
+Participant-local sequence establishes observed order within one participant.
+Explicit instruction/acknowledgement, request/response, boundary-transition,
+dependency, and causation records establish supported cross-participant
+relationships. Correlation, timestamp order, and Observation-capture membership
+alone create no causal edge.
+
+A cross-process timing profile records local monotonic time and calibration
+evidence sufficient to estimate a Scenario-time interval with explicit
+uncertainty. Overlapping intervals remain unordered. Timing that contradicts a
+known causal edge beyond its uncertainty is an instrumentation defect, not
+permission to rewrite causal order.
+
+Every generated choice derives from the recorded seed. This reproduces inputs,
+requested timing, workloads, and fault choices, but not internal host or sync
+interleaving. Recorded boundary replay is a separate capability: it names the
+boundaries controlled, records their release decisions, and reports the first
+divergence.
+
+## Fault Semantics (LS.SYS.VER.SCEN-R11)
+
+Fault injection occurs at the highest boundary that still exercises the target
+behavior. A Participant connectivity fault is distinct from shared backend
+unavailability. Schema-invalid Events, malformed protocol payloads, impossible
+reordering, or packet-level corruption require an explicitly adversarial
+realization and never silently weaken a production-shaped claim.
+
+The trace distinguishes Fault injection, Fault removal, Recovery observation,
+Recovery completion, and Settlement. Removing a fault ends only the injected
+condition.
+
+## Scenario Trace Protocol (LS.SYS.VER.SCEN-R13, R19, R21)
+
+Every record carries protocol version, run and record identity, runner receipt
+index, payload kind and version, component/participant scope, correlation,
+causal dependencies when known, and typed payload data. Participant-local
+sequence and timing evidence are present when supplied by the profile.
+
+Portable payload families include run and phase boundaries, instructions,
+Control acknowledgements, Operation outcomes, topology/lifecycle changes,
+faults and Recovery, backend/Leader/session observations, application actions,
+Settlement, Scenario verdicts, and failures.
+
+An Observation capture groups facts sampled during one collection pass. It is
+not an atomic distributed snapshot and does not prove simultaneous transitions.
+Records distinguish an instrumented transition from a fact first observed by
+sampling.
+
+Operation identity spans its instruction, host response, related observations,
+and outcome. Outcome certainty is separate from Participant-host failure
+category. A derived Operation history declares which operation families and
+invocation/completion boundaries it covers; the Scenario trace remains the
+authoritative evidence envelope.
+
+Portable consumers ignore unknown namespaced diagnostics. Private queue depth,
+SQLite details, provider payloads, runtime stack traces, and OTel data do not
+become portable evidence merely because a realization records them.
+
+## Event Identity and Observation
+
+Scrubbing selects a monotonically increasing observation-index boundary and
+projects the complete trace prefix. It never claims an atomic global state.
+
+When a profile can prove Event lineage, it assigns a run-local Event reference
+to actual encoded Event facts and carries it through explicit rebase,
+confirmation, rejection, and propagation mappings. Equivalent fields,
+positions, timing, or occurrence order are insufficient to prove lineage.
+Without that capability, correlation may aid debugging but oracles and causal
+projections must not treat it as identity evidence.
+
+Participant hosts and backend realizations observe actual LiveStore State,
+Eventlogs, and boundary transitions rather than simulating product state from
+runner instructions. Scenario verification alone does not justify adding
+lineage fields or hot-path observers to the sync engine.
+
+## Properties, Oracles, and Settlement (LS.SYS.VER.SCEN-R14, R15)
+
+Scenario properties are explicit claims under declared assumptions. Scenario
+oracles return bounded verdicts with evidence references. Property families
+include Eventlog safety and Convergence, pending resolution, rebase
+preservation, State convergence, rematerialization, liveness, resource bounds,
+and optional performance thresholds.
+
+A settle phase:
+
+1. stops new Workload actions and awaits dispatched Control acknowledgements;
+2. removes the named injected faults;
+3. declares the Convergence group and intentional exclusions; and
+4. evaluates a profile-appropriate bounded barrier.
+
+Successful Settlement requires Quiescence plus the declared stable
+Convergence predicate. Matching heads alone are insufficient proof of equal
+Eventlogs. Oracle evaluation follows Settlement and cannot change whether the
+barrier completed. A trace-history oracle may omit Settlement only when its
+contract needs no terminal snapshot.
+
+Rebase preservation and practical bounded liveness are compositional claims:
+they combine Operation outcomes, Recovery/Settlement evidence, Eventlog
+properties, and Application State evidence rather than inventing a hidden
+single signal. A timeout preserves the last available evidence and emits a
+failed boundary; increasing a timeout is not a substitute for an observable
+barrier.
+
+## Artifacts and Visualization (LS.SYS.VER.SCEN-R16, R17, R20)
+
+A Scenario run artifact contains the normalized AST, Application/source
+identity, component versions, Execution configuration, environment metadata,
+seed, controlled schedule when present, Scenario trace, verdicts, failure
+explanation, and relevant snapshots or measurements.
+
+Once execution begins, an Operation failure still produces a valid failed
+artifact containing the complete available trace prefix. Preflight validation
+may fail without an artifact because no participant execution began.
+
+The viewer consumes a live trace or completed artifact. Any control goes
+through an explicit runner API; the viewer never inspects or mutates
+participants directly.
+
+The same immutable records support:
+
+- a causal-flow projection exposing partial-order structure without claiming
+  sibling transitions were simultaneous; and
+- an elapsed-time projection exposing delay and uncertainty without claiming
+  timestamp order is causality.
+
+Aggregation, semantic zoom, visibility filtering, and derived playback moments
+do not remove access to raw records or define a second cursor. Record playback
+visits every observation-index boundary; moment playback may visit a derived
+subset while still reducing the complete trace prefix. Selecting a record for
+inspection does not change projected system state.
+
+## Repository Boundary (LS.SYS.VER.SCEN-R18)
+
+The canonical contract, terminology, and generalized core testing seams live
+in this repository. The runner/viewer realization and all Scenario-specific
+implementation intent live in `livestore-contrib`:
+
+```text
+livestore-contrib Scenario realization ── uses ──▶ @livestore/*
+@livestore/* ── must not depend on ──▶ contrib Scenario realization
+```
+
+The contrib intent node cites the `LS.SYS.VER.SCEN-*` requirements and records
+realization-specific profiles, paths, deltas, and implementation decisions.
+Core's [realizations.md](./realizations.md) remains the cross-repository
+registry.
+
+## Open Design Questions
+
+- **LS.SYS.VER.SCEN-DQ1 Failure minimization:** How are generated failing runs
+  minimized without destroying the causal interleaving?
+- **LS.SYS.VER.SCEN-DQ2 Trace retention:** How are large traces sampled,
+  compressed, referenced, or streamed without losing causal evidence?
+- **LS.SYS.VER.SCEN-DQ3 Performance reuse:** Which correctness Scenarios can
+  also provide trustworthy wall-clock evidence, and which require distinct
+  configurations?

--- a/context/02-system/09-verification/intuition.md
+++ b/context/02-system/09-verification/intuition.md
@@ -19,6 +19,7 @@ shape to evidence shape:
 | Performance promise (LS-R14) | Maintained perf suites with comparable runs |
 | Protocol stability (devtools, sync) | Executable compatibility tests |
 | Determinism | Runtime hash checks, not convention |
+| Composed sync behavior under faults and recovery | Reproducible scenarios, semantic traces, bounded oracles |
 
 ## Conformance is the flip side of pluggability
 
@@ -31,6 +32,13 @@ Adapter and framework-integration suites are now contracted but not yet
 built (open deltas in
 [02-conformance/](./02-conformance/requirements.md)); read-model
 conformance remains the open question (LS.SYS.VER.CONF-DQ1).
+
+Scenario verification is a different evidence shape from dimension
+conformance. It composes real Stores, processors, materialization, topology,
+faults, and recovery into a reviewable run while preserving explicit
+instructions, observations, and verdicts. Its mechanism-independent contract
+lives in [06-scenarios/](./06-scenarios/requirements.md); the runner and
+viewer realization is registered there and implemented in `livestore-contrib`.
 
 ## Where evidence lives
 

--- a/context/02-system/09-verification/requirements.md
+++ b/context/02-system/09-verification/requirements.md
@@ -2,9 +2,10 @@
 
 Defines how LiveStore proves its own contracts: test lanes, conformance
 suites for the pluggable dimensions, performance evidence, protocol
-compatibility, and determinism guards. Refines the realization-proving and
-performance criteria of the root ([LS-R08], [LS-R14]; vision success
-criterion 6).
+compatibility, determinism guards, and reproducible system-wide scenarios.
+Refines the root's correctness and evidence criteria (notably [LS-R03],
+[LS-R05], [LS-R06], [LS-R08], [LS-R10], [LS-R13], and [LS-R14]; vision
+success criterion 6).
 
 ## Context
 
@@ -31,3 +32,7 @@ Lane/dimension requirements live in the child nodes; the former
 | [03-performance/](./03-performance/requirements.md) | Perf evidence | R04 → `LS.SYS.VER.PERF-R01` |
 | [04-protocol-compat/](./04-protocol-compat/requirements.md) | Protocol compat tests | R05 → `LS.SYS.VER.PROTO-R01` |
 | [05-determinism/](./05-determinism/requirements.md) | Determinism guards | R06 → `LS.SYS.VER.DET-R01` |
+
+Reproducible composed-system evidence is owned by
+[06-scenarios/](./06-scenarios/requirements.md) under the
+`LS.SYS.VER.SCEN-*` namespace.

--- a/context/02-system/09-verification/spec.md
+++ b/context/02-system/09-verification/spec.md
@@ -20,6 +20,7 @@ Verification maps claim shapes to evidence shapes (see
 | [03-performance/](./03-performance/spec.md) | Latency/memory measurement suites |
 | [04-protocol-compat/](./04-protocol-compat/spec.md) | Executable protocol-compatibility tests |
 | [05-determinism/](./05-determinism/spec.md) | Determinism guards and (missing) oracles |
+| [06-scenarios/](./06-scenarios/spec.md) | Reproducible system-wide scenarios, traces, and bounded oracles |
 
 Evidence conventions: benchmark results, prototype outcomes, and validation
 runs that inform contracts are recorded as `.experiments/` records in the

--- a/context/ontology.md
+++ b/context/ontology.md
@@ -98,6 +98,99 @@
   telemetry. _Avoid:_ introspection channel (not a webmesh channel).
 - **Control operation** — A devtools message that mutates engine state
   (reset, import, event injection) rather than inspecting it.
+- **Application definition** — A Scenario dependency wrapping a real
+  `LiveStoreSchema` together with named actions and optional normalized State
+  inspectors; it never redeclares the Application's materializers.
+- **Scenario specification** — A versioned, serializable description of a
+  Scenario's topology, execution requirements, plans, Workload patterns,
+  faults, completion, and Scenario oracles.
+- **Scenario participant** — A Client or Client session instantiated and
+  managed by a Scenario runner. A Leader is a role within a Client, and a Sync
+  backend is a separate topology component.
+- **Participant host** — A transport-neutral execution-profile realization
+  that creates and controls Scenario participants behind serializable control
+  and Scenario trace boundaries.
+- **Participant execution profile** — The environment and isolation model in
+  which Scenario participants run, such as in-process, worker/process, or
+  browser.
+- **Sync-backend realization** — A Scenario-side realization of the backend
+  boundary, such as mock/in-memory, local concrete, or deployed.
+- **Execution configuration** — The composition of a Participant execution
+  profile, Sync-backend realization, and optional State capabilities for one
+  Scenario run.
+- **Workload pattern** — A named, parameterized, seeded generator of
+  Application actions assigned to Scenario participants.
+- **Scenario operation** — A runner-invoked interaction identified across its
+  instruction, Participant-host response, related observations, and Operation
+  outcome.
+- **Control acknowledgement** — Evidence that a Participant host completed
+  handling a controller request at its advertised boundary. It is neither Sync
+  backend confirmation nor proof of propagation.
+- **Participant-host failure** — A portable failure category at the
+  Participant-host boundary: host infrastructure failure, request rejection,
+  invalid response, response timeout, or transport failure. Category is
+  independent from definite or indefinite Operation outcome certainty.
+- **Operation outcome** — The controller's classification of a Scenario
+  operation as successful, definitely failed, or indefinite. An indefinite
+  outcome means the completion boundary was lost; it does not prove that the
+  requested effect did not occur.
+- **Scenario operation history** — A projection of Scenario operation
+  invocations and outcomes for history-based checks. It is complete only for
+  the operation families and invocation/completion boundaries retained by the
+  Scenario trace.
+- **Scenario fault model** — The supported adverse connectivity, availability,
+  latency, lifecycle, or capacity conditions and assumptions of an Execution
+  configuration.
+- **Fault injection** — A Scenario operation that introduces a condition from
+  the Scenario fault model.
+- **Fault removal** — A Scenario operation that stops an injected condition.
+  It does not itself prove Recovery.
+- **Recovery** — Observed progression after Fault removal toward the required
+  operating or converged state.
+- **Quiescence** — No new Scenario workload and no relevant in-flight
+  runner-controlled work; background streams and future polling may remain.
+- **Convergence** — The required participants reach a declared agreement
+  condition under the Scenario's stated assumptions.
+- **Convergence group** — The Scenario participants that a settle phase
+  requires to reach the same authoritative Eventlog and, when requested,
+  equivalent normalized State.
+- **Settlement barrier** — A profile-appropriate, bounded confirmation that
+  the selected Convergence predicates form a stable fixed point after required
+  Quiescence and Fault removal. It does not include Scenario property verdicts.
+- **Scenario runner** — The headless orchestrator that validates a Scenario
+  specification, controls participants and faults, and emits a Scenario trace.
+  _Avoid:_ Scenario runtime (conflicts with LiveStore's Runtime).
+- **Scenario trace** — A versioned semantic stream of Scenario instructions,
+  Control acknowledgements, Operation outcomes, observations, and verdicts.
+  OTel spans and other implementation details are namespaced diagnostic
+  extensions. Its canonical ordering evidence is a causal partial order;
+  runner receipt order and timestamps remain separately inspectable facts.
+- **Scenario observation capture** — One runner-initiated collection of
+  component observations. It groups facts sampled during the same collection
+  pass but is neither an atomic distributed snapshot nor proof that the
+  observed transitions happened simultaneously.
+- **Scenario correlation** — Association of evidence belonging to the same
+  Scenario operation or investigation. Correlation alone establishes neither
+  direction nor causation.
+- **Scenario dependency** — An evidence-supported ordering relationship
+  between Scenario trace records.
+- **Scenario causal order** — The partial order supported by
+  Participant-local sequence and explicit Scenario dependency or causation
+  edges. Correlation, timestamps, and Observation-capture membership alone
+  never create an edge.
+- **Calibrated Scenario time** — An estimated shared monotonic elapsed-time
+  interval derived from a participant's local monotonic clock and a recorded
+  clock calibration. Its uncertainty is part of the estimate; it measures
+  latency but never establishes LiveStore sync causality.
+- **Scenario property** — A declared correctness or reliability claim under
+  stated Scenario assumptions.
+- **Scenario oracle** — The mechanism that evaluates a Scenario property from
+  bounded Scenario trace, observation, and State evidence.
+- **Scenario verdict** — A Scenario oracle's result for one Scenario property,
+  including its evidence references and explanation.
+- **Scenario run artifact** — The reproduction bundle containing the
+  normalized Scenario specification, source and Application identity,
+  Execution configuration, seed, Scenario trace, snapshots, and verdicts.
 - **Changeset (SQLite session)** — A SQLite session-extension changeset
   recorded per materialization, used to roll back state during rebase.
 - **Changeset (release)** — A pnpm changeset file describing a package-level
@@ -118,6 +211,7 @@ them, derives from them, or observes the result.
 | Order | Eventlog, Event sequence number, Sync backend, Rebase, Facts _(experimental)_ |
 | Derive | Materializer, State, Client document |
 | Observe | Live query, Reactivity graph, Devtools |
+| Verify | Scenario specification, Scenario runner, Scenario trace, Scenario property, Scenario oracle, Scenario verdict |
 
 ### Term families and leitwörter
 
@@ -145,6 +239,17 @@ in their name:
 - **Devtools family** (leitwort "devtools") — anchor **Devtools**; follower
   Devtools protocol version. SessionInfo, Introspection surface, and
   Control operation are its discovery/inspection vocabulary.
+- **Scenario family** (leitwort "Scenario") — anchor **Scenario
+  specification**; followers Scenario participant, Scenario runner, Scenario
+  operation, Scenario operation history, Scenario trace, Scenario observation
+  capture, Scenario correlation, Scenario dependency, Scenario causal order,
+  Scenario property, Scenario oracle, Scenario verdict, and Scenario run
+  artifact. Application definition, Participant host, Participant execution
+  profile, Execution configuration, Workload pattern, Scenario fault model,
+  Fault injection, Fault removal, Recovery, Quiescence, Convergence,
+  Convergence group, Settlement barrier, Control acknowledgement,
+  Participant-host failure, Operation outcome, and Calibrated Scenario time are
+  its execution and evidence vocabulary.
 
 ### Naming rubric
 
@@ -160,6 +265,9 @@ in their name:
   State → Live query → App.
 - **Containment:** A Client contains one or more Client sessions plus the
   Leader role; sessions reach the leader through a proxy.
+- **Scenario topology:** A Scenario runner controls Client and Client-session
+  participants through a Participant host; a Sync backend remains a separate
+  topology component selected through a Sync-backend realization.
 - **Pluggable dimensions:** Adapter, Sync provider, Framework integration,
   State realization, Devtools surface — each is a contract with multiple
   realizations.

--- a/context/spec.md
+++ b/context/spec.md
@@ -56,7 +56,7 @@ context/                     root: LiveStore the product (this node)
       01-react/  02-effect/  realizations (hooks; Store.Tag layer API)
     09-verification/         verification contract
       01-lanes/  02-conformance/  03-performance/  04-protocol-compat/
-      05-determinism/
+      05-determinism/  06-scenarios/
   03-delivery/               delivery identity boundary
     01-composition/          repo/package composition, locks, tooling, docs
     02-release/              versioning, publish flow, dependency policy
@@ -98,8 +98,9 @@ kinds (e.g. `04-docs/` vs `05-contributing/`) is reading order only.
   integrations, devtools surfaces) use the composable contract/realization
   pattern: the dimension node states the mechanism-agnostic contract once;
   each realization is a child node whose requirements declare
-  `refines: <parent-id>`. Contrib-owned realizations get a contract-level stub
-  child here; their implementation specs live in `livestore-contrib`.
+  `refines: <parent-id>`. Contrib-owned realizations are listed in the core
+  dimension's `realizations.md` registry; their implementation specs and
+  `LSC.*` IDs live in `livestore-contrib`.
 - Child requirements that constrain a parent concept declare a backticked
   `` `refines: <parent-ids>` `` marker at the end of the requirement bullet
   so the tree reads upward.
@@ -123,7 +124,7 @@ questions `DQ`, deltas `DELTA`, decisions by number):
 | `LS.SYS.OBS-*` | `02-system/06-observability/` |
 | `LS.SYS.DT-*` | `02-system/07-devtools/` |
 | `LS.SYS.INT-*` / `LS.SYS.INT.REACT-*`, `LS.SYS.INT.EFFECT-*` | `02-system/08-integrations/` and realizations |
-| `LS.SYS.VER-*` / `LS.SYS.VER.LANE-*`, `LS.SYS.VER.CONF-*`, `LS.SYS.VER.PERF-*`, `LS.SYS.VER.PROTO-*`, `LS.SYS.VER.DET-*` | `02-system/09-verification/` and children |
+| `LS.SYS.VER-*` / `LS.SYS.VER.LANE-*`, `LS.SYS.VER.CONF-*`, `LS.SYS.VER.PERF-*`, `LS.SYS.VER.PROTO-*`, `LS.SYS.VER.DET-*`, `LS.SYS.VER.SCEN-*` | `02-system/09-verification/` and children |
 | `LS.DEL-*` / `LS.DEL.COMP-*`, `LS.DEL.COMP.DEV-*`, `LS.DEL.REL-*`, `LS.DEL.ART-*`, `LS.DEL.INFRA-*` | `03-delivery/` and children |
 | `LS.DOCS-*` / `LS.DOCS.EX-*`, `LS.DOCS.SEARCH-*`, `LS.DOCS.OPS-*` | `04-docs/` and children |
 | `LS.CONTRIB-*` / `LS.CONTRIB.COLLAB-*`, `LS.CONTRIB.COMM-*` | `05-contributing/` and children |

--- a/packages/@livestore/common/src/sync/mock-sync-backend.test.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.test.ts
@@ -1,0 +1,92 @@
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect, Fiber, Option, Stream, SubscriptionRef } from '@livestore/utils/effect'
+
+import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
+import { makeMockSyncBackend } from './mock-sync-backend.ts'
+
+Vitest.describe('makeMockSyncBackend', () => {
+  Vitest.live('broadcasts live events to every backend connection', () =>
+    Effect.gen(function* () {
+      const mockBackend = yield* makeMockSyncBackend({ startConnected: true })
+      const backendA = yield* mockBackend.makeSyncBackend
+      const backendB = yield* mockBackend.makeSyncBackend
+      const nextBatch = (backend: typeof backendA) =>
+        backend.pull(Option.none(), { live: true }).pipe(
+          Stream.filter((item) => item.batch.length > 0),
+          Stream.runFirstUnsafe,
+        )
+
+      const pullA = yield* nextBatch(backendA).pipe(Effect.forkScoped)
+      const pullB = yield* nextBatch(backendB).pipe(Effect.forkScoped)
+      const event = makeEvent(1)
+
+      yield* mockBackend.advance(event)
+
+      Vitest.expect((yield* Fiber.join(pullA)).batch.map((item) => item.eventEncoded)).toEqual([event])
+      Vitest.expect((yield* Fiber.join(pullB)).batch.map((item) => item.eventEncoded)).toEqual([event])
+    }),
+  )
+
+  Vitest.live('seeds a new backend connection with existing live events', () =>
+    Effect.gen(function* () {
+      const mockBackend = yield* makeMockSyncBackend({ startConnected: true })
+      const event = makeEvent(1)
+      yield* mockBackend.advance(event)
+
+      const backend = yield* mockBackend.makeSyncBackend
+      const item = yield* backend.pull(Option.none(), { live: true }).pipe(
+        Stream.filter((item) => item.batch.length > 0),
+        Stream.runFirstUnsafe,
+      )
+
+      Vitest.expect(item.batch.map((entry) => entry.eventEncoded)).toEqual([event])
+    }),
+  )
+
+  Vitest.live('filters seeded live events against the requested cursor', () =>
+    Effect.gen(function* () {
+      const mockBackend = yield* makeMockSyncBackend({ startConnected: true })
+      const existing = makeEvent(1)
+      const next = makeEvent(2)
+      yield* mockBackend.advance(existing)
+
+      const backend = yield* mockBackend.makeSyncBackend
+      const cursor = Option.some({
+        eventSequenceNumber: existing.seqNum,
+        metadata: Option.none(),
+      })
+      const pull = yield* backend.pull(cursor, { live: true }).pipe(
+        Stream.filter((item) => item.batch.length > 0),
+        Stream.runFirstUnsafe,
+        Effect.forkScoped,
+      )
+
+      yield* mockBackend.advance(next)
+
+      Vitest.expect((yield* Fiber.join(pull)).batch.map((entry) => entry.eventEncoded)).toEqual([next])
+    }),
+  )
+
+  Vitest.live('exposes authoritative events and shared availability for diagnostics', () =>
+    Effect.gen(function* () {
+      const mockBackend = yield* makeMockSyncBackend()
+      const event = makeEvent(1)
+
+      Vitest.expect(yield* SubscriptionRef.get(mockBackend.isConnected)).toBe(false)
+      yield* mockBackend.connect
+      yield* mockBackend.advance(event)
+
+      Vitest.expect(yield* SubscriptionRef.get(mockBackend.isConnected)).toBe(true)
+      Vitest.expect(yield* mockBackend.events).toEqual([event])
+    }),
+  )
+})
+
+const makeEvent = (seqNum: number): LiveStoreEvent.Global.Encoded => ({
+  name: 'v1.TestEvent',
+  args: { id: `event-${seqNum}` },
+  seqNum: EventSequenceNumber.Global.make(seqNum),
+  parentSeqNum: EventSequenceNumber.Global.make(seqNum - 1),
+  clientId: 'client-a',
+  sessionId: 'session-a',
+})

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -18,6 +18,10 @@ import { validatePushPayload } from './validate-push-payload.ts'
 
 export interface MockSyncBackend {
   pushedEvents: Stream.Stream<LiveStoreEvent.Global.Encoded>
+  /** Snapshot of the authoritative eventlog, intended for verification and diagnostics. */
+  events: Effect.Effect<ReadonlyArray<LiveStoreEvent.Global.Encoded>>
+  /** Current backend availability shared by all mock connections. */
+  isConnected: SubscriptionRef.SubscriptionRef<boolean>
   connect: Effect.Effect<void>
   disconnect: Effect.Effect<void>
   makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
@@ -57,8 +61,15 @@ export const makeMockSyncBackend = (
     const syncIsConnectedRef = yield* SubscriptionRef.make(options?.startConnected ?? false)
 
     // Queues for streaming
-    const syncPullQueue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
+    const syncPullQueues = new Set<Queue.Queue<LiveStoreEvent.Global.Encoded>>()
     const pushedEventsQueue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
+
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        for (const queue of syncPullQueues) yield* Queue.shutdown(queue)
+        syncPullQueues.clear()
+      }),
+    )
 
     // Failure simulation state
     const failPushRef = yield* Ref.make<
@@ -97,27 +108,12 @@ export const makeMockSyncBackend = (
 
     const pullNonLive = (cursor: Option.Option<{ eventSequenceNumber: EventSequenceNumber.Global.Type }>) =>
       Effect.gen(function* () {
-        const lastSeen = Option.match(cursor, {
-          onNone: () => EventSequenceNumber.Client.ROOT.global,
-          onSome: (_) => _.eventSequenceNumber,
-        })
+        const lastSeen = cursorPosition(cursor)
         const allEvents = yield* Ref.get(allEventsRef)
-        const slice = allEvents.filter((e) => e.seqNum > lastSeen)
-
-        // Split into chunks with remaining count for pageInfo
-        const chunks: Array<{ events: LiveStoreEvent.Global.Encoded[]; remaining: number }> = []
-        for (let i = 0; i < slice.length; i += nonLiveChunkSize) {
-          const end = Math.min(i + nonLiveChunkSize, slice.length)
-          chunks.push({
-            events: slice.slice(i, end),
-            remaining: Math.max(slice.length - end, 0),
-          })
-        }
-        // Always return at least one empty chunk
-        if (chunks.length === 0) {
-          chunks.push({ events: [], remaining: 0 })
-        }
-        return chunks
+        return chunkEvents(
+          allEvents.filter((event) => event.seqNum > lastSeen),
+          nonLiveChunkSize,
+        )
       }).pipe(
         Effect.map((chunks) =>
           Stream.fromIterable(chunks).pipe(
@@ -131,18 +127,38 @@ export const makeMockSyncBackend = (
         Stream.flatten(),
       )
 
-    const pullLive = Stream.concat(
-      Stream.make(SyncBackend.pullResItemEmpty()),
-      Stream.fromQueue(syncPullQueue).pipe(
-        Stream.chunks,
-        Stream.map((chunk) => ({
-          batch: [...chunk].map((eventEncoded) => ({ eventEncoded, metadata: Option.none() })),
-          pageInfo: SyncBackend.pageInfoNoMore,
-        })),
-      ),
-    )
-
     const makeSyncBackend = Effect.gen(function* () {
+      // Every backend connection needs its own live cursor. A shared queue would
+      // load-balance events across Clients instead of broadcasting the log.
+      const syncPullQueue = yield* Effect.acquireRelease(
+        Queue.unbounded<LiveStoreEvent.Global.Encoded>(),
+        Queue.shutdown,
+      )
+      yield* semaphore.withPermits(1)(
+        Effect.gen(function* () {
+          const existingEvents = yield* Ref.get(allEventsRef)
+          syncPullQueues.add(syncPullQueue)
+          yield* Queue.offerAll(syncPullQueue, existingEvents)
+        }),
+      )
+      yield* Effect.addFinalizer(() => Effect.sync(() => syncPullQueues.delete(syncPullQueue)))
+
+      const pullLive = (cursor: Option.Option<{ eventSequenceNumber: EventSequenceNumber.Global.Type }>) => {
+        const lastSeen = cursorPosition(cursor)
+        return Stream.concat(
+          Stream.make(SyncBackend.pullResItemEmpty()),
+          Stream.fromQueue(syncPullQueue).pipe(
+            Stream.chunks,
+            Stream.map((chunk) => ({
+              batch: [...chunk]
+                .filter((eventEncoded) => eventEncoded.seqNum > lastSeen)
+                .map((eventEncoded) => ({ eventEncoded, metadata: Option.none() })),
+              pageInfo: SyncBackend.pageInfoNoMore,
+            })),
+          ),
+        )
+      }
+
       // TODO consider making offline state actively error pull/push.
       // Currently, offline only reflects in `isConnected`, while operations still succeed,
       // mirroring how some real providers behave during transient disconnects.
@@ -157,7 +173,7 @@ export const makeMockSyncBackend = (
               new UnknownError({ cause: new Error('MockSyncBackend: simulated pull failure') }),
             ),
           ).pipe(
-            Stream.flatMap(() => (pullOptions?.live === true ? pullLive : pullNonLive(cursor))),
+            Stream.flatMap(() => (pullOptions?.live === true ? pullLive(cursor) : pullNonLive(cursor))),
             Stream.withSpan('MockSyncBackend:pull', { parent: span }),
           ),
         push: (batch) =>
@@ -174,7 +190,10 @@ export const makeMockSyncBackend = (
             yield* Effect.sleep(10).pipe(Effect.withSpan('MockSyncBackend:push:sleep')) // Simulate network latency
 
             yield* Queue.offerAll(pushedEventsQueue, batch)
-            yield* Queue.offerAll(syncPullQueue, batch)
+            yield* Effect.forEach(syncPullQueues, (queue) => Queue.offerAll(queue, batch), {
+              concurrency: 'unbounded',
+              discard: true,
+            })
             yield* Ref.update(allEventsRef, (events) => events.concat(batch))
             yield* Ref.set(syncHeadRef, batch.at(-1)!.seqNum)
           }).pipe(
@@ -199,7 +218,10 @@ export const makeMockSyncBackend = (
       Effect.gen(function* () {
         yield* Ref.set(syncHeadRef, batch.at(-1)!.seqNum)
         yield* Ref.update(allEventsRef, (events) => events.concat(batch))
-        yield* Queue.offerAll(syncPullQueue, batch)
+        yield* Effect.forEach(syncPullQueues, (queue) => Queue.offerAll(queue, batch), {
+          concurrency: 'unbounded',
+          discard: true,
+        })
       }).pipe(
         Effect.withSpan('MockSyncBackend:advance', {
           parent: span,
@@ -220,6 +242,8 @@ export const makeMockSyncBackend = (
 
     return {
       pushedEvents: Stream.fromQueue(pushedEventsQueue),
+      events: Ref.get(allEventsRef),
+      isConnected: syncIsConnectedRef,
       connect: SubscriptionRef.set(syncIsConnectedRef, true),
       disconnect: SubscriptionRef.set(syncIsConnectedRef, false),
       makeSyncBackend,
@@ -233,4 +257,22 @@ export const makeMockSyncBackend = (
 interface FailureState<E, Args extends unknown[]> {
   remaining: number
   error: ((...args: Args) => Effect.Effect<never, E>) | undefined
+}
+
+const cursorPosition = (
+  cursor: Option.Option<{ eventSequenceNumber: EventSequenceNumber.Global.Type }>,
+): EventSequenceNumber.Global.Type =>
+  Option.match(cursor, {
+    onNone: () => EventSequenceNumber.Client.ROOT.global,
+    onSome: (_) => _.eventSequenceNumber,
+  })
+
+const chunkEvents = (events: ReadonlyArray<LiveStoreEvent.Global.Encoded>, chunkSize: number) => {
+  const chunks: Array<{ events: ReadonlyArray<LiveStoreEvent.Global.Encoded>; remaining: number }> = []
+  for (let index = 0; index < events.length; index += chunkSize) {
+    const end = Math.min(index + chunkSize, events.length)
+    chunks.push({ events: events.slice(index, end), remaining: Math.max(events.length - end, 0) })
+  }
+  if (chunks.length === 0) chunks.push({ events: [], remaining: 0 })
+  return chunks
 }


### PR DESCRIPTION
## Problem

The long-lived Scenario runner branch combines two different ownership concerns: a product-wide verification contract that must remain canonical in LiveStore core, and a private runner/viewer realization whose profiles, browser/runtime dependencies, artifacts, and implementation intent belong in `livestore-contrib`.

Moving the branch wholesale would either duplicate the contract or carry Scenario-only workspace and tooling wiring into core. The contrib realization also needs one generalized core testing seam: a mock Sync backend must fan out live Events to every connection and expose bounded read-only diagnostics.

## Solution

- Add the mechanism-independent Scenario verification node at `context/02-system/09-verification/06-scenarios/` under `LS.SYS.VER.SCEN-*`, including canonical terminology, trace/oracle/Settlement invariants, and five consolidated decisions.
- Record the cross-repository ownership decision and realization registry: core owns the contract and reusable package seams; `livestore-contrib` owns the runner, Participant hosts, backend profiles, corpus, artifacts, viewer, and implementation deltas.
- Fix `MockSyncBackend` live pull behavior so each connection has an independent cursor and receives a broadcast rather than load-balanced Events. Late live pulls are seeded from the authoritative Eventlog and filtered against their requested cursor.
- Expose read-only mock-backend Eventlog and connectivity observations for verification/diagnostics, with a focused `@livestore/common` patch changeset.

Trade-offs and scope:

- No database-diagnostics API was added; the contrib source does not justify a new product seam.
- Scenario code, viewer code, artifacts, root workspace/TypeScript/Vitest/lock wiring, the already-merged browser rebase metadata fix, the stale rebase delta, and the superseded devenv task fix are intentionally excluded.
- Realization-specific decisions and deltas move with the contrib implementation rather than being duplicated in core.
- No `CHANGELOG.md` entry: this changes contributor verification infrastructure, not application-facing behavior. The public package change is represented by the changeset.

## Validation

- `vitest run tests/package-common/src/intent-layer/intent-layer.test.ts packages/@livestore/common/src/sync/mock-sync-backend.test.ts` — 2 files, 12 tests passed.
- Whole-workspace TypeScript build via the task's underlying `tsgo --build tsconfig.dev.json --pretty false` — passed.
- `devenv tasks run lint:full:fix` — passed (format, Oxlint fixes, Nix format/dead-code, Markdown imports, dependency cycles, quarantine).
- `devenv tasks run lint:full` — all executed checks passed except the unrelated Genie projection check, which fails while importing the existing `.github/workflows/deploy-prod.yml.genie.ts`; this PR changes no Genie source or generated projection.
- `pnpm exec changeset status` — passed.
- `git diff upstream/main...HEAD --check` — passed.
- Not run: the full `test:run` matrix; validation is scoped to the intent invariants, changed mock backend, whole-workspace types, and lint gates.

### Demo

```text
LiveStore core                         livestore-contrib
LS.SYS.VER.SCEN-* contract  ───────▶  LSC Scenario realization intent
MockSyncBackend seam        ───────▶  runner profiles / oracles / viewer

push or advance ──▶ connection A live cursor
                └─▶ connection B live cursor
```

## Related issues

- Closes #1517
- Follow-up to the architecture review in #1442
