### PR TITLE
Stop CODEOWNERS from gating docs by narrowing /.github/ to workflow YAML

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Release-sensitive repository policy and release automation.
-/.github/ @schickling
+/.github/workflows/*.yml @schickling
 /release/ @schickling
 /scripts/src/commands/changesets.ts @schickling
 /scripts/src/commands/devtools-artifact.ts @schickling


### PR DESCRIPTION
## Problem

`.github/CODEOWNERS` contains `/.github/ @schickling`, which owns **every** file under that path —
workflow YAML, but also prose, issue templates, and repo-config data. The `main-branch-rules` ruleset
sets `require_code_owner_review: true`, so any change to any of those files makes @schickling a
mandatory reviewer.

The concrete case: #1528 (https://github.com/livestorejs/livestore/pull/1528) is a seven-file docs PR. Six of its seven files have no code owner at all.
The seventh is a one-line relative-link repair in `.github/workflows/README.md`. That single file is
what pulls the whole PR under mandatory code-owner review. Verified against the API at the time of
writing: all 16 required status checks are `SUCCESS`, the ruleset's
`required_approving_review_count` is `0`, and `mergeStateStatus` is `BLOCKED` — leaving
`require_code_owner_review` as the only thing holding it.

This is not a one-off. Docs and template changes under `.github/` recur, and each one queues on a
review that has nothing to do with what the entry exists to protect.

## Solution

One line, one file:

```diff
-/.github/ @schickling
+/.github/workflows/*.yml @schickling
```

The other four patterns and the header comment are unchanged. Workflow logic — the eight committed
`.github/workflows/*.yml` files, including `release.yml`, `deploy-prod.yml`, and `ci.yml` — stays
owned.

### The trade-off

This is not a pure win, and the cost is not hypothetical.

@schickling is giving up visibility he currently has. Today nothing under `.github/` changes without
him seeing it. After this change, **22 of the 30 files under `.github/` become unowned** and can
merge without him; the 8 that stay owned are the workflow `*.yml` files. Some of what is given up is
the intended target and uncontroversial — `pull_request_template.md`, the three `ISSUE_TEMPLATE/`
files, `FUNDING.yml`, `workflows/README.md`. But "prose" is not a synonym for "inconsequential":
`workflows/README.md` documents how the release and deploy workflows are operated, and a wrong
instruction there can be acted on by a human even though no workflow logic changed. Someone who
thinks that README is part of the release surface rather than commentary on it would be describing
this change accurately, not misreading it.

Some of the 22 go beyond prose and deserve to be named rather than absorbed into a count:

| File | What it is |
| --- | --- |
| `.github/CODEOWNERS` | This file. It currently owns itself via `/.github/`; after this change it does not. That makes the change self-unlocking: the rule governing what @schickling sees is no longer something he sees, so what he gives up is not only sight of prose but the ability to notice the next narrowing. |
| `.github/repo-settings.json` (+ `.genie.ts`) | Declarative repo configuration, including the branch ruleset and required checks — what makes a green PR mean anything. Weaken a required check and every later PR still reports green, because green now means less; the signal that would normally flag it is the thing that was edited. |
| `.github/labels.json` (+ `.genie.ts`), `.github/reconcile-app-manifest.json` | Repo policy as data. |
| `.github/scripts/pr-snapshot-artifact.mjs` (+ its test) | CI script logic invoked by workflows, which `*.yml` does not match. |

One more, listed so it is not a later surprise: `*.yml` does not match `*.yml.genie.ts`, so the eight
workflow **authoring sources** are not owned by the new pattern. This one is enforced elsewhere
rather than merely unlikely — `lint:check:genie` watches `.github/workflows/*.genie.ts` and runs
under the required `lint` check, so a `.genie.ts` edit that is not accompanied by its regenerated
`.yml` fails a required check, and the regenerated `.yml` is owned. Editing the source alone cannot
change what GitHub executes without touching an owned file.

This PR implements exactly the narrowing that was asked for. Whether the `repo-settings.json` /
`.github/scripts/` gap should also be covered is a separate decision and a possible follow-up — not
something this PR widens on its own.

What is bought for that cost: agent-authored docs PRs stop pulling @schickling in over one-line link
repairs. That is the whole of the benefit — a recurring class of low-value review requests goes away,
in exchange for a real and permanent reduction in what he sees.

### Expected: this PR needs his approval

This change lands under the **old** `/.github/` rule, so it is itself code-owner-gated. That is
intended, not something to route around: it is one approval that removes a recurring class of them.

No changeset is included — this is repository policy, not a published-package change.

## Validation

- `devenv tasks run check:quick` — exit 0.
- Diff is exactly one file, +1/-1. The other four CODEOWNERS patterns and the header comment are
  byte-identical.
- Counted rather than asserted: `fd --hidden --type f . .github/` gives 30 files; 8 match
  `/.github/workflows/*.yml`, 22 do not. That is where the table above comes from. There are no
  `*.yaml` workflows and no `.github/actions/` composite actions, so the new pattern covers every
  workflow file that exists today.
- Ruleset and #1528 status read from the GitHub API rather than inferred, as quoted in Problem above.
- The new pattern was validated by GitHub itself, not just by eye:
  `gh api "repos/livestorejs/livestore/codeowners/errors?ref=<this branch>"` returns `{"errors":[]}`.
  This is the check that could have falsified the change — an unparseable pattern is dropped
  silently, which would leave `release.yml` and `deploy-prod.yml` unowned rather than owned.

## Related issues

- #1528 (https://github.com/livestorejs/livestore/pull/1528) — the motivating case; blocked solely by this CODEOWNERS entry. Not modified by this PR.

<!-- agent-footer:begin v=1 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.livestore.codeowners-narrow.q39.worker |
| `agent_persona` | worker |
| `agent_supervisor` | dev3.livestore.main.issue-1497.core |
| `agent_tool` | Claude Code |
| `agent_tool_version` | 2.1.221 |
| `agent_runtime` | Claude Code 2.1.221 |
| `tooling_profile` | dotfiles@1682127 |
</details>
<!-- agent-footer:end -->