### PR TITLE
refactor: persist state DB snapshot's HEAD

### DIFF
--- a/.changeset/persist-state-head.md
+++ b/.changeset/persist-state-head.md
@@ -1,0 +1,8 @@
+---
+"@livestore/adapter-cloudflare": patch
+"@livestore/adapter-web": patch
+"@livestore/common": patch
+"@livestore/livestore": patch
+---
+
+Persist the state database snapshot head separately from SQLite rollback changesets and use it when restoring persisted web sessions. The new system table changes the compound state-schema hash, so persisted stores select a fresh state database and rebuild it from the eventlog.

--- a/docs/src/content/docs/building-with-livestore/state/sqlite.md
+++ b/docs/src/content/docs/building-with-livestore/state/sqlite.md
@@ -35,6 +35,8 @@ LiveStore operates two SQLite databases by default: a state database (your mater
   - Tracks the schema hash and last update time per materialized table. Used for migrations and compatibility checks.
 - `__livestore_schema_event_defs`
   - Tracks the schema hash and last update time per event definition. Used to detect incompatible event schema changes during rematerialization.
+- `__livestore_state_head`
+  - Stores the latest composite event sequence number reflected by the state database snapshot.
 - `__livestore_session_changeset`
   - Stores SQLite session changeset blobs keyed by event sequence numbers. Used to efficiently roll back and re‑apply state during rebases.
 - Your application tables

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -6,6 +6,7 @@ import {
   makeClientSession,
   type SyncOptions,
   UnknownError,
+  StateHead,
 } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
 import {
@@ -93,7 +94,7 @@ export const makeAdapter =
           shutdownChannel,
           syncPayloadEncoded,
           syncPayloadSchema,
-        }),
+        }).pipe(Layer.provide(StateHead.layer({ dbState }))),
       )
 
       const { leaderThread, initialSnapshot } = yield* Effect.gen(function* () {

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -5,6 +5,7 @@ import {
   type LockStatus,
   makeClientSession,
   migrateDb,
+  StateHead,
   type SyncOptions,
   UnknownError,
 } from '@livestore/common'
@@ -272,7 +273,7 @@ const makeLeaderThread = ({
         shutdownChannel,
         syncPayloadEncoded,
         syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
-      }),
+      }).pipe(Layer.provide(StateHead.layer({ dbState }))),
     )
 
     return yield* Effect.gen(function* () {

--- a/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
+++ b/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
@@ -17,11 +17,10 @@ import type { Adapter, BootWarningReason, ClientSession, LockStatus } from '@liv
 import {
   IntentionalShutdownCause,
   makeClientSession,
+  StateHead,
   StoreInterrupted,
-  sessionChangesetMetaTable,
   UnknownError,
 } from '@livestore/common'
-import { EventSequenceNumber } from '@livestore/common/schema'
 import { sqliteDbFactory } from '@livestore/sqlite-wasm/browser'
 import { shouldNeverHappen, tryAsFunctionAndNew } from '@livestore/utils'
 import {
@@ -335,25 +334,9 @@ export const makeSingleTabAdapter =
         })
       }
 
