### PR TITLE
Fix extension Playwright launches by preserving caller args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@ For maintainers and contributors:
   `Effect.ignore` on CI, so their failures produced a passing required check.
   Removing that also restores the intent-layer invariant suite as a real gate on
   `context/` changes ([#1404](https://github.com/livestorejs/livestore/issues/1404)).
-- **Tooling:** The DevTools Playwright suite is currently broken (0/15) and
-  carries a declared, expiring quarantine entry instead of an unrecorded
-  `|| echo` wrapper. Its check does **not** gate merges yet — the quarantine
-  records the failure with a reason, an issue, and an expiry date rather than
-  hiding it ([#1489](https://github.com/livestorejs/livestore/issues/1489)).
+- **Tooling:** Extension-backed Playwright launches now preserve caller-supplied
+  Chromium arguments alongside the required extension flags. The DevTools suite
+  remains quarantined while its published-extension selectors are brought in
+  sync with current source ([#1497](https://github.com/livestorejs/livestore/issues/1497),
+  [#1489](https://github.com/livestorejs/livestore/issues/1489)).
 - **Tooling:** Cloudflare sync-provider failures now block merges. All six `cf-*`
   matrix cells previously exited 0 on failure, which is why the Durable Object
   hibernation guards could not gate merges

--- a/packages/@livestore/effect-playwright/package.json
+++ b/packages/@livestore/effect-playwright/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "test": "echo 'No tests'"
+    "test": "vitest"
   },
   "dependencies": {
     "@livestore/utils": "workspace:^"

--- a/packages/@livestore/effect-playwright/package.json
+++ b/packages/@livestore/effect-playwright/package.json
@@ -24,7 +24,8 @@
     "@playwright/test": "1.61.0",
     "@standard-schema/spec": "1.1.0",
     "@types/node": "25.3.3",
-    "effect": "4.0.0-beta.99"
+    "effect": "4.0.0-beta.99",
+    "vitest": "4.1.9"
   },
   "peerDependencies": {
     "@playwright/test": "^1.56.0"

--- a/packages/@livestore/effect-playwright/package.json.genie.ts
+++ b/packages/@livestore/effect-playwright/package.json.genie.ts
@@ -7,7 +7,7 @@ const runtimeDeps = catalog.compose({
     workspace: [utilsPkg],
   },
   devDependencies: {
-    external: effectDevDeps('@playwright/test', '@types/node'),
+    external: effectDevDeps('@playwright/test', '@types/node', 'vitest'),
   },
   peerDependencies: {
     external: {

--- a/packages/@livestore/effect-playwright/package.json.genie.ts
+++ b/packages/@livestore/effect-playwright/package.json.genie.ts
@@ -26,7 +26,7 @@ export default packageJson(
       '.': './src/index.ts',
     },
     scripts: {
-      test: "echo 'No tests'",
+      test: 'vitest',
     },
   },
   runtimeDeps,

--- a/packages/@livestore/effect-playwright/src/index.ts
+++ b/packages/@livestore/effect-playwright/src/index.ts
@@ -5,6 +5,8 @@ import * as PW from '@playwright/test'
 import { envTruish } from '@livestore/utils'
 import { Cause, Context, Effect, Layer, Option, Queue, Schema, Stream } from '@livestore/utils/effect'
 
+import { makeExtensionLaunchOptions } from './launch-options.ts'
+
 export class BrowserContext extends Context.Service<
   BrowserContext,
   {
@@ -61,15 +63,10 @@ export const browserContext = ({
       process.env.PW_CHROMIUM_ATTACH_TO_OTHER = '1'
 
       browserContext = yield* Effect.promise(() =>
-        PW.chromium.launchPersistentContext(persistentContextPath, {
-          ...launchOptions,
-          headless: false, // Using `--headless` flag below instead
-          args: [
-            headless === true ? `--headless=new` : '', // Headless mode https://playwright.dev/docs/chrome-extensions#headless-mode
-            `--disable-extensions-except=${extensionPath}`,
-            `--load-extension=${extensionPath}`,
-          ],
-        }),
+        PW.chromium.launchPersistentContext(
+          persistentContextPath,
+          makeExtensionLaunchOptions({ extensionPath, headless, launchOptions }),
+        ),
       )
 
       // TODO bring back once Playwright supports console messages for workers/service workers

--- a/packages/@livestore/effect-playwright/src/launch-options.test.ts
+++ b/packages/@livestore/effect-playwright/src/launch-options.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { makeExtensionLaunchOptions } from './launch-options.ts'
+
+describe('makeExtensionLaunchOptions', () => {
+  it('preserves caller args alongside extension-required args', () => {
+    const options = makeExtensionLaunchOptions({
+      extensionPath: '/tmp/livestore-extension',
+      headless: true,
+      launchOptions: {
+        args: ['--auto-open-devtools-for-tabs'],
+        chromiumSandbox: true,
+      },
+    })
+
+    expect(options).toEqual({
+      args: [
+        '--auto-open-devtools-for-tabs',
+        '--headless=new',
+        '--disable-extensions-except=/tmp/livestore-extension',
+        '--load-extension=/tmp/livestore-extension',
+      ],
+      chromiumSandbox: true,
+      headless: false,
+    })
+  })
+})

--- a/packages/@livestore/effect-playwright/src/launch-options.ts
+++ b/packages/@livestore/effect-playwright/src/launch-options.ts
@@ -1,0 +1,20 @@
+import type * as PW from '@playwright/test'
+
+export const makeExtensionLaunchOptions = ({
+  extensionPath,
+  headless,
+  launchOptions,
+}: {
+  extensionPath: string
+  headless: boolean
+  launchOptions: Omit<PW.LaunchOptions, 'headless'> | undefined
+}): PW.LaunchOptions => ({
+  ...launchOptions,
+  headless: false, // Use Chromium's new headless mode so extensions remain available.
+  args: [
+    ...(launchOptions?.args ?? []),
+    ...(headless === true ? ['--headless=new'] : []),
+    `--disable-extensions-except=${extensionPath}`,
+    `--load-extension=${extensionPath}`,
+  ],
+})

--- a/packages/@livestore/effect-playwright/vitest.config.ts
+++ b/packages/@livestore/effect-playwright/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: {
+    name: '@livestore/effect-playwright',
+    root: import.meta.dirname,
+    include: ['src/**/*.test.ts'],
+    server: { deps: { inline: ['@effect/vitest'] } },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.99
         version: 4.0.0-beta.99
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jsdom@26.1.0)(vite@7.3.6(@types/node@25.3.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/@livestore/framework-toolkit:
     dependencies:


### PR DESCRIPTION
## Problem

`@livestore/effect-playwright` spread caller `launchOptions` and then replaced `args` when loading an extension. The DevTools suite correctly passed `--auto-open-devtools-for-tabs`, but the helper discarded it before Chromium launched, so extension tests stopped at `No devtools page found`.

This corrects the diagnosis in #1489: the test was already passing the required flag. The option merge in `effect-playwright`, not the test call site, made it unreachable.

## Goal

Preserve caller-supplied Chromium launch arguments while retaining the flags that extension-backed launches require.

## Decisions

Caller arguments are merged before the helper-owned headless and extension flags. Appending the required flags keeps extension loading under the helper's control instead of allowing a caller to replace `--load-extension` or `--disable-extensions-except` accidentally.

The merge lives in a small internal option builder so the regression is covered without starting Chromium. A package-local Vitest project follows the root discovery convention and makes this package's tests part of the unit gate. Vitest is declared through the package's Genie source, with the generated manifest and authoritative root lockfile kept in sync.

## Verification

- Adversarial source review validated that the implementation forms a genuine union: caller args first, the conditional headless flag next, and mandatory extension flags last. It also confirmed that the regression test fails for both the original overwrite and the inverse implementation where caller args replace required flags.
- `CI=1 devenv shell -- vitest run packages/@livestore/effect-playwright/src/launch-options.test.ts`
  - 1 test file passed, 1 test passed.
- `CI=1 devenv tasks run test:unit`
  - Passed in 59.4 seconds.
- `CI=1 devenv tasks run ts:check`
  - Passed.
- `CI=1 devenv tasks run lint:full:fix`
  - Passed, including quarantine validation and dependency-cycle checks.
- Pre-commit `check-quick`
  - Passed.
- Review-fix CI attempt `30462975063` exposed an incomplete generated dependency change before tests ran: the generated package manifest declared `vitest@4.1.9`, but `pnpm-lock.yaml` did not yet contain the importer entry. The repository-standard lockfile-only resolution added exactly that three-line entry; validation is rerunning on the corrected head.
- A narrow local browser probe ran `browser-extension.play.ts`, `single tab (adapter=persisted)`, with one worker and zero retries. This observation has not been independently reproduced because CI quarantines the underlying failure.
  - Locally, the run advanced beyond `No devtools page found` and reached the extension DevTools UI.
  - It then failed at `getByTitle('Undock into separate window')`, which matched two elements at line 128. Treat this as author-reported evidence pending independent reproduction.

## Complexity

One internal option-builder module and one standard package Vitest config are added. The module boundary keeps merge behavior directly testable without browser startup.

## Concerns

Chromium can receive conflicting duplicate flags from callers. Helper-required extension flags are intentionally appended after caller flags so the extension path cannot be silently redirected.

## Friction & bottlenecks

The repository instructions reference `devenv tasks run test:run`, but that task is absent on current `main`; the current unit gate is `test:unit`. The package also advertised `No tests` and had no Vitest project, so the first regression-test invocation was not collected. This PR fills that discovery gap.

The behavioral proof was deliberately limited to one browser cell because browser launches are CPU-heavy.

## Follow-ups

- The published v0.4.0 extension still has selector drift against the current suite. That remains part of #1497 and is not changed here.
- The DevTools suite remains quarantined through 2026-09-30. This PR neither removes nor extends the quarantine; renew-or-remove ownership must be resolved with the later suite relocation.
- Relocate the browser-extension suite only after this core fix lands, because contrib consumes this core package.
- `context/03-delivery/01-composition/spec.md` records that `@livestore/effect-playwright` is not part of either repository's final package set and belongs in `overengineeringstudio/effect-utils`. This fix and its new package-local Vitest project must travel with that relocation rather than being dropped.

## References

Refs #1497
Refs #1489

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_name` | unknown |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.220 |
| `agent_runtime` | Claude Code 2.1.220 |
| `agent_session_lookup` | unavailable |
| `tooling_profile` | dotfiles@unknown-dirty |
</details>
<!-- agent-footer:end -->