### PR TITLE
refactor(sync-cf): scope DO-RPC client pull routing per DO instance

### DIFF
--- a/.changeset/scope-do-rpc-client-pull-routing.md
+++ b/.changeset/scope-do-rpc-client-pull-routing.md
@@ -1,0 +1,5 @@
+---
+"@livestore/sync-cf": minor
+---
+
+**Cloudflare DO-RPC client:** Scope the client's live-pull routing to the Durable Object instance. `handleSyncUpdateRpc` now takes the DO's `ctx` (`handleSyncUpdateRpc(ctx, payload)`) and `makeDoRpcSync` takes a `durableObjectState` option, so routing resets when the client Durable Object is reconstructed (deploy, eviction, hibernation) and cannot leak across co-located instances. This also fixes a routing-map queue leak. A reconstructed client still drops the in-flight update until the follow-up recovery change lands (#1415).

--- a/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/client-do.ts
+++ b/docs/src/content/_assets/code/reference/platform-adapters/cloudflare/client-do.ts
@@ -79,6 +79,7 @@ export class LiveStoreClientDO extends DurableObject<Env> implements ClientDoWit
   }
 
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
-    await handleSyncUpdateRpc(payload)
+    // @ts-expect-error TODO remove once CF types are fixed in https://github.com/cloudflare/workerd/issues/4811
+    await handleSyncUpdateRpc(this.ctx, payload)
   }
 }

--- a/docs/src/content/_assets/code/reference/syncing/cloudflare/client-do-rpc.ts
+++ b/docs/src/content/_assets/code/reference/syncing/cloudflare/client-do-rpc.ts
@@ -6,6 +6,7 @@ declare const syncBackendDurableObject: CfTypes.DurableObjectStub<SyncBackendRpc
 
 export const syncBackend = makeDoRpcSync({
   syncBackendStub: syncBackendDurableObject,
+  durableObjectState: state,
   durableObjectContext: {
     bindingName: 'CLIENT_DO',
     durableObjectId: state.id.toString(),

--- a/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
+++ b/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
@@ -113,7 +113,7 @@ Creates a LiveStore instance inside a Durable Object.
 
 ### `syncUpdateRpc(payload)`
 
-Client Durable Objects must implement this method so the sync backend can deliver live updates. `createStoreDoPromise` wires it up automatically—just forward the payload to `handleSyncUpdateRpc` (see the client Durable Object example above).
+Client Durable Objects must implement this method so the sync backend can deliver live updates. `createStoreDoPromise` wires it up automatically—just forward the DO's `ctx` and the payload to `handleSyncUpdateRpc(ctx, payload)` (see the client Durable Object example above).
 
 ## Resetting LiveStore persistence (development only)
 

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -162,6 +162,7 @@ Creates a Durable Object RPC-based sync backend (for internal use).
 
 **Options:**
 - `syncBackendStub` - Durable Object stub implementing `SyncBackendRpcInterface`
+- `durableObjectState` - The client Durable Object's `ctx` (`DurableObjectState`); scopes live-pull routing to this instance so it resets on reconstruction
 - `durableObjectContext` - Context for RPC callbacks:
   - `bindingName` - Wrangler binding name for the client DO
   - `durableObjectId` - Client Durable Object ID
@@ -171,9 +172,9 @@ Creates a Durable Object RPC-based sync backend (for internal use).
 - Real-time live pull via callbacks
 - Hibernation support
 
-### `handleSyncUpdateRpc(payload)`
+### `handleSyncUpdateRpc(ctx, payload)`
 
-Handles RPC callback for live pull updates in Durable Objects.
+Handles the RPC callback for live-pull updates in Durable Objects. Pass the client DO's `ctx` (`DurableObjectState`) so the update is routed to that instance's live pull; a reconstructed DO with no matching pull drops the update.
 
 <SNIPPETS.clientDo />
 

--- a/examples/cloudflare-todomvc/src/live-store-client-do.ts
+++ b/examples/cloudflare-todomvc/src/live-store-client-do.ts
@@ -72,6 +72,6 @@ export class LiveStoreClientDO extends DurableObject<Env> implements ClientDoWit
   }
 
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
-    await handleSyncUpdateRpc(payload)
+    await handleSyncUpdateRpc(this.ctx, payload)
   }
 }