-      // Restore leader head from SESSION_CHANGESET_META_TABLE
-      const initialLeaderHeadRes = sqliteDb.select(
-        sessionChangesetMetaTable
-          .select('seqNumClient', 'seqNumGlobal', 'seqNumRebaseGeneration')
-          .orderBy([
-            { col: 'seqNumGlobal', direction: 'desc' },
-            { col: 'seqNumClient', direction: 'desc' },
-          ])
-          .first(),
-      )
-
-      const initialLeaderHead =
-        initialLeaderHeadRes !== undefined
-          ? EventSequenceNumber.Client.Composite.make({
-              global: initialLeaderHeadRes.seqNumGlobal,
-              client: initialLeaderHeadRes.seqNumClient,
-              rebaseGeneration: initialLeaderHeadRes.seqNumRebaseGeneration,
-            })
-          : EventSequenceNumber.Client.ROOT
+      // The state snapshot carries its own cursor, so the fast path does not
+      // need to export or transfer the eventlog database.
+      const initialLeaderHead = yield* StateHead.make({ dbState: sqliteDb }).get
 
       yield* Effect.addFinalizer((ex: Exit.Exit<unknown, unknown>) =>
         Effect.gen(function* () {

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -3,14 +3,13 @@ import {
   IntentionalShutdownCause,
   liveStoreVersion,
   makeClientSession,
+  StateHead,
   StoreInterrupted,
-  sessionChangesetMetaTable,
   UnknownError,
 } from '@livestore/common'
 // TODO bring back - this currently doesn't work due to https://github.com/vitejs/vite/issues/8427
 // NOTE We're using a non-relative import here for Vite to properly resolve the import during app builds
 // import LiveStoreSharedWorker from '@livestore/adapter-web/internal-shared-worker?sharedworker'
-import { EventSequenceNumber } from '@livestore/common/schema'
 import { sqliteDbFactory } from '@livestore/sqlite-wasm/browser'
 import { isDevEnv, omitUndefineds, shouldNeverHappen, tryAsFunctionAndNew } from '@livestore/utils'
 import {
@@ -461,26 +460,9 @@ export const makePersistedAdapter =
         })
       }
 
-      // We're restoring the leader head from the SESSION_CHANGESET_META_TABLE, not from the eventlog db/table
-      // in order to avoid exporting/transferring the eventlog db/table, which is important to speed up the fast path.
-      const initialLeaderHeadRes = sqliteDb.select(
-        sessionChangesetMetaTable
-          .select('seqNumClient', 'seqNumGlobal', 'seqNumRebaseGeneration')
-          .orderBy([
-            { col: 'seqNumGlobal', direction: 'desc' },
-            { col: 'seqNumClient', direction: 'desc' },
-          ])
-          .first(),
-      )
-
-      const initialLeaderHead =
-        initialLeaderHeadRes !== undefined
-          ? EventSequenceNumber.Client.Composite.make({
-              global: initialLeaderHeadRes.seqNumGlobal,
-              client: initialLeaderHeadRes.seqNumClient,
-              rebaseGeneration: initialLeaderHeadRes.seqNumRebaseGeneration,
-            })
-          : EventSequenceNumber.Client.ROOT
+      // The state snapshot carries its own cursor, so the fast path does not
+      // need to export or transfer the eventlog database.
+      const initialLeaderHead = yield* StateHead.make({ dbState: sqliteDb }).get
 
       // console.debug('[@livestore/adapter-web:client-session] initialLeaderHead', initialLeaderHead)
 

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -1,7 +1,7 @@
 import type * as otel from '@opentelemetry/api'
 
 import type { BootStatus, BootWarningReason, LogConfig, SqliteDb, SyncOptions } from '@livestore/common'
-import { Devtools, UnknownError } from '@livestore/common'
+import { Devtools, StateHead, UnknownError } from '@livestore/common'
 import type { DevtoolsOptions, StreamEventsOptions } from '@livestore/common/leader-thread'
 import {
   configureConnection,
@@ -280,7 +280,7 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
               syncPayloadEncoded,
               syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
               ...(bootWarning !== undefined ? { bootWarning } : {}),
-            }),
+            }).pipe(Layer.provide(StateHead.layer({ dbState }))),
             leaderThreadScope,
           )
         }).pipe(

--- a/packages/@livestore/common/src/StateHead.ts
+++ b/packages/@livestore/common/src/StateHead.ts
@@ -1,0 +1,80 @@
+import { Context, Effect, Layer } from '@livestore/utils/effect'
+
+import type { SqliteDb, SqliteError } from './adapter-types.ts'
+import { execSql, selectSql } from './leader-thread/connection.ts'
+import * as EventSequenceNumber from './schema/EventSequenceNumber/mod.ts'
+import { SystemTables } from './schema/mod.ts'
+import { findManyRows, insertRow } from './sql-queries/index.ts'
+
+export const TypeId = '~@livestore/common/StateHead' as const
+export type TypeId = typeof TypeId
+
+const STATE_HEAD_ROW_ID = 1
+
+/**
+ * Persists and reads the latest event sequence number reflected by the state database.
+ */
+export interface Service {
+  readonly [TypeId]: TypeId
+  /** Persists the latest event sequence number reflected by the state database. */
+  set: (head: EventSequenceNumber.Client.Composite) => Effect.Effect<void, SqliteError>
+  /** Returns the persisted head, or the root when the current-schema table has no row. */
+  get: Effect.Effect<EventSequenceNumber.Client.Composite, SqliteError>
+}
+
+export class StateHead extends Context.Service<StateHead, Service>()('@livestore/common/StateHead') {}
+
+interface Options {
+  readonly dbState: SqliteDb
+}
+
+export const make = ({ dbState }: Options) => {
+  return StateHead.of({
+    [TypeId]: TypeId,
+    set: (head) => {
+      const [statement, bindValues] = insertRow({
+        tableName: SystemTables.STATE_HEAD_META_TABLE,
+        columns: SystemTables.stateHeadMetaTable.sqliteDef.columns,
+        values: {
+          id: STATE_HEAD_ROW_ID,
+          seqNumGlobal: head.global,
+          seqNumClient: head.client,
+          seqNumRebaseGeneration: head.rebaseGeneration,
+        },
+        options: { orReplace: true },
+      })
+
+      return execSql(dbState, statement, bindValues)
+    },
+    get: Effect.suspend(() => {
+      const [statement, bindValues] = findManyRows({
+        tableName: SystemTables.STATE_HEAD_META_TABLE,
+        columns: SystemTables.stateHeadMetaTable.sqliteDef.columns,
+        where: { id: STATE_HEAD_ROW_ID },
+        limit: 1,
+      })
+      return selectSql<SystemTables.StateHeadMetaRow>(dbState, statement, bindValues).pipe(
+        Effect.map(([row]) =>
+          row === undefined
+            ? EventSequenceNumber.Client.ROOT
+            : EventSequenceNumber.Client.Composite.make({
+                global: row.seqNumGlobal,
+                client: row.seqNumClient,
+                rebaseGeneration: row.seqNumRebaseGeneration,
+              }),
+        ),
+      )
+    }),
+  })
+}
+
+export const layer = (options: Options) => Layer.succeed(StateHead, make(options))
+
+export const layerTest = Layer.succeed(
+  StateHead,
+  StateHead.of({
+    [TypeId]: TypeId,
+    set: () => Effect.void,
+    get: Effect.succeed(EventSequenceNumber.Client.ROOT),
+  }),
+)

--- a/packages/@livestore/common/src/index.ts
+++ b/packages/@livestore/common/src/index.ts
@@ -17,6 +17,7 @@ export {
   type BindableWithSessionIdSymbol,
 } from './session-id-symbol.ts'
 export * as SqliteDbHelper from './sqlite-db-helper.ts'
+export * as StateHead from './StateHead.ts'
 export * from './sync/index.ts'
 export * as SyncState from './sync/syncstate.ts'
 export * from './util.ts'

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -27,13 +27,14 @@ import {
   TxQueue,
 } from '@livestore/utils/effect'
 
-import { type MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
+import { MaterializeError, type SqliteDb, UnknownError } from '../adapter-types.ts'
 import type { UnknownEventError } from '../errors.ts'
 import { IntentionalShutdownCause } from '../errors.ts'
 import { makeMaterializerHash } from '../materializer-helper.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from '../schema/mod.ts'
 import { EVENTLOG_META_TABLE, SYNC_STATUS_TABLE } from '../schema/state/sqlite/system-tables/eventlog-tables.ts'
+import * as StateHead from '../StateHead.ts'
 import type { BackendIdMismatchError, IsOfflineError, SyncBackend } from '../sync/sync.ts'
 import * as SyncState from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
@@ -210,6 +211,7 @@ export const make = Effect.fnUntraced(function* ({
   params,
   testing,
 }: Options) {
+  const stateHead = yield* StateHead.StateHead
   const syncBackendPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
   const localPushBatchSize = params.localPushBatchSize ?? 10
   const backendPushBatchSize = params.backendPushBatchSize ?? 50
@@ -490,6 +492,9 @@ export const make = Effect.fnUntraced(function* ({
                 dbEventlog,
                 eventNumsToRollback: mergeResult.rollbackEvents.map((_) => _.seqNum),
               })
+              yield* stateHead
+                .set(mergeResult.rollbackEvents[0]!.parentSeqNum)
+                .pipe(Effect.mapError((cause) => MaterializeError.make({ cause })))
             }
 
             yield* connectedClientSessionPullQueues.offer({

--- a/packages/@livestore/common/src/leader-thread/connection.ts
+++ b/packages/@livestore/common/src/leader-thread/connection.ts
@@ -83,14 +83,18 @@ export const execSql = (sqliteDb: SqliteDb, sql: string, bind: BindValues) => {
   )
 }
 
-// const selectSqlPrepared = <T>(stmt: PreparedStatement, bind: BindValues) => {
-//   const bindValues = prepareBindValues(bind, stmt.sql)
-//   return Effect.try({
-//     try: () => stmt.select<T>(bindValues),
-//     catch: (cause) =>
-//       new SqliteError({ cause, query: { bindValues, sql: stmt.sql }, code: (cause as WaSqlite.SQLiteError).code }),
-//   })
-// }
+export const selectSql = <T>(sqliteDb: SqliteDb, sql: string, bind: BindValues) => {
+  const bindValues = prepareBindValues(bind, sql)
+  return Effect.try({
+    try: () => sqliteDb.select<T>(sql, bindValues),
+    catch: (cause) =>
+      new SqliteError({ cause, query: { bindValues, sql }, code: (cause as WaSqlite.SQLiteError).code }),
+  }).pipe(
+    Effect.withSpan(`@livestore/common:selectSql`, {
+      attributes: { 'span.label': sql, sql, bindValueKeys: Object.keys(bindValues) },
+    }),
+  )
+}
 
 // TODO actually use prepared statements
 export const execSqlPrepared = (sqliteDb: SqliteDb, sql: string, bindValues: PreparedBindValues) => {

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -27,6 +27,7 @@ import type { MigrationsReport } from '../defs.ts'
 import type * as Devtools from '../devtools/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '../schema/mod.ts'
+import type * as StateHead from '../StateHead.ts'
 import type { SyncBackend, SyncOptions } from '../sync/sync.ts'
 import { SyncState } from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
@@ -88,7 +89,11 @@ export const makeLeaderThreadLayer = ({
   bootWarning,
   params,
   testing,
-}: MakeLeaderThreadLayerParams): Layer.Layer<LeaderThreadCtx, UnknownError, Scope.Scope | HttpClient.HttpClient> =>
+}: MakeLeaderThreadLayerParams): Layer.Layer<
+  LeaderThreadCtx,
+  UnknownError,
+  Scope.Scope | HttpClient.HttpClient | StateHead.StateHead
+> =>
   Effect.gen(function* () {
     const syncPayloadDecoded =
       syncPayloadEncoded === undefined

--- a/packages/@livestore/common/src/leader-thread/materialize-event.ts
+++ b/packages/@livestore/common/src/leader-thread/materialize-event.ts
@@ -7,6 +7,7 @@ import { logDeprecationWarnings } from '../schema/EventDef/deprecated.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { EventSequenceNumber, resolveEventDef, SystemTables, UNKNOWN_EVENT_SCHEMA_HASH } from '../schema/mod.ts'
 import { insertRow } from '../sql-queries/index.ts'
+import * as StateHead from '../StateHead.ts'
 import { sql } from '../util.ts'
 import { execSql, execSqlPrepared } from './connection.ts'
 import * as Eventlog from './eventlog.ts'
@@ -21,8 +22,9 @@ export const makeMaterializeEvent = ({
   schema: LiveStoreSchema
   dbState: SqliteDb
   dbEventlog: SqliteDb
-}): Effect.Effect<MaterializeEvent> =>
+}): Effect.Effect<MaterializeEvent, never, StateHead.StateHead> =>
   Effect.gen(function* () {
+    const stateHead = yield* StateHead.StateHead
     const eventDefSchemaHashMap = new Map(
       // TODO Running `Schema.hash` can be a bottleneck for larger schemas. There is an opportunity to run this
       // at build time and lookup the pre-computed hash at runtime.
@@ -53,6 +55,7 @@ export const makeMaterializeEvent = ({
             )
           }
 
+          yield* stateHead.set(eventEncoded.seqNum)
           dbState.debug.head = eventEncoded.seqNum
 
           return {
@@ -123,6 +126,7 @@ export const makeMaterializeEvent = ({
             },
           }),
         )
+        yield* stateHead.set(eventEncoded.seqNum)
 
         // console.groupEnd()
 

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -4,7 +4,7 @@ import { Effect, Option, ReadonlyArray as EffectArray, Schema, Stream } from '@l
 import { type SqliteDb, UnknownError } from './adapter-types.ts'
 import type { MaterializeEvent } from './leader-thread/mod.ts'
 import type { EventDef, LiveStoreSchema } from './schema/mod.ts'
-import { EventSequenceNumber, LiveStoreEvent, resolveEventDef, SystemTables } from './schema/mod.ts'
+import { EventSequenceNumber, LiveStoreEvent, SystemTables } from './schema/mod.ts'
 import type { PreparedBindValues } from './util.ts'
 import { sql } from './util.ts'
 
@@ -52,18 +52,15 @@ export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerial
       sessionId: row.sessionId,
     })
 
-    const resolution = yield* resolveEventDef(schema, {
-      operation: '@livestore/common:rematerializeFromEventlog:processEvent',
-      event: eventEncoded,
-    }).pipe(UnknownError.mapToUnknownError)
+    const eventDef = schema.eventsDefsMap.get(row.name)
+    const materializer = schema.state.materializers.get(row.name)
 
-    if (resolution._tag === 'unknown') {
-      // Old snapshots can contain newer events. Skip until the runtime has
-      // been updated; the event stays in the log for future replays.
+    if (eventDef === undefined || materializer === undefined) {
+      // Route unknown events through the normal materialization boundary so
+      // they advance the state snapshot head as no-ops.
+      yield* materializeEvent(eventEncoded, { skipEventlog: true })
       return
     }
-
-    const { eventDef } = resolution
 
     if (hashEventDef(eventDef) !== row.schemaHash) {
       yield* Effect.logWarning(

--- a/packages/@livestore/common/src/schema/state/sqlite/system-tables/state-tables.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/system-tables/state-tables.ts
@@ -43,6 +43,27 @@ export const schemaEventDefsMetaTable = table({
 
 export type SchemaEventDefsMetaRow = typeof schemaEventDefsMetaTable.Type
 
+export const STATE_HEAD_META_TABLE = '__livestore_state_head'
+
+/**
+ * Single-row marker for the latest event sequence number reflected by the state DB.
+ *
+ * @remarks
+ * This is separate from the session changeset table because confirmed changesets
+ * can be removed after they are no longer needed for rollback.
+ */
+export const stateHeadMetaTable = table({
+  name: STATE_HEAD_META_TABLE,
+  columns: {
+    id: SqliteDsl.integer({ primaryKey: true }),
+    seqNumGlobal: SqliteDsl.integer({ schema: EventSequenceNumber.Global.Schema }),
+    seqNumClient: SqliteDsl.integer({ schema: EventSequenceNumber.Client.Schema }),
+    seqNumRebaseGeneration: SqliteDsl.integer({}),
+  },
+})
+
+export type StateHeadMetaRow = typeof stateHeadMetaTable.Type
+
 /**
  * Table which stores SQLite changeset blobs which is used for rolling back
  * read-model state during rebasing.
@@ -64,6 +85,11 @@ export const sessionChangesetMetaTable = table({
 
 export type SessionChangesetMetaRow = typeof sessionChangesetMetaTable.Type
 
-export const stateSystemTables = [schemaMetaTable, schemaEventDefsMetaTable, sessionChangesetMetaTable] as const
+export const stateSystemTables = [
+  schemaMetaTable,
+  schemaEventDefsMetaTable,
+  stateHeadMetaTable,
+  sessionChangesetMetaTable,
+] as const
 
 export const isStateSystemTable = (tableName: string) => stateSystemTables.some((_) => _.sqliteDef.name === tableName)

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -18,12 +18,13 @@ import {
 } from '@livestore/utils/effect'
 
 import type { ClientSession } from '../adapter-types.ts'
-import type { MaterializeError } from '../errors.ts'
+import { MaterializeError } from '../errors.ts'
 import { isRejectedPushError } from '../leader-thread/RejectedPushError.ts'
 import * as EventSequenceNumber from '../schema/EventSequenceNumber/mod.ts'
 import * as LiveStoreEvent from '../schema/LiveStoreEvent/mod.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
 import { resolveSessionIdSymbolInEventArgs } from '../session-id-symbol.ts'
+import * as StateHead from '../StateHead.ts'
 import * as SyncState from './syncstate.ts'
 
 /** Serialize value to JSON string for trace attributes */
@@ -86,7 +87,8 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
    * If true, registers a beforeunload event listener to confirm unsaved changes.
    */
   confirmUnsavedChanges: boolean
-}): Effect.fn.Return<ClientSessionSyncProcessor> {
+}) {
+  const stateHead = yield* StateHead.StateHead
   const eventSchema = LiveStoreEvent.Client.makeSchemaMemo(schema)
 
   const rebaseBarrier = (point: RebaseBarrierPoint): Effect.Effect<void> =>
@@ -238,6 +240,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
                 rollback(event.meta.sessionChangeset.data)
                 event.meta.sessionChangeset = { _tag: 'unset' }
               }
+            }
+            if (mergeResult.rollbackEvents.length > 0) {
+              yield* stateHead
+                .set(mergeResult.rollbackEvents[0]!.parentSeqNum)
+                .pipe(Effect.mapError((cause) => MaterializeError.make({ cause })))
             }
 
             // Barrier: before the atomic queue reconciliation (the "discard + re-offer" step).

--- a/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
+++ b/packages/@livestore/livestore/src/live-queries/__snapshots__/db-query.test.ts.snap
@@ -126,6 +126,19 @@ exports[`otel > QueryBuilder subscription - async iterator 2`] = `
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -269,6 +282,19 @@ exports[`otel > QueryBuilder subscription - async iterator with skipInitialRun 2
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],
@@ -416,6 +442,19 @@ exports[`otel > QueryBuilder subscription - basic functionality 2`] = `
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -561,6 +600,19 @@ exports[`otel > QueryBuilder subscription - direct table subscription 2`] = `
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -704,6 +756,19 @@ exports[`otel > QueryBuilder subscription - skipInitialRun 2`] = `
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],
@@ -877,6 +942,19 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -915,6 +993,19 @@ exports[`otel > QueryBuilder subscription - unsubscribe functionality 2`] = `
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],
@@ -1050,6 +1141,19 @@ exports[`otel > otel 4`] = `
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],
@@ -1365,6 +1469,19 @@ exports[`otel > with thunks 8`] = `
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -1504,6 +1621,19 @@ exports[`otel > with thunks with query builder and without labels 4`] = `
                 "_name": "livestore.in-memory-db:execute",
                 "attributes": {
                   "sql.query": "INSERT INTO 'todos' ("id", "text", "completed") VALUES (?, ?, ?)",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -16,6 +16,8 @@ import {
   prepareBindValues,
   QueryBuilderAstSymbol,
   resolveSessionIdSymbolInBindValues,
+  SqliteDbHelper,
+  StateHead,
   type StorageMode,
   type SyncState,
   UnknownError,
@@ -207,6 +209,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     this.storageMode = clientSession.leaderThread.initialState.storageMode
 
     const reactivityGraph = makeReactivityGraph()
+    const stateHead = StateHead.make({ dbState: clientSession.sqliteDb })
 
     const syncProcessor = makeClientSessionSyncProcessor({
       schema,
@@ -223,6 +226,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
             if (resolution._tag === 'unknown') {
               // Runtime schema doesn't know this event yet; skip materialization but
               // keep the log entry so upgraded clients can replay it later.
+              yield* stateHead.set(eventEncoded.seqNum)
               return {
                 writeTables: new Set<string>(),
                 sessionChangeset: { _tag: 'no-op' as const },
@@ -288,9 +292,13 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
             }
 
             const sessionChangeset = this[StoreInternalsSymbol].sqliteDbWrapper.withChangeset(exec).changeset
+            yield* stateHead.set(eventEncoded.seqNum)
 
             return { writeTables: writeTablesForEvent, sessionChangeset, materializerHash }
-          }).pipe(Effect.mapError((cause) => MaterializeError.make({ cause }))),
+          }).pipe(
+            SqliteDbHelper.withSavepoint(clientSession.sqliteDb),
+            Effect.mapError((cause) => MaterializeError.make({ cause })),
+          ),
       ),
       rollback: (changeset) => {
         this[StoreInternalsSymbol].sqliteDbWrapper.rollback(changeset)
@@ -310,7 +318,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
         }),
       },
       confirmUnsavedChanges,
-    }).pipe(Effect.runSyncWith(effectContext.services))
+    }).pipe(Effect.provideService(StateHead.StateHead, stateHead), Effect.runSyncWith(effectContext.services))
 
     // TODO generalize the `tableRefs` concept to allow finer-grained refs
     const tableRefs: { [key: string]: Ref<null, ReactivityGraphContext, RefreshReason> } = {}

--- a/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
+++ b/packages/@livestore/react/src/__snapshots__/useClientDocument.test.tsx.snap
@@ -211,6 +211,19 @@ exports[`useClientDocument > otel > should update the data based on component ke
     ",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -253,6 +266,19 @@ exports[`useClientDocument > otel > should update the data based on component ke
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
     ",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],
@@ -423,6 +449,19 @@ exports[`useClientDocument > otel > should update the data based on component ke
     ",
                 },
               },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                },
+              },
             ],
           },
         ],
@@ -465,6 +504,19 @@ exports[`useClientDocument > otel > should update the data based on component ke
       VALUES (?, ?)
       ON CONFLICT (id) DO UPDATE SET value = json_set(value, ?, json(?))
     ",
+                },
+              },
+              {
+                "_name": "@livestore/common:execSql",
+                "attributes": {
+                  "bindValueKeys": "[
+  "$id",
+  "$seqNumGlobal",
+  "$seqNumClient",
+  "$seqNumRebaseGeneration"
+]",
+                  "span.label": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
+                  "sql": "INSERT OR REPLACE INTO __livestore_state_head (id, seqNumGlobal, seqNumClient, seqNumRebaseGeneration) VALUES ($id, $seqNumGlobal, $seqNumClient, $seqNumRebaseGeneration)",
                 },
               },
             ],

