### PR TITLE
Prevent duplicate events by keeping sync work ordered and tracked

### DIFF
--- a/.changeset/fix-prefix-fenced-sync-propagation.md
+++ b/.changeset/fix-prefix-fenced-sync-propagation.md
@@ -3,4 +3,4 @@
 '@livestore/livestore': patch
 ---
 
-Prevent later client-session events from reaching the leader before an older rejected pending prefix is reconciled. Rejected pushes now fence upstream propagation until pull recovery atomically reseeds the complete pending suffix, and the leader rejects pushed batches that skip their required sequence or parent prefix.
+Prevent later client-session events from reaching the leader before an older rejected pending prefix is reconciled. Rejected pushes now fence upstream propagation until pull recovery atomically reseeds the complete pending suffix. Leader admission atomically reserves validated batches through queue drain until apply, rejection, or stale dropping, and parent contiguity compares DAG position independently of local rebase generation while stale epochs remain checked separately.

--- a/.changeset/fix-prefix-fenced-sync-propagation.md
+++ b/.changeset/fix-prefix-fenced-sync-propagation.md
@@ -1,0 +1,6 @@
+---
+'@livestore/common': patch
+'@livestore/livestore': patch
+---
+
+Prevent later client-session events from reaching the leader before an older rejected pending prefix is reconciled. Rejected pushes now fence upstream propagation until pull recovery atomically reseeds the complete pending suffix, and the leader rejects pushed batches that skip their required sequence or parent prefix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ### Changed
 
 - Removed redundant devenv package entries now owned by the task guard modules.