--- a/examples/web-email-client/src/cf-worker/MailboxClientDO.ts
+++ b/examples/web-email-client/src/cf-worker/MailboxClientDO.ts
@@ -121,6 +121,6 @@ export class MailboxClientDO extends DurableObject<Env> implements ClientDoWithR
 
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     // Make sure to wake up the store before processing the sync update
-    await handleSyncUpdateRpc(payload)
+    await handleSyncUpdateRpc(this.ctx as SyncBackend.CfTypes.DurableObjectState, payload)
   }
 }

--- a/examples/web-email-client/src/cf-worker/ThreadClientDO.ts
+++ b/examples/web-email-client/src/cf-worker/ThreadClientDO.ts
@@ -149,6 +149,6 @@ export class ThreadClientDO extends DurableObject<Env> implements ClientDoWithRp
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
     // Make sure to wake up the store before processing the sync update
     await this.subscribeToStore()
-    await handleSyncUpdateRpc(payload)
+    await handleSyncUpdateRpc(this.ctx as SyncBackend.CfTypes.DurableObjectState, payload)
   }
 }

--- a/packages/@livestore/adapter-cloudflare/src/create-store-do.ts
+++ b/packages/@livestore/adapter-cloudflare/src/create-store-do.ts
@@ -122,6 +122,7 @@ export const createStoreDo = <
       syncOptions: {
         backend: makeDoRpcSync({
           syncBackendStub,
+          durableObjectState: ctx,
           durableObjectContext: { bindingName, durableObjectId },
         }),
         livePull, // Uses DO RPC callbacks for reactive pull

--- a/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
+++ b/packages/@livestore/sync-cf/src/client/transport/do-rpc-client.ts
@@ -27,13 +27,14 @@ type PushBatchItem = SyncMessage.PushRequest['batch'][number]
 
 export interface SyncBackendRpcStub extends CfTypes.DurableObjectStub, SyncBackendRpcInterface {}
 
-// TODO we probably need better scoping for the requestIdQueueMap (i.e. support multiple stores, ...)
-type EffectRpcRequestId = string // 0, 1, 2, ...
-const requestIdQueueMap = new Map<EffectRpcRequestId, Queue.Queue<SyncMessage.PullResponse>>()
-
 export interface DoRpcSyncOptions {
   /** Durable Object stub that implements the SyncDoRpc interface */
   syncBackendStub: SyncBackendRpcStub
+  /**
+   * State handle of the client DurableObject running this sync backend. Scopes live-pull routing to
+   * this instance so it resets when the DO is reconstructed (see {@link handleSyncUpdateRpc}).
+   */
+  durableObjectState: CfTypes.DurableObjectState
   /** Information about this DurableObject instance so the Sync DO instance can call back to this instance */
   durableObjectContext: {
     /** See `wrangler.toml` for the binding name */
@@ -49,7 +50,11 @@ export interface DoRpcSyncOptions {
  * Used internally by `@livestore/adapter-cf` to connect to the sync backend.
  */
 export const makeDoRpcSync =
-  ({ syncBackendStub, durableObjectContext }: DoRpcSyncOptions): SyncBackend.SyncBackendConstructor<SyncMetadata> =>
+  ({
+    syncBackendStub,
+    durableObjectState,
+    durableObjectContext,
+  }: DoRpcSyncOptions): SyncBackend.SyncBackendConstructor<SyncMetadata> =>
   ({ storeId, payload }) =>
     Effect.gen(function* () {
       const isConnected = yield* SubscriptionRef.make(true)
@@ -85,11 +90,15 @@ export const makeDoRpcSync =
                   if (res._tag === 'None')
                     return shouldNeverHappen('There should at least be a no-more page info response')
 
+                  const requestId = res.value.rpcRequestId
+                  const routing = pullRoutingFor(durableObjectState)
+
                   const queue = yield* Effect.acquireRelease(Queue.unbounded<SyncMessage.PullResponse>(), (queue) =>
-                    Queue.shutdown(queue).pipe(Effect.asVoid),
+                    // Drop the routing entry on release so it can't outlive its (now shut-down) queue
+                    Effect.sync(() => routing.delete(requestId)).pipe(Effect.andThen(Queue.shutdown(queue))),
                   )
 
-                  requestIdQueueMap.set(res.value.rpcRequestId, queue)
+                  routing.set(requestId, queue)
 
                   return Stream.fromQueue(queue)
                 }).pipe(Stream.unwrap),
@@ -171,12 +180,12 @@ export const makeDoRpcSync =
  *   // ...
  *
  *   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
- *     return handleSyncUpdateRpc(payload)
+ *     return handleSyncUpdateRpc(this.ctx, payload)
  *   }
  * }
  * ```
  */
-export const handleSyncUpdateRpc = (payload: Uint8Array<ArrayBuffer>) =>
+export const handleSyncUpdateRpc = (ctx: CfTypes.DurableObjectState, payload: Uint8Array<ArrayBuffer>) =>
   Effect.gen(function* () {
     const parser = RpcSerialization.msgPack.makeUnsafe()
     const decodedMessage = parser.decode(payload)
@@ -186,7 +195,7 @@ export const handleSyncUpdateRpc = (payload: Uint8Array<ArrayBuffer>) =>
       decodedPayload.values[0],
     )
 
-    const pullStreamQueue = requestIdQueueMap.get(decodedPayload.requestId)
+    const pullStreamQueue = pullRoutingFor(ctx).get(decodedPayload.requestId)
 
     if (pullStreamQueue === undefined) {
       // Case: DO was hibernated, so we need to manually update the store
@@ -201,3 +210,24 @@ const ResponseChunkEncoded = Schema.Struct({
   requestId: Schema.String,
   values: Schema.Array(Schema.Any),
 })
+
+type EffectRpcRequestId = string // 0, 1, 2, ...
+type PullRouting = Map<EffectRpcRequestId, Queue.Queue<SyncMessage.PullResponse>>
+
+/**
+ * Per-instance map from a live pull's request id to its response queue, keyed off the client DO's
+ * `DurableObjectState` (not a module global) for two independent reasons:
+ * - Per-instance: a reconstructed DO starts empty, so a reverse-RPC whose store is gone hits the
+ *   `handleSyncUpdateRpc` drop branch (the recovery hook) instead of a stale queue that outlived it.
+ * - Keyed by request id: a late chunk from a superseded pull generation finds no entry and is
+ *   dropped here — never reaching `SyncState.merge`, which dies on an event at/below the upstream head.
+ */
+const pullRoutingByInstance = new WeakMap<CfTypes.DurableObjectState, PullRouting>()
+
+const pullRoutingFor = (ctx: CfTypes.DurableObjectState): PullRouting => {
+  const existing = pullRoutingByInstance.get(ctx)
+  if (existing !== undefined) return existing
+  const routing: PullRouting = new Map()
+  pullRoutingByInstance.set(ctx, routing)
+  return routing
+}

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -204,7 +204,7 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
   }
 
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
-    await handleSyncUpdateRpc(payload)
+    await handleSyncUpdateRpc(this.ctx, payload)
   }
 
   private ensureSqlTracking() {

--- a/tests/sync-provider/src/do-rpc-client-reconstruction.test.ts
+++ b/tests/sync-provider/src/do-rpc-client-reconstruction.test.ts
@@ -1,0 +1,156 @@
+import { expect } from 'vitest'
+
+import { EventFactory } from '@livestore/common/testing'
+import { nanoid } from '@livestore/livestore'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { type Duration, Effect, Schedule } from '@livestore/utils/effect'
+
+import {
+  awaitDelivery,
+  collectReceivedIds,
+  makeEventFactory,
+  probeSyncDo,
+  setupProviderRuntime,
+  SyncDoProbeError,
+  syncProvider,
+} from './do-idle-helpers.ts'
+import * as CloudflareDoRpcProvider from './providers/cloudflare-do-rpc.ts'
+import { isProviderSelected } from './providers/registry.ts'
+
+const idleWindow: Duration.Input = '14 seconds' // past the ~9-11s workerd eviction window
+const testTimeoutMs = 120_000
+
+/**
+ * The suite below is red until the client scopes its DO-RPC pull routing per DO instance, which lands in
+ * the PR stacked on top of this one. Without it the module-global routing map survives reconstruction under
+ * `wrangler dev`, so the drop is non-deterministic. Stacked merges require every PR below to have passing
+ * checks, so the suite is gated off here and this flag is flipped to `true` alongside the fix.
+ */
+const pullRoutingScopedPerInstance = false
+
+const describeDoRpcDo = Vitest.describe.skipIf(
+  pullRoutingScopedPerInstance === false || isProviderSelected('cf-do-rpc-do') === false,
+)
+
+describeDoRpcDo(`${CloudflareDoRpcProvider.doSqlite.name} sync provider — DO-RPC client reconstruction`, () => {
+  const getContext = setupProviderRuntime(CloudflareDoRpcProvider.doSqlite.layer)
+
+  Vitest.live(
+    'a reconstructed DO-RPC client store drops the reverse-RPC update from its materialized state',
+    () => storeDropsLiveUpdateAfterClientReconstruction.pipe(Effect.provide(getContext())),
+    testTimeoutMs,
+  )
+})
+
+const writerClient = EventFactory.clientIdentity('do-rpc-client-writer', 'do-rpc-client-writer-session')
+const catchupClient = EventFactory.clientIdentity('do-rpc-client-catchup', 'do-rpc-client-catchup-session')
+
+type StoreProbe = { instanceId: string; todoIds: ReadonlyArray<string> }
+
+/** Boots the subscriber store inside StoreClientDo (livePull). Never re-boots — a reverse-RPC wake stays store-less. */
+const bootStoreClient = ({ port, storeId }: { port: number; storeId: string }) =>
+  Effect.promise(() => fetch(`http://localhost:${port}/store/boot?storeId=${storeId}`, { method: 'POST' }))
+
+/** Reads the client's materialized todos via the store-probe endpoint. */
+const probeStoreClient = ({ port, storeId }: { port: number; storeId: string }) =>
+  Effect.promise(() => fetch(`http://localhost:${port}/store/probe?storeId=${storeId}`).then((res) => res.json())).pipe(
+    Effect.map((json) => json as StoreProbe),
+  )
+
+/** Polls the store probe until `id` lands in the materialized todos (i.e. it was applied). */
+const awaitPersisted = (
+  { port, storeId, id }: { port: number; storeId: string; id: string },
+  timeout: Duration.Input = '10 seconds',
+) =>
+  probeStoreClient({ port, storeId }).pipe(
+    Effect.flatMap((probe) =>
+      probe.todoIds.includes(id) === true
+        ? Effect.void
+        : Effect.fail(new SyncDoProbeError({ message: `not yet persisted: ${id}` })),
+    ),
+    Effect.retry(Schedule.spaced('300 millis')),
+    Effect.timeoutOrElse({
+      duration: timeout,
+      orElse: () => new SyncDoProbeError({ message: `store never persisted "${id}"` }),
+    }),
+  )
+
+// Idles the CLIENT DO into a real reconstruction while keeping the SERVER warm: probing the sync DO
+// every few seconds never touches the client DO, so only the client's idle timer runs out.
+const awaitClientReconstruction = ({
+  port,
+  storeId,
+  baselineId,
+}: {
+  port: number
+  storeId: string
+  baselineId: string
+}) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      yield* probeSyncDo({ port, storeId }).pipe(
+        Effect.delay('3 seconds'),
+        Effect.forever,
+        Effect.timeout(idleWindow),
+        Effect.ignore,
+      )
+      const probe = yield* probeStoreClient({ port, storeId })
+      if (probe.instanceId !== baselineId) return probe
+    }
+    return yield* new SyncDoProbeError({ message: 'client DO never reconstructed within the idle windows' })
+  })
+
+// A DO-RPC client store loses a live update once it is reconstructed. Unlike the transport-level view,
+// this observes the client's OWN materialized state via the store API — heal-free — so the drop is real.
+//
+//   writer ──push──►  server  ──reverse-RPC──►  StoreClientDo (real subscriber store, livePull)
+//                     (subscription persisted in the server's KV)
+//
+//   1. boot + warm          push "before"  ──►  reverse-RPC applied + persisted to eventlog          ✓
+//   2. idle the CLIENT ~14s  ──►  it evicts & rebuilds  ──►  its per-instance pull-routing map = { }
+//      (the server is probed every 3s, so only the client sleeps)
+//   3. rebuilt              push "after"   ──►  server still reverse-RPCs the client, but
+//      handleSyncUpdateRpc finds no queue for the request id ──►  update dropped, never persisted
+//
+// Contract: the test passes by asserting the DROP — the reconstructed client's todos never gain
+// "after-reconstruct". When the client-recovery fix lands, flip the last assertion to `toContain`.
+const storeDropsLiveUpdateAfterClientReconstruction = Effect.gen(function* () {
+  const { makeProvider, port } = yield* syncProvider
+  const storeId = `do-rpc-client-reconstruction-${nanoid()}`
+
+  // The subscriber is a real store inside StoreClientDo. No pingSchedule keeps it idle-evictable.
+  yield* bootStoreClient({ port, storeId })
+
+  const writer = yield* makeProvider({ storeId, clientId: writerClient.clientId, payload: undefined })
+  const writerFactory = makeEventFactory({ client: writerClient, startSeq: 1, initialParent: 'root' })
+  yield* writer.connect
+
+  yield* Effect.sleep('1 second')
+  yield* writer.push([writerFactory.todoCreated.next({ id: 'before-reconstruct', text: 'before', completed: false })])
+
+  // Live reverse-RPC applies + materializes it: proves the store probe sees applied events (non-vacuous).
+  yield* awaitPersisted({ port, storeId, id: 'before-reconstruct' })
+
+  const clientBefore = yield* probeStoreClient({ port, storeId })
+  const serverBefore = yield* probeSyncDo({ port, storeId })
+
+  const clientAfter = yield* awaitClientReconstruction({ port, storeId, baselineId: clientBefore.instanceId })
+  const serverAfter = yield* probeSyncDo({ port, storeId })
+
+  expect(clientAfter.instanceId).not.toBe(clientBefore.instanceId)
+  expect(serverAfter.instanceId).toBe(serverBefore.instanceId)
+
+  yield* writer.push([writerFactory.todoCreated.next({ id: 'after-reconstruct', text: 'after', completed: false })])
+
+  // A brand-new subscriber still receives "after-reconstruct" from the server: proof the drop below is the
+  // reconstructed client losing it, not a broken push that would pass the negative assertion vacuously.
+  const catchup = yield* makeProvider({ storeId, clientId: catchupClient.clientId, payload: undefined })
+  yield* catchup.connect
+  const catchupReceived = yield* collectReceivedIds(catchup)
+  yield* awaitDelivery({ received: catchupReceived, id: 'after-reconstruct' })
+
+  // Heal-free read: "before" survived the eviction; "after" was dropped by the store-less reverse-RPC wake.
+  const finalProbe = yield* probeStoreClient({ port, storeId })
+  expect(finalProbe.todoIds).toContain('before-reconstruct')
+  expect(finalProbe.todoIds).not.toContain('after-reconstruct')
+})