--- a/tests/package-common/src/StateHead.test.ts
+++ b/tests/package-common/src/StateHead.test.ts
@@ -1,0 +1,62 @@
+import { expect } from 'vitest'
+
+import { migrateDb, StateHead } from '@livestore/common'
+import { EventSequenceNumber } from '@livestore/common/schema'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect } from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+import { schema } from './leader-thread/fixture.ts'
+
+Vitest.describe.concurrent('StateHead', () => {
+  Vitest.live('get returns the root head for an empty current-schema state database', (test) =>
+    Effect.gen(function* () {
+      const stateHead = StateHead.make({ dbState: yield* makeDb })
+
+      expect(yield* stateHead.get).toEqual(EventSequenceNumber.Client.ROOT)
+    }).pipe(Vitest.withTestCtx(test), Effect.provide(PlatformNode.NodeFileSystem.layer)),
+  )
+
+  Vitest.live('set persists a state head', (test) =>
+    Effect.gen(function* () {
+      const dbState = yield* makeDb
+      const head = EventSequenceNumber.Client.Composite.make({ global: 1, client: 0, rebaseGeneration: 0 })
+
+      yield* StateHead.make({ dbState }).set(head)
+
+      expect(yield* StateHead.make({ dbState }).get).toEqual(head)
+    }).pipe(Vitest.withTestCtx(test), Effect.provide(PlatformNode.NodeFileSystem.layer)),
+  )
+
+  Vitest.live('set replaces the complete persisted state head', (test) =>
+    Effect.gen(function* () {
+      const dbState = yield* makeDb
+      const stateHead = StateHead.make({ dbState })
+      const initialHead = EventSequenceNumber.Client.Composite.make({
+        global: 3,
+        client: 2,
+        rebaseGeneration: 1,
+      })
+      const replacementHead = EventSequenceNumber.Client.Composite.make({
+        global: 2,
+        client: 4,
+        rebaseGeneration: 7,
+      })
+
+      yield* stateHead.set(initialHead)
+      yield* stateHead.set(replacementHead)
+
+      expect(yield* stateHead.get).toEqual(replacementHead)
+    }).pipe(Vitest.withTestCtx(test), Effect.provide(PlatformNode.NodeFileSystem.layer)),
+  )
+})
+
+const makeDb = Effect.gen(function* () {
+  const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+  const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+  const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
+  yield* migrateDb({ db: dbState, schema })
+  return dbState
+})

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -7,12 +7,13 @@ import {
   type ClientSessionLeaderThreadProxy,
   LeaderAheadError,
   makeMockSyncBackend,
+  StateHead,
   SyncState,
   type UnknownError,
 } from '@livestore/common'
 import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
