### PR TITLE
Preserve release tags by creating GitHub Releases after npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1632,6 +1632,31 @@ jobs:
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'
           bash "$__genie_ci_retry_script" 'devenv tasks run release:stable:publish' 'if [ -n "${NIX_CONFIG:-}" ]; then NIX_CONFIG_WITH_APPEND=$(printf '"'"'%s\n%s'"'"' "$NIX_CONFIG" '"'"'restrict-eval = false'"'"'); else NIX_CONFIG_WITH_APPEND='"'"'restrict-eval = false'"'"'; fi; NIX_CONFIG="$NIX_CONFIG_WITH_APPEND" PNPM_HOME="${PNPM_HOME:-${{ github.workspace }}/.pnpm-home}" PNPM_STORE_DIR="${PNPM_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" PNPM_CONFIG_STORE_DIR="${PNPM_CONFIG_STORE_DIR:-${{ github.workspace }}/.pnpm-store}" DEVENV_TASK_PASSTHROUGH=1 DEVENV_TUI=false "${DEVENV_BIN:?DEVENV_BIN not set}" tasks run release:stable:publish'
+      - name: Create or update GitHub Release
+        run: |
+          set -euo pipefail
+          tag="v${LIVESTORE_RELEASE_VERSION}"
+          notes_path="release/release-notes.md"
+
+          # The release PR commits this file. Missing notes mean the plan is malformed.
+          if [[ ! -f "$notes_path" ]]; then
+            echo "::error::Missing committed GitHub Release notes: $notes_path" >&2
+            exit 1
+          fi
+
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$tag" --repo "$GITHUB_REPOSITORY" --notes-file "$notes_path"
+          else
+            prerelease_args=()
+            if [[ "$LIVESTORE_RELEASE_VERSION" == *-* ]]; then
+              prerelease_args+=(--prerelease)
+            fi
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$tag" \
+              --notes-file "$notes_path" \
+              "${prerelease_args[@]}"
+          fi
       - name: Certify DevTools artifact liveness
         run: |
           __genie_ci_retry_script='${{ runner.temp }}/genie-ci-scripts/run-with-nix-gc-race-retry.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1638,9 +1638,9 @@ jobs:
           tag="v${LIVESTORE_RELEASE_VERSION}"
           notes_path="release/release-notes.md"
 
-          # The release PR commits this file. Missing notes mean the plan is malformed.
-          if [[ ! -f "$notes_path" ]]; then
-            echo "::error::Missing committed GitHub Release notes: $notes_path" >&2
+          # The release PR commits nonempty notes. Missing or blank notes mean the plan is malformed.
+          if [[ ! -f "$notes_path" ]] || ! grep -q '[^[:space:]]' "$notes_path"; then
+            echo "::error::Missing or empty committed GitHub Release notes: $notes_path" >&2
             exit 1
           fi
 
