### PR TITLE
fix(sync-cf): persist DO-RPC subscriber registry across backend reconstruction

### DIFF
--- a/.changeset/some-suits-tease.md
+++ b/.changeset/some-suits-tease.md
@@ -1,0 +1,5 @@
+---
+"@livestore/sync-cf": patch
+---
+
+Persist the sync backend's DO-RPC subscriber registry in the Durable Object's KV storage (`ctx.storage.kv`), keyed by client Durable Object id, so live updates keep flowing to Durable-Object-resident clients after the backend is evicted and rebuilt (deploy, eviction, hibernation). Previously the registry lived only in memory and was lost on reconstruction, silently stopping live sync over DO-RPC and dropping the push echo that can wedge a replica (#1462). WebSocket clients were unaffected; no config or migration is required.

--- a/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/layer.ts
@@ -5,7 +5,7 @@ import { shouldNeverHappen } from '@livestore/utils'
 import { Context, Effect, Layer, Predicate } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 
-import type { Env, MakeDurableObjectClassOptions, RpcSubscription } from '../shared.ts'
+import type { Env, MakeDurableObjectClassOptions } from '../shared.ts'
 import { contextTable, eventlogTable } from './sqlite.ts'
 import { makeStorage, type SyncStorage } from './sync-storage.ts'
 
@@ -31,7 +31,6 @@ export interface Service {
   readonly doOptions: MakeDurableObjectClassOptions | undefined
   readonly env: Env
   readonly ctx: CfTypes.DurableObjectState
-  readonly rpcSubscriptions: Map<string, RpcSubscription>
 }
 
 export class DoCtx extends Context.Service<DoCtx, Service>()('@livestore/sync-cf/DoCtx') {}
@@ -113,8 +112,6 @@ export const make = Effect.fn(
       doSelf[CacheSymbol].currentHeadRef = { current: currentHead }
     }
 
-    const rpcSubscriptions = new Map<string, RpcSubscription>()
-
     const storageCache = {
       storeId,
       backendId,
@@ -124,7 +121,6 @@ export const make = Effect.fn(
       doOptions,
       env: doSelf.env,
       ctx: doSelf.ctx,
-      rpcSubscriptions,
     }
 
     ;(doSelf as any)[CacheSymbol] = storageCache

--- a/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/push.ts
@@ -9,6 +9,8 @@ import {
   type Env,
   type ForwardedHeaders,
   type MakeDurableObjectClassOptions,
+  rpcSubscriptionKeyPrefix,
+  type RpcSubscription,
   type StoreId,
   WebSocketAttachmentSchema,
 } from '../shared.ts'
@@ -39,7 +41,7 @@ export const makePush =
   (pushRequest: Omit<SyncMessage.PushRequest, '_tag'>) =>
     Effect.gen(function* () {
       // yield* Effect.log(`Pushing ${decodedMessage.batch.length} events`, decodedMessage.batch)
-      const { backendId, storage, currentHeadRef, updateCurrentHead, rpcSubscriptions } = yield* DoCtx.DoCtx
+      const { backendId, storage, currentHeadRef, updateCurrentHead } = yield* DoCtx.DoCtx
 
       if (pushRequest.batch.length === 0) {
         return SyncMessage.PushAck.make({})
@@ -166,9 +168,11 @@ export const makePush =
           yield* Effect.logDebug(`Broadcasted to ${connectedClients.length} WebSocket clients`)
         }
 
-        // RPC broadcasting would require reconstructing client stubs from clientIds
-        if (rpcSubscriptions.size > 0) {
-          for (const subscription of rpcSubscriptions.values()) {
+        // Subscribers live in the DO's KV storage (single source of truth), so fan-out survives reconstruction.
+        // emitStreamResponse reconstructs each client stub from its callerContext.
+        const rpcSubscriptions = Array.from(ctx.storage.kv.list<RpcSubscription>({ prefix: rpcSubscriptionKeyPrefix }))
+        if (rpcSubscriptions.length > 0) {
+          for (const [, subscription] of rpcSubscriptions) {
             for (const { encoded } of responses) {
               yield* emitStreamResponse({
                 callerContext: subscription.callerContext,
@@ -179,7 +183,7 @@ export const makePush =
             }
           }
 
-          yield* Effect.logDebug(`Broadcasted to ${rpcSubscriptions.size} RPC clients`)
+          yield* Effect.logDebug(`Broadcasted to ${rpcSubscriptions.length} RPC clients`)
         }
       }).pipe(
         Effect.tapCauseLogPretty,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -3,6 +3,7 @@ import { type CfTypes, toDurableObjectHandler } from '@livestore/common-cf'
 import { Effect, Headers, Option, Stream } from '@livestore/utils/effect'
 
 import { SyncDoRpc } from '../../../common/do-rpc-schema.ts'
+import { rpcSubscriptionKeyPrefix, type RpcSubscription } from '../../shared.ts'
 import * as DoCtx from '../layer.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
@@ -17,25 +18,26 @@ export const createDoRpcHandler = (
 ): Effect.Effect<Uint8Array<ArrayBuffer> | CfTypes.ReadableStream> =>
   Effect.gen({ self: this }, function* () {
     const { payload, input } = options
-    // const { rpcSubscriptions, backendId, doOptions, ctx, env } = yield* DoCtx
 
     // TODO add admin RPCs
     const RpcLive = SyncDoRpc.toLayer({
       'SyncDoRpc.Ping': () => Effect.void,
       'SyncDoRpc.Pull': (req, { headers }) =>
         Effect.gen({ self: this }, function* () {
-          const { rpcSubscriptions } = yield* DoCtx.DoCtx
+          const { ctx } = yield* DoCtx.DoCtx
 
           // TODO rename `req.rpcContext` to something more appropriate
           if (req.rpcContext !== undefined) {
-            // Key by client DO id, not storeId: one backend serves many client DOs, so storeId would clobber siblings.
-            rpcSubscriptions.set(req.rpcContext.callerContext.durableObjectId, {
+            const subscription: RpcSubscription = {
               storeId: req.storeId,
               subscribedAt: Date.now(),
               requestId: Headers.get(headers, 'x-rpc-request-id').pipe(Option.getOrThrow),
               callerContext: req.rpcContext.callerContext,
               ...(req.payload !== undefined ? { payload: req.payload } : {}),
-            })
+            }
+            // Keyed by client DO id (not storeId — one backend serves many client DOs). The DO's synchronous KV
+            // storage is the single source of truth, so the entry outlives backend reconstruction.
+            ctx.storage.kv.put(`${rpcSubscriptionKeyPrefix}${subscription.callerContext.durableObjectId}`, subscription)
           }
 
           // DO-RPC doesn't have HTTP headers context - headers are undefined

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -28,7 +28,8 @@ export const createDoRpcHandler = (
 
           // TODO rename `req.rpcContext` to something more appropriate
           if (req.rpcContext !== undefined) {
-            rpcSubscriptions.set(req.storeId, {
+            // Key by client DO id, not storeId: one backend serves many client DOs, so storeId would clobber siblings.
+            rpcSubscriptions.set(req.rpcContext.callerContext.durableObjectId, {
               storeId: req.storeId,
               subscribedAt: Date.now(),
               requestId: Headers.get(headers, 'x-rpc-request-id').pipe(Option.getOrThrow),

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -168,6 +168,9 @@ export type RpcSubscription = {
   }
 }
 
+/** Key prefix for DO-RPC subscriptions persisted in the DO's synchronous KV storage. */
+export const rpcSubscriptionKeyPrefix = 'rpc-sub:'
+
 /**
  * Durable Object interface supporting the DO RPC protocol for DO <> DO syncing.
  */

--- a/tests/sync-provider/src/do-rpc-server-reconstruction.test.ts
+++ b/tests/sync-provider/src/do-rpc-server-reconstruction.test.ts
@@ -20,16 +20,7 @@ import { isProviderSelected } from './providers/registry.ts'
 const idleWindow: Duration.Input = '14 seconds' // past the ~9-11s workerd eviction window
 const testTimeoutMs = 120_000
 
-/**
- * The suite below is red until the backend persists its DO-RPC subscriber registry, which lands in
- * the PR stacked on top of this one. Stacked merges require every PR below to have passing checks,
- * so the suite is gated off here and this flag is flipped to `true` alongside the fix.
- */
-const registryIsPersisted = false
-
-const describeDoRpcDo = Vitest.describe.skipIf(
-  registryIsPersisted === false || isProviderSelected('cf-do-rpc-do') === false,
-)
+const describeDoRpcDo = Vitest.describe.skipIf(isProviderSelected('cf-do-rpc-do') === false)
 
 describeDoRpcDo(`${CloudflareDoRpcProvider.doSqlite.name} sync provider — DO-RPC server reconstruction`, () => {
   const getContext = setupProviderRuntime(CloudflareDoRpcProvider.doSqlite.layer)


### PR DESCRIPTION
## Problem

The sync backend Durable Object keeps its **DO-RPC** subscriber registry (clients that are themselves Durable Objects, syncing over DO-to-DO RPC) only in memory. When the DO is evicted and rebuilt — deploy, eviction, hibernation — the registry is gone, so the rebuilt instance fans out live events to no DO-RPC subscribers: silent live-sync loss. Separately, the registry was keyed by `storeId`, but one backend serves many client DOs, so a second subscriber to the same store overwrote the first. WebSocket clients are unaffected. #1541 reproduces the reconstruction case as a failing test.

## Solution

- Key the registry by the client's durable-object id (not `storeId`), so multiple DO-RPC subscribers to one store coexist.
- Persist it in the DO's synchronous KV storage (`ctx.storage.kv`, backed by SQLite — schemaless, no migration) as the **single source of truth**: write on subscribe, read on fan-out. No in-memory copy, so the two can't drift.
- The rebuilt backend reads the surviving entries and resumes fan-out.

Each subscriber is plain data (`{ storeId, requestId, callerContext }`) — no live objects — so persisting is just saving who to push to and how.

Out of scope: removing subscribers. Neither the graceful `Interrupt` teardown (#1418) nor reaping ungracefully-abandoned entries (a separate, measurement-gated follow-up) is implemented here — the registry is written and read, never deleted.

## Validation

`cd tests/sync-provider`:

- `TEST_SYNC_PROVIDER=cf-do-rpc-do vitest run src/do-rpc-server-reconstruction.test.ts` → **green** (was red on #1541)
- `TEST_SYNC_PROVIDER=cf-do-rpc-do vitest run src/do-rpc-hibernation.test.ts` → green
- `TEST_SYNC_PROVIDER=cf-ws-do vitest run src/do-hibernation.test.ts` → green
- `tsgo --build`, type-aware oxlint, oxfmt → clean

No public API change (independently audited): the registry lives on the internal `DoCtx` service, `RpcSubscription` is unchanged, and the only public delta is an additive const. No wire/schema change, no user config change, no migration — KV starts empty and refills as clients subscribe.

## Demo

```text
Before                                    After
subscribe ──▶ in-memory Map               subscribe ──▶ ctx.storage.kv.put("rpc-sub:<doId>")
evict + rebuild ──▶ Map = { }             evict + rebuild ──▶ KV survives
push ──▶ fan-out to nobody       ✗        push ──▶ read KV ──▶ fan-out resumes    ✓
```

## Trade-offs and follow-up

- No removal path yet: entries are written on subscribe and never deleted, so abandoned DO-RPC subscribers linger in KV and get a reverse-RPC on every push. Graceful `Interrupt` teardown is tracked in #1418; reaping ungracefully-abandoned entries (hibernated/dead clients that never send `Interrupt`) is a distinct follow-up.
- Client-side next hop, not addressed here: with the callback now firing, a client DO that hibernated still drops the update because its own in-memory routing map is empty — #1415.
- Fan-out now does one local `ctx.storage.kv.list` per push instead of iterating memory — a microsecond-scale SQLite read, dwarfed by the reverse-RPCs already on that path.

## Related

- **#1338** — superseded end-to-end hibernation PR (closed) that first bundled this as "Bug 2 / persist the registry"; this is its reworked server half (it used a SQLite table; this uses `ctx.storage.kv`).
- **#1435** — the DO-RPC hibernation guard test explicitly deferred this exact bug ("the rebuilt DO drops its in-memory subscribers … tracked separately"); this PR is that deferred fix.
- **#1328** — the hibernation fix ("Bug 1", closed) that made this reconstruction loss ("Bug 2") routine; causal origin, not the same bug.
- **#1462** — removes the server-side leg of that production wedge (its failure-chain step 1: the in-memory subscriber `Map` wiped on reconstruction). The downstream stale-parent/`ServerAheadError` deadlock and the client-side leg remain out of scope.
- **#1418** — the graceful-`Interrupt` teardown path for DO-RPC subscribers is still a TODO, so the now-persistent registry is written but never deleted; persisting makes that gap load-bearing.