-import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
+import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '@livestore/common/schema'
 import {
   type ClientSessionSyncProcessor,
   makeClientSessionSyncProcessor,
@@ -134,7 +135,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
     refreshTables: () => undefined,
     params: { leaderPushBatchSize, rebaseBarriers },
     confirmUnsavedChanges: false,
-  })
+  }).pipe(Effect.provide(StateHead.layerTest))
 
   const scope = yield* Scope.make()
   yield* processor.boot.pipe(Scope.provide(scope))
@@ -163,7 +164,30 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
       store.commit(events.todoCreated({ id: '1', text: 't1', completed: false }))
 
+      const syncState = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
+      expect(yield* StateHead.make({ dbState: store[StoreInternalsSymbol].sqliteDbWrapper }).get).toEqual(
+        syncState.localHead,
+      )
+
       yield* mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('rolls back materialized state when persisting the state head fails', (test) =>
+    Effect.gen(function* () {
+      const { makeStore } = yield* TestContext
+      const store = yield* makeStore()
+      const { sqliteDbWrapper, syncProcessor } = store[StoreInternalsSymbol]
+      const encodedEvents = yield* syncProcessor.encodeEvents([
+        events.todoCreated({ id: 'rolled-back', text: 'rolled-back', completed: false }),
+      ])
+
+      sqliteDbWrapper.execute(`DROP TABLE ${SystemTables.STATE_HEAD_META_TABLE}`)
+
+      const exit = yield* syncProcessor.materializeEvents(encodedEvents).pipe(Effect.exit)
+
+      expect(exit._tag).toEqual('Failure')
+      expect(sqliteDbWrapper.select(tables.todos.asSql().query)).toEqual([])
     }).pipe(withTestCtx(test)),
   )
 
