### PR TITLE
Define backend-confirmed sync as a synchronous Store contract

### DIFF
--- a/context/02-system/05-store/.decisions/0002-synchronous-backend-confirmation-status.md
+++ b/context/02-system/05-store/.decisions/0002-synchronous-backend-confirmation-status.md
@@ -1,0 +1,47 @@
+# 0002 — Surface backend confirmation through synchronous sync status
+
+Status: accepted (2026-08-11, user-confirmed design for #1553)
+
+## Context
+
+`SyncStatus.isSynced` describes the session→leader boundary. It can be true
+while the leader still has events awaiting confirmation from the sync backend.
+Backend-confirmed events are already available through `events` and
+`eventsStream`, but the Store does not expose aggregate pending state for the
+leader→backend boundary.
+
+## Options
+
+- Add a separate asynchronous backend-status read.
+- Extend the existing synchronous `SyncStatus` with the latest leader state
+  observed by the session (chosen).
+- Infer delivery status from the confirmed-event stream. Rejected because the
+  stream exposes confirmed history, not the aggregate pending state.
+
+## Decision
+
+Keep one flat, synchronous `SyncStatus`. Preserve the existing fields and their
+session→leader meanings, and add `backendHead`, `backendPendingCount`, and
+`isBackendSynced` for end-to-end confirmation. Derive the new fields from the
+latest leader state observed by the session; do not turn `syncStatus()` into an
+asynchronous request.
+
+`isBackendSynced` is conservative: it may remain false while a newer leader
+observation is in transit, but it must not become true from a leader snapshot
+that predates the leader head already observed by the session.
+
+The aggregate describes latest-observed delivery convergence, not sync-worker
+health. A terminal worker may be parked while the observed heads are already
+converged, in which case `isBackendSynced` remains true; this status makes no
+claim about whether a future delivery attempt can make progress.
+
+## Consequences
+
+- Existing callers keep the current `isSynced` behavior.
+- Sync-status streams react to both session and leader state changes.
+- A synchronous snapshot is latest-observed state, not instantaneous global
+  truth.
+- Worker lifecycle and delivery progress diagnostics require a separate
+  contract; they are not inferred from `isBackendSynced`.
+- Per-event receipts and backend retry/failure classification remain separate
+  concerns.

--- a/context/02-system/05-store/.delta/DELTA-001-backend-confirmation-status-missing.md
+++ b/context/02-system/05-store/.delta/DELTA-001-backend-confirmation-status-missing.md
@@ -1,0 +1,21 @@
+# DELTA-001 — Store sync status omits backend confirmation
+
+Status: open
+
+## Divergence
+
+The Store sync-status contract distinguishes session→leader delivery from
+leader→backend confirmation. The shipping `SyncStatus` exposes only
+`localHead`, `upstreamHead`, `pendingCount`, and `isSynced`, all derived from
+session→leader state.
+
+## VRS
+
+Diverges from the [sync-status contract](../spec.md#sync-status).
+
+## Close Condition
+
+Close when `SyncStatus` exposes `backendHead`, `backendPendingCount`, and
+`isBackendSynced`; synchronous snapshots and subscriptions combine session and
+leader observations conservatively; and regression tests cover a session that
+is synced to its leader while the leader still awaits backend confirmation.

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -37,6 +37,45 @@ The Effect-native binding (`Store.Tag`) is a realization of the integration
 contract — see
 [../08-integrations/02-effect/](../08-integrations/02-effect/spec.md).
 
+### Sync status
+
+`SyncStatus` is one flat status value spanning both propagation boundaries:
+
+```ts
+type SyncStatus = {
+  localHead: string
+  upstreamHead: string
+  pendingCount: number
+  isSynced: boolean
+  backendHead: string
+  backendPendingCount: number
+  isBackendSynced: boolean
+}
+```
+
+The existing fields retain their session→leader meaning: `upstreamHead` is
+the latest leader head observed by the session, `pendingCount` counts session
+events not yet accepted by the leader, and `isSynced` is true when that count
+is zero. `backendHead` is the latest backend-confirmed head observed through
+the leader; `backendPendingCount` counts synced events accepted by the leader
+but not yet confirmed by the backend.
+
+`isBackendSynced` is true only when the latest observed states show no pending
+events at either boundary and the observed leader state covers the leader head
+already known by the session. `syncStatus()` remains synchronous: it returns a
+conservative snapshot from locally observed session and leader state and does
+not perform an on-demand remote read. The snapshot may therefore briefly
+report `false` after confirmation, but stale leader state must not produce a
+`true` result for a session head it does not yet cover. `syncStatusStream` and
+`subscribeSyncStatus` react to status changes at either boundary.
+
+This aggregate status describes latest-observed delivery convergence, not the
+health or lifecycle state of a sync worker. `isBackendSynced` may remain true
+when the observed heads are converged even if a terminal backend worker is
+parked; it makes no claim that future delivery attempts can currently make
+progress. The status does not provide a per-event confirmation receipt or
+classify why backend delivery remains pending.
+
 ### Creation options
 
 `createStore` / `RegistryStoreOptions` (`src/store/create-store.ts`):


### PR DESCRIPTION
## Problem

`SyncStatus.isSynced` describes session-to-leader delivery and can be `true` while the leader still has events awaiting confirmation from the sync backend. The Store intent layer does not currently define how a session observes that second boundary.

## Solution

Define one flat, synchronous `SyncStatus` spanning both propagation boundaries. The existing fields keep their current meaning; `backendHead`, `backendPendingCount`, and `isBackendSynced` expose the latest backend confirmation state observed through the leader.

The contract is deliberately conservative: a synchronous snapshot may briefly remain false while a newer leader observation is in transit, but stale leader state must not produce a backend-synced result. `isBackendSynced` describes latest-observed delivery convergence, not sync-worker health: it may remain true when observed heads are converged even if a terminal worker is parked, and it does not guarantee future progress.

This is the intent-only bottom layer of the stacked change. It does not change runtime behavior, add a worker-health API, add per-event receipts, or classify backend delivery failures.

## Validation

- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check`
- `devenv tasks run test:unit`
- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` (8 passed)

## Stack

- Layer 1: this PR — synchronous Store contract
- Layer 2: #1573 — regression tests and implementation

## Related issues

- #1553
- #1580 clarifies why delivery convergence and worker health must remain separate concepts