+- **Sync correctness:** Prevented a later client-session event from reaching the
+  leader before an older rejected pending prefix is reconciled, avoiding
+  duplicate event materialization during multi-writer rebases
+  ([#1530](https://github.com/livestorejs/livestore/pull/1530)).
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@
 ### Changed
 
 - Removed redundant devenv package entries now owned by the task guard modules.
-- **Sync correctness:** Prevented a later client-session event from reaching the
-  leader before an older rejected pending prefix is reconciled, avoiding
-  duplicate event materialization during multi-writer rebases
+- **Sync correctness:** Prevented later client-session events from crossing an
+  older rejected pending prefix, and made leader admission retain explicit
+  reservation ownership through queue drain until apply, rejection, or stale
+  dropping. Parent contiguity now compares DAG position independently of local
+  rebase generation while stale epochs remain checked separately, avoiding
+  duplicate materialization and ghost fences during multi-writer rebases
   ([#1530](https://github.com/livestorejs/livestore/pull/1530)).
 
 ### Internal Changes

--- a/context/02-system/03-sync/01-syncstate/spec.md
+++ b/context/02-system/03-sync/01-syncstate/spec.md
@@ -67,6 +67,22 @@ Branch semantics:
   plus all local pending, then re-parents pending onto the new upstream
   head; propagates an upstream-initiated rebase downstream.
 
+### Prefix-confirmation precondition
+
+An upstream advance may confirm only a prefix of this node's pending events.
+Equivalently, an incoming event must not be another incarnation of an event
+that appears later in pending behind an unresolved older event. `merge` is
+positional and cannot recover that identity after rebase has changed sequence
+positions: given incoming `[B]` and pending `[A, B]`, it treats both pending
+events as divergent and schedules `[B, A', B']` for materialization.
+
+The processor drivers own this precondition. A rejected or uncertain push must
+fence later pending events until pull reconciliation confirms the accepted
+prefix or rebases the complete remaining suffix (LS.SYS.SYNC.PROC-R04 and its
+[decision](../02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md)).
+The current client-session rejection path violates that contract; see
+[DELTA-001](../02-processors/.delta/DELTA-001-session-rejection-prefix-bypass.md).
+
 ## Invariants
 
 `validateSyncState` (`:532-566`) and `validateMergeResult` (`:568-613`)

--- a/context/02-system/03-sync/01-syncstate/spec.md
+++ b/context/02-system/03-sync/01-syncstate/spec.md
@@ -80,7 +80,7 @@ The processor drivers own this precondition. A rejected or uncertain push must
 fence later pending events until pull reconciliation confirms the accepted
 prefix or rebases the complete remaining suffix (LS.SYS.SYNC.PROC-R04 and its
 [decision](../02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md)).
-The current client-session rejection path violates that contract; see
+The processor implementation and its resolved divergence are recorded in
 [DELTA-001](../02-processors/.delta/DELTA-001-session-rejection-prefix-bypass.md).
 
 ## Invariants

--- a/context/02-system/03-sync/02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md
@@ -55,4 +55,5 @@ transaction spanning the session, leader, and backend.
   receiver prevents a buggy downstream from bypassing its prefix.
 - The existing leader→backend `ServerAheadError` path already approximates the
   chosen state machine by parking until pull interrupts and reseeds it. The
-  client-session rejection path is the tracked implementation gap.
+  client-session path now uses the same park, reconcile, reseed, and resume
+  transition; the leader additionally rejects non-contiguous pushed batches.

--- a/context/02-system/03-sync/02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md
@@ -1,0 +1,58 @@
+# 0001 — Fence unresolved upstream prefixes before sending later events
+
+Status: accepted (SF-03 reduction evidence and maintainer confirmation,
+2026-07-31).
+
+## Context
+
+The merge core confirms pending events by matching an incoming prefix. SF-03
+showed a client session with pending `[A, B]` receiving `B` from its leader at
+an earlier sequence position. Positional divergence at `A` caused merge to
+schedule incoming `B` plus rebased `[A, B]`, materializing `B` twice.
+
+The processor schedule permits this state after an older push is rejected: the
+session records the rejection and clears its queue, but a later local commit can
+enqueue and send only its new event before pull reconciliation reconstructs the
+full pending prefix. The leader accepts monotonically newer batches without a
+per-session fence for the unresolved generation.
+
+The required atomicity is a protocol transition: no later pending event becomes
+admissible upstream between rejection and reconciliation. It is not a database
+transaction spanning the session, leader, and backend.
+
+## Options
+
+- **(a) Fence later upstream propagation until the unresolved prefix is
+  reconciled — chosen.** Local commits continue to materialize and append to
+  pending. The background driver pauses sending at that boundary. Pull either
+  confirms an accepted prefix or rebases the full remaining suffix; the driver
+  then reseeds from current pending and resumes in FIFO order. Apply the same
+  invariant at session→leader and leader→backend.
+- **(b) Give events immutable IDs and teach merge to recognize non-positional
+  overlap.** Valuable as a possible idempotency hardening, but it expands the
+  event envelope, wire protocol, persistence format, and merge semantics. It is
+  not required to prevent the processor from creating the invalid non-prefix
+  transition.
+- **(c) Block `store.commit()` behind push/rebase ownership.** Rejected because
+  upstream propagation is asynchronous and must not suspend the synchronous
+  local commit path (LS.SYS.STORE-R04).
+- **(d) Deduplicate by event name/args or application primary key.** Rejected:
+  repeated identical commits are valid, and application-level upsert/ignore
+  would hide sync corruption rather than preserve event semantics.
+
+## Consequences
+
+- Confirmed/pending overlap remains possible while acknowledgement propagates,
+  but it must be prefix-aligned and is therefore mergeable without duplicate
+  materialization.
+- Rejection and uncertain-result handling become explicit processor states;
+  later commits accumulate locally without crossing the fenced boundary.
+- This is a drain-gating rule, not a requirement to replace the FIFO queue. The
+  existing queue type can remain if its single worker cannot drain while the
+  boundary is fenced.
+- Upstream admission must accept or reject a batch as a unit and acknowledge
+  only after admission completes. Defensive generation/session fencing at the
+  receiver prevents a buggy downstream from bypassing its prefix.
+- The existing leader→backend `ServerAheadError` path already approximates the
+  chosen state machine by parking until pull interrupts and reseeds it. The
+  client-session rejection path is the tracked implementation gap.

--- a/context/02-system/03-sync/02-processors/.decisions/0002-explicit-leader-push-reservations.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0002-explicit-leader-push-reservations.md
@@ -1,0 +1,39 @@
+# 0002 — Track leader push reservations until terminal processing
+
+Status: accepted (browser/local-sync-cf reduction and deterministic barrier
+regression, 2026-08-01).
+
+## Context
+
+The leader prefix fence previously stored only the maximum sequence position.
+It advanced before queue publication and did not own a concrete reservation.
+Interruption, queue rejection, stale-generation dropping, or a pull between
+queue take and local merge could therefore leave either a ghost suffix or an
+unfenced in-flight batch. With two sessions sharing one leader, later rebased
+pushes could be rejected forever even though the leader had zero pending work.
+
+Rebase generations are local epochs rather than part of the global/client DAG
+position. A confirmed leader head and a session head can legitimately use
+different generations for the same parent position.
+
+## Decision
+
+Leader admission serializes validation, reservation, and queue publication in
+one uninterruptible critical section. Every admitted queue item remains in an
+explicit reservation set after the drain worker takes it. Processing releases
+the reservation only when the item is applied, dropped as stale, or rejected.
+Pull reconciliation combines its authoritative head with remaining compatible
+reservations instead of inferring ownership from a queue snapshot.
+
+Contiguity requires exact event sequence numbers but compares parent
+global/client position independently of rebase generation. Stale-generation
+checks remain explicit and prevent older epochs from crossing the fence.
+
+## Consequences
+
+- Queue take no longer makes in-flight work temporarily invisible to admission.
+- Rejected and dropped batches cannot retain a ghost prefix fence.
+- A newer session generation can continue from the same confirmed parent
+  position without waiting for an unrelated future pull.
+- Test-only admission hooks support deterministic barriers without adding
+  production scheduling delays.

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-001-session-rejection-prefix-bypass.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-001-session-rejection-prefix-bypass.md
@@ -1,6 +1,6 @@
 # DELTA-001 — Session rejection permits a later event to bypass its pending prefix
 
-Status: open
+Status: resolved (2026-07-31)
 
 ## Divergence
 
@@ -42,6 +42,17 @@ then resume its single worker. Add a receiver-side session/generation fence and
 whole-batch admission checks as defense in depth; do not block the synchronous
 commit path.
 
-Close when deterministic tests prove that a later commit cannot reach the
-leader before the rejected prefix is reconciled, the SF-03 regression passes,
-and the equivalent leader→backend fence remains covered.
+## Resolution
+
+The client-session push worker now parks after recording and clearing a rejected
+batch. Local commits continue accumulating synchronously, but pull must confirm
+or rebase the rejected prefix before it atomically reseeds the FIFO from live
+pending and restarts the worker. Rejection handling serializes with pull so a
+late rejection response cannot install a stale fence after recovery.
+
+The leader now validates that every pushed event forms the exact sequence and
+parent chain after its admitted `pushHead`; a sender cannot bypass the fence by
+submitting a later suffix directly. Deterministic tests cover advance recovery,
+rebase recovery, the late-response race, receiver rejection, and orderly
+shutdown. The leader→backend `ServerAheadError` path retains its equivalent
+park-until-pull behavior.

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-001-session-rejection-prefix-bypass.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-001-session-rejection-prefix-bypass.md
@@ -1,0 +1,47 @@
+# DELTA-001 — Session rejection permits a later event to bypass its pending prefix
+
+Status: open
+
+## Divergence
+
+LS.SYS.SYNC.PROC-R04 requires an unresolved upstream prefix to fence later
+pending events. `ClientSessionSyncProcessor` instead records
+`LeaderAheadError`, clears `leaderPushQueue`, and continues the push-worker
+loop. A commit admitted before pull reconciliation appends to the live pending
+suffix and queues only its newly encoded event. The worker can therefore send
+that later event while the rejected prefix remains pending
+(`packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts:157-168,
+446-457`).
+
+The leader's admission checks require a monotonically ascending batch whose
+first sequence number is ahead of `pushHeadRef`; they do not maintain a
+per-session fence for a previously rejected generation. The later event can be
+accepted and delivered first. The session then presents incoming `[B]` and
+pending `[A, B]` to positional merge, which schedules `[B, A', B']` and
+materializes `B` twice
+(`packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts:1037-1066`).
+
+Evidence: contrib Scenario System finding SF-03 (`many-writer-convergence`),
+the captured `many-writer-396` transition, and the deterministic core regression
+`does not rematerialize a pending event accepted ahead of its pending prefix`
+(`tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts:176`).
+
+## VRS
+
+Violates [requirements.md](../requirements.md) LS.SYS.SYNC.PROC-R04 and the
+prefix-confirmation precondition in
+[syncstate/spec.md](../../01-syncstate/spec.md#prefix-confirmation-precondition).
+
+## Implementation Contract
+
+On rejection or an uncertain in-flight outcome, fence the affected boundary:
+continue admitting local commits into pending, but do not send later events.
+Pull reconciliation must first confirm the accepted prefix or rebase the full
+remaining suffix, atomically reseed the push FIFO from current pending, and only
+then resume its single worker. Add a receiver-side session/generation fence and
+whole-batch admission checks as defense in depth; do not block the synchronous
+commit path.
+
+Close when deterministic tests prove that a later commit cannot reach the
+leader before the rejected prefix is reconciled, the SF-03 regression passes,
+and the equivalent leader→backend fence remains covered.

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -38,6 +38,18 @@ Builds on [../requirements.md](../requirements.md) and
   2026-07-19 (#1465, store
   [`.decisions/0001`](../../05-store/.decisions/0001-client-session-shutdown-drain.md)).
   `refines: LS.SYS.STORE-R07`
+- **LS.SYS.SYNC.PROC-R04 Prefix-fenced upstream propagation:** At both the
+  session→leader and leader→backend boundaries, a rejected push or an
+  uncertain in-flight result fences every later pending event at that boundary.
+  Local commits remain synchronously admitted and materialized, but the driver
+  must not send them past the unresolved prefix. Pull reconciliation either
+  confirms an accepted prefix or rebases the complete remaining suffix; only
+  then may the driver reseed its FIFO from current pending and resume. An
+  upstream accepts or rejects a pushed batch as a unit and does not acknowledge
+  success before admission is complete. Adopted 2026-07-31 from SF-03 reduction
+  evidence and maintainer review; see
+  [decision 0001](./.decisions/0001-prefix-fence-unresolved-upstream.md).
+  `refines: LS.SYS.SYNC.SS-R03, LS.SYS.STORE-R04`
 
 Further processor requirements (e.g. the crash-atomicity contract of batch
 materialization) remain open pending `LS.SYS.STATE-DQ2`;

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -30,19 +30,20 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 - **Local pushes** (`:235-239, 263-296`): `localPushesQueue` holds
   `[event, deferred]` items; a background fiber drains
   `takeBetween(1, localPushBatchSize)` per cycle (default 10, `:214`).
-  `validatePushBatch` (`:1037-1066`) requires strictly ascending batches
+  `validatePushBatch` requires strictly ascending batches
   (`NonMonotonicBatchError`) whose first event is ahead of
-  `pushHeadRef.current` (`LeaderAheadError`); `pushHead` advances on push
-  and on every pull merge (`:648, 521`).
+  `pushHeadRef.current` (`LeaderAheadError`) and whose complete sequence/parent
+  chain is contiguous with that head (`NonContiguousBatchError`); `pushHead`
+  advances on push and on every pull merge.
 - **Generations** (`:271-296, 321-366`): each queued item carries its
   seqNum's `rebaseGeneration`. After acquiring the mutex, items with a
   stale generation are dropped and their deferreds failed with
   `StaleRebaseGenerationError`. A merge `reject` fails the batch's
   deferreds with `LeaderAheadError`, bumps the generation, and drains
   same-generation queued items present at that moment — sessions rebase and
-  re-push. A later arrival from the rejected session/generation is not fenced
-  by the leader itself; the client-session driver is currently expected to
-  withhold it, but does not yet do so (see
+  re-push. The session driver fences later arrivals until that reconciliation;
+  leader-side contiguous-chain validation rejects a later suffix that bypasses
+  the fence (see resolved
   [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md)).
 - **Backend pushing** (`:575-637`): drains
   `takeBetween(1, backendPushBatchSize)` (default 50, `:215`), pushes
@@ -73,7 +74,9 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   is **not crash-atomic across the two databases**: a process death
   between the two COMMITs can diverge state from eventlog (healed only by
   state rebuild when the state DB is absent — see
-  `../../02-state/01-sqlite/`).
+  `../../02-state/01-sqlite/`). Local push acknowledgements are completed only
+  after the batch is materialized, published in leader sync state, offered to
+  session pull queues, and queued for backend propagation.
 - **Boot** (`:684-755`): initial sync state rehydrates from the eventlog
   (`../../04-runtime/spec.md` Leadership Handover); error routing via
   `onError: ignore|shutdown` and `BackendIdMismatchError` handling
@@ -89,12 +92,13 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   `takeBetween(1, leaderPushBatchSize)` and pushes to the leader (`:153-168`).
   Coalescing is opportunistic (whatever accumulated while the previous
   push was in flight); there is no time-based debounce. A rejected push
-  records the unresolved batch and clears the whole queue (`:161-168`), but
-  the worker remains able to drain events admitted by later commits before the
-  next pull reconciles that batch. This permits a later pending event to bypass
-  its unresolved prefix and is the open divergence from
-  LS.SYS.SYNC.PROC-R04 tracked by
-  [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md).
+  records the unresolved batch, clears the queue, and parks the sole worker.
+  Later commits remain synchronous and accumulate in pending/the FIFO without
+  crossing the boundary. Pull recovery atomically reseeds the FIFO from live
+  pending and restarts the worker. Rejection transition setup serializes with
+  pull so a late response cannot install a fence after that pull already
+  recovered the batch (resolved
+  [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md)).
 - **Pull** (`:145-168, 226-253`): a lazily-restarted stream from the
   leader (cursor = current `upstreamHead`) feeds `SyncState.merge`; a
   `reject` from upstream is impossible and dies (`:162-165`). New events
@@ -132,10 +136,6 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 
 ## Backpressure and Known Gaps
 
-- The client-session rejection path does not yet fence later events until pull
-  reconciliation. SF-03 demonstrates that the leader can consequently confirm
-  a later event while an older session prefix remains pending; see
-  [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md).
 - All processor queues are unbounded; there is no producer backpressure.
   Anti-thrash relies on interrupt/clear on rebase and queue-clear on
   rejection.

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -33,8 +33,16 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   `validatePushBatch` requires strictly ascending batches
   (`NonMonotonicBatchError`) whose first event is ahead of
   `pushHeadRef.current` (`LeaderAheadError`) and whose complete sequence/parent
-  chain is contiguous with that head (`NonContiguousBatchError`); `pushHead`
-  advances on push and on every pull merge.
+  chain is contiguous with that head (`NonContiguousBatchError`). Parent
+  continuity compares global/client position because a confirmed leader head
+  and a rebased session head may name the same position with different local
+  generations. Admission atomically records explicit per-item reservations
+  before queue publication; a reservation survives queue take and is released
+  only when its item is applied, dropped, or rejected. Pull reconciliation
+  derives `pushHead` from the authoritative head plus those live reservations,
+  so in-flight or old-generation suffixes cannot leave a ghost fence or expose
+  an unfenced gap (see
+  [.decisions/0002-explicit-leader-push-reservations.md](./.decisions/0002-explicit-leader-push-reservations.md)).
 - **Generations** (`:271-296, 321-366`): each queued item carries its
   seqNum's `rebaseGeneration`. After acquiring the mutex, items with a
   stale generation are dropped and their deferreds failed with

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -30,7 +30,7 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 - **Local pushes** (`:235-239, 263-296`): `localPushesQueue` holds
   `[event, deferred]` items; a background fiber drains
   `takeBetween(1, localPushBatchSize)` per cycle (default 10, `:214`).
-  `validatePushBatch` (`:1024-1054`) requires strictly ascending batches
+  `validatePushBatch` (`:1037-1066`) requires strictly ascending batches
   (`NonMonotonicBatchError`) whose first event is ahead of
   `pushHeadRef.current` (`LeaderAheadError`); `pushHead` advances on push
   and on every pull merge (`:648, 521`).
@@ -39,7 +39,11 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   stale generation are dropped and their deferreds failed with
   `StaleRebaseGenerationError`. A merge `reject` fails the batch's
   deferreds with `LeaderAheadError`, bumps the generation, and drains
-  same-generation queued items — sessions rebase and re-push.
+  same-generation queued items present at that moment — sessions rebase and
+  re-push. A later arrival from the rejected session/generation is not fenced
+  by the leader itself; the client-session driver is currently expected to
+  withhold it, but does not yet do so (see
+  [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md)).
 - **Backend pushing** (`:575-637`): drains
   `takeBetween(1, backendPushBatchSize)` (default 50, `:215`), pushes
   `toGlobal()` batches. Retry: `Schedule.exponential(1s)` clamped to 30s,
@@ -80,13 +84,17 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 `sync/ClientSessionSyncProcessor.ts`. One unbounded STM `leaderPushQueue`
 (`:104`) decouples `push()` (synchronous commit path) from leader I/O:
 
-- **Push** (`:341-343`): synchronously merge into local sync state and enqueue
+- **Push** (`:454-456`): synchronously merge into local sync state and enqueue
   the merge's `newEvents` without waiting for pull/rebase ownership; a background fiber drains
-  `takeBetween(1, leaderPushBatchSize)` and pushes to the leader (`:128-129`).
+  `takeBetween(1, leaderPushBatchSize)` and pushes to the leader (`:153-168`).
   Coalescing is opportunistic (whatever accumulated while the previous
   push was in flight); there is no time-based debounce. A rejected push
-  clears the whole queue (`:130-133`) — events are re-derived from the
-  next pull.
+  records the unresolved batch and clears the whole queue (`:161-168`), but
+  the worker remains able to drain events admitted by later commits before the
+  next pull reconciles that batch. This permits a later pending event to bypass
+  its unresolved prefix and is the open divergence from
+  LS.SYS.SYNC.PROC-R04 tracked by
+  [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md).
 - **Pull** (`:145-168, 226-253`): a lazily-restarted stream from the
   leader (cursor = current `upstreamHead`) feeds `SyncState.merge`; a
   `reject` from upstream is impossible and dies (`:162-165`). New events
@@ -124,6 +132,10 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 
 ## Backpressure and Known Gaps
 
+- The client-session rejection path does not yet fence later events until pull
+  reconciliation. SF-03 demonstrates that the leader can consequently confirm
+  a later event while an older session prefix remains pending; see
+  [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md).
 - All processor queues are unbounded; there is no producer backpressure.
   Anti-thrash relies on interrupt/clear on rebase and queue-clear on
   rejection.

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -123,9 +123,9 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   `Effect.runSyncWith` as an indivisible unit that can only interleave in the
   pull fiber's async gaps, so a synchronous commit admitted during a rebase
   park is folded into the reconciliation instead of being torn away by the
-  clear. This replaces the earlier blocking `rebaseOwnership` permit on `push`,
-  which violated the synchronous-commit invariant (LS.SYS.STORE-R09) by
-  suspending the commit path (see `.decisions/`, #1465). Deterministic
+  clear. This replaces the earlier design where `push` acquired the pull-
+  reconciliation mutex, which violated the synchronous-commit invariant
+  (LS.SYS.STORE-R09) by suspending the commit path (see `.decisions/`, #1465). Deterministic
   `rebaseBarriers` hooks at 3 labeled points let tests inject a concurrent
   push/shutdown into this window (the F1 no-loss oracle).
 - **Shutdown drain:** orderly shutdown closes new `push()` admission, stops

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -43,6 +43,7 @@ import { rollback } from './materialize-event.ts'
 import {
   isRejectedPushError,
   LeaderAheadError,
+  NonContiguousBatchError,
   NonMonotonicBatchError,
   type RejectedPushError,
   StaleRebaseGenerationError,
@@ -382,7 +383,7 @@ export const make = Effect.fnUntraced(function* ({
           return yield* Effect.dieDebugger('Local push events must be retained in pending state')
         }
 
-        yield* materializeEventsBatch({ batchItems: acceptedPendingEvents, deferreds })
+        yield* materializeEventsBatch({ batchItems: acceptedPendingEvents })
 
         yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
 
@@ -400,6 +401,10 @@ export const make = Effect.fnUntraced(function* ({
         const globalOrUnknownEvents = acceptedPendingEvents.filter((e) => !isClientOnlyEvent(e))
 
         yield* TxQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
+
+        // A push is acknowledged only after the complete batch is materialized, published in
+        // leader sync state, exposed to sessions, and queued for backend propagation.
+        yield* Effect.forEach(deferreds, (deferred) => Deferred.succeed(deferred, void 0))
       }).pipe(localPushBackendPullMutex.withPermits(1))
     }
   })
@@ -533,7 +538,7 @@ export const make = Effect.fnUntraced(function* ({
 
           advancePushHead(mergeResult.newSyncState.localHead)
 
-          yield* materializeEventsBatch({ batchItems: mergeResult.newEvents, deferreds: undefined })
+          yield* materializeEventsBatch({ batchItems: mergeResult.newEvents })
 
           yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
         }).pipe(Effect.exit)
@@ -656,7 +661,7 @@ export const make = Effect.fnUntraced(function* ({
 
       // console.debug('push', newEvents)
 
-      yield* validatePushBatch(newEvents, pushHeadRef.current)
+      yield* validatePushBatch(newEvents, pushHeadRef.current, isClientOnlyEvent)
 
       advancePushHead(newEvents.at(-1)!.seqNum)
 
@@ -849,17 +854,10 @@ export const layer = (options: Options) => Layer.effect(LeaderSyncProcessor, mak
 
 type MaterializeEventsBatch = (_: {
   batchItems: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>
-  /**
-   * The deferreds are used by the caller to know when the mutation has been processed.
-   * Indexes are aligned with `batchItems`
-   */
-  deferreds:
-    | ReadonlyArray<Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError> | undefined>
-    | undefined
 }) => Effect.Effect<void, MaterializeError, LeaderThreadCtx>
 
 // TODO how to handle errors gracefully
-const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds }) =>
+const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems }) =>
   Effect.gen(function* () {
     const { dbState: db, dbEventlog, materializeEvent } = yield* LeaderThreadCtx
 
@@ -881,10 +879,6 @@ const materializeEventsBatch: MaterializeEventsBatch = ({ batchItems, deferreds 
       const { sessionChangeset, hash } = yield* materializeEvent(batchItems[i]!)
       batchItems[i]!.meta.sessionChangeset = sessionChangeset
       batchItems[i]!.meta.materializerHashLeader = hash
-
-      if (deferreds?.[i] !== undefined) {
-        yield* Deferred.succeed(deferreds[i]!, void 0)
-      }
     }
 
     db.execute('COMMIT', undefined) // Commit the transaction
@@ -1037,6 +1031,7 @@ const makePullQueueSet = Effect.gen(function* () {
 const validatePushBatch = (
   batch: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>,
   pushHead: EventSequenceNumber.Client.Composite,
+  isClientOnlyEvent: (event: LiveStoreEvent.Client.EncodedWithMeta) => boolean,
 ) =>
   Effect.gen(function* () {
     if (batch.length === 0) {
@@ -1063,6 +1058,40 @@ const validatePushBatch = (
         providedNum: batch[0]!.seqNum,
         sessionId: batch[0]!.sessionId,
       })
+    }
+
+    if (batch[0]!.seqNum.rebaseGeneration < pushHead.rebaseGeneration) {
+      return yield* StaleRebaseGenerationError.make({
+        currentRebaseGeneration: pushHead.rebaseGeneration,
+        providedRebaseGeneration: batch[0]!.seqNum.rebaseGeneration,
+        sessionId: batch[0]!.sessionId,
+      })
+    }
+
+    let precedingSeqNum = pushHead
+    for (let i = 0; i < batch.length; i++) {
+      const event = batch[i]!
+      const expectedPair = EventSequenceNumber.Client.nextPair({
+        seqNum: precedingSeqNum,
+        isClientOnly: isClientOnlyEvent(event),
+        rebaseGeneration: event.seqNum.rebaseGeneration,
+      })
+
+      if (
+        EventSequenceNumber.Client.isEqual(event.seqNum, expectedPair.seqNum) === false ||
+        EventSequenceNumber.Client.isEqual(event.parentSeqNum, expectedPair.parentSeqNum) === false
+      ) {
+        return yield* NonContiguousBatchError.make({
+          expectedSeqNum: expectedPair.seqNum,
+          providedSeqNum: event.seqNum,
+          expectedParentSeqNum: expectedPair.parentSeqNum,
+          providedParentSeqNum: event.parentSeqNum,
+          violationIndex: i,
+          sessionId: event.sessionId,
+        })
+      }
+
+      precedingSeqNum = event.seqNum
     }
   })
 

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -198,6 +198,9 @@ interface Options {
     readonly delays?: {
       readonly localPushProcessing?: Effect.Effect<void>
     }
+    readonly hooks?: {
+      readonly localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
+    }
   }
 }
 
@@ -240,8 +243,11 @@ export const make = Effect.fnUntraced(function* ({
     deferred: Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError>,
   ]
   const localPushesQueue = yield* TxQueue.unbounded<LocalPushQueueItem>()
+  const reservedLocalPushItems = new Set<LocalPushQueueItem>()
   // Ensures mutual exclusion between local push and backend pull processing.
   const localPushBackendPullMutex = yield* Semaphore.make(1)
+  // Serializes validation, queue admission, and prefix-fence reconciliation.
+  const pushAdmissionSemaphore = yield* Semaphore.make(1)
 
   /**
    * Additionally to the `syncStateSref` we also need the `pushHeadRef` in order to prevent old/duplicate
@@ -252,10 +258,34 @@ export const make = Effect.fnUntraced(function* ({
    *
    * Thus the purpose of the pushHeadRef is the guard the integrity of the local push queue
    */
-  const pushHeadRef = { current: EventSequenceNumber.Client.ROOT }
-  const advancePushHead = (eventNum: EventSequenceNumber.Client.Composite) => {
-    pushHeadRef.current = EventSequenceNumber.Client.max(pushHeadRef.current, eventNum)
-  }
+  const pushHeadRef = { current: initialSyncState.localHead }
+  const reconcilePushHead = (authoritativeHead: EventSequenceNumber.Client.Composite) =>
+    pushAdmissionSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        const latestCurrentGenerationItem = [...reservedLocalPushItems].findLast(
+          ([event]) => event.seqNum.rebaseGeneration >= authoritativeHead.rebaseGeneration,
+        )
+        pushHeadRef.current = latestCurrentGenerationItem?.[0].seqNum ?? authoritativeHead
+        yield* syncDiagnostic('leader.push-fence.reconciled', {
+          authoritativeHead: EventSequenceNumber.Client.toString(authoritativeHead),
+          pushHead: EventSequenceNumber.Client.toString(pushHeadRef.current),
+          reservationCount: reservedLocalPushItems.size,
+        })
+      }).pipe(Effect.uninterruptible),
+    )
+  const releasePushReservations = (
+    items: ReadonlyArray<LocalPushQueueItem>,
+    authoritativeHead: EventSequenceNumber.Client.Composite,
+  ) =>
+    pushAdmissionSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        for (const item of items) reservedLocalPushItems.delete(item)
+        const latestCurrentGenerationItem = [...reservedLocalPushItems].findLast(
+          ([event]) => event.seqNum.rebaseGeneration >= authoritativeHead.rebaseGeneration,
+        )
+        pushHeadRef.current = latestCurrentGenerationItem?.[0].seqNum ?? authoritativeHead
+      }).pipe(Effect.uninterruptible),
+    )
 
   const backgroundApplyLocalPushes = Effect.gen(function* () {
     while (true) {
@@ -297,6 +327,8 @@ export const make = Effect.fnUntraced(function* ({
               }),
             ),
           )
+
+          yield* releasePushReservations(droppedItems, syncState.localHead)
         }
 
         if (filteredItems.length === 0) {
@@ -352,6 +384,11 @@ export const make = Effect.fnUntraced(function* ({
               ...remainingEventsMatchingGeneration.map(([_, deferred]) => deferred),
             ]
 
+            yield* releasePushReservations(
+              [...filteredItems, ...remainingEventsMatchingGeneration],
+              syncState.localHead,
+            )
+
             yield* Effect.forEach(allDeferredsToReject, (deferred) =>
               Deferred.fail(
                 deferred,
@@ -402,6 +439,8 @@ export const make = Effect.fnUntraced(function* ({
 
         yield* TxQueue.offerAll(syncBackendPushQueue, globalOrUnknownEvents)
 
+        yield* releasePushReservations(filteredItems, mergeResult.newSyncState.localHead)
+
         // A push is acknowledged only after the complete batch is materialized, published in
         // leader sync state, exposed to sessions, and queued for backend propagation.
         yield* Effect.forEach(deferreds, (deferred) => Deferred.succeed(deferred, void 0))
@@ -435,6 +474,10 @@ export const make = Effect.fnUntraced(function* ({
       pageInfo: SyncBackend.PullResPageInfo,
     ) =>
       Effect.gen(function* () {
+        yield* syncDiagnostic('leader.backend-pull.received', {
+          pageInfo: pageInfo._tag,
+          batch: summarizeClientBatch(newEvents),
+        })
         if (ctxRef.current?.devtoolsLatch !== undefined) {
           yield* ctxRef.current.devtoolsLatch.await
         }
@@ -536,7 +579,7 @@ export const make = Effect.fnUntraced(function* ({
           // Removes the changeset rows which are no longer needed as we'll never have to rollback beyond this point
           trimChangesetRows(db, newBackendHead)
 
-          advancePushHead(mergeResult.newSyncState.localHead)
+          yield* reconcilePushHead(mergeResult.newSyncState.localHead)
 
           yield* materializeEventsBatch({ batchItems: mergeResult.newEvents })
 
@@ -599,6 +642,8 @@ export const make = Effect.fnUntraced(function* ({
 
       const queueItems = yield* TxQueue.takeBetween(syncBackendPushQueue, 1, backendPushBatchSize)
 
+      yield* syncDiagnostic('leader.backend-push.started', { batch: summarizeClientBatch(queueItems) })
+
       yield* SubscriptionRef.waitUntil(syncBackend.isConnected, (isConnected) => isConnected === true)
 
       if (ctxRef.current?.devtoolsLatch !== undefined) {
@@ -619,6 +664,11 @@ export const make = Effect.fnUntraced(function* ({
         const iteration = yield* Schedule.CurrentMetadata
 
         const pushResult = yield* syncBackend.push(queueItems.map((_) => _.toGlobal())).pipe(Effect.result)
+
+        yield* syncDiagnostic('leader.backend-push.completed', {
+          batch: summarizeClientBatch(queueItems),
+          result: Result.isSuccess(pushResult) === true ? 'success' : pushResult.failure._tag,
+        })
 
         const retries = iteration.attempt
         if (retries > 0 && Result.isSuccess(pushResult) === true) {
@@ -659,19 +709,27 @@ export const make = Effect.fnUntraced(function* ({
     Effect.gen(function* () {
       if (newEvents.length === 0) return
 
-      // console.debug('push', newEvents)
-
-      yield* validatePushBatch(newEvents, pushHeadRef.current, isClientOnlyEvent)
-
-      advancePushHead(newEvents.at(-1)!.seqNum)
-
       const deferreds = yield* Effect.forEach(newEvents, () =>
         Deferred.make<void, LeaderAheadError | StaleRebaseGenerationError>(),
       )
 
       const items = newEvents.map((eventEncoded, i) => [eventEncoded, deferreds[i]] as LocalPushQueueItem)
 
-      yield* TxQueue.offerAll(localPushesQueue, items)
+      yield* pushAdmissionSemaphore.withPermits(1)(
+        Effect.gen(function* () {
+          yield* validatePushBatch(newEvents, pushHeadRef.current, isClientOnlyEvent)
+          for (const item of items) reservedLocalPushItems.add(item)
+          yield* TxQueue.offerAll(localPushesQueue, items)
+          pushHeadRef.current = newEvents.at(-1)!.seqNum
+          yield* syncDiagnostic('leader.push-fence.admitted', {
+            batch: summarizeClientBatch(newEvents),
+            pushHead: EventSequenceNumber.Client.toString(pushHeadRef.current),
+          })
+          if (testing.hooks?.localPushAdmitted !== undefined) {
+            yield* testing.hooks.localPushAdmitted(newEvents)
+          }
+        }).pipe(Effect.uninterruptible),
+      )
 
       yield* Effect.all(deferreds.map(Deferred.await))
     }).pipe(
@@ -747,6 +805,9 @@ export const make = Effect.fnUntraced(function* ({
       yield* backgroundBackendPulling({
         restartBackendPushing: (filteredRebasedPending) =>
           Effect.gen(function* () {
+            yield* syncDiagnostic('leader.backend-push.restarting', {
+              pending: summarizeClientBatch(filteredRebasedPending),
+            })
             // Stop current pushing fiber
             yield* FiberHandle.clear(backendPushingFiberHandle)
 
@@ -1079,7 +1140,7 @@ const validatePushBatch = (
 
       if (
         EventSequenceNumber.Client.isEqual(event.seqNum, expectedPair.seqNum) === false ||
-        EventSequenceNumber.Client.isEqual(event.parentSeqNum, expectedPair.parentSeqNum) === false
+        isSameSequencePosition(event.parentSeqNum, expectedPair.parentSeqNum) === false
       ) {
         return yield* NonContiguousBatchError.make({
           expectedSeqNum: expectedPair.seqNum,
@@ -1094,6 +1155,20 @@ const validatePushBatch = (
       precedingSeqNum = event.seqNum
     }
   })
+
+const summarizeClientBatch = (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => ({
+  count: events.length,
+  first: events[0]?.toJSON(),
+  last: events.at(-1)?.toJSON(),
+})
+
+const isSameSequencePosition = (
+  left: EventSequenceNumber.Client.Composite,
+  right: EventSequenceNumber.Client.Composite,
+) => left.global === right.global && left.client === right.client
+
+const syncDiagnostic = (transition: string, detail: unknown): Effect.Effect<void> =>
+  TRACE_VERBOSE === true ? Effect.logDebug(`[livestore-sync] ${transition} ${JSON.stringify(detail)}`) : Effect.void
 
 /**
  * Handles a BackendIdMismatchError based on the configured behavior.

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -243,6 +243,8 @@ export const make = Effect.fnUntraced(function* ({
     deferred: Deferred.Deferred<void, LeaderAheadError | StaleRebaseGenerationError>,
   ]
   const localPushesQueue = yield* TxQueue.unbounded<LocalPushQueueItem>()
+  // Reservations cover admitted pushes from validation until they are applied or rejected. The Set's
+  // insertion order mirrors admission order, so its last relevant item is the optimistic sequence head.
   const reservedLocalPushItems = new Set<LocalPushQueueItem>()
   // Ensures mutual exclusion between local push and backend pull processing.
   const localPushBackendPullMutex = yield* Semaphore.make(1)
@@ -250,15 +252,20 @@ export const make = Effect.fnUntraced(function* ({
   const pushAdmissionSemaphore = yield* Semaphore.make(1)
 
   /**
-   * Additionally to the `syncStateSref` we also need the `pushHeadRef` in order to prevent old/duplicate
-   * events from being pushed in a scenario like this:
-   * - client session A pushes e1
-   * - leader sync processor takes a bit and hasn't yet taken e1 from the localPushesQueue
-   * - client session B also pushes e1 (which should be rejected)
+   * Admission fence for local pushes. Unlike `syncState.localHead`, this advances as soon as an event
+   * is queued, so another session cannot claim the same sequence number while that event is waiting
+   * to be applied. With authoritative head e0 and reserved pushes e1/e2, this points to e2.
    *
-   * Thus the purpose of the pushHeadRef is the guard the integrity of the local push queue
+   * All reads and writes are protected by `pushAdmissionSemaphore` so validation and reservation are
+   * one atomic operation from the perspective of concurrent sessions and backend pulls.
    */
   const pushHeadRef = { current: initialSyncState.localHead }
+
+  /**
+   * A backend pull may advance or rebase authoritative history while local pushes remain reserved.
+   * Keep the fence at the newest reservation that is still valid for that history; if none remains,
+   * fall back to the authoritative head. Stale reservations are released later by the queue worker.
+   */
   const reconcilePushHead = (authoritativeHead: EventSequenceNumber.Client.Composite) =>
     pushAdmissionSemaphore.withPermits(1)(
       Effect.gen(function* () {
@@ -266,13 +273,12 @@ export const make = Effect.fnUntraced(function* ({
           ([event]) => event.seqNum.rebaseGeneration >= authoritativeHead.rebaseGeneration,
         )
         pushHeadRef.current = latestCurrentGenerationItem?.[0].seqNum ?? authoritativeHead
-        yield* syncDiagnostic('leader.push-fence.reconciled', {
-          authoritativeHead: EventSequenceNumber.Client.toString(authoritativeHead),
-          pushHead: EventSequenceNumber.Client.toString(pushHeadRef.current),
-          reservationCount: reservedLocalPushItems.size,
-        })
       }).pipe(Effect.uninterruptible),
     )
+  /**
+   * Stop completed, rejected, or stale queue items from extending the admission fence, then rebuild
+   * the fence from any pushes that are still reserved.
+   */
   const releasePushReservations = (
     items: ReadonlyArray<LocalPushQueueItem>,
     authoritativeHead: EventSequenceNumber.Client.Composite,
@@ -384,6 +390,8 @@ export const make = Effect.fnUntraced(function* ({
               ...remainingEventsMatchingGeneration.map(([_, deferred]) => deferred),
             ]
 
+            // The rejected batch and its drained same-generation suffix will never advance leader state,
+            // so release their sequence-number reservations before clients retry from the authoritative head.
             yield* releasePushReservations(
               [...filteredItems, ...remainingEventsMatchingGeneration],
               syncState.localHead,
@@ -474,10 +482,6 @@ export const make = Effect.fnUntraced(function* ({
       pageInfo: SyncBackend.PullResPageInfo,
     ) =>
       Effect.gen(function* () {
-        yield* syncDiagnostic('leader.backend-pull.received', {
-          pageInfo: pageInfo._tag,
-          batch: summarizeClientBatch(newEvents),
-        })
         if (ctxRef.current?.devtoolsLatch !== undefined) {
           yield* ctxRef.current.devtoolsLatch.await
         }
@@ -579,8 +583,12 @@ export const make = Effect.fnUntraced(function* ({
           // Removes the changeset rows which are no longer needed as we'll never have to rollback beyond this point
           trimChangesetRows(db, newBackendHead)
 
+          // The backend merge may advance or rebase the authoritative head. Realign the admission
+          // fence now so newly arriving pushes are validated against that history, not the pre-pull head.
           yield* reconcilePushHead(mergeResult.newSyncState.localHead)
 
+          // Apply the merged events to storage before publishing the new sync state below, so readers
+          // cannot observe a leader head whose events have not yet been materialized.
           yield* materializeEventsBatch({ batchItems: mergeResult.newEvents })
 
           yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
@@ -642,8 +650,6 @@ export const make = Effect.fnUntraced(function* ({
 
       const queueItems = yield* TxQueue.takeBetween(syncBackendPushQueue, 1, backendPushBatchSize)
 
-      yield* syncDiagnostic('leader.backend-push.started', { batch: summarizeClientBatch(queueItems) })
-
       yield* SubscriptionRef.waitUntil(syncBackend.isConnected, (isConnected) => isConnected === true)
 
       if (ctxRef.current?.devtoolsLatch !== undefined) {
@@ -664,11 +670,6 @@ export const make = Effect.fnUntraced(function* ({
         const iteration = yield* Schedule.CurrentMetadata
 
         const pushResult = yield* syncBackend.push(queueItems.map((_) => _.toGlobal())).pipe(Effect.result)
-
-        yield* syncDiagnostic('leader.backend-push.completed', {
-          batch: summarizeClientBatch(queueItems),
-          result: Result.isSuccess(pushResult) === true ? 'success' : pushResult.failure._tag,
-        })
 
         const retries = iteration.attempt
         if (retries > 0 && Result.isSuccess(pushResult) === true) {
@@ -715,16 +716,16 @@ export const make = Effect.fnUntraced(function* ({
 
       const items = newEvents.map((eventEncoded, i) => [eventEncoded, deferreds[i]] as LocalPushQueueItem)
 
+      // Validation, reservation, enqueueing, and fence advancement form one admission transaction.
+      // Serializing them prevents concurrent sessions from both validating against the same head and
+      // prevents backend reconciliation from changing the fence midway through admission.
       yield* pushAdmissionSemaphore.withPermits(1)(
+        // Cancellation must not leave reservations, queue contents, and the admission fence disagreeing.
         Effect.gen(function* () {
           yield* validatePushBatch(newEvents, pushHeadRef.current, isClientOnlyEvent)
           for (const item of items) reservedLocalPushItems.add(item)
           yield* TxQueue.offerAll(localPushesQueue, items)
           pushHeadRef.current = newEvents.at(-1)!.seqNum
-          yield* syncDiagnostic('leader.push-fence.admitted', {
-            batch: summarizeClientBatch(newEvents),
-            pushHead: EventSequenceNumber.Client.toString(pushHeadRef.current),
-          })
           if (testing.hooks?.localPushAdmitted !== undefined) {
             yield* testing.hooks.localPushAdmitted(newEvents)
           }
@@ -805,9 +806,6 @@ export const make = Effect.fnUntraced(function* ({
       yield* backgroundBackendPulling({
         restartBackendPushing: (filteredRebasedPending) =>
           Effect.gen(function* () {
-            yield* syncDiagnostic('leader.backend-push.restarting', {
-              pending: summarizeClientBatch(filteredRebasedPending),
-            })
             // Stop current pushing fiber
             yield* FiberHandle.clear(backendPushingFiberHandle)
 
@@ -1121,6 +1119,8 @@ const validatePushBatch = (
       })
     }
 
+    // A rebase replaces the optimistic history that the client built on. Events from an older
+    // generation may now have the wrong parent and must be recreated from the leader's current head.
     if (batch[0]!.seqNum.rebaseGeneration < pushHead.rebaseGeneration) {
       return yield* StaleRebaseGenerationError.make({
         currentRebaseGeneration: pushHead.rebaseGeneration,
@@ -1129,9 +1129,12 @@ const validatePushBatch = (
       })
     }
 
+    // Validate the batch as one unbroken chain starting at the admission fence. Checking only that
+    // numbers increase would still allow gaps or events that point at an unrelated parent.
     let precedingSeqNum = pushHead
     for (let i = 0; i < batch.length; i++) {
       const event = batch[i]!
+      // Global events advance the global position; client-only events advance its client-local suffix.
       const expectedPair = EventSequenceNumber.Client.nextPair({
         seqNum: precedingSeqNum,
         isClientOnly: isClientOnlyEvent(event),
@@ -1156,19 +1159,14 @@ const validatePushBatch = (
     }
   })
 
-const summarizeClientBatch = (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => ({
-  count: events.length,
-  first: events[0]?.toJSON(),
-  last: events.at(-1)?.toJSON(),
-})
-
+/**
+ * Parent linkage identifies a position in the event chain. Rebase generation describes the version
+ * of optimistic history, so it is validated on the event itself rather than as part of parent identity.
+ */
 const isSameSequencePosition = (
   left: EventSequenceNumber.Client.Composite,
   right: EventSequenceNumber.Client.Composite,
 ) => left.global === right.global && left.client === right.client
-
-const syncDiagnostic = (transition: string, detail: unknown): Effect.Effect<void> =>
-  TRACE_VERBOSE === true ? Effect.logDebug(`[livestore-sync] ${transition} ${JSON.stringify(detail)}`) : Effect.void
 
 /**
  * Handles a BackendIdMismatchError based on the configured behavior.

--- a/packages/@livestore/common/src/leader-thread/RejectedPushError.ts
+++ b/packages/@livestore/common/src/leader-thread/RejectedPushError.ts
@@ -1,7 +1,7 @@
 /**
  * Push validation errors returned by {@link LeaderSyncProcessor.push}.
  *
- * All three errors share a common {@link RejectedPushErrorTypeId} so consumers can catch the
+ * All errors share a common {@link RejectedPushErrorTypeId} so consumers can catch the
  * family as a group via {@link isRejectedPushError} instead of matching individual tags.
  * Recovery is the same in every case: the client should rebase and retry.
  *
@@ -37,6 +37,24 @@ export class NonMonotonicBatchError extends Schema.TaggedErrorClass<NonMonotonic
 
   override get message(): string {
     return `Pushed events' sequence numbers are not strictly increasing at index ${this.violationIndex} (session ${this.sessionId}): ${EventSequenceNumber.Client.toString(this.precedingSeqNum)} >= ${EventSequenceNumber.Client.toString(this.violatingSeqNum)}`
+  }
+}
+
+/** A pushed batch skips an event required to connect it to the leader's admitted push prefix. */
+export class NonContiguousBatchError extends Schema.TaggedErrorClass<NonContiguousBatchError>(
+  `${RejectedPushErrorTypeId}/NonContiguousBatchError`,
+)('NonContiguousBatchError', {
+  expectedSeqNum: EventSequenceNumber.Client.Composite,
+  providedSeqNum: EventSequenceNumber.Client.Composite,
+  expectedParentSeqNum: EventSequenceNumber.Client.Composite,
+  providedParentSeqNum: EventSequenceNumber.Client.Composite,
+  violationIndex: Schema.Finite,
+  sessionId: Schema.String,
+}) {
+  readonly [RejectedPushErrorTypeId] = RejectedPushErrorTypeId
+
+  override get message(): string {
+    return `Pushed events are not contiguous at index ${this.violationIndex} (session ${this.sessionId}): expected ${EventSequenceNumber.Client.toString(this.expectedSeqNum)} after ${EventSequenceNumber.Client.toString(this.expectedParentSeqNum)}, got ${EventSequenceNumber.Client.toString(this.providedSeqNum)} after ${EventSequenceNumber.Client.toString(this.providedParentSeqNum)}`
   }
 }
 
@@ -88,7 +106,12 @@ export class LeaderAheadError extends Schema.TaggedErrorClass<LeaderAheadError>(
   }
 }
 
-export const RejectedPushError = Schema.Union([LeaderAheadError, NonMonotonicBatchError, StaleRebaseGenerationError])
+export const RejectedPushError = Schema.Union([
+  LeaderAheadError,
+  NonContiguousBatchError,
+  NonMonotonicBatchError,
+  StaleRebaseGenerationError,
+])
 
 export type RejectedPushError = typeof RejectedPushError.Type
 

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -70,6 +70,9 @@ export interface MakeLeaderThreadLayerParams {
       delays?: {
         localPushProcessing?: Effect.Effect<void>
       }
+      hooks?: {
+        localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
+      }
     }
   }
 }
@@ -187,7 +190,7 @@ export const makeLeaderThreadLayer = ({
         }),
       },
       testing: {
-        ...omitUndefineds({ delays: testing?.syncProcessor?.delays }),
+        ...omitUndefineds({ delays: testing?.syncProcessor?.delays, hooks: testing?.syncProcessor?.hooks }),
       },
     })
 

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -126,6 +126,15 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   let leaderPushingFiberHandle: FiberHandle.FiberHandle<void, never> | undefined
   let pullingFiberHandle: FiberHandle.FiberHandle<void, never> | undefined
 
+  /** Rebuild the upstream FIFO from the authoritative live pending suffix without racing synchronous commits. */
+  const reconcileLeaderPushQueue = Effect.tx(
+    Effect.gen(function* () {
+      const livePending = syncStateRef.current.pending
+      yield* TxQueue.clear(leaderPushQueue)
+      yield* TxQueue.offerAll(leaderPushQueue, livePending)
+    }),
+  )
+
   const boot: ClientSessionSyncProcessor['boot'] = Effect.gen(function* () {
     if (
       confirmUnsavedChanges === true &&
@@ -158,13 +167,36 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         if (batch === undefined) return
 
         yield* clientSession.leaderThread.events.push(batch).pipe(
-          Effect.catchIf(isRejectedPushError, (error) => {
-            debugInfo.rejectCount++
-            if (shutdownStarted === true) return Effect.die(error)
+          Effect.catchIf(isRejectedPushError, (error) =>
+            rebaseOwnership
+              .withPermits(1)(
+                Effect.gen(function* () {
+                  debugInfo.rejectCount++
+                  if (shutdownStarted === true) return yield* Effect.die(error)
 
-            unresolvedRejection = { error, events: batch }
-            return TxQueue.clear(leaderPushQueue).pipe(Effect.andThen(Deferred.succeed(rejectionObserved, undefined)))
-          }),
+                  // A concurrent pull may have already confirmed or rebased this batch while the
+                  // push response was in flight. In that case, rebuild from the reconciled suffix
+                  // and continue instead of creating a fence that no future pull could release.
+                  if (isRejectedBatchRecovered(batch, syncStateRef.current.pending) === true) {
+                    yield* reconcileLeaderPushQueue
+                    yield* Deferred.succeed(rejectionObserved, undefined)
+                    return false
+                  }
+
+                  unresolvedRejection = { error, events: batch }
+                  yield* TxQueue.clear(leaderPushQueue)
+                  yield* Deferred.succeed(rejectionObserved, undefined)
+                  return true
+                }),
+              )
+              .pipe(
+                Effect.flatMap((shouldFence) =>
+                  // Local commits remain synchronous and continue accumulating in pending/the FIFO,
+                  // but this sole drain worker stays parked until pull reconciliation reseeds it.
+                  shouldFence === true ? Effect.never : Effect.void,
+                ),
+              ),
+          ),
         )
       }
     }).pipe(
@@ -207,6 +239,11 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           )
 
           syncStateRef.current = mergeResult.newSyncState
+
+          const recoveredRejection =
+            rejectionAtPullStart !== undefined &&
+            unresolvedRejection === rejectionAtPullStart &&
+            isRejectedBatchRecovered(rejectionAtPullStart.events, mergeResult.newSyncState.pending) === true
 
           if (mergeResult._tag === 'rebase') {
             yield* Effect.spanEvent('merge:pull:rebase', {
@@ -265,17 +302,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             // `mergeResult.newSyncState.pending` snapshot captured at merge time, so any event a
             // concurrent push appended during the async steps above (fiber interrupt / rollback /
             // barriers) is included. `Effect.tx` commits the clear+offer as one transaction.
-            const livePending = syncStateRef.current.pending
-            yield* Effect.tx(
-              Effect.gen(function* () {
-                yield* TxQueue.clear(leaderPushQueue)
-                yield* TxQueue.offerAll(leaderPushQueue, livePending)
-              }),
-            )
+            yield* reconcileLeaderPushQueue
 
             // Barrier: before restarting the leader-push worker.
             yield* rebaseBarrier('before_leader_push_fiber_run')
 
+            if (recoveredRejection === true) unresolvedRejection = undefined
             yield* FiberHandle.run(leaderPushingHandle, backgroundLeaderPushing)
           } else {
             yield* Effect.spanEvent('merge:pull:advance', {
@@ -286,14 +318,13 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
             })
 
             debugInfo.advanceCount++
-          }
 
-          if (
-            rejectionAtPullStart !== undefined &&
-            unresolvedRejection === rejectionAtPullStart &&
-            isRejectedBatchRecovered(rejectionAtPullStart.events, mergeResult.newSyncState.pending) === true
-          ) {
-            unresolvedRejection = undefined
+            if (recoveredRejection === true) {
+              yield* FiberHandle.clear(leaderPushingHandle)
+              yield* reconcileLeaderPushQueue
+              unresolvedRejection = undefined
+              yield* FiberHandle.run(leaderPushingHandle, backgroundLeaderPushing)
+            }
           }
 
           if (mergeResult.newEvents.length === 0) {
@@ -355,7 +386,13 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
         yield* Deferred.succeed(drainStartedSignal, undefined)
       }),
     )
-    if (leaderPushingFiberHandle !== undefined) yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+    if (leaderPushingFiberHandle !== undefined) {
+      if (unresolvedRejection === undefined) {
+        yield* FiberHandle.awaitEmpty(leaderPushingFiberHandle)
+      } else {
+        yield* FiberHandle.clear(leaderPushingFiberHandle)
+      }
+    }
     if (terminalPushCause !== undefined) return yield* Effect.failCause(terminalPushCause)
     if (unresolvedRejection !== undefined) return yield* Effect.die(unresolvedRejection.error)
   })

--- a/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
+++ b/packages/@livestore/common/src/sync/ClientSessionSyncProcessor.ts
@@ -111,7 +111,15 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
   /** We're queuing push requests to reduce the number of messages sent to the leader by batching them */
   const leaderPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta, Cause.Done>()
-  const rebaseOwnership = yield* Semaphore.make(1)
+  /**
+   * Prevents pull reconciliation, push-rejection handling, and shutdown from running concurrently.
+   * These transitions inspect or update the pending events, leader push queue, and rejection state,
+   * so each must observe the others either fully before or fully after—not midway through bookkeeping.
+   *
+   * Regular local commits do not acquire this mutex; they remain synchronous and are incorporated
+   * when `reconcileLeaderPushQueue` reads the current pending events transactionally.
+   */
+  const pullReconciliationMutex = yield* Semaphore.make(1)
   const shutdownDone = yield* Deferred.make<void>()
   const drainStartedSignal = yield* Deferred.make<void>()
   const rejectionObserved = yield* Deferred.make<void>()
@@ -126,7 +134,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   let leaderPushingFiberHandle: FiberHandle.FiberHandle<void, never> | undefined
   let pullingFiberHandle: FiberHandle.FiberHandle<void, never> | undefined
 
-  /** Rebuild the upstream FIFO from the authoritative live pending suffix without racing synchronous commits. */
+  /** Rebuild the leader push queue from the current pending events without racing synchronous commits. */
   const reconcileLeaderPushQueue = Effect.tx(
     Effect.gen(function* () {
       const livePending = syncStateRef.current.pending
@@ -168,15 +176,18 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
         yield* clientSession.leaderThread.events.push(batch).pipe(
           Effect.catchIf(isRejectedPushError, (error) =>
-            rebaseOwnership
+            // A pull carrying the leader's corrective history can complete before or after this
+            // rejection response. Use the same mutex as pull reconciliation so this decision uses
+            // one stable view of pending events and cannot install a stale rejection fence after recovery.
+            pullReconciliationMutex
               .withPermits(1)(
                 Effect.gen(function* () {
                   debugInfo.rejectCount++
                   if (shutdownStarted === true) return yield* Effect.die(error)
 
                   // A concurrent pull may have already confirmed or rebased this batch while the
-                  // push response was in flight. In that case, rebuild from the reconciled suffix
-                  // and continue instead of creating a fence that no future pull could release.
+                  // push response was in flight. In that case, rebuild the queue from the reconciled
+                  // pending events instead of creating a fence that no future pull could release.
                   if (isRejectedBatchRecovered(batch, syncStateRef.current.pending) === true) {
                     yield* reconcileLeaderPushQueue
                     yield* Deferred.succeed(rejectionObserved, undefined)
@@ -286,19 +297,19 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
 
             // Barrier: before the atomic queue reconciliation (the "discard + re-offer" step).
             // A `push` admitted here appends its event to `syncStateRef.current.pending` AND to
-            // `leaderPushQueue`; the reconciliation below re-reads the LIVE pending, so that event
-            // is preserved rather than torn away by the clear.
+            // `leaderPushQueue`; the reconciliation below re-reads the current pending events, so
+            // that event is preserved rather than removed by the queue clear.
             yield* rebaseBarrier('before_queue_reconcile')
 
             // Atomic queue reconciliation. `push` runs via `Effect.runSyncWith` (a synchronous run,
             // per the store's fully-synchronous commit contract), so it executes as an indivisible
             // unit that can only interleave in THIS fiber's async gaps — never inside a synchronous
-            // stretch. By reading the live pending, clearing, and re-offering with no async park
-            // between them, this block is atomic w.r.t. `push`. This replaces the blocking
-            // `rebaseOwnership` permit that previously forced `push` to wait: push↔rebase is now
-            // serialized WITHOUT ever suspending the synchronous commit path.
+            // stretch. By reading the current pending events, clearing, and re-offering with no async
+            // park between them, this block is atomic w.r.t. `push`. This replaces the blocking
+            // `pullReconciliationMutex` permit that previously forced `push` to wait: queue rebuilding
+            // and synchronous commits cannot interleave, without suspending the commit path.
             //
-            // We re-read `syncStateRef.current.pending` (the LIVE pending) instead of the stale
+            // We re-read the current `syncStateRef.current.pending` instead of the stale
             // `mergeResult.newSyncState.pending` snapshot captured at merge time, so any event a
             // concurrent push appended during the async steps above (fiber interrupt / rollback /
             // barriers) is included. `Effect.tx` commits the clear+offer as one transaction.
@@ -355,7 +366,7 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
           // We're only triggering the sync state update after all events have been materialized
           yield* Queue.offer(syncStateUpdateQueue, mergeResult.newSyncState)
         }).pipe(
-          rebaseOwnership.withPermits(1),
+          pullReconciliationMutex.withPermits(1),
           Effect.tapCauseLogPretty,
           Effect.catchCause((cause) => clientSession.shutdown(Exit.failCause(cause))),
         ),
@@ -374,12 +385,12 @@ export const makeClientSessionSyncProcessor = Effect.fn('makeClientSessionSyncPr
   ) {
     if (Exit.isFailure(exit) === true) {
       if (pullingFiberHandle !== undefined) yield* FiberHandle.clear(pullingFiberHandle)
-      yield* rebaseOwnership.withPermits(1)(TxQueue.end(leaderPushQueue))
+      yield* pullReconciliationMutex.withPermits(1)(TxQueue.end(leaderPushQueue))
       if (leaderPushingFiberHandle !== undefined) yield* FiberHandle.clear(leaderPushingFiberHandle)
       return
     }
 
-    yield* rebaseOwnership.withPermits(1)(
+    yield* pullReconciliationMutex.withPermits(1)(
       Effect.gen(function* () {
         if (pullingFiberHandle !== undefined) yield* FiberHandle.clear(pullingFiberHandle)
         yield* TxQueue.end(leaderPushQueue)

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -155,7 +155,7 @@ const makeClientProcessorHarness = Effect.fn(function* ({
 })
 
 // TODO use property tests for simulation params
-/** Verifies: LS.SYS.SYNC.SS-R01, LS.SYS.SYNC.SS-R04 */
+/** Verifies: LS.SYS.SYNC.SS-R01, LS.SYS.SYNC.SS-R04, LS.SYS.SYNC.PROC-R04 */
 Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
   Vitest.live('from scratch', (test) =>
     Effect.gen(function* () {
@@ -173,10 +173,14 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.live('does not rematerialize a pending event accepted ahead of its pending prefix', (test) =>
+  Vitest.live('does not send a later pending event before its rejected prefix is reconciled', (test) =>
     Effect.gen(function* () {
       const shutdownDeferred = yield* makeShutdownDeferred
       const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushRejected = yield* Deferred.make<void>()
+      const laterPushAccepted = yield* Deferred.make<void>()
+      const pushedIds: string[] = []
+      let pushCount = 0
       const adapter = makeTestAdapter({
         clientId: 'client-2',
         sessionId: 'session-2',
@@ -186,7 +190,20 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
               leaderThreadProxy: () => ({
                 events: {
                   pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
-                  push: () => Effect.void,
+                  push: (batch) =>
+                    Effect.gen(function* () {
+                      pushCount++
+                      pushedIds.push(...batch.map((event) => event.args.id as string))
+                      if (pushCount === 1) {
+                        yield* Deferred.succeed(firstPushRejected, undefined)
+                        return yield* new LeaderAheadError({
+                          minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+                          providedNum: batch[0]!.seqNum,
+                          sessionId: batch[0]!.sessionId,
+                        })
+                      }
+                      yield* Deferred.succeed(laterPushAccepted, undefined)
+                    }),
                   stream: () => Stream.empty,
                 },
               }),
@@ -202,39 +219,41 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       })
 
       store.commit(events.todoCreated({ id: 'older-pending', text: 'older', completed: false }))
-      store.commit(events.todoCreated({ id: 'accepted-ahead', text: 'accepted', completed: false }))
+      yield* Deferred.await(firstPushRejected)
+      yield* store[StoreInternalsSymbol].syncProcessor.debug.awaitRejection
 
-      const before = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
-      const acceptedPending = before.pending[1]!
-      // Reduced from SF-03's production trace: the leader accepted this action at an earlier
-      // position while the session still retained the same action behind an older pending prefix.
-      const acceptedByLeader = new LiveStoreEvent.Client.EncodedWithMeta({
-        name: acceptedPending.name,
-        args: acceptedPending.args,
-        clientId: acceptedPending.clientId,
-        sessionId: acceptedPending.sessionId,
-        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0, rebaseGeneration: 0 }),
-        parentSeqNum: EventSequenceNumber.Client.ROOT,
-      })
+      const rejectedPrefix = (yield* store[StoreInternalsSymbol].syncProcessor.syncState.get).pending[0]!
+      store.commit(events.todoCreated({ id: 'later-pending', text: 'later', completed: false }))
 
-      const reconciled = store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
-        Stream.filter((state) => state.upstreamHead.global === 1),
+      // The old worker loop drained `later-pending` here. Its leader delivery then appeared before
+      // `older-pending`, producing merge materialization `[B, A', B']` and the SF-03 UNIQUE failure.
+      yield* Effect.yieldNow
+      expect(yield* Deferred.isDone(laterPushAccepted)).toBe(false)
+
+      const recovered = store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
+        Stream.filter(
+          (state) =>
+            EventSequenceNumber.Client.isEqual(state.upstreamHead, rejectedPrefix.seqNum) === true &&
+            state.pending.length === 1,
+        ),
         Stream.take(1),
         Stream.runDrain,
         Effect.raceFirst(Deferred.await(shutdownDeferred)),
         Effect.forkChild,
       )
-      const reconciledFiber = yield* reconciled
+      const recoveredFiber = yield* recovered
 
-      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [acceptedByLeader] }))
-      yield* Fiber.join(reconciledFiber)
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedPrefix] }))
+      yield* Fiber.join(recoveredFiber)
+      yield* Deferred.await(laterPushAccepted)
 
       expect(
         store
           .query(tables.todos)
           .map((row) => row.id)
           .toSorted(),
-      ).toEqual(['accepted-ahead', 'older-pending'])
+      ).toEqual(['later-pending', 'older-pending'])
+      expect(pushedIds).toEqual(['older-pending', 'later-pending'])
     }).pipe(withTestCtx(test)),
   )
 
@@ -928,7 +947,97 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  Vitest.it.effect('clears a recovered rejection while newer admitted events remain pending', (test) =>
+  Vitest.it.effect('does not leave a fence behind when pull recovers an in-flight push before it rejects', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushStarted = yield* Deferred.make<void>()
+      const releaseFirstPush = yield* Deferred.make<void>()
+      const laterPushAccepted = yield* Deferred.make<void>()
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: () => {
+          pushCount++
+          return pushCount === 1
+            ? Deferred.succeed(firstPushStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseFirstPush)),
+                Effect.andThen(Effect.fail(rejection)),
+              )
+            : Deferred.succeed(laterPushAccepted, undefined).pipe(Effect.asVoid)
+        },
+      })
+
+      const [inFlightEvent] = yield* pushIds(['in-flight'])
+      yield* Deferred.await(firstPushStarted)
+
+      const recoveredFiber = yield* processor.syncState.changes.pipe(
+        Stream.filter((state) => state.pending.length === 0),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkChild,
+      )
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [inFlightEvent!] }))
+      yield* Fiber.join(recoveredFiber)
+
+      yield* Deferred.succeed(releaseFirstPush, undefined)
+      yield* processor.debug.awaitRejection
+      yield* pushIds(['after-late-rejection'])
+      yield* Deferred.await(laterPushAccepted)
+
+      const closeExit = yield* close().pipe(Effect.exit)
+      expect(Exit.isSuccess(closeExit)).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('reseeds the complete pending suffix when a rebase recovers a rejection', (test) =>
+    Effect.gen(function* () {
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const firstPushRejected = yield* Deferred.make<void>()
+      const rebasedSuffixAccepted = yield* Deferred.make<void>()
+      const acceptedIds: string[] = []
+      const rejection = new LeaderAheadError({
+        minimumExpectedNum: EventSequenceNumber.Client.ROOT,
+        providedNum: EventSequenceNumber.Client.ROOT,
+        sessionId: 'session-test',
+      })
+      let pushCount = 0
+      const { processor, pushIds, close } = yield* makeClientProcessorHarness({
+        pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+        push: (batch) => {
+          pushCount++
+          if (pushCount === 1) {
+            return Effect.fail(rejection).pipe(Effect.ensuring(Deferred.succeed(firstPushRejected, undefined)))
+          }
+          return Effect.sync(() => acceptedIds.push(...batch.map((event) => event.args.id as string))).pipe(
+            Effect.flatMap((acceptedCount) =>
+              acceptedCount < 2 ? Effect.void : Deferred.succeed(rebasedSuffixAccepted, undefined).pipe(Effect.asVoid),
+            ),
+          )
+        },
+      })
+
+      yield* pushIds(['rejected-prefix'])
+      yield* Deferred.await(firstPushRejected)
+      yield* processor.debug.awaitRejection
+      yield* pushIds(['newer-pending'])
+      yield* Effect.yieldNow
+      expect(acceptedIds).toEqual([])
+
+      yield* Queue.offer(pullQueue, yield* makeConflictingUpstream(processor))
+      yield* Deferred.await(rebasedSuffixAccepted)
+
+      const closeExit = yield* close().pipe(Effect.exit)
+      expect(Exit.isSuccess(closeExit)).toBe(true)
+      expect(acceptedIds).toEqual(['rejected-prefix', 'newer-pending'])
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.it.effect('fences newer admitted events until the rejected prefix is recovered', (test) =>
     Effect.gen(function* () {
       const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
       const secondPushAccepted = yield* Deferred.make<void>()
@@ -953,12 +1062,14 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
       yield* Deferred.await(firstPushRejected)
       yield* processor.debug.awaitRejection
       yield* pushIds(['newer-admitted'])
-      yield* Deferred.await(secondPushAccepted)
+      yield* Effect.yieldNow
+      expect(yield* Deferred.isDone(secondPushAccepted)).toBe(false)
       // Drain both local notifications so the next one proves the upstream confirmation was processed.
       yield* processor.syncState.changes.pipe(Stream.take(2), Stream.runDrain)
 
       yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [rejectedEvent!] }))
       yield* processor.syncState.changes.pipe(Stream.take(1), Stream.runDrain)
+      yield* Deferred.await(secondPushAccepted)
 
       const closeExit = yield* close().pipe(Effect.exit)
 

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -173,6 +173,71 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
+  Vitest.live('does not rematerialize a pending event accepted ahead of its pending prefix', (test) =>
+    Effect.gen(function* () {
+      const shutdownDeferred = yield* makeShutdownDeferred
+      const pullQueue = yield* Queue.unbounded<typeof SyncState.PayloadUpstream.Type>()
+      const adapter = makeTestAdapter({
+        clientId: 'client-2',
+        sessionId: 'session-2',
+        testing: {
+          overrides: {
+            clientSession: {
+              leaderThreadProxy: () => ({
+                events: {
+                  pull: () => Stream.fromQueue(pullQueue).pipe(Stream.map((payload) => ({ payload }))),
+                  push: () => Effect.void,
+                  stream: () => Stream.empty,
+                },
+              }),
+            },
+          },
+        },
+      })
+      const store = yield* createStore({
+        schema: schema as LiveStoreSchema,
+        adapter,
+        storeId: 'sf-03-overlapping-advance',
+        shutdownDeferred,
+      })
+
+      store.commit(events.todoCreated({ id: 'older-pending', text: 'older', completed: false }))
+      store.commit(events.todoCreated({ id: 'accepted-ahead', text: 'accepted', completed: false }))
+
+      const before = yield* store[StoreInternalsSymbol].syncProcessor.syncState.get
+      const acceptedPending = before.pending[1]!
+      // Reduced from SF-03's production trace: the leader accepted this action at an earlier
+      // position while the session still retained the same action behind an older pending prefix.
+      const acceptedByLeader = new LiveStoreEvent.Client.EncodedWithMeta({
+        name: acceptedPending.name,
+        args: acceptedPending.args,
+        clientId: acceptedPending.clientId,
+        sessionId: acceptedPending.sessionId,
+        seqNum: EventSequenceNumber.Client.Composite.make({ global: 1, client: 0, rebaseGeneration: 0 }),
+        parentSeqNum: EventSequenceNumber.Client.ROOT,
+      })
+
+      const reconciled = store[StoreInternalsSymbol].syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.upstreamHead.global === 1),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.raceFirst(Deferred.await(shutdownDeferred)),
+        Effect.forkChild,
+      )
+      const reconciledFiber = yield* reconciled
+
+      yield* Queue.offer(pullQueue, SyncState.PayloadUpstreamAdvance.make({ newEvents: [acceptedByLeader] }))
+      yield* Fiber.join(reconciledFiber)
+
+      expect(
+        store
+          .query(tables.todos)
+          .map((row) => row.id)
+          .toSorted(),
+      ).toEqual(['accepted-ahead', 'older-pending'])
+    }).pipe(withTestCtx(test)),
+  )
+
   Vitest.live('rolls back materialized state when persisting the state head fails', (test) =>
     Effect.gen(function* () {
       const { makeStore } = yield* TestContext

--- a/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
+++ b/tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts
@@ -781,7 +781,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
     }).pipe(withTestCtx(test)),
   )
 
-  // F1 no-loss oracle for shutdown↔rebase (guarded by the `rebaseOwnership` permit shared by the
+  // F1 no-loss oracle for shutdown↔rebase (guarded by the `pullReconciliationMutex` permit shared by the
   // pull tap and `runShutdown`): an orderly shutdown that interleaves a rebase at any point of the
   // discard→re-offer window must still flush the rebased pending event. Removing the permit from
   // `runShutdown` makes the pre-reconcile cases (points 1/2) fail — the queue is ended and the pull
@@ -818,7 +818,7 @@ Vitest.describe.concurrent('ClientSessionSyncProcessor', () => {
         yield* barrier.awaitReached
 
         // Start an orderly shutdown while the rebase is parked. The success path takes the
-        // `rebaseOwnership` permit still held by the parked pull fiber, so it cannot end the queue
+        // `pullReconciliationMutex` permit still held by the parked pull fiber, so it cannot end the queue
         // until the rebase releases the permit (i.e. after re-offering the rebased pending event).
         const closeFiber = yield* close().pipe(Effect.forkChild)
         yield* barrier.release

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -6,6 +6,7 @@ import {
   type MockSyncBackend,
   type MockSyncBackendOptions,
   makeMockSyncBackend,
+  NonContiguousBatchError,
   type RejectedPushError,
   ServerAheadError,
   StateHead,
@@ -87,7 +88,7 @@ const seedPaginatedBackendTodos = (mockBackend: MockSyncBackend) => {
   )
 }
 
-/** Verifies: LS.SYS.SYNC.PROC-R01, LS.SYS.SYNC.PROC-R02, LS.SYS.SYNC.SS-R06, LS.SYS.SYNC-R03, LS.SYS.RT-R10 */
+/** Verifies: LS.SYS.SYNC.PROC-R01, LS.SYS.SYNC.PROC-R02, LS.SYS.SYNC.PROC-R04, LS.SYS.SYNC.SS-R06, LS.SYS.SYNC-R03, LS.SYS.RT-R10 */
 Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
   Vitest.live('sync', (test) =>
     Effect.gen(function* () {
@@ -548,6 +549,35 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
       expect(EventSequenceNumber.Client.toString(error.minimumExpectedNum)).toBe('e6')
       expect(EventSequenceNumber.Client.toString(error.providedNum)).toBe('e2')
+    }).pipe(withTestCtx()(test)),
+  )
+
+  Vitest.live('leader push API rejects a batch that skips its pending prefix', (test) =>
+    Effect.gen(function* () {
+      const testContext = yield* TestContext
+      const skippedPrefixFactory = makeEventFactory({
+        client: EventFactory.clientIdentity('client-skipped-prefix', 'session-skipped-prefix'),
+        startSeq: 2,
+        initialParent: 1,
+      })
+
+      const eventAfterMissingPrefix = skippedPrefixFactory.todoCreated.next({
+        id: 'after-missing-prefix',
+        text: 'after-missing-prefix',
+        completed: false,
+      })
+      const result = yield* testContext.pushEncoded(eventAfterMissingPrefix).pipe(Effect.result)
+
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isSuccess(result) === true) return
+
+      expect(result.failure).toBeInstanceOf(NonContiguousBatchError)
+      expect(result.failure._tag).toBe('NonContiguousBatchError')
+      if (result.failure._tag !== 'NonContiguousBatchError') return
+
+      expect(EventSequenceNumber.Client.toString(result.failure.expectedSeqNum)).toBe('e1')
+      expect(EventSequenceNumber.Client.toString(result.failure.providedSeqNum)).toBe('e2')
+      expect(result.failure.violationIndex).toBe(0)
     }).pipe(withTestCtx()(test)),
   )
 

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -30,6 +30,7 @@ import {
   Duration,
   Effect,
   FetchHttpClient,
+  Fiber,
   Layer,
   Queue,
   References,
@@ -68,9 +69,10 @@ const withTestCtx = (
 ) =>
   Vitest.makeWithTestCtx({
     makeLayer: () =>
-      Layer.provideMerge(LeaderThreadCtxLive(args), PlatformNode.NodeFileSystem.layer).pipe(
-        Layer.provide(Layer.succeed(References.MinimumLogLevel, 'Debug')),
-      ),
+      Layer.provideMerge(
+        LeaderThreadCtxLive({ ...args, syncProcessor: args.testing?.syncProcessor }),
+        PlatformNode.NodeFileSystem.layer,
+      ).pipe(Layer.provide(Layer.succeed(References.MinimumLogLevel, 'Debug'))),
     forceOtel: true,
   })
 
@@ -580,6 +582,84 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       expect(result.failure.violationIndex).toBe(0)
     }).pipe(withTestCtx()(test)),
   )
+
+  Vitest.live('releases rejected queue reservations before admitting a rebased session retry', (test) => {
+    const localProcessingStarted = Deferred.makeUnsafe<void>()
+    const allowLocalProcessing = Deferred.makeUnsafe<void>()
+    const localPushAdmitted = Deferred.makeUnsafe<void>()
+
+    return Effect.gen(function* () {
+      const leaderThreadCtx = yield* LeaderThreadCtx
+      const testContext = yield* TestContext
+      const queuedFactory = makeEventFactory({
+        client: EventFactory.clientIdentity('shared-client', 'queued-session'),
+        startSeq: 1,
+        initialParent: 'root',
+      })
+      const backendFactory = makeEventFactory({
+        client: EventFactory.clientIdentity('remote-client', 'remote-session'),
+        startSeq: 1,
+        initialParent: 'root',
+      })
+
+      yield* Deferred.await(localProcessingStarted)
+
+      const queuedPush = yield* testContext
+        .pushEncoded(
+          ...Array.from({ length: 6 }, (_, index) =>
+            queuedFactory.todoCreated.next({ id: `queued-${index}`, text: `queued-${index}`, completed: false }),
+          ),
+        )
+        .pipe(Effect.result, Effect.forkChild)
+      yield* Deferred.await(localPushAdmitted)
+
+      // Advance the authoritative head while e1…e6 are reserved but not yet processed.
+      yield* testContext.mockSyncBackend.advance(
+        backendFactory.todoCreated.next({ id: 'remote-1', text: 'remote-1', completed: false }),
+      )
+      yield* leaderThreadCtx.syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.upstreamHead.global === 1),
+        Stream.runFirstUnsafe,
+      )
+
+      yield* Deferred.succeed(allowLocalProcessing, undefined)
+      const queuedResult = yield* Fiber.join(queuedPush)
+      expect(Result.isFailure(queuedResult)).toBe(true)
+
+      const retryBase = backendFactory.todoCreated.next({ id: 'retry-2', text: 'retry-2', completed: false })
+      const retryPair = EventSequenceNumber.Client.nextPair({
+        seqNum: EventSequenceNumber.Client.fromString('e1r1'),
+        isClientOnly: false,
+        rebaseGeneration: 1,
+      })
+      const rebasedRetry = LiveStoreEvent.Client.EncodedWithMeta.make({
+        ...LiveStoreEvent.Global.toClientEncoded(retryBase),
+        ...retryPair,
+        clientId: 'shared-client',
+        sessionId: 'retry-session',
+      })
+
+      yield* leaderThreadCtx.syncProcessor.push([rebasedRetry])
+      yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain, Effect.timeout(5000))
+    }).pipe(
+      withTestCtx({
+        mockBackendOptions: { startConnected: true },
+        testing: {
+          syncProcessor: {
+            delays: {
+              localPushProcessing: Effect.gen(function* () {
+                yield* Deferred.succeed(localProcessingStarted, undefined)
+                yield* Deferred.await(allowLocalProcessing)
+              }),
+            },
+            hooks: {
+              localPushAdmitted: () => Deferred.succeed(localPushAdmitted, undefined),
+            },
+          },
+        },
+      })(test),
+    )
+  })
 
   // TODO tests for
   // - aborting local pushes


### PR DESCRIPTION
## Summary

LiveStore moves events through several processing stages:

```text
session pending → leader processing → backend propagation → confirmed history
```

At every stage, once a component accepts an event, it must keep a concrete record of that event until it is applied, rejected, discarded as stale, or visibly handed to the next stage. If an earlier event remains unresolved, later dependent events must not overtake it.

This PR fixes two violations of that invariant in the session-to-leader path:

1. A session could continue sending later pending events after an earlier push was rejected.
2. The leader could accept work but temporarily lose track of it between queue admission, queue drain, and processing.

Together, these gaps could either materialize an event twice or leave the leader’s admission head pointing at work that no longer existed.

The issue was initially exposed as SF-03 by the LiveStore contrib Scenario System, a multi-writer stress and replay harness. The simulator made the race occur naturally; a deterministic core test then reduced it to two local events and one concurrent leader advance without relying on the simulator or sleeps.

## Problem

### Later session events could overtake an unresolved event

A session could have two locally materialized pending events:

```text
[A, B]
```

If the leader rejected `A`, the session push worker cleared its queue but continued running. A concurrent local commit could therefore make `B` available to the worker before pull/rebase had recovered `A`.

The resulting order was:

```text
session pending:  [A, B]
leader confirmed: [B]
```

When the session reconciled those states, it scheduled the incoming `B` together with its rebased pending events:

```text
[B, A', B']
```

The second materialization of `B` violated the application table’s unique key.

The required ordering rule is:

> A later pending event must not overtake an unresolved earlier event from the same session.

### The leader could lose track of accepted work

The leader tracked accepted work using a scalar `pushHead` and the contents of its processing queue:

```text
validate
→ advance pushHead
→ publish to queue
→ take from queue
→ apply, reject, or discard
```

That representation had several gaps:

- `pushHead` could advance before the batch was published to the queue.
- Taking an item removed it from the queue while it was still being processed.
- Rejection or stale-generation dropping could remove the work without correcting `pushHead`.

As a result, `pushHead` could claim that the leader had accepted and was still tracking an event even though the event was neither queued nor otherwise tracked. This stale admission state could incorrectly reject a valid rebased retry. Conversely, pull reconciliation could overlook work that was still in flight because queue take had made it invisible.

### Parent validation included a local implementation detail

Parent continuity also compared the local rebase generation as if it were part of the parent event’s identity.

For example, `e1r0` and `e1r1` refer to the same event position but were produced during different local reconciliation attempts. A valid retry could therefore be rejected solely because it used a newer rebase generation.

## Solution

### Park session propagation until reconciliation

After an earlier pending event is rejected, the session push worker now parks.

Local commits remain synchronous and continue accumulating in the session’s pending state, but no later event is sent to the leader until pull/rebase has reconciled the rejected event. Recovery atomically rebuilds the leader push queue from the current pending events before restarting propagation.

A late rejection response cannot install a stale parked state after pull has already recovered the batch because rejection handling and pull reconciliation use the same `pullReconciliationMutex`. The mutex prevents those transitions, and orderly shutdown, from running concurrently. Regular local commits remain synchronous and cannot interleave with the leader push queue rebuild.

### Track accepted leader work with explicit reservations

The leader now records each accepted queue item in a reservation set:

```text
validate + reserve + publish + advance head
                    ↓
             reservation remains
                    ↓
       apply / reject / discard as stale
                    ↓
             release reservation
```

Validation, reservation, queue publication, and admission-head advancement occur in one atomic critical section.

The reservation remains visible after the worker takes the item from the queue. It is released only when processing reaches a terminal outcome.

Pull reconciliation now derives the admission head from:

```text
confirmed head + compatible live reservations
```

The leader’s head therefore always corresponds either to confirmed history or to concrete work the leader is still tracking.

### Compare parent position separately from rebase generation

Event sequence continuity remains exact. Parent continuity now compares the parent’s global and client sequence position while ignoring the local rebase generation.

References such as `e1r0` and `e1r1` are therefore recognized as the same parent position. Rebase generation is checked separately to reject genuinely stale work.

### Complete the processing handoff

The leader acknowledges a session push only after the events have been:

- materialized;
- published in leader sync state;
- offered to connected session pull streams; and
- queued for backend propagation.

This PR completes the core session-to-leader ordering and tracking guarantees. The related Cloudflare backend admission/publication fix is tracked separately in #1537.

## Trade-offs

- The existing FIFO queues remain unchanged; the fix controls when they may drain and adds explicit reservation tracking outside the queue.
- Leader admission uses one short critical section per leader. Independent leaders remain independent.
- No event-envelope or immutable-event-ID migration is required.
- Test-only admission hooks provide deterministic barriers without introducing production delays.

## Validation

- New leader rejected-reservation regression: 10/10 independent runs passed.
- Existing focused session/leader regressions plus the reservation regression: 6 passed.
- Full unit test task (`devenv tasks run test:unit`) — passed.
- `devenv tasks run lint:full:fix` — passed.
- `devenv tasks run ts:check` — passed.
- `git diff --check` — passed.

The existing 12-create browser negative control passed 5/5 during the combined investigation. This leader-only PR does not claim that the complete reduced browser scenario passes without the separate backend-side fix in #1537.

## Related issues

- #1537 — separate Cloudflare admission and publication fix exposed by the same investigation
- SF-03 — discovered through the LiveStore contrib Scenario System