@@ -404,7 +428,9 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
             const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
 
             const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
-            const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog })
+            const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
+              Effect.provide(StateHead.layer({ dbState })),
+            )
             yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
 
             return { dbEventlog, dbState }
@@ -445,6 +471,11 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         { id: 'client_0', text: 't1', completed: false, deletedAt: null },
         { id: 'backend_0', text: 't2', completed: false, deletedAt: null },
       ])
+
+      const syncState = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
+      expect(yield* StateHead.make({ dbState: store[StoreInternalsSymbol].sqliteDbWrapper }).get).toEqual(
+        syncState.localHead,
+      )
     }).pipe(withTestCtx(test)),
   )
 
@@ -1011,7 +1042,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
         params: { leaderPushBatchSize: 10 },
         confirmUnsavedChanges: false,
-      })
+      }).pipe(Effect.provide(StateHead.layerTest))
 
       const encoded = yield* syncProcessor.encodeEvents([
         events.todoCreated({ id: 'post-rebase', text: 'after', completed: false }),
@@ -1175,7 +1206,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
 
         params: { leaderPushBatchSize: 10 },
         confirmUnsavedChanges: false,
-      })
+      }).pipe(Effect.provide(StateHead.layerTest))
 
       const unknownEvent = LiveStoreEvent.Client.EncodedWithMeta.make({
         name: 'unknown_event_test',

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -8,6 +8,7 @@ import {
   makeMockSyncBackend,
   type RejectedPushError,
   ServerAheadError,
+  StateHead,
   StaleRebaseGenerationError,
   type SyncBackend,
   type SyncOptions,
@@ -16,7 +17,7 @@ import {
 } from '@livestore/common'
 import type { MakeLeaderThreadLayerParams } from '@livestore/common/leader-thread'
 import { LeaderThreadCtx, makeLeaderThreadLayer, ShutdownChannel as Shutdown } from '@livestore/common/leader-thread'
-import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
+import { EventSequenceNumber, LiveStoreEvent, SystemTables } from '@livestore/common/schema'
 import { EventFactory } from '@livestore/common/testing'
 import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
 import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
@@ -106,11 +107,13 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       )
 
       const result = leaderThreadCtx.dbState.select(tables.todos.asSql().query)
+      const syncState = yield* leaderThreadCtx.syncProcessor.syncState.get
 
       expect(result).toEqual([
         { id: '1', text: 't1', completed: 0, deletedAt: null },
         { id: '2', text: 't2', completed: 0, deletedAt: null },
       ])
+      expect(yield* StateHead.make({ dbState: leaderThreadCtx.dbState }).get).toEqual(syncState.localHead)
 
       yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(2), Stream.runDrain)
     }).pipe(withTestCtx()(test)),