--- a/tests/sync-provider/src/do-rpc-client-reconstruction.test.ts
+++ b/tests/sync-provider/src/do-rpc-client-reconstruction.test.ts
@@ -20,17 +20,7 @@ import { isProviderSelected } from './providers/registry.ts'
 const idleWindow: Duration.Input = '14 seconds' // past the ~9-11s workerd eviction window
 const testTimeoutMs = 120_000
 
-/**
- * The suite below is red until the client scopes its DO-RPC pull routing per DO instance, which lands in
- * the PR stacked on top of this one. Without it the module-global routing map survives reconstruction under
- * `wrangler dev`, so the drop is non-deterministic. Stacked merges require every PR below to have passing
- * checks, so the suite is gated off here and this flag is flipped to `true` alongside the fix.
- */
-const pullRoutingScopedPerInstance = false
-
-const describeDoRpcDo = Vitest.describe.skipIf(
-  pullRoutingScopedPerInstance === false || isProviderSelected('cf-do-rpc-do') === false,
-)
+const describeDoRpcDo = Vitest.describe.skipIf(isProviderSelected('cf-do-rpc-do') === false)
 
 describeDoRpcDo(`${CloudflareDoRpcProvider.doSqlite.name} sync provider — DO-RPC client reconstruction`, () => {
   const getContext = setupProviderRuntime(CloudflareDoRpcProvider.doSqlite.layer)

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -117,6 +117,7 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
 
               return yield* makeDoRpcSync({
                 syncBackendStub: this.env.SYNC_BACKEND_DO.get(this.env.SYNC_BACKEND_DO.idFromName(storeId)),
+                durableObjectState: this.ctx,
                 durableObjectContext: { bindingName: 'TEST_CLIENT_DO', durableObjectId: this.ctx.id.toString() },
               })({ storeId, clientId, payload }).pipe(Scope.provide(syncBackendScope), Effect.orDie)
             }),
