### PR TITLE
Fix hanging CF HTTP responseHeaders test by asserting through the real client

### DIFF
--- a/tests/sync-provider/src/cloudflare-http-specific.test.ts
+++ b/tests/sync-provider/src/cloudflare-http-specific.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'vitest'
 import { EventFactory } from '@livestore/common/testing'
 import { nanoid } from '@livestore/livestore'
 import { events } from '@livestore/livestore/internal/testing-utils'
+import { SearchParamsSchema, SyncHttpRpc } from '@livestore/sync-cf/common'
 import { objectToString } from '@livestore/utils'
 import { OtelLiveHttp } from '@livestore/utils-dev/node'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
@@ -17,7 +18,10 @@ import {
   Logger,
   ManagedRuntime,
   References,
-  type Schema,
+  RpcClient,
+  RpcSerialization,
+  Schema,
+  UrlParams,
 } from '@livestore/utils/effect'
 
 import { isProviderSelected, providerRegistry } from './providers/registry.ts'
@@ -78,48 +82,51 @@ describeHttpProviders('$name HTTP transport', { timeout: 30000 }, ({ layer, name
       ).pipe(Effect.provide(runtimeContext)),
     )
 
-  // Skipped: the hand-rolled RPC envelope below no longer completes, so the server's 10s
-  // timeout fires before `responseHeaders` is applied and the assertion sees `undefined`.
-  // The header feature itself works; the test's coupling to the wire format is the problem.
-  // https://github.com/livestorejs/livestore/issues/1490
-  Vitest.live.skip('HTTP responses include custom headers', (test) =>
+  Vitest.live('HTTP responses include custom headers', (test) =>
     Effect.gen(function* () {
+      const storeId = `test-store-${name}-${test.task.name}-${testId}`
       const syncBackend = yield* makeProvider(test.task.name)
-      const http = yield* HttpClient.HttpClient
 
-      // Get the sync backend URL from metadata
-      const metadata = syncBackend.metadata
-      expect(metadata.protocol).toBe('http')
-      const baseUrl = metadata.url
-
-      // Make a raw HTTP request to the ping endpoint
-      const searchParams = new URLSearchParams({
-        storeId: `test-store-${name}-${test.task.name}-${testId}`,
-        transport: 'http',
-      })
-
+      expect(syncBackend.metadata.protocol).toBe('http')
+      const baseUrl = syncBackend.metadata.url
       const baseUrlString = typeof baseUrl === 'string' ? baseUrl : objectToString(baseUrl)
-      const requestUrl = new URL(baseUrlString)
-      requestUrl.search = searchParams.toString()
-      const req = HttpClientRequest.post(requestUrl.href).pipe(
-        HttpClientRequest.setHeader('content-type', 'application/json'),
-        HttpClientRequest.setHeader('x-livestore-store-id', `test-store-${name}-${test.task.name}-${testId}`),
-        HttpClientRequest.bodyJsonUnsafe({
-          _tag: 'Request',
-          id: 'test-req-1',
-          tag: 'SyncHttpRpc.Ping',
-          payload: {
-            storeId: `test-store-${name}-${test.task.name}-${testId}`,
-            payload: undefined,
-          },
-        }),
-      )
 
-      const pingResponse = yield* http.execute(req).pipe(Effect.scoped)
+      // Route the request to the store's DO the same way the real HTTP client does.
+      const urlParams = yield* Schema.encodeEffect(SearchParamsSchema)({
+        storeId,
+        payload: undefined,
+        transport: 'http',
+      }).pipe(Effect.map(UrlParams.fromInput))
 
-      // Verify custom response headers are present
-      expect(pingResponse.headers['x-custom-header']).toBe('test-value')
-      expect(pingResponse.headers['x-livestore-version']).toBe('1.0.0')
+      // Drive a real, correctly-framed Ping through the supported RPC client and read the
+      // response headers off its own `transformClient` seam — the hook the client already
+      // exposes for request rewriting works just as well for observing the response.
+      const captured: { customHeader?: string; version?: string } = {}
+      const HttpProtocol = RpcClient.layerProtocolHttp({
+        url: baseUrlString,
+        transformClient: (client) =>
+          client.pipe(
+            HttpClient.mapRequest((request) =>
+              request.pipe(
+                HttpClientRequest.appendUrlParams(urlParams),
+                HttpClientRequest.setHeader('x-livestore-store-id', storeId),
+              ),
+            ),
+            HttpClient.tap((response) =>
+              Effect.sync(() => {
+                captured.customHeader = response.headers['x-custom-header']
+                captured.version = response.headers['x-livestore-version']
+              }),
+            ),
+          ),
+      }).pipe(Layer.provide(RpcSerialization.layerJson))
+
+      const rpcClient = yield* RpcClient.make(SyncHttpRpc).pipe(Effect.provide(HttpProtocol))
+
+      yield* rpcClient['SyncHttpRpc.Ping']({ storeId, payload: undefined })
+
+      expect(captured.customHeader).toBe('test-value')
+      expect(captured.version).toBe('1.0.0')
     }).pipe(
       Effect.provide(runtimeContext),
       Vitest.makeWithTestCtx({


### PR DESCRIPTION
## Problem

`cloudflare-http-specific.test.ts` → `HTTP responses include custom headers` hung to a 10s server timeout instead of checking anything. It hand-rolled a raw `@effect/rpc` request envelope and POSTed it as a single JSON body, but the server (`RpcServer.toHttpEffect` + JSON serialization) expects the exact framing the real client emits — an NDJSON stream terminated by an end-of-input signal. So the server never finished reading the request and never replied; `createHttpRpcHandler` wraps the handler in `Effect.timeout(10000)`, the request died at ~10s, and the `responseHeaders` were never applied or observed.

The test had **never run in CI** (cells were selected by suite title, and this suite's title didn't match) until selection moved to the registry (#1484) — at which point it started failing deterministically on both HTTP providers. It's currently `.skip`-ped, leaving `responseHeaders` (a public API) with no working test.

The feature itself is not broken — `can ping sync backend` passes for every provider. The bug is the test's coupling to an internal wire format.

## Solution

Talk to the server the way real clients do: drive a correctly-framed `Ping` through the supported `SyncHttpRpc` client (`RpcClient.layerProtocolHttp` + JSON serialization, same wiring as production) and read the response headers off the client's own `transformClient` seam — the `HttpClient` hook the real client already uses to rewrite outgoing requests works just as well to observe the incoming response (`HttpClient.tap`). No product code changes.

Because the request is now correctly framed, the server actually replies (no hang), and the reply carries the custom headers the Durable Object is configured to set.

## Validation

Mutation proof — the test now has teeth:

| stage | result | time |
| --- | --- | --- |
| old test, un-skipped | `TimeoutError` — server never answers the malformed envelope | ~10,011 ms |
| rewrite | passes | ~0.7 s |
| corrupt the worker's header value | fails: `expected 'MUTATED…' to be 'test-value'` | 49 ms |

The last row is the point: with a wrong header the test fails **fast and legibly** instead of hanging, so it genuinely guards `responseHeaders`. Passes on both HTTP providers (`cf-http-do`, `cf-http-d1`); the sibling push-payload test in the same file is unaffected. `tsc --build` and the type-aware oxlint are clean.

## Notes

- **Stacked on #1548** (base `bohdan/fix/http-push-payload`); GitHub retargets this PR to `main` once #1548 merges. Only the top commit belongs to this PR.
- Test-only change (no published package touched) → no changeset.
- Out of scope: the secondary "a malformed RPC body hangs 10s instead of erroring fast" behavior noted in #1490 — its own concern.

## Related issues

- Resolves #1490
