### PR TITLE
Raise Cloudflare sync payload budget with framing headroom

### DIFF
--- a/.changeset/large-sync-frames.md
+++ b/.changeset/large-sync-frames.md
@@ -1,0 +1,5 @@
+---
+'@livestore/sync-cf': patch
+---
+
+Raise the Cloudflare sync transport payload budget to 28 MiB, leaving 4 MiB of headroom below Cloudflare's received-message limit.

--- a/context/02-system/03-sync/03-cf/.decisions/0002-transport-payload-headroom.md
+++ b/context/02-system/03-sync/03-cf/.decisions/0002-transport-payload-headroom.md
@@ -1,0 +1,21 @@
+# 0002 — Reserve 4 MiB below Cloudflare's received-message ceiling
+
+Status: accepted (official Cloudflare [WebSocket limits](https://developers.cloudflare.com/workers/runtime-apis/websockets/) and [October 2025 changelog](https://developers.cloudflare.com/changelog/post/2025-10-31-increased-websocket-message-size-limit/) retrieved 2026-08-03).
+
+## Context
+
+The 900,000-byte transport budget was chosen below Cloudflare's former 1 MiB
+received-WebSocket-message limit. Cloudflare increased that limit to 32 MiB in
+October 2025. Using the full limit would leave no room for LiveStore and Effect
+RPC framing outside the measured payload.
+
+## Options
+
+- **28 MiB — chosen.** Leaves 4 MiB (12.5%) for framing while retaining one
+  budget across WebSocket, HTTP, and DO-RPC.
+- **32 MiB.** Rejected because LiveStore does not measure every outer frame.
+- **900,000 bytes.** Rejected because it reflects the obsolete platform limit.
+
+## Consequences
+
+- Existing count- and byte-based chunking is unchanged.

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -48,7 +48,9 @@ arbitrates pushes and fans out live pull streams to subscribers
   fail with `BackendIdMismatchError` (client records it lazily from pull
   responses).
 - **Limits** (`common/constants.ts`): `MAX_TRANSPORT_PAYLOAD_BYTES =
-  900_000` (below the ~1 MB hibernated-WS frame cap),
+  28 MiB`. Cloudflare's received-WebSocket-message limit is 32 MiB; the
+  4 MiB (12.5%) reserve covers Effect RPC envelopes, LiveStore framing,
+  and serialization differences across WS, HTTP, and DO-RPC.
   `MAX_PULL_EVENTS_PER_MESSAGE = MAX_PUSH_EVENTS_PER_REQUEST = 100`. D1
   paths additionally paginate adaptively (~1 MB response target, page size
   shrinking from 256) and chunk inserts to 14 events per statement

--- a/context/02-system/03-sync/spec.md
+++ b/context/02-system/03-sync/spec.md
@@ -55,7 +55,7 @@ SyncBackend = {
   polled.
 - **Chunking (LS.SYS.SYNC-R04):** bounds live at the provider transport
   boundary, not the leader — the Cloudflare transports cap 100 events per
-  message and 900 kB per frame (`sync-cf/src/common/constants.ts`);
+  message and 28 MiB per transport payload (`sync-cf/src/common/constants.ts`);
   `transport-chunking.ts` splits oversized payloads
   (`OversizeChunkItemError` when a single item exceeds the cap). The
   leader's own batch sizes are smaller

--- a/packages/@livestore/sync-cf/src/common/constants.ts
+++ b/packages/@livestore/sync-cf/src/common/constants.ts
@@ -1,12 +1,8 @@
-// Shared transport limits for Cloudflare sync provider
-// Keep payloads comfortably below ~1MB frame caps across Cloudflare transports.
+// Keep payloads 4 MiB below Cloudflare's 32 MiB received-message limit for framing headroom.
 // References:
-// - Durable Objects WebSockets + hibernation best practices:
-//   https://developers.cloudflare.com/durable-objects/best-practices/websockets/
-// - Workers platform limits (general context):
-//   https://developers.cloudflare.com/workers/platform/limits/
-// Empirically, frames just below 1MB can fail on hibernated DO WebSockets; we use 900_000 bytes to keep a safety margin.
-export const MAX_TRANSPORT_PAYLOAD_BYTES = 900_000
+// - https://developers.cloudflare.com/workers/runtime-apis/websockets/
+// - https://developers.cloudflare.com/changelog/post/2025-10-31-increased-websocket-message-size-limit/
+export const MAX_TRANSPORT_PAYLOAD_BYTES = 28 * 1024 * 1024
 
 export const MAX_WS_MESSAGE_BYTES = MAX_TRANSPORT_PAYLOAD_BYTES
 export const MAX_DO_RPC_REQUEST_BYTES = MAX_TRANSPORT_PAYLOAD_BYTES


### PR DESCRIPTION
## Problem

`@livestore/sync-cf` still uses a 900,000-byte transport payload budget that was chosen below Cloudflare's former 1 MiB received-WebSocket-message limit. Cloudflare raised that platform limit to 32 MiB in October 2025, so the existing budget now causes large event batches to be split much more conservatively than the platform requires.

This is a draft because the policy is still up for discussion: we may decide not to raise the LiveStore limit, or we may choose a different value.

## Solution

Raise the shared Cloudflare sync transport payload budget to 28 MiB. This leaves 4 MiB (12.5%) below Cloudflare's 32 MiB ceiling for LiveStore/Effect framing and operational compatibility across WebSocket, HTTP, and DO-RPC transports.

The PR is deliberately small:

- preserve the existing count- and byte-based batch chunking behavior
- update the owning intent-layer specifications and record the headroom decision
- add the package changeset
- avoid changes to client/provider error mapping or public error types

A possible follow-up would preserve the existing typed oversize-item diagnostic across the public sync/provider boundary instead of allowing it to become an `UnknownError`. That requires propagating the error type more broadly through provider, leader, and store shutdown contracts. We intentionally left that larger contract change out until we decide whether it is needed.

The main trade-off is that larger individual transport messages can increase per-message memory and operational risk. The 28 MiB budget is therefore a proposed conservative value, not an attempt to consume Cloudflare's full platform maximum.

## Validation

- `devenv tasks run lint:full:fix` — passed
- `git diff --check` — passed
- Tests were not run because this is a constant-and-documentation-only change that preserves the existing chunking implementation.

## Related issues

No matching public issue found.