@@ -1653,6 +1653,7 @@ jobs:
             fi
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
               --title "$tag" \
               --notes-file "$notes_path" \
               "${prerelease_args[@]}"

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -972,9 +972,9 @@ fi`,
 tag="v\${LIVESTORE_RELEASE_VERSION}"
 notes_path="release/release-notes.md"
 
-# The release PR commits this file. Missing notes mean the plan is malformed.
-if [[ ! -f "$notes_path" ]]; then
-  echo "::error::Missing committed GitHub Release notes: $notes_path" >&2
+# The release PR commits nonempty notes. Missing or blank notes mean the plan is malformed.
+if [[ ! -f "$notes_path" ]] || ! grep -q '[^[:space:]]' "$notes_path"; then
+  echo "::error::Missing or empty committed GitHub Release notes: $notes_path" >&2
   exit 1
 fi
 
@@ -987,6 +987,7 @@ else
   fi
   gh release create "$tag" \\
     --repo "$GITHUB_REPOSITORY" \\
+    --target "$GITHUB_SHA" \\
     --title "$tag" \\
     --notes-file "$notes_path" \\
     "\${prerelease_args[@]}"

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -967,6 +967,32 @@ fi`,
           run: runDevenvTasksBefore('release:stable:publish'),
         },
         {
+          name: 'Create or update GitHub Release',
+          run: `set -euo pipefail
+tag="v\${LIVESTORE_RELEASE_VERSION}"
+notes_path="release/release-notes.md"
+
+# The release PR commits this file. Missing notes mean the plan is malformed.
+if [[ ! -f "$notes_path" ]]; then
+  echo "::error::Missing committed GitHub Release notes: $notes_path" >&2
+  exit 1
+fi
+
+if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+  gh release edit "$tag" --repo "$GITHUB_REPOSITORY" --notes-file "$notes_path"
+else
+  prerelease_args=()
+  if [[ "$LIVESTORE_RELEASE_VERSION" == *-* ]]; then
+    prerelease_args+=(--prerelease)
+  fi
+  gh release create "$tag" \\
+    --repo "$GITHUB_REPOSITORY" \\
+    --title "$tag" \\
+    --notes-file "$notes_path" \\
+    "\${prerelease_args[@]}"
+fi`,
+        },
+        {
           name: 'Certify DevTools artifact liveness',
           run: runDevenvTasksBefore('release:devtools-artifact:certify-liveness:no-install'),
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 For maintainers and contributors:
 
+- **Release tooling:** GitHub Release and git tag creation now runs directly
+  after npm publication instead of depending on the DevTools artifact publisher
+  ([#1497](https://github.com/livestorejs/livestore/issues/1497)).
 - **Tooling:** Shell entry no longer runs the full TypeScript build after
   dependency and generated-source setup. The shared Effect-utils
   `otel:profile:setup` task captures the strict setup graph through native

--- a/context/03-delivery/02-release/release-workflows-runbook.md
+++ b/context/03-delivery/02-release/release-workflows-runbook.md
@@ -124,18 +124,19 @@ the `release:notes:extract` task (which calls
 release-plan PR so reviewers see exactly what will land on the GitHub Release
 page.
 
-The DevTools artifact publish step then uses that file when it creates or
-updates the GitHub Release tag:
+After npm publication succeeds, the `publish-release` job uses that file when
+it creates or updates the GitHub Release tag:
 
 - On `gh release create`, it passes `--notes-file release/release-notes.md`
-  instead of the legacy hardcoded `Release <version>` body.
+  and creates the git tag for the published version.
 - On subsequent reruns (the release already exists), it also calls
   `gh release edit --notes-file release/release-notes.md` so a corrected
   `CHANGELOG.md` section actually lands on the GitHub Release page.
 
 If `release/release-notes.md` is missing at publish time, the publish step
-falls back to the legacy `Release <version>` body and logs a warning. To
-refresh it locally for a planned release:
+fails because the committed release plan is malformed. It does not fall back
+to the legacy `Release <version>` body, which could silently publish stale
+notes. To refresh the file locally for a planned release:
 
 ```bash
 mono release extract-release-notes

--- a/scripts/src/commands/devtools-artifact.ts
+++ b/scripts/src/commands/devtools-artifact.ts
@@ -1,15 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import {
-  createWriteStream,
-  existsSync,
-  mkdtempSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs'
+import { createWriteStream, mkdtempSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { readdir, readFile, stat } from 'node:fs/promises'
 import { get as httpGet } from 'node:http'
 import { get as httpsGet } from 'node:https'
@@ -587,56 +578,9 @@ const materializeChromeZipAsset = (version: string, chromeZipPath: string, workD
   return assetPath
 }
 
-/**
- * Resolves the release notes file emitted by `mono release extract-release-notes`.
- * Returns `undefined` (with a warning) when the file is missing so DevTools-artifact
- * publishing remains unblocked. In that case the GitHub Release falls back to the
- * legacy `Release <version>` body.
- */
-const resolveReleaseNotesPath = (version: string): string | undefined => {
-  const workspaceRoot = process.env.WORKSPACE_ROOT ?? process.cwd()
-  const candidate = path.resolve(workspaceRoot, 'release/release-notes.md')
-  if (existsSync(candidate) === false) {
-    console.warn(
-      `[publishChromeZipReleaseAsset] release/release-notes.md not found for v${version}; ` +
-        'falling back to "Release <version>" body. Run `mono release extract-release-notes` to populate it.',
-    )
-    return undefined
-  }
-  return candidate
-}
-
-const publishChromeZipReleaseAsset = (version: string, assetPath: string) => {
+const uploadChromeZipReleaseAsset = (version: string, assetPath: string) => {
   const repo = process.env.GITHUB_REPOSITORY ?? 'livestorejs/livestore'
   const tag = `v${version}`
-  const notesPath = resolveReleaseNotesPath(version)
-
-  const releaseExists = spawnSync('gh', ['release', 'view', tag, '--repo', repo], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
-
-  if (releaseExists.status === 0) {
-    /**
-     * Refresh the body on reruns so a corrected `release/release-notes.md` actually lands
-     * on the GitHub Release page. Without this, only the very first create call sets the
-     * body, and later DevTools-artifact uploads silently leave a stale "Release <version>"
-     * body in place — which is exactly the regression we hit on v0.4.0.
-     */
-    if (notesPath !== undefined) {
-      run(['gh', 'release', 'edit', tag, '--repo', repo, '--notes-file', notesPath])
-    }
-  } else {
-    const createArgs = ['gh', 'release', 'create', tag, '--repo', repo, '--title', tag]
-    if (notesPath === undefined) {
-      createArgs.push('--notes', `Release ${version}`)
-    } else {
-      createArgs.push('--notes-file', notesPath)
-    }
-    if (version.includes('-') === true) createArgs.push('--prerelease')
-    run(createArgs)
-  }
-
   run(['gh', 'release', 'upload', tag, assetPath, '--repo', repo, '--clobber'])
 }
 
@@ -751,7 +695,7 @@ const repackArtifact = async (flags: Map<string, string | true>) => {
       if (isSnapshotVersion(version) === true) {
         console.log(`Snapshot Chrome zip prepared for workflow artifact upload: ${chromeZipAssetPath}`)
       } else {
-        publishChromeZipReleaseAsset(version, chromeZipAssetPath)
+        uploadChromeZipReleaseAsset(version, chromeZipAssetPath)
       }
     }
   }

--- a/scripts/src/commands/release.test.ts
+++ b/scripts/src/commands/release.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
 import { sliceChangelogSection } from './release.ts'
@@ -91,5 +94,33 @@ describe('sliceChangelogSection', () => {
   it('extracts the last section in the file (no following ## heading)', () => {
     const changelog = ['## 0.4.0 - 2026-06-02', '', 'final notes', ''].join('\n')
     expect(sliceChangelogSection(changelog, '0.4.0')).toBe('final notes\n')
+  })
+})
+
+describe('publish-release workflow', () => {
+  const workflowPath = fileURLToPath(new URL('../../../.github/workflows/release.yml', import.meta.url))
+  const workflow = readFileSync(workflowPath, 'utf8')
+
+  it('creates or updates the GitHub Release only after npm publishing succeeds', () => {
+    const npmPublishIndex = workflow.indexOf('      - name: Publish stable package release')
+    const githubReleaseIndex = workflow.indexOf('      - name: Create or update GitHub Release')
+    const devtoolsPublishIndex = workflow.indexOf('      - name: Publish DevTools artifact release')
+
+    expect(npmPublishIndex).toBeGreaterThan(-1)
+    expect(githubReleaseIndex).toBeGreaterThan(npmPublishIndex)
+    expect(devtoolsPublishIndex).toBeGreaterThan(githubReleaseIndex)
+
+    const nextStepIndex = workflow.indexOf('\n      - name:', githubReleaseIndex + 1)
+    const githubReleaseStep = workflow.slice(githubReleaseIndex, nextStepIndex)
+
+    expect(githubReleaseStep).toContain('::error::Missing committed GitHub Release notes: $notes_path')
+    expect(githubReleaseStep).toContain('exit 1')
+    expect(githubReleaseStep).toContain('gh release view')
+    expect(githubReleaseStep).toContain('gh release edit')
+    expect(githubReleaseStep).toContain('gh release create')
+    expect(githubReleaseStep).toContain('--notes-file "$notes_path"')
+    expect(githubReleaseStep).toContain('prerelease_args+=(--prerelease)')
+    expect(githubReleaseStep).not.toMatch(/--notes(?:\s|")/)
+    expect(githubReleaseStep).not.toContain('gh release upload')
   })
 })

--- a/scripts/src/commands/release.test.ts
+++ b/scripts/src/commands/release.test.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-import { Schema } from '@livestore/utils/effect'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
+
+import { Schema } from '@livestore/utils/effect'
 
 import { sliceChangelogSection } from './release.ts'
 
@@ -84,9 +85,7 @@ describe('sliceChangelogSection', () => {
     const empty = ['## 0.4.0', '', '## 0.3.0', '', 'old'].join('\n')
     const whitespaceOnly = ['## 0.4.0', '', '  ', '\t', '', '## 0.3.0', '', 'old'].join('\n')
 
-    expect(() => sliceChangelogSection(empty, '0.4.0')).toThrow(
-      /Changelog section for version 0\.4\.0 is empty/,
-    )
+    expect(() => sliceChangelogSection(empty, '0.4.0')).toThrow(/Changelog section for version 0\.4\.0 is empty/)
     expect(() => sliceChangelogSection(whitespaceOnly, '0.4.0')).toThrow(
       /Changelog section for version 0\.4\.0 is empty/,
     )
@@ -145,9 +144,7 @@ describe('publish-release workflow', () => {
 
     expect(npmPublishStep['continue-on-error']).not.toBe(true)
     expect(githubReleaseStep['continue-on-error']).not.toBe(true)
-    expect(githubReleaseScript).toContain(
-      '::error::Missing or empty committed GitHub Release notes: $notes_path',
-    )
+    expect(githubReleaseScript).toContain('::error::Missing or empty committed GitHub Release notes: $notes_path')
     expect(githubReleaseScript).toContain(`grep -q '[^[:space:]]' "$notes_path"`)
     expect(githubReleaseScript).toContain('exit 1')
     expect(githubReleaseScript).toContain('gh release view')

--- a/scripts/src/commands/release.test.ts
+++ b/scripts/src/commands/release.test.ts
@@ -1,9 +1,25 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
+import { Schema } from '@livestore/utils/effect'
 import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
 
 import { sliceChangelogSection } from './release.ts'
+
+const WorkflowStep = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  run: Schema.optional(Schema.String),
+  'continue-on-error': Schema.optional(Schema.Boolean),
+})
+
+const ReleaseWorkflow = Schema.Struct({
+  jobs: Schema.Struct({
+    'publish-release': Schema.Struct({
+      steps: Schema.Array(WorkflowStep),
+    }),
+  }),
+})
 
 describe('sliceChangelogSection', () => {
   it('extracts the verbatim block for a stable version with date heading', () => {
@@ -64,6 +80,18 @@ describe('sliceChangelogSection', () => {
     )
   })
 
+  it('throws when the matching section is empty or whitespace-only', () => {
+    const empty = ['## 0.4.0', '', '## 0.3.0', '', 'old'].join('\n')
+    const whitespaceOnly = ['## 0.4.0', '', '  ', '\t', '', '## 0.3.0', '', 'old'].join('\n')
+
+    expect(() => sliceChangelogSection(empty, '0.4.0')).toThrow(
+      /Changelog section for version 0\.4\.0 is empty/,
+    )
+    expect(() => sliceChangelogSection(whitespaceOnly, '0.4.0')).toThrow(
+      /Changelog section for version 0\.4\.0 is empty/,
+    )
+  })
+
   it('reads up to the next ## heading even with deeper ### subheadings in between', () => {
     const changelog = [
       '## 0.4.0 - 2026-06-02',
@@ -99,28 +127,34 @@ describe('sliceChangelogSection', () => {
 
 describe('publish-release workflow', () => {
   const workflowPath = fileURLToPath(new URL('../../../.github/workflows/release.yml', import.meta.url))
-  const workflow = readFileSync(workflowPath, 'utf8')
+  const workflow = Schema.decodeUnknownSync(ReleaseWorkflow)(parse(readFileSync(workflowPath, 'utf8')))
+  const steps = workflow.jobs['publish-release'].steps
 
   it('creates or updates the GitHub Release only after npm publishing succeeds', () => {
-    const npmPublishIndex = workflow.indexOf('      - name: Publish stable package release')
-    const githubReleaseIndex = workflow.indexOf('      - name: Create or update GitHub Release')
-    const devtoolsPublishIndex = workflow.indexOf('      - name: Publish DevTools artifact release')
+    const npmPublishIndex = steps.findIndex((step) => step.name === 'Publish stable package release')
+    const githubReleaseIndex = steps.findIndex((step) => step.name === 'Create or update GitHub Release')
+    const devtoolsPublishIndex = steps.findIndex((step) => step.name === 'Publish DevTools artifact release')
 
     expect(npmPublishIndex).toBeGreaterThan(-1)
     expect(githubReleaseIndex).toBeGreaterThan(npmPublishIndex)
     expect(devtoolsPublishIndex).toBeGreaterThan(githubReleaseIndex)
 
-    const nextStepIndex = workflow.indexOf('\n      - name:', githubReleaseIndex + 1)
-    const githubReleaseStep = workflow.slice(githubReleaseIndex, nextStepIndex)
+    const npmPublishStep = steps[npmPublishIndex]!
+    const githubReleaseStep = steps[githubReleaseIndex]!
+    const githubReleaseScript = githubReleaseStep.run!
 
-    expect(githubReleaseStep).toContain('::error::Missing committed GitHub Release notes: $notes_path')
-    expect(githubReleaseStep).toContain('exit 1')
-    expect(githubReleaseStep).toContain('gh release view')
-    expect(githubReleaseStep).toContain('gh release edit')
-    expect(githubReleaseStep).toContain('gh release create')
-    expect(githubReleaseStep).toContain('--notes-file "$notes_path"')
-    expect(githubReleaseStep).toContain('prerelease_args+=(--prerelease)')
-    expect(githubReleaseStep).not.toMatch(/--notes(?:\s|")/)
-    expect(githubReleaseStep).not.toContain('gh release upload')
+    expect(npmPublishStep['continue-on-error']).not.toBe(true)
+    expect(githubReleaseStep['continue-on-error']).not.toBe(true)
+    expect(githubReleaseScript).toContain('::error::Missing or empty committed GitHub Release notes: $notes_path')
+    expect(githubReleaseScript).toContain(`grep -q '[^[:space:]]' "$notes_path"`)
+    expect(githubReleaseScript).toContain('exit 1')
+    expect(githubReleaseScript).toContain('gh release view')
+    expect(githubReleaseScript).toContain('gh release edit')
+    expect(githubReleaseScript).toContain('gh release create')
+    expect(githubReleaseScript).toContain('--target "$GITHUB_SHA"')
+    expect(githubReleaseScript).toContain('--notes-file "$notes_path"')
+    expect(githubReleaseScript).toContain('prerelease_args+=(--prerelease)')
+    expect(githubReleaseScript).not.toMatch(/--notes(?:\s|")/)
+    expect(githubReleaseScript).not.toContain('gh release upload')
   })
 })

--- a/scripts/src/commands/release.test.ts
+++ b/scripts/src/commands/release.test.ts
@@ -145,7 +145,9 @@ describe('publish-release workflow', () => {
 
     expect(npmPublishStep['continue-on-error']).not.toBe(true)
     expect(githubReleaseStep['continue-on-error']).not.toBe(true)
-    expect(githubReleaseScript).toContain('::error::Missing or empty committed GitHub Release notes: $notes_path')
+    expect(githubReleaseScript).toContain(
+      '::error::Missing or empty committed GitHub Release notes: $notes_path',
+    )
     expect(githubReleaseScript).toContain(`grep -q '[^[:space:]]' "$notes_path"`)
     expect(githubReleaseScript).toContain('exit 1')
     expect(githubReleaseScript).toContain('gh release view')

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -120,8 +120,9 @@ const releaseNotesPath = (cwd: string) => `${cwd}/release/release-notes.md`
  * stopping at the next `## ` heading. Trailing blank lines are trimmed; a
  * single trailing newline is normalized.
  *
- * Throws when the heading is not found, or when more than one `## <version>`
- * heading exists (defensive — should never happen, but cheap to guard).
+ * Throws when the heading is not found, is empty, or when more than one
+ * `## <version>` heading exists (defensive — should never happen, but cheap
+ * to guard).
  */
 export const sliceChangelogSection = (changelog: string, version: string): string => {
   const lines = changelog.split('\n')
@@ -167,6 +168,10 @@ export const sliceChangelogSection = (changelog: string, version: string): strin
   while (start < endIndex && lines[start]!.trim() === '') start += 1
   let end = endIndex
   while (end > start && lines[end - 1]!.trim() === '') end -= 1
+
+  if (start === end) {
+    throw new Error(`Changelog section for version ${version} is empty in CHANGELOG.md`)
+  }
 
   return `${lines.slice(start, end).join('\n')}\n`
 }


### PR DESCRIPTION
## Problem

Core creates GitHub Releases and their implicit git tags inside the DevTools
Chrome ZIP publisher. Deleting that publisher in the repository split would
therefore silently stop core releases and tags, even though npm publication
continues.

The initial version of this PR moved `gh release create` without adding
`--target`. That was a correctness defect: for a missing tag, `gh` resolves the
latest state of the default branch rather than the checked-out release-plan
commit. A concurrent `main` advance could therefore make `v<version>` point at
code different from the code npm received. Moving creation earlier also changed
the resolution window, so the initial claim that commitish behavior was
preserved was incorrect.

The old path also falls back to a generic `Release <version>` body when the
committed release notes are missing, which can preserve stale release notes.

## Goal

Keep core GitHub Release and tag creation independent of DevTools artifact
machinery while guaranteeing the tag names the exact workflow commit that
published the release.

This is a standalone prerequisite for #1497 and can merge independently of the
rest of that epic.

## Decisions

- Create or update the GitHub Release in the existing `publish-release` job,
  immediately after stable npm publication succeeds.
- Pin automatic tag creation with `--target "$GITHUB_SHA"`. For the release-plan
  push and main-only manual dispatch paths, that immutable SHA is the workflow
  commit whose checkout was published.
- Keep the existing rerun behavior: edit notes when the Release exists,
  otherwise create the Release/tag and mark prerelease versions.
- Require nonempty committed `release/release-notes.md`. Missing or
  whitespace-only notes fail during extraction and again at publish time.
- Do not add a `publish-release` concurrency stanza. It cannot prevent unrelated
  pushes from advancing `main`, and cancellation or serialization would change
  release recovery behavior. Pinning the immutable target directly closes the
  integrity hole.
- Leave `gh release upload` in `devtools-artifact.ts`. The Chrome ZIP does not
  move to a core Release destination; its removal remains part of the later
  DevTools cleanup.

## Verification

Initial relocation checks before the P1 follow-up:

- `CI=1 devenv tasks run genie:check` (passed)
- `CI=1 devenv tasks run lint:full` (passed)
- `CI=1 devenv tasks run ts:check` (passed)
- `CI=1 devenv shell -- vitest run scripts/src/commands/release.test.ts`
  (8 tests passed)
- `CI=1 devenv shell -- vitest run tests/package-common/src/intent-layer/intent-layer.test.ts`
  (8 tests passed)
- `CI=1 devenv tasks run test:unit` (passed)

P1 follow-up verification:

- Final HEAD `19bed7f24737189139c0f5adb68722cb32b14c0e` passed all executable
  GitHub checks: 26 succeeded, 8 release-event-only jobs skipped, 0 failed.
  Main CI run `30464531113`, Release run `30464531326`, and DevTools manifest
  run `30464531272` all completed successfully.
- The workflow guard now parses generated YAML and asserts npm-before-Release
  ordering, no `continue-on-error`, exact `--target "$GITHUB_SHA"`, Release
  view/edit/create behavior, prerelease behavior, semantic nonempty notes, and
  the absence of core-side upload in the relocated step.
- The release-note extractor has negative tests for empty and whitespace-only
  version sections.
- Final CI passed lint, type-check, unit, all seven sync-provider cells,
  Playwright (DevTools/misc/TodoMVC), wa-sqlite, perf, package snapshot,
  examples, docs, source policies, release-plan validation, and manifest
  update.
- In particular, `test-integration-sync-provider (cf-ws-do)` passed on this
  branch. Its comparison branch #1520 also passed after correcting a missing
  lockfile entry; an earlier #1520 cell never reached tests because frozen
  install rejected that lockfile.

Local builds were intentionally frozen during the dev3 disk incident. The
one-off commit-hook bypass cost two deterministic CI formatting round-trips:
the first manual repair guessed incorrectly, then the approved single-file
configured `oxfmt` output and matching `--check` produced the green final
commit. This is evidence of the verification-relocation trade, not precedent
for skipping local gates.

The documented `devenv tasks run test:run` command is absent in this checkout.
An earlier aggregate `CI=1 devenv shell -- mono test` attempt observed unrelated
webmesh and package-common failures, then the integration launcher hit the
repository's direct-pnpm passthrough guard. The dedicated managed unit task
passed before that aggregate attempt.

### Demo

```text
publish commit A to npm
         |
         v
gh release create v<version> --target A
         |
         v
tag v<version> permanently names published commit A
```

## Complexity

No new job, permission, dependency, or abstraction. The change adds one
generated workflow step and parsed structural coverage for its release
integrity contract.

## Concerns

- The first post-merge dev or stable release remains the real end-to-end proof
  of GitHub token/API behavior. Static coverage proves the generated command and
  ordering, not a live GitHub tag write.
- Open PR #1505 overlaps `release.yml.genie.ts` and `CHANGELOG.md`; open PR
  #1445 overlaps `devtools-artifact.ts` and `CHANGELOG.md`, so landing order may
  require regeneration or conflict resolution.

## Friction & bottlenecks

- Repository instructions still name a removed `test:run` task.
- The aggregate local test command invokes Playwright through direct `pnpm`,
  which the repository task guard rejects.
- P1 follow-up verification moved to off-host CI because dev3 is under an
  explicit build freeze after rapid disk consumption.

## Follow-ups

- #1497 removes the remaining core-side Chrome ZIP upload and DevTools artifact
  machinery only after this relocation is proven by a real release.

## References

- Refs #1497