@@ -207,7 +208,7 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
   }
 
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
-    await handleSyncUpdateRpc(payload)
+    await handleSyncUpdateRpc(this.ctx, payload)
   }
 }
 
@@ -254,7 +255,7 @@ export class StoreClientDo extends DurableObjectBase implements ClientDoWithRpcC
   }
 
   async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
-    await handleSyncUpdateRpc(payload)
+    await handleSyncUpdateRpc(this.ctx, payload)
   }
 }
 

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -2,8 +2,11 @@
 
 import { DurableObject } from 'cloudflare:workers'
 
+import { createStoreDoPromise, makeAdapter } from '@livestore/adapter-cloudflare'
 import { type ClientDoWithRpcCallback, setupDurableObjectWebSocketRpc } from '@livestore/common-cf'
 import type { CfDeclare } from '@livestore/common-cf/declare'
+import { createStore, provideOtel, type Store } from '@livestore/livestore'
+import { schema, tables } from '@livestore/livestore/internal/testing-utils'
 import {
   type CfTypes,
   handleSyncRequest,
@@ -42,9 +45,15 @@ interface TestClientDoProbe {
   getClientProbe(): { instanceId: string }
 }
 
+interface StoreClientDoProbe {
+  bootStore(storeId: string): Promise<void>
+  getStoreProbe(storeId: string): Promise<{ instanceId: string; todoIds: string[] }>
+}
+
 export interface Env {
   SYNC_BACKEND_DO: CfTypes.DurableObjectNamespace<SyncBackendRpcInterface & SyncDoProbe>
   TEST_CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback & TestClientDoProbe>
+  STORE_CLIENT_DO: CfTypes.DurableObjectNamespace<ClientDoWithRpcCallback & StoreClientDoProbe>
   /** Eventlog database */
   DB: CfTypes.D1Database
 }
@@ -202,6 +211,53 @@ export class TestClientDo extends DurableObjectBase implements ClientDoWithRpcCa
   }
 }
 
+/**
+ * A real LiveStore client running inside a DO: it boots a store that subscribes to the sync backend,
+ * so a reverse-RPC update is applied to (and persisted in) its own eventlog. Used to observe that a
+ * reconstructed client drops the update, via a heal-free read of the persisted eventlog.
+ */
+export class StoreClientDo extends DurableObjectBase implements ClientDoWithRpcCallback {
+  __DURABLE_OBJECT_BRAND = 'ClientDO' as never
+  env: Env
+  ctx: CfTypes.DurableObjectState
+  /** Never persisted: a different id means this DO was evicted and rebuilt. */
+  instanceId = crypto.randomUUID()
+  /** The live `livePull` subscriber. A reverse-RPC wake never boots it, so a reconstructed DO stays store-less. */
+  #store: Store<typeof schema> | undefined
+
+  constructor(state: CfTypes.DurableObjectState, env: Env) {
+    super(state, env)
+    this.ctx = state
+    this.env = env
+  }
+
+  async bootStore(storeId: string): Promise<void> {
+    if (this.#store !== undefined) return
+    this.#store = await createStoreDoPromise({
+      schema,
+      storeId,
+      clientId: 'store-client-do',
+      sessionId: 'store-client-do-session',
+      durableObject: { ctx: this.ctx, env: this.env, bindingName: 'STORE_CLIENT_DO' },
+      syncBackendStub: this.env.SYNC_BACKEND_DO.get(this.env.SYNC_BACKEND_DO.idFromName(storeId)),
+      livePull: true,
+    })
+  }
+
+  /** Materialized todos via the store API. A store-less DO (post-reconstruction) reads through a backend-less store that can't heal the drop. */
+  async getStoreProbe(storeId: string): Promise<{ instanceId: string; todoIds: string[] }> {
+    const todoIds =
+      this.#store === undefined
+        ? await readPersistedTodoIds({ storage: this.ctx.storage, storeId })
+        : this.#store.query(tables.todos).map((todo) => todo.id)
+    return { instanceId: this.instanceId, todoIds }
+  }
+
+  async syncUpdateRpc(payload: Uint8Array<ArrayBuffer>) {
+    await handleSyncUpdateRpc(payload)
+  }
+}
+
 export default {
   fetch: async (request: CfTypes.Request, env: Env, ctx: CfTypes.ExecutionContext) => {
     const url = new URL(request.url)
@@ -217,6 +273,24 @@ export default {
 
     if (url.pathname.endsWith('/instance/client') === true) {
       const probe = await env.TEST_CLIENT_DO.get(env.TEST_CLIENT_DO.idFromName('test-client-do')).getClientProbe()
+      return new Response(JSON.stringify(probe), { headers: { 'content-type': 'application/json' } })
+    }
+
+    if (url.pathname.endsWith('/store/boot') === true) {
+      const storeId = url.searchParams.get('storeId')
+      if (storeId === null) {
+        return new Response('storeId required', { status: 400 })
+      }
+      await env.STORE_CLIENT_DO.get(env.STORE_CLIENT_DO.idFromName(storeId)).bootStore(storeId)
+      return new Response(null, { status: 204 })
+    }
+
+    if (url.pathname.endsWith('/store/probe') === true) {
+      const storeId = url.searchParams.get('storeId')
+      if (storeId === null) {
+        return new Response('storeId required', { status: 400 })
+      }
+      const probe = await env.STORE_CLIENT_DO.get(env.STORE_CLIENT_DO.idFromName(storeId)).getStoreProbe(storeId)
       return new Response(JSON.stringify(probe), { headers: { 'content-type': 'application/json' } })
     }
 
@@ -249,3 +323,25 @@ type SyncBackendArgs = {
   storeId: string
   payload: any
 }
+
+/**
+ * Reads the materialized todos through a transient store over the DO's persisted storage.
+ * No sync backend => no boot catch-up pull => the read can't heal a dropped update.
+ */
+const readPersistedTodoIds = ({
+  storage,
+  storeId,
+}: {
+  storage: CfTypes.DurableObjectStorage
+  storeId: string
+}): Promise<string[]> =>
+  Effect.gen(function* () {
+    const adapter = makeAdapter({
+      clientId: 'store-client-do',
+      sessionId: 'store-client-do-session',
+      storage,
+      syncOptions: { initialSyncOptions: { _tag: 'Skip' } },
+    })
+    const store = yield* createStore({ schema, adapter, storeId })
+    return store.query(tables.todos).map((todo) => todo.id)
+  }).pipe(Effect.scoped, provideOtel({}), Effect.runPromise)

--- a/tests/sync-provider/src/providers/cloudflare/wrangler-d1.toml
+++ b/tests/sync-provider/src/providers/cloudflare/wrangler-d1.toml
@@ -18,6 +18,10 @@ class_name = "SyncBackendDO"
 name = "TEST_CLIENT_DO"
 class_name = "TestClientDo"
 
+[[durable_objects.bindings]]
+name = "STORE_CLIENT_DO"
+class_name = "StoreClientDo"
+
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["SyncBackendDO", "TestClientDo"]
+new_sqlite_classes = ["SyncBackendDO", "TestClientDo", "StoreClientDo"]

--- a/tests/sync-provider/src/providers/cloudflare/wrangler-do-sqlite.toml
+++ b/tests/sync-provider/src/providers/cloudflare/wrangler-do-sqlite.toml
@@ -13,6 +13,10 @@ class_name = "SyncBackendDO"
 name = "TEST_CLIENT_DO"
 class_name = "TestClientDo"
 
+[[durable_objects.bindings]]
+name = "STORE_CLIENT_DO"
+class_name = "StoreClientDo"
+
 [[migrations]]
 tag = "v1"
-new_sqlite_classes = ["SyncBackendDO", "TestClientDo"]
+new_sqlite_classes = ["SyncBackendDO", "TestClientDo", "StoreClientDo"]


### PR DESCRIPTION
## What this is

**Preparation** for the DO-RPC client reconstruction fix. It scopes the client's live-pull routing per Durable Object instance, brings the whole public surface (API, examples, docs) along, and adds a regression test that documents the current drop. **This is not the behavioural fix yet** — a reconstructed client still drops the in-flight update; the follow-up recovery change makes it survive.

## Problem

A **DO-RPC** subscriber (a LiveStore client that is itself a Durable Object, syncing over DO-to-DO RPC) loses a live update when the client DO is evicted and rebuilt. Its live-pull routing map was a module global. Cloudflare discards in-memory state — [globals included](https://developers.cloudflare.com/durable-objects/reference/in-memory-state/) — on hibernation/eviction, and may leak it across co-located DOs, so a reconstructed instance either reuses a stale entry or leaks one, and the backend's *reverse-RPC* push (the backend calling `syncUpdateRpc` on the client DO) is misrouted or dropped. #1541 / #1542 fixed the mirror-image loss on the server.

## Public API change (breaking for DO-RPC clients)

- `handleSyncUpdateRpc(payload)` → `handleSyncUpdateRpc(ctx, payload)` — pass the client DO's `ctx`.
- `makeDoRpcSync` gains a `durableObjectState` option.

Routing now lives in a `WeakMap` keyed by the DO's `ctx`, so it resets on reconstruction and can't bleed across co-located instances. Also fixes a routing-map queue leak (entries are deleted on pull-stream release).

**Surface updated:** examples (`cloudflare-todomvc`, `web-email-client` Mailbox + Thread), docs code snippets, the integration worker, and the public reference pages (`sync-providers/cloudflare`, `platform-adapters/cloudflare-durable-object-adapter`).

## The test

A store-based reconstruction test under the `cf-do-rpc-do` provider (`wrangler dev`, real-idle eviction): a new `StoreClientDo` boots a real `livePull` subscriber store, applies + persists an event pushed *before* reconstruction, is idled into a genuine eviction (instance id changes) while the server stays warm, then a heal-free eventlog probe shows the *after* event was dropped while a fresh catch-up subscriber still receives it from the server. It asserts the current DROP (`not.toContain('after-reconstruct')`); the follow-up recovery change flips it to `toContain`.

**Notes:**
- **Why a new `StoreClientDo` (not reuse `TestClientDo`)** — `TestClientDo` is the WS→DO relay every `cf-do-rpc` test rides on; it forwards RPCs but never boots a store, so it has no eventlog to read. Converting it would break every relay-dependent test.
- **Heal-free read** — the probe reads the persisted `eventlog` raw and boots no store; any store-level read would trigger a boot catch-up pull that masks the drop (`livePull: false` / `initialSyncOptions: Skip` don't prevent it — only *no backend* does).
- **Alternative tried** — the deterministic, gate-able path is `@cloudflare/vitest-pool-workers` + `evictDurableObject`, but it can't run in this repo yet (a `vite`/`vitest` duplicate stops the workerd runner from collecting). Fell back to the `wrangler dev` real-idle harness.

## Where the routing map lives (options considered)

*Where the map is stored / how it's linked to the instance:*

| Option | Where stored / how linked | Verdict |
|---|---|---|
| module global (baseline) | `Map` at module scope; the free function reaches it only as a global | the bug — shared/stale across co-located instances, survives reconstruction locally, entries leak |
| **B — `WeakMap<ctx>`** ✅ | `WeakMap<DurableObjectState, Map<reqId, Queue>>` keyed by `ctx`; `handleSyncUpdateRpc(ctx, payload)` gains a `ctx` param | **chosen** — per-instance, dead entries auto-GC, no cast, no leaked types, no `createStoreDo` shape change, one-line consumer edit |
| G — opaque handle | library handle held as a DO instance property, passed back into `createStoreDo` | runner-up — no leak, but adds an input option + consumer ceremony |
| A — instance field | raw `Map` on the DO (`this.map`) | leaks Effect internals (`Queue<PullResponse>`) into the consumer DO's type |
| C — `Symbol` on `ctx` | `(ctx as any)[sym]` | needs `as any` + mutates a CF-owned object (repo forbids casts) |
| E — return `{ store, syncUpdateRpc }` | closed over inside `createStoreDo` | breaks the "returns a store" contract |
| F — method on `Store` | `store.syncUpdateRpc(...)` | wrong layer — `Store` is cross-environment (browser/node/expo) |

## Follow-up

- **The actual fix (separate PR):** client recovery — a reconstructed, store-less client re-boots its store and catches up on the reverse-RPC wake, turning the drop into an applied update (flips the test assertion to `toContain`).
- Replace the raw-`eventlog` probe with a backend-less-store + store-API read to drop the persistence-format coupling (needs `createStoreDo` to not require a `syncBackendStub`).

## Related

- #1415 — the client-side dropped-update report this scopes/characterizes.
- #1541 / #1542 — the mirror-image server-side loss (test + fix); this is the client counterpart.