@@ -405,6 +408,9 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         { id: '1', text: 't1', completed: 0, deletedAt: null },
         { id: '2', text: 't2', completed: 0, deletedAt: null },
       ])
+
+      const syncState = yield* leaderThreadCtx.syncProcessor.syncState.get
+      expect(yield* StateHead.make({ dbState: leaderThreadCtx.dbState }).get).toEqual(syncState.localHead)
 
       const queueResults = yield* Queue.clear(testContext.pullQueue)
       expect(queueResults[0]!.payload._tag).toEqual('upstream-advance')
@@ -887,6 +893,8 @@ const LeaderThreadCtxLive = ({
     const shutdownProxy =
       captureShutdown === true ? yield* WebChannel.queueChannelProxy({ schema: Shutdown.All }) : undefined
 
+    const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
+    const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
     const leaderContextLayer = makeLeaderThreadLayer({
       schema,
       storeId: 'test',
@@ -904,15 +912,15 @@ const LeaderThreadCtxLive = ({
           initialSyncOptions: syncOptions?.initialSyncOptions,
         }),
       },
-      dbState: yield* makeSqliteDb({ _tag: 'in-memory' }),
-      dbEventlog: yield* makeSqliteDb({ _tag: 'in-memory' }),
+      dbState,
+      dbEventlog,
       devtoolsOptions: { enabled: false },
       shutdownChannel: shutdownProxy?.webChannel ?? (yield* WebChannel.noopChannel<any, any>()),
       testing: {
         ...omitUndefineds({ syncProcessor }),
       },
       ...omitUndefineds({ params }),
-    }).pipe(Layer.provide(FetchHttpClient.layer))
+    }).pipe(Layer.provide(StateHead.layer({ dbState })), Layer.provide(FetchHttpClient.layer))
 
     const testContextLayer = Effect.gen(function* () {
       const leaderThreadCtx = yield* LeaderThreadCtx

--- a/tests/package-common/src/leader-thread/stream-events.test.ts
+++ b/tests/package-common/src/leader-thread/stream-events.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest'
 
 import type { BootStatus } from '@livestore/common'
-import { SyncState } from '@livestore/common'
+import { StateHead, SyncState } from '@livestore/common'
 import { Eventlog, makeMaterializeEvent, recreateDb, streamEventsWithSyncState } from '@livestore/common/leader-thread'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
 import { EventFactory } from '@livestore/common/testing'
@@ -46,7 +46,9 @@ const makeTestEnvironment = Effect.gen(function* () {
   yield* Eventlog.initEventlogDb(dbEventlog)
 
   const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
-  const materializeEvent = yield* makeMaterializeEvent({ schema: fixtureSchema, dbState, dbEventlog })
+  const materializeEvent = yield* makeMaterializeEvent({ schema: fixtureSchema, dbState, dbEventlog }).pipe(
+    Effect.provide(StateHead.layer({ dbState })),
+  )
   yield* recreateDb({ dbState, dbEventlog, schema: fixtureSchema, bootStatusQueue, materializeEvent })
   yield* Queue.shutdown(bootStatusQueue)
 

--- a/tests/package-common/src/leader-thread/unknown-events.test.ts
+++ b/tests/package-common/src/leader-thread/unknown-events.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'vitest'
 
-import { sql } from '@livestore/common'
-import { Eventlog, makeMaterializeEvent } from '@livestore/common/leader-thread'
+import type { BootStatus } from '@livestore/common'
+import { sql, StateHead } from '@livestore/common'
+import { Eventlog, makeMaterializeEvent, recreateDb } from '@livestore/common/leader-thread'
 import type { UnknownEvents } from '@livestore/common/schema'
 import {
   EventSequenceNumber,
@@ -14,7 +15,7 @@ import {
 import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
 import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Effect, Option, Result, Schema } from '@livestore/utils/effect'
+import { Effect, Option, Queue, Result, Schema } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
 // Verifies the behaviour of LiveStore's unknown-event handling strategies across
@@ -25,7 +26,7 @@ import { PlatformNode } from '@livestore/utils/node'
 Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
   Vitest.live('warn strategy keeps event in log and continues', (test) =>
     Effect.gen(function* () {
-      const { materializeEvent, dbEventlog } = yield* setup({ strategy: 'warn' })
+      const { materializeEvent, dbEventlog, dbState } = yield* setup({ strategy: 'warn' })
       const event = makeUnknownEncodedEvent()
 
       const result = yield* materializeEvent(event, { skipEventlog: false })
@@ -35,6 +36,7 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
 
       const rows = dbEventlog.select<{ name: string; schemaHash: number }>(sql`SELECT name, schemaHash FROM eventlog`)
       expect(rows).toEqual([{ name: event.name, schemaHash: UNKNOWN_EVENT_SCHEMA_HASH }])
+      expect(yield* StateHead.make({ dbState }).get).toEqual(event.seqNum)
     }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
   )
 
@@ -108,7 +110,12 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
       const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
       yield* Eventlog.initEventlogDb(dbEventlog)
 
-      const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog })
+      const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
+      const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
+        Effect.provide(StateHead.layer({ dbState })),
+      )
+      yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
+      yield* Queue.shutdown(bootStatusQueue)
 
       const event = new LiveStoreEvent.Client.EncodedWithMeta({
         name: 'known-event',
@@ -122,6 +129,35 @@ Vitest.describe.concurrent('unknown event handling in materializeEvent', () => {
       const result = yield* materializeEvent(event, {})
 
       expect(result.sessionChangeset._tag).toEqual('no-op')
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+
+  Vitest.live('rematerialization advances the state head over unknown no-op events', (test) =>
+    Effect.gen(function* () {
+      const { materializeEvent: sourceMaterializeEvent, dbEventlog, schema } = yield* setup({ strategy: 'warn' })
+      const event = makeUnknownEncodedEvent()
+      yield* sourceMaterializeEvent(event, { skipEventlog: false })
+
+      const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+      const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+      const rematerializedState = yield* makeSqliteDb({ _tag: 'in-memory' })
+      const rematerializeEvent = yield* makeMaterializeEvent({
+        schema,
+        dbState: rematerializedState,
+        dbEventlog,
+      }).pipe(Effect.provide(StateHead.layer({ dbState: rematerializedState })))
+
+      const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
+      yield* recreateDb({
+        dbState: rematerializedState,
+        dbEventlog,
+        schema,
+        bootStatusQueue,
+        materializeEvent: rematerializeEvent,
+      })
+      yield* Queue.shutdown(bootStatusQueue)
+
+      expect(yield* StateHead.make({ dbState: rematerializedState }).get).toEqual(event.seqNum)
     }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
   )
 })
@@ -155,7 +191,12 @@ const setup = (config: UnknownEvents.HandlingConfig) =>
     const schema = makeSchemaWith(config)
     yield* Eventlog.initEventlogDb(dbEventlog)
 
-    const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog })
+    const bootStatusQueue = yield* Queue.unbounded<BootStatus>()
+    const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
+      Effect.provide(StateHead.layer({ dbState })),
+    )
+    yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
+    yield* Queue.shutdown(bootStatusQueue)
 
-    return { materializeEvent, dbEventlog, schema }
+    return { materializeEvent, dbEventlog, dbState, schema }
   })

--- a/tests/package-common/src/test-adapter.ts
+++ b/tests/package-common/src/test-adapter.ts
@@ -6,6 +6,7 @@ import {
   makeClientSession,
   migrateDb,
   type SqliteDb,
+  StateHead,
   type SyncOptions,
   UnknownError,
 } from '@livestore/common'
@@ -174,7 +175,7 @@ const makeLocalLeaderThread = ({
         shutdownChannel,
         syncPayloadEncoded,
         syncPayloadSchema,
-      }),
+      }).pipe(Layer.provide(StateHead.layer({ dbState }))),
     )
 
     return yield* Effect.gen(function* () {


### PR DESCRIPTION
## Problem

Persisted web sessions currently infer the state snapshot cursor from the latest `__livestore_session_changeset` row. Those rows are rollback metadata rather than durable snapshot identity, so their retention policy is coupled to fast-path restore correctness. This also makes a no-op or unknown event invisible to the snapshot cursor during rematerialization.

This is the first independently mergeable slice extracted from #1299.

## Solution

- Add a `StateHead` Effect service backed by a dedicated single-row `__livestore_state_head` table.
- Advance the state head after leader and client-session materialization, including unknown-event no-ops, and restore it to the rollback point during rebases.
- Provide the service to `makeMaterializeEvent`, `LeaderSyncProcessor`, and `ClientSessionSyncProcessor` through Effect layers.
- Restore persisted and single-tab web snapshots from the dedicated head.

The physical session-changeset table, event metadata, rollback mechanism, and leader/session pull contract remain unchanged in this PR. Journal abstraction and confirmation-driven pruning stay in later #1299 slices.

Trade-off: this adds one internal SQLite system table.

## Validation

- `devenv tasks run lint:full:fix`
- `devenv tasks run lint:full`
- `devenv tasks run ts:check`
- `devenv tasks run test:unit`
- `vitest run` for `StateHead`, `unknown-events`, `stream-events`, `LeaderSyncProcessor`, and `ClientSessionSyncProcessor` suites
  - 66 tests passed across the final focused runs; 1 pre-existing test skipped
- Commit hook `check-quick`
- `git diff --check`

## Related issues

- Extracted from #1299