### PR TITLE
fix(utils)!: preserve failures in sync/Promise/Effect helper

### DIFF
--- a/.changeset/fix-try-effect-helper.md
+++ b/.changeset/fix-try-effect-helper.md
@@ -1,0 +1,7 @@
+---
+"@livestore/utils": minor
+---
+
+Breaking: rename `Effect.tryAll` to `Effect.trySyncOrPromiseOrEffect`.
+
+Promise rejections now fail with `Cause.UnknownError`, and returned Effects preserve their failure and service channels.

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -43,7 +43,8 @@ export const recreateDb = ({
     const tmpDb = dbState
     yield* configureConnection(tmpDb, { foreignKeys: true })
 
-    yield* Effect.tryAll(() => hooks?.init?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user hook errors are immediately normalized to LiveStore UnknownError
+    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.init?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
 
     const migrationsReport = yield* migrateDb({
       db: tmpDb,
@@ -51,7 +52,8 @@ export const recreateDb = ({
       onProgress: ({ done, total }) => Queue.offer(bootStatusQueue, { stage: 'migrating', progress: { done, total } }),
     })
 
-    yield* Effect.tryAll(() => hooks?.pre?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user hook errors are immediately normalized to LiveStore UnknownError
+    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.pre?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
 
     yield* rematerializeFromEventlog({
       // db: tmpDb,
@@ -62,7 +64,8 @@ export const recreateDb = ({
         Queue.offer(bootStatusQueue, { stage: 'rehydrating', progress: { done, total } }),
     })
 
-    yield* Effect.tryAll(() => hooks?.post?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user hook errors are immediately normalized to LiveStore UnknownError
+    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.post?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
 
     // TODO bring back
     // Import the temporary in-memory database into the persistent database

--- a/packages/@livestore/common/src/schema/unknown-events.ts
+++ b/packages/@livestore/common/src/schema/unknown-events.ts
@@ -72,7 +72,8 @@ const handleUnknownEvent = ({
       case 'callback': {
         const callback = config.onUnknownEvent
 
-        yield* Effect.tryAll<void>(() => callback(context, error)).pipe(
+        // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user callback errors are immediately handled and logged below
+        yield* Effect.trySyncOrPromiseOrEffect(() => callback(context, error)).pipe(
           Effect.catch((cause) =>
             Effect.logWarning('@livestore/common:schema:unknown-event:callback-error', {
               event: context.event,

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -434,7 +434,8 @@ export const createStore = <
 
       if (boot !== undefined) {
         // TODO also incorporate `boot` function progress into `bootStatusQueue`
-        yield* Effect.tryAll(() =>
+        // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user boot errors are immediately normalized to LiveStore UnknownError
+        yield* Effect.trySyncOrPromiseOrEffect(() =>
           boot(store, { migrationsReport: clientSession.leaderThread.initialState.migrationsReport, parentSpan: span }),
         ).pipe(
           UnknownError.mapToUnknownError,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/pull.ts
@@ -31,7 +31,7 @@ export const makeEndingPullStream = ({
     const { doOptions, backendId, storeId, storage } = yield* DoCtx.DoCtx
 
     if (doOptions?.onPull !== undefined) {
-      yield* Effect.tryAll(() =>
+      yield* Effect.trySyncOrPromiseOrEffect(() =>
         doOptions.onPull!(req, {
           storeId,
           ...(payload !== undefined ? { payload } : {}),
@@ -79,7 +79,7 @@ export const makeEndingPullStream = ({
       Stream.tap(
         Effect.fn(function* (res) {
           if (doOptions?.onPullRes !== undefined) {
-            yield* Effect.tryAll(() => doOptions.onPullRes!(res)).pipe(UnknownError.mapToUnknownError)
+            yield* Effect.trySyncOrPromiseOrEffect(() => doOptions.onPullRes!(res)).pipe(UnknownError.mapToUnknownError)
           }
         }),
       ),

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -46,7 +46,7 @@ export const makePush =
       }
 
       if (options?.onPush !== undefined) {
-        yield* Effect.tryAll(() =>
+        yield* Effect.trySyncOrPromiseOrEffect(() =>
           options.onPush!(pushRequest, {
             storeId,
             ...(payload !== undefined ? { payload } : {}),
@@ -140,7 +140,9 @@ export const makePush =
           for (const { response, encoded } of responses) {
             // Only calling once for now.
             if (options?.onPullRes !== undefined) {
-              yield* Effect.tryAll(() => options.onPullRes!(response)).pipe(UnknownError.mapToUnknownError)
+              yield* Effect.trySyncOrPromiseOrEffect(() => options.onPullRes!(response)).pipe(
+                UnknownError.mapToUnknownError,
+              )
             }
 
             // NOTE we're also sending the pullRes chunk to the pushing ws client as confirmation
@@ -194,7 +196,9 @@ export const makePush =
       Effect.tap(
         Effect.fn(function* (message) {
           if (options?.onPushRes !== undefined) {
-            yield* Effect.tryAll(() => options.onPushRes!(message)).pipe(UnknownError.mapToUnknownError)
+            yield* Effect.trySyncOrPromiseOrEffect(() => options.onPushRes!(message)).pipe(
+              UnknownError.mapToUnknownError,
+            )
           }
         }),
       ),

--- a/packages/@livestore/utils/src/effect/Effect.test.ts
+++ b/packages/@livestore/utils/src/effect/Effect.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, expectTypeOf, it } from '@effect/vitest'
+import { Cause, Effect } from 'effect'
+
+import { trySyncOrPromiseOrEffect } from './Effect.ts'
+
+interface RequiredService {
+  readonly RequiredService: unique symbol
+}
+
+declare const contextualEffect: Effect.Effect<number, 'effect-error', RequiredService>
+
+describe('trySyncOrPromiseOrEffect', () => {
+  it.effect('returns a plain value', () =>
+    Effect.gen(function* () {
+      const result = yield* trySyncOrPromiseOrEffect(() => 42 as const)
+
+      expect(result).toBe(42)
+    }),
+  )
+
+  it.effect('evaluates the operation lazily for each execution', () =>
+    Effect.gen(function* () {
+      let executions = 0
+      const effect = trySyncOrPromiseOrEffect(() => ++executions)
+
+      expect(executions).toBe(0)
+      expect(yield* effect).toBe(1)
+      expect(yield* effect).toBe(2)
+    }),
+  )
+
+  it.effect('maps a synchronous throw to an UnknownError', () =>
+    Effect.gen(function* () {
+      const thrown = new Error('thrown')
+      const failure = yield* trySyncOrPromiseOrEffect(() => {
+        throw thrown
+      }).pipe(Effect.flip)
+
+      expect(failure).toBeInstanceOf(Cause.UnknownError)
+      if (failure instanceof Cause.UnknownError) {
+        expect(failure.cause).toBe(thrown)
+      }
+    }),
+  )
+
+  it.effect('awaits a resolving Promise', () =>
+    Effect.gen(function* () {
+      const result = yield* trySyncOrPromiseOrEffect(() => Promise.resolve('resolved'))
+
+      expect(result).toBe('resolved')
+    }),
+  )
+
+  it.effect('maps a rejected Promise to an UnknownError', () =>
+    Effect.gen(function* () {
+      const rejected = new Error('rejected')
+      const failure = yield* trySyncOrPromiseOrEffect(() => Promise.reject(rejected)).pipe(Effect.flip)
+
+      expect(failure).toBeInstanceOf(Cause.UnknownError)
+      if (failure instanceof Cause.UnknownError) {
+        expect(failure.cause).toBe(rejected)
+      }
+    }),
+  )
+
+  it.effect('executes and returns the value of a returned Effect', () =>
+    Effect.gen(function* () {
+      const result = yield* trySyncOrPromiseOrEffect(() => Effect.succeed('effect-value'))
+
+      expect(result).toBe('effect-value')
+    }),
+  )
+
+  it.effect('preserves a returned Effect failure', () =>
+    Effect.gen(function* () {
+      const expected = { _tag: 'ExpectedError' as const }
+      const failure = yield* trySyncOrPromiseOrEffect(() => Effect.fail(expected)).pipe(Effect.flip)
+
+      expect(failure).toBe(expected)
+    }),
+  )
+
+  it('preserves returned Effect success, error, and requirements types', () => {
+    const normalized = trySyncOrPromiseOrEffect(() => contextualEffect)
+
+    expectTypeOf(normalized).toEqualTypeOf<
+      Effect.Effect<number, 'effect-error' | Cause.UnknownError, RequiredService>
+    >()
+  })
+
+  it('returns an Effect when the operation only throws', () => {
+    const normalized = trySyncOrPromiseOrEffect((): never => {
+      throw new Error('thrown')
+    })
+
+    expectTypeOf(normalized).toEqualTypeOf<Effect.Effect<never, Cause.UnknownError>>()
+  })
+})

--- a/packages/@livestore/utils/src/effect/Effect.test.ts
+++ b/packages/@livestore/utils/src/effect/Effect.test.ts
@@ -63,6 +63,25 @@ describe('trySyncOrPromiseOrEffect', () => {
     }),
   )
 
+  it.effect('maps a throwing Promise-like then getter to an UnknownError', () =>
+    Effect.gen(function* () {
+      const thrown = new Error('throwing then getter')
+      const thenable = {
+        // oxlint-disable-next-line eslint-plugin-unicorn(no-thenable) -- intentionally exercises Promise-like classification
+        get then(): PromiseLike<never>['then'] {
+          throw thrown
+        },
+      } satisfies PromiseLike<never>
+
+      const failure = yield* trySyncOrPromiseOrEffect(() => thenable).pipe(Effect.flip)
+
+      expect(failure).toBeInstanceOf(Cause.UnknownError)
+      if (failure instanceof Cause.UnknownError) {
+        expect(failure.cause).toBe(thrown)
+      }
+    }),
+  )
+
   it.effect('executes and returns the value of a returned Effect', () =>
     Effect.gen(function* () {
       const result = yield* trySyncOrPromiseOrEffect(() => Effect.succeed('effect-value'))

--- a/packages/@livestore/utils/src/effect/Effect.ts
+++ b/packages/@livestore/utils/src/effect/Effect.ts
@@ -49,20 +49,31 @@ export type SyncOrPromiseOrEffect<TResult, TError = never, TContext = never> =
   | Promise<TResult>
   | Effect.Effect<TResult, TError, TContext>
 
-export const tryAll = <Res>(
-  fn: () => Res,
-): Res extends Effect.Effect<infer A, infer E>
-  ? Effect.Effect<A, E | Cause.UnknownError>
-  : Res extends Promise<infer A>
-    ? Effect.Effect<A, Cause.UnknownError>
-    : Effect.Effect<Res, Cause.UnknownError> =>
-  Effect.try({ try: () => fn(), catch: (cause) => new Cause.UnknownError(cause) }).pipe(
-    Effect.andThen((fnRes) =>
-      Effect.isEffect(fnRes) === true
-        ? (fnRes as any as Effect.Effect<any>)
-        : Predicate.isPromiseLike(fnRes) === true
-          ? Effect.promise(() => fnRes)
-          : Effect.succeed(fnRes),
+/**
+ * Creates an Effect from an operation that may return a value, a Promise-like value, or another Effect.
+ *
+ * @remarks
+ * Synchronous values succeed directly, and Promise-like values are awaited. Synchronous throws and Promise rejections
+ * are mapped to `Cause.UnknownError`. When the operation returns an Effect, that Effect is executed rather than
+ * produced as a successful value; its failures and service requirements are preserved.
+ *
+ * @param operation - A callback that may return a synchronous value, a Promise-like value, or an Effect
+ * @returns An Effect representing the normalized outcome of the operation
+ */
+export const trySyncOrPromiseOrEffect = <Return>(
+  operation: () => Return,
+): Effect.Effect<
+  Return extends Effect.Effect<infer A, infer _E, infer _R> ? A : Return extends PromiseLike<infer A> ? A : Return,
+  Cause.UnknownError | (Return extends Effect.Effect<infer _A, infer E, infer _R> ? E : never),
+  Return extends Effect.Effect<infer _A, infer _E, infer R> ? R : never
+> =>
+  Effect.try({ try: operation, catch: (cause) => new Cause.UnknownError(cause) }).pipe(
+    Effect.andThen((result) =>
+      Effect.isEffect(result) === true
+        ? result
+        : Predicate.isPromiseLike(result) === true
+          ? Effect.tryPromise(() => result)
+          : Effect.succeed(result),
     ),
   ) as any
 

--- a/packages/@livestore/utils/src/effect/Effect.ts
+++ b/packages/@livestore/utils/src/effect/Effect.ts
@@ -60,22 +60,32 @@ export type SyncOrPromiseOrEffect<TResult, TError = never, TContext = never> =
  * @param operation - A callback that may return a synchronous value, a Promise-like value, or an Effect
  * @returns An Effect representing the normalized outcome of the operation
  */
-export const trySyncOrPromiseOrEffect = <Return>(
+export function trySyncOrPromiseOrEffect<Return>(
   operation: () => Return,
 ): Effect.Effect<
   Return extends Effect.Effect<infer A, infer _E, infer _R> ? A : Return extends PromiseLike<infer A> ? A : Return,
   Cause.UnknownError | (Return extends Effect.Effect<infer _A, infer E, infer _R> ? E : never),
   Return extends Effect.Effect<infer _A, infer _E, infer R> ? R : never
-> =>
-  Effect.try({ try: operation, catch: (cause) => new Cause.UnknownError(cause) }).pipe(
-    Effect.andThen((result) =>
-      Effect.isEffect(result) === true
-        ? result
-        : Predicate.isPromiseLike(result) === true
-          ? Effect.tryPromise(() => result)
-          : Effect.succeed(result),
-    ),
-  ) as any
+>
+export function trySyncOrPromiseOrEffect(operation: () => unknown): Effect.Effect<unknown, unknown, unknown> {
+  return Effect.try({
+    try: () => {
+      const result = operation()
+
+      if (Effect.isEffect(result) === true) {
+        // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- dynamic implementation boundary; the public overload preserves exact Effect error and requirement channels
+        return result
+      }
+
+      if (Predicate.isPromiseLike(result) === true) {
+        return Effect.tryPromise(() => result)
+      }
+
+      return Effect.succeed(result)
+    },
+    catch: (cause) => new Cause.UnknownError(cause),
+  }).pipe(Effect.flatten)
+}
 
 export const acquireReleaseLog = (label: string) =>
   Effect.acquireRelease(Effect.log(`${label} acquire`), (_, ex) => Effect.log(`${label} release`, ex))


### PR DESCRIPTION
## Problem

The exported `Effect.tryAll` utility did not preserve the full contract of operations that can return synchronous values, Promise-like values, or Effects:

- rejected Promises were passed through `Effect.promise`, turning rejection into a defect instead of a typed `Cause.UnknownError`
- inspecting a Promise-like result could throw outside the typed boundary, also turning the failure into a defect
- returned Effect service requirements were dropped from the declared result
- returned Effect errors were not reliably preserved alongside wrapper failures
- an operation returning `never` collapsed the conditional return type instead of producing an Effect

## Solution

- Rename the helper to `trySyncOrPromiseOrEffect` and update every repository call site.
- Use `Effect.tryPromise` for Promise-like results so rejection stays in the typed error channel.
- Run both the operation and runtime result classification inside `Effect.try`, then flatten the selected Effect so classification-time throws become typed `Cause.UnknownError` failures.
- Preserve returned Effect success, error, and service channels while retaining `Cause.UnknownError` for wrapper failures.
- Use a precise generic overload with an `unknown`-based implementation boundary, removing the previous `as any` assertion without weakening caller inference.
- Add focused runtime and compile-time tests for values, repeated execution, throws, Promise resolution/rejection, a throwing Promise-like `then` getter, returned Effect success/failure, exact A/E/R preservation, and `Return = never`.
- Document the public behavior with conformant TSDoc and add the required minor changeset.
- Scope Effect language-service suppressions to dynamic or user-provided boundaries whose `unknown` channels are immediately normalized or handled.

The compatibility trade-off is intentional: no `tryAll` alias remains. Consumers of `@livestore/utils/effect` must rename their calls, and the changeset records this as a pre-1.0 minor breaking change.

## Validation

- `pnpm exec vitest run packages/@livestore/utils/src/effect/Effect.test.ts --project @livestore/utils` (10 tests passed)
- `pnpm exec vitest run --project @livestore/utils` (46 tests across 10 files passed)
- `devenv tasks run test:unit` (passed before and after rebasing onto current `main`)
- `devenv tasks run ts:check` (passed after the Promise-like classification fix)
- pre-commit `check:quick` (passed)
- `devenv tasks run lint:full:fix` (passed)
- `devenv tasks run lint:full` (passed)
- `devenv tasks run release:changeset:check-bodies` (passed)
- `git diff --check` and stale `tryAll` source searches (passed; the changeset migration reference is intentional)

The older documented `devenv tasks run test:run` command is not exposed by this revision, so the current repository-wide `test:unit` task was used instead.

### Demo (optional)

```text
operation()
├─ value              → Effect.succeed
├─ PromiseLike<A>     → Effect.tryPromise → Cause.UnknownError on rejection or inspection throw
└─ Effect<A, E, R>    → Effect<A, Cause.UnknownError | E, R>
```

## Related issues

- Closes #1526