### PR TITLE
fix(sync-cf): forward client payload to onPush over the HTTP transport

### DIFF
--- a/.changeset/http-sync-forward-push-payload.md
+++ b/.changeset/http-sync-forward-push-payload.md
@@ -2,4 +2,4 @@
 "@livestore/sync-cf": patch
 ---
 
-**Cloudflare HTTP sync:** Forward the client `payload` to the Durable Object `onPush` callback over the HTTP transport. The HTTP push handler previously passed `undefined`, so auth/validation payloads never reached `onPush` over HTTP even though the WebSocket and DO-RPC transports already forwarded it. No config or migration needed (#1417).
+**Cloudflare HTTP sync:** Forward the client `payload` to the Durable Object `onPush` callback over the HTTP transport. The HTTP push handler previously passed `undefined`, so auth/validation payloads never reached `onPush` over HTTP even though the WebSocket and DO-RPC transports already forwarded it (#1417). No config or migration is needed, but an `onPush` that validates the payload may now reject HTTP pushes it previously let through while the payload arrived as `undefined`.

--- a/.changeset/http-sync-forward-push-payload.md
+++ b/.changeset/http-sync-forward-push-payload.md
@@ -1,0 +1,5 @@
+---
+"@livestore/sync-cf": patch
+---
+
+**Cloudflare HTTP sync:** Forward the client `payload` to the Durable Object `onPush` callback over the HTTP transport. The HTTP push handler previously passed `undefined`, so auth/validation payloads never reached `onPush` over HTTP even though the WebSocket and DO-RPC transports already forwarded it. No config or migration needed (#1417).

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -65,8 +65,11 @@ arbitrates pushes and fans out live pull streams to subscribers
 | Transport | Schema | Liveness | Notes |
 | --- | --- | --- | --- |
 | WebSocket | `ws-rpc-schema.ts` | server-held stream (`live` flag + `Stream.never`), pushed chunks | default; DO auto ping/pong; hibernation-aware |
-| HTTP | `http-rpc-schema.ts` | client-side polling (~5 s default) | 10 s hard request timeout; explicit `Ping` RPC; push `payload` not threaded (see gaps) |
+| HTTP | `http-rpc-schema.ts` | client-side polling (~5 s default) | 10 s hard request timeout; explicit `Ping` RPC |
 | DO-RPC | `do-rpc-schema.ts` | RPC callback queue (`rpcContext` presence = live) | for same-Cloudflare-app callers (`adapter-cloudflare`); explicit `Ping` |
+
+All three transports thread the client `payload` (per-connection auth/multi-tenancy
+context) into the DO `onPush`/`onPull` callbacks.
 
 Message payloads share `sync-message-types.ts`
 (PullRequest/PullResponse/PushRequest/PushAck/Ping/Pong + unwired admin
@@ -87,10 +90,6 @@ Current reality a consumer must not read as guaranteed behavior:
 - **Cross-store subscription bleed risk.** The DO-RPC client's
   `requestIdQueueMap` is module-global with a scoping TODO
   (`do-rpc-client.ts:30`; issue #1416).
-- **HTTP push drops `payload`.** The per-push payload (used for
-  auth/multi-tenancy) is passed as `undefined` server-side over HTTP but
-  threaded on WS/DO-RPC (`cf-worker/transport/http-rpc-server.ts:47`;
-  issue #1417).
 - **Live-subscriber leaks on abnormal disconnect.** WS `Interrupt` emits
   no Exit and DO-RPC `Interrupt` handling is a TODO
   (`cf-worker/durable-object.ts:136`, `cf-worker/do/pull.ts:19`;

--- a/docs/src/content/docs/patterns/auth.mdx
+++ b/docs/src/content/docs/patterns/auth.mdx
@@ -39,7 +39,7 @@ When you rely on `syncPayload`, treat it as untrusted input. Decode the token in
 
 - `validatePayload` runs once per connection and rejects mismatched tokens before LiveStore upgrades to WebSocket.
 - `onPush` (and `onPull`, if you need it) must repeat the verification because the payload forwarded to the Durable Object is the original client input.
-- The HTTP transport does not forward payloads today; embed the necessary authorization context directly in the events or move those clients to WebSocket/DO-RPC if you must rely on shared payload metadata.
+- All transports (WebSocket, HTTP, and DO-RPC) forward the payload to `onPush`/`onPull`, so this verification applies uniformly regardless of transport.
 
 You can extend `ensureAuthorized` to project additional claims, memoise verification per `authToken`, or enforce application-specific policies without changing LiveStore internals.
 

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/http-rpc-server.ts
@@ -44,7 +44,7 @@ const createHttpRpcLayer = (forwardedHeaders: Record<string, string> | undefined
     'SyncHttpRpc.Push': (req) =>
       Effect.gen(function* () {
         const { ctx, env, doOptions, storeId } = yield* DoCtx.DoCtx
-        const push = makePush({ payload: undefined, headers, options: doOptions, storeId, ctx, env })
+        const push = makePush({ payload: req.payload, headers, options: doOptions, storeId, ctx, env })
 
         return yield* push(req)
       }),

--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'vitest'
 
+import { EventFactory } from '@livestore/common/testing'
 import { nanoid } from '@livestore/livestore'
+import { events } from '@livestore/livestore/internal/testing-utils'
 import { objectToString } from '@livestore/utils'
 import { OtelLiveHttp } from '@livestore/utils-dev/node'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
@@ -15,12 +17,17 @@ import {
   Logger,
   ManagedRuntime,
   References,
+  Schema,
 } from '@livestore/utils/effect'
 
 import { isProviderSelected, providerRegistry } from './providers/registry.ts'
 import { SyncProviderImpl, type SyncProviderOptions } from './types.ts'
 
 /** Cloudflare HTTP-specific tests for response headers and HTTP transport features */
+
+/** Event factory + client identity for building a real push in the payload-threading regression test (#1417). */
+const makeFactory = EventFactory.makeFactory(events)
+const eventClient = EventFactory.clientIdentity('test-client', 'test-session')
 
 const cloudflareHttpKeys = ['cf-http-d1', 'cf-http-do'] as const
 const selectedHttpKeys = cloudflareHttpKeys.filter((key) => isProviderSelected(key))
@@ -58,14 +65,14 @@ describeHttpProviders('$name HTTP response headers', { timeout: 30000 }, ({ laye
 
   Vitest.afterAll(async () => await runtime.dispose())
 
-  const makeProvider = (testName?: string, options?: SyncProviderOptions) =>
+  const makeProvider = (testName?: string, options?: SyncProviderOptions, payload?: Schema.Json) =>
     Effect.suspend(() =>
       Effect.andThen(SyncProviderImpl, (_) =>
         _.makeProvider(
           {
             storeId: `test-store-${name}-${testName}-${testId}`,
             clientId: 'test-client',
-            payload: undefined,
+            payload,
           },
           options,
         ),
@@ -114,6 +121,44 @@ describeHttpProviders('$name HTTP response headers', { timeout: 30000 }, ({ laye
       // Verify custom response headers are present
       expect(pingResponse.headers['x-custom-header']).toBe('test-value')
       expect(pingResponse.headers['x-livestore-version']).toBe('1.0.0')
+    }).pipe(
+      Effect.provide(runtimeContext),
+      Vitest.makeWithTestCtx({
+        makeLayer: (_testContext) => Layer.mergeAll(Logger.layer([Logger.consolePretty()]), KeyValueStore.layerMemory),
+        forceOtel: true,
+      })(test),
+    ),
+  )
+
+  // Regression for #1417: the HTTP push handler must thread the client `payload` into the
+  // server-side `onPush` callback. WS/DO-RPC already do; HTTP hardcoded `undefined` and dropped it.
+  // The payload is consumed server-side and never echoed back, so we observe it via the test
+  // worker's `/instance/push-probe` route (records what `onPush` saw for the store).
+  Vitest.live('HTTP push threads the client payload through to onPush', (test) =>
+    Effect.gen(function* () {
+      const storeId = `test-store-${name}-${test.task.name}-${testId}`
+      const syncPayload = 'issue-1417-http-payload'
+
+      const syncBackend = yield* makeProvider(test.task.name, undefined, syncPayload)
+
+      yield* syncBackend.connect
+
+      const eventFactory = makeFactory({ client: eventClient })
+      yield* syncBackend.push([eventFactory.todoCreated.next({ id: 'e1', text: 'issue-1417', completed: false })])
+
+      // Ask the backend which payload `onPush` actually observed for this store.
+      const http = yield* HttpClient.HttpClient
+      const baseUrl = syncBackend.metadata.url
+      const baseUrlString = typeof baseUrl === 'string' ? baseUrl : objectToString(baseUrl)
+      const probeUrl = new URL(baseUrlString)
+      probeUrl.pathname = '/instance/push-probe'
+      probeUrl.search = new URLSearchParams({ storeId }).toString()
+
+      const response = yield* http.get(probeUrl.href).pipe(Effect.scoped)
+      const probe = (yield* response.json) as { observed: boolean; payload: unknown }
+
+      expect(probe.observed).toBe(true)
+      expect(probe.payload).toBe(syncPayload)
     }).pipe(
       Effect.provide(runtimeContext),
       Vitest.makeWithTestCtx({

--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -43,7 +43,7 @@ type RuntimeServices = SyncProviderImpl | HttpClient.HttpClient
 
 const describeHttpProviders = Vitest.describe.skipIf(skipUnlessHttpSelected).each(cloudflareHttpProviders)
 
-describeHttpProviders('$name HTTP response headers', { timeout: 30000 }, ({ layer, name }) => {
+describeHttpProviders('$name HTTP transport', { timeout: 30000 }, ({ layer, name }) => {
   let runtime: ManagedRuntime.ManagedRuntime<RuntimeServices, never>
   let runtimeContext: Context.Context<RuntimeServices>
   let testId: string

--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -17,7 +17,7 @@ import {
   Logger,
   ManagedRuntime,
   References,
-  Schema,
+  type Schema,
 } from '@livestore/utils/effect'
 
 import { isProviderSelected, providerRegistry } from './providers/registry.ts'

--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -25,7 +25,6 @@ import { SyncProviderImpl, type SyncProviderOptions } from './types.ts'
 
 /** Cloudflare HTTP-specific tests for response headers and HTTP transport features */
 
-/** Event factory + client identity for building a real push in the payload-threading regression test (#1417). */
 const makeFactory = EventFactory.makeFactory(events)
 const eventClient = EventFactory.clientIdentity('test-client', 'test-session')
 
@@ -130,10 +129,6 @@ describeHttpProviders('$name HTTP response headers', { timeout: 30000 }, ({ laye
     ),
   )
 
-  // Regression for #1417: the HTTP push handler must thread the client `payload` into the
-  // server-side `onPush` callback. WS/DO-RPC already do; HTTP hardcoded `undefined` and dropped it.
-  // The payload is consumed server-side and never echoed back, so we observe it via the test
-  // worker's `/instance/push-probe` route (records what `onPush` saw for the store).
   Vitest.live('HTTP push threads the client payload through to onPush', (test) =>
     Effect.gen(function* () {
       const storeId = `test-store-${name}-${test.task.name}-${testId}`

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -37,8 +37,16 @@ declare class WebSocketPair extends CfDeclare.WebSocketPair {}
 /** Module-scoped JSON decoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
 const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
 
+/**
+ * Records the `payload` each `onPush` observes, keyed by storeId, so a test can assert a transport
+ * threaded the client payload through to the DO callback (regression guard for #1417). The push and
+ * the probe hit the same `idFromName(storeId)` DO instance, so this module-scoped map bridges them.
+ */
+const observedPushPayloads = new Map<string, unknown>()
+
 interface SyncDoProbe {
   getHibernationProbe(): { instanceId: string; webSocketCount: number }
+  getPushProbe(storeId: string): { observed: boolean; payload: unknown }
 }
 
 interface TestClientDoProbe {
@@ -59,12 +67,9 @@ export interface Env {
 }
 
 export class SyncBackendDO extends makeDurableObject({
-  // onPush: async (message) => {
-  //   console.log('onPush', message.batch)
-  // },
-  // onPull: async (message) => {
-  //   console.log('onPull', message)
-  // },
+  onPush: (_message, context) => {
+    observedPushPayloads.set(context.storeId, context.payload)
+  },
   http: {
     responseHeaders: {
       'X-Custom-Header': 'test-value',
@@ -83,6 +88,13 @@ export class SyncBackendDO extends makeDurableObject({
 
   getHibernationProbe(): { instanceId: string; webSocketCount: number } {
     return { instanceId: this.instanceId, webSocketCount: this.#state.getWebSockets().length }
+  }
+
+  getPushProbe(storeId: string): { observed: boolean; payload: unknown } {
+    return {
+      observed: observedPushPayloads.has(storeId),
+      payload: observedPushPayloads.get(storeId) ?? null,
+    }
   }
 }
 
@@ -271,6 +283,15 @@ export default {
         return new Response('storeId required', { status: 400 })
       }
       const probe = await env.SYNC_BACKEND_DO.get(env.SYNC_BACKEND_DO.idFromName(storeId)).getHibernationProbe()
+      return new Response(JSON.stringify(probe), { headers: { 'content-type': 'application/json' } })
+    }
+
+    if (url.pathname.endsWith('/instance/push-probe') === true) {
+      const storeId = url.searchParams.get('storeId')
+      if (storeId === null) {
+        return new Response('storeId required', { status: 400 })
+      }
+      const probe = await env.SYNC_BACKEND_DO.get(env.SYNC_BACKEND_DO.idFromName(storeId)).getPushProbe(storeId)
       return new Response(JSON.stringify(probe), { headers: { 'content-type': 'application/json' } })
     }
 

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -38,9 +38,9 @@ declare class WebSocketPair extends CfDeclare.WebSocketPair {}
 const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
 
 /**
- * Records the `payload` each `onPush` observes, keyed by storeId, so a test can assert a transport
- * threaded the client payload through to the DO callback (regression guard for #1417). The push and
- * the probe hit the same `idFromName(storeId)` DO instance, so this module-scoped map bridges them.
+ * Records what each `onPush` observes, keyed by storeId, so a test can assert a transport threaded
+ * the client payload through. Push and probe hit the same `idFromName(storeId)` DO instance, so this
+ * module-scoped map bridges them.
  */
 const observedPushPayloads = new Map<string, unknown>()
 

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -42,11 +42,11 @@ const jsonParse = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)
  * the client payload through. Push and probe hit the same `idFromName(storeId)` DO instance, so this
  * module-scoped map bridges them.
  */
-const observedPushPayloads = new Map<string, unknown>()
+const observedPushPayloads = new Map<string, Schema.Json | undefined>()
 
 interface SyncDoProbe {
   getHibernationProbe(): { instanceId: string; webSocketCount: number }
-  getPushProbe(storeId: string): { observed: boolean; payload: unknown }
+  getPushProbe(storeId: string): { observed: boolean; payload: Schema.Json | null }
 }
 
 interface TestClientDoProbe {
@@ -90,7 +90,7 @@ export class SyncBackendDO extends makeDurableObject({
     return { instanceId: this.instanceId, webSocketCount: this.#state.getWebSockets().length }
   }
 
-  getPushProbe(storeId: string): { observed: boolean; payload: unknown } {
+  getPushProbe(storeId: string): { observed: boolean; payload: Schema.Json | null } {
     return {
       observed: observedPushPayloads.has(storeId),
       payload: observedPushPayloads.get(storeId) ?? null,


### PR DESCRIPTION
## Problem

Over the Cloudflare **HTTP** sync transport, the client `payload` — the arbitrary JSON a client attaches to its sync connection, typically an auth token or tenant id — never reached the Durable Object `onPush` callback. The HTTP push handler hardcoded `payload: undefined`, so `onPush(message, { payload })` always saw `undefined` on HTTP. The WebSocket and DO-RPC transports already forwarded `req.payload`, so auth/validation logic written against `onPush` silently worked on WS/DO-RPC but misfired on HTTP (#1417).

The payload was already on the request (`SyncHttpRpc.Push` carries it) and the `onPush` plumbing already accepts it — only the HTTP handler dropped it.

## Solution

Thread `req.payload` into `makePush` in the HTTP Push handler, matching the WebSocket handler, the DO-RPC handler, and the Pull handler one line above:

```diff
  // http-rpc-server.ts — SyncHttpRpc.Push
- const push = makePush({ payload: undefined, headers, options: doOptions, storeId, ctx, env })
+ const push = makePush({ payload: req.payload, headers, options: doOptions, storeId, ctx, env })
```

One line, no schema or API change.

Docs updated to match the fixed behavior: the intent-layer Cloudflare node (`context/02-system/03-sync/03-cf/spec.md`) drops the now-resolved "HTTP push drops `payload`" gap and records that all three transports thread the payload to `onPush`/`onPull`; `docs/patterns/auth.mdx` no longer tells users to move off HTTP for payload-based auth (that guidance described the bug, not the intended contract).

## Validation

**Mutation proof (red → green).** A new regression test in `tests/sync-provider/src/cloudflare-http-specific.test.ts` drives the real HTTP client, pushes one event carrying a sentinel payload, then reads back what `onPush` observed via a test-only Durable Object probe (`/instance/push-probe`, backed by an `onPush` recorder in the test worker). Before the fix the probe reports the payload was observed but `null` (dropped); after the fix it reports the sentinel. The test runs standalone — it does **not** depend on the skipped `responseHeaders` test (#1490).

```
cd tests/sync-provider
TEST_SYNC_PROVIDER=cf-http-do vitest run src/cloudflare-http-specific.test.ts \
  -t "HTTP push threads the client payload through to onPush"
# before fix: red  — expected 'issue-1417-http-payload', received null
# after  fix: green — 1 passed | 1 skipped
```

`ts:check` green; type-aware oxlint (the CI `lint` check) clean.

### Demo

```
client push (payload: "token") ──HTTP──▶ Durable Object  onPush(message, { payload })

BEFORE   makePush({ payload: undefined })    ──▶  onPush sees  payload: undefined   ✗
AFTER    makePush({ payload: req.payload })  ──▶  onPush sees  payload: "token"      ✓

WebSocket and DO-RPC already forwarded it — this brings HTTP to parity.
```

## Related issues

- Resolves #1417
