### PR TITLE
refactor(common): simplify system-table checks with ReadonlyArray.every

### DIFF
--- a/.changeset/empty-table-checks.md
+++ b/.changeset/empty-table-checks.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Refactors internal system-table checks only.

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -9,6 +9,7 @@ import {
   Layer,
   Option,
   Queue,
+  ReadonlyArray,
   Schema,
   Stream,
   Subscribable,
@@ -244,24 +245,12 @@ export const makeLeaderThreadLayer = ({
 
 const hasEventlogTables = (db: SqliteDb) => {
   const tableNames = new Set(db.select<{ name: string }>(sql`select name from sqlite_master`).map((_) => _.name))
-  const eventlogTables = new Set(SystemTables.eventlogSystemTables.map((_) => _.sqliteDef.name))
-  return isSubsetOf(eventlogTables, tableNames)
+  return ReadonlyArray.every(SystemTables.eventlogSystemTables, (_) => tableNames.has(_.sqliteDef.name))
 }
 
 const hasStateTables = (db: SqliteDb) => {
   const tableNames = new Set(db.select<{ name: string }>(sql`select name from sqlite_master`).map((_) => _.name))
-  const stateTables = new Set(SystemTables.stateSystemTables.map((_) => _.sqliteDef.name))
-  return isSubsetOf(stateTables, tableNames)
-}
-
-const isSubsetOf = (a: Set<string>, b: Set<string>): boolean => {
-  for (const item of a) {
-    if (b.has(item) === false) {
-      return false
-    }
-  }
-
-  return true
+  return ReadonlyArray.every(SystemTables.stateSystemTables, (_) => tableNames.has(_.sqliteDef.name))
 }
 
 const getInitialSyncState = ({


### PR DESCRIPTION
## Problem

Leader-thread boot used a local `isSubsetOf` helper and constructed temporary sets for the required eventlog and state system tables. The helper duplicated a standard collection predicate and made the table-existence checks more indirect.

## Solution

Use Effect's `ReadonlyArray.every` directly over the existing system-table arrays while retaining the native `Set` for SQLite table-name lookups. This removes the helper and avoids constructing a second set for each check without changing table-detection behavior.

An empty changeset records that this internal refactor has no release-note impact. No intent-layer or derived documentation changed because system behavior and contracts are unchanged.

## Validation

- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check`
- `devenv tasks run test:unit`
- Repository pre-commit `check-quick` hook
- `git diff --check`

The documented `devenv tasks run test:run` command is not available on current `main`; the repository-wide `test:unit` task was used as the relevant replacement.

## Related issues

- None. The existing issue search did not find a directly related tracker for this internal cleanup.