### PR TITLE
Publish fork PR snapshots through a revocable trust label

### DIFF
--- a/.changeset/empty-fork-snapshot-label.md
+++ b/.changeset/empty-fork-snapshot-label.md
@@ -1,0 +1,6 @@
+---
+---
+
+No package release impact. CI now produces secretless snapshot candidates for
+fork PRs and gates their npm publication on the maintainer-managed
+`ci:publish-snapshot` label (#1559).

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -86,6 +86,11 @@
       "description": "Trigger docs deployment for fork PRs · Set: manual"
     },
     {
+      "name": "ci:publish-snapshot",
+      "color": "0e8a16",
+      "description": "Trust this fork PR branch for snapshot publishing · Set: manual"
+    },
+    {
       "name": "cli",
       "color": "d23bad",
       "description": "CLI · Set: manual"

--- a/.github/labels.json.genie.ts
+++ b/.github/labels.json.genie.ts
@@ -68,6 +68,11 @@ const livestoreDomainLabels: readonly LabelDef[] = [
   { name: 'web:ssr', color: 'f2e7f6', description: 'SSR / server rendering · Set: manual' },
   { name: 'website', color: 'aaaaaa', description: 'Website / docs site · Set: manual' },
   { name: 'ci:deploy-docs', color: '0E8A16', description: 'Trigger docs deployment for fork PRs · Set: manual' },
+  {
+    name: 'ci:publish-snapshot',
+    color: '0E8A16',
+    description: 'Trust this fork PR branch for snapshot publishing · Set: manual',
+  },
 ]
 
 /** Workflow / process / experience labels specific to livestore. */

--- a/.github/scripts/pr-snapshot-artifact.mjs
+++ b/.github/scripts/pr-snapshot-artifact.mjs
@@ -122,8 +122,9 @@ export const successfulProducerAttempt = ({ jobs, jobName }) => {
   return Math.max(...matches.map((job) => positiveInteger(job.run_attempt, `${jobName} run attempt`)))
 }
 
-export const selectEligibleProducerRun = ({ runs, prNumber, headSha }) => {
-  const parsedPrNumber = positiveInteger(prNumber, 'PR number')
+export const selectEligibleProducerRun = ({ runs, headRepository, headBranch, headSha }) => {
+  if (typeof headRepository !== 'string' || headRepository === '') fail('Head repository is required')
+  if (typeof headBranch !== 'string' || headBranch === '') fail('Head branch is required')
   if (shaPattern.test(headSha) === false) fail(`Invalid head SHA: ${headSha}`)
   if (Array.isArray(runs) === false) fail('Workflow runs response is not an array')
 
@@ -133,9 +134,9 @@ export const selectEligibleProducerRun = ({ runs, prNumber, headSha }) => {
         (run) =>
           run?.event === 'pull_request' &&
           run?.conclusion === 'success' &&
-          run.pullRequests?.some(
-            (pullRequest) => pullRequest?.number === parsedPrNumber && pullRequest?.headSha === headSha,
-          ) === true &&
+          run?.headRepository === headRepository &&
+          run?.headBranch === headBranch &&
+          run?.headSha === headSha &&
           Number.isSafeInteger(run.packAttempt) === true &&
           run.packAttempt > 0 &&
           run.artifacts?.some(
@@ -154,6 +155,22 @@ export const hasCurrentHeadApproval = ({ headSha, currentHeadSha, reviews }) => 
 
 export const isAuthorizedReviewState = ({ headSha, currentHeadSha, reviewDecision, reviews }) =>
   reviewDecision === 'APPROVED' && hasCurrentHeadApproval({ headSha, currentHeadSha, reviews })
+
+export const isAuthorizedSnapshotState = ({
+  repository,
+  headRepository,
+  headSha,
+  currentHeadSha,
+  labelNames,
+  reviewDecision,
+  reviews,
+}) => {
+  if (headSha !== currentHeadSha) return false
+  if (headRepository !== repository) {
+    return Array.isArray(labelNames) === true && labelNames.includes('ci:publish-snapshot')
+  }
+  return isAuthorizedReviewState({ headSha, currentHeadSha, reviewDecision, reviews })
+}
 
 export const assessRegistryCohort = ({ expectedVersion, packageStates, hasVerifiedReceipt }) => {
   if (typeof expectedVersion !== 'string' || expectedVersion === '') fail('Expected registry version is required')

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -10,6 +10,7 @@ import {
   createManifest,
   hasCurrentHeadApproval,
   isAuthorizedReviewState,
+  isAuthorizedSnapshotState,
   selectEligibleProducerRun,
   snapshotTag,
   snapshotVersion,
@@ -192,11 +193,55 @@ test('requires the authoritative required-review decision', () => {
   )
 })
 
+test('authorizes repository-owned snapshots by review and fork snapshots by live label', () => {
+  const headSha = 'a'.repeat(40)
+  const common = {
+    repository: 'livestorejs/livestore',
+    headSha,
+    currentHeadSha: headSha,
+    labelNames: [],
+    reviewDecision: 'APPROVED',
+    reviews: [{ state: 'APPROVED', commit_id: headSha }],
+  }
+
+  assert.equal(isAuthorizedSnapshotState({ ...common, headRepository: common.repository }), true)
+  assert.equal(
+    isAuthorizedSnapshotState({
+      ...common,
+      headRepository: 'contributor/livestore',
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [],
+    }),
+    false,
+  )
+  assert.equal(
+    isAuthorizedSnapshotState({
+      ...common,
+      headRepository: 'contributor/livestore',
+      labelNames: ['ci:publish-snapshot'],
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [],
+    }),
+    true,
+  )
+  assert.equal(
+    isAuthorizedSnapshotState({
+      ...common,
+      headRepository: 'contributor/livestore',
+      currentHeadSha: 'b'.repeat(40),
+      labelNames: ['ci:publish-snapshot'],
+      reviewDecision: 'REVIEW_REQUIRED',
+      reviews: [],
+    }),
+    false,
+  )
+})
+
 test('generated promotion workflow is anchored to trusted main', async () => {
   const workflow = await readFile(new URL('../workflows/release.yml', import.meta.url), 'utf8')
   assert.doesNotMatch(workflow, /pull_request_review:/)
   assert.match(workflow, /cron: '\*\/5 \* \* \* \*'/)
-  const dispatchStart = workflow.indexOf('\n  dispatch-approved-pr-snapshots:')
+  const dispatchStart = workflow.indexOf('\n  dispatch-authorized-pr-snapshots:')
   const validateStart = workflow.indexOf('\n  validate-pr-snapshot:', dispatchStart)
   const dispatch = workflow.slice(dispatchStart, validateStart)
   assert.match(dispatch, /actions: write/)
@@ -205,7 +250,11 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(dispatch, /pulls\?state=open&base=main&per_page=100.*--slurp/)
   assert.match(dispatch, /pullRequest\(number:\$number\)\{reviewDecision\}/)
   assert.match(dispatch, /reviewDecision.*APPROVED/s)
-  assert.match(dispatch, /any\(\.pull_requests\[\]\?; \.number == \$pr_number and \.head\.sha == \$sha\)/)
+  assert.match(dispatch, /ci:publish-snapshot/)
+  assert.match(dispatch, /\.head_repository\.full_name == \$head_repository/)
+  assert.match(dispatch, /\.head_branch == \$head_ref/)
+  assert.match(dispatch, /\.head_sha == \$sha/)
+  assert.doesNotMatch(dispatch, /\.pull_requests/)
   assert.match(dispatch, /pack-pr-snapshot.*conclusion == "success"/s)
   assert.match(dispatch, /artifacts\?per_page=100.*expired == false/s)
   assert.match(dispatch, /ci_run_id="\$selected_run_id"/)
@@ -233,6 +282,7 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(workflow.slice(validateStart, attestStart), /pull-requests: read/)
   assert.match(workflow.slice(attestStart, authorizeStart), /id-token: write/)
   assert.match(workflow.slice(authorizeStart, publishStart), /pull-requests: read/)
+  assert.match(workflow.slice(authorizeStart, publishStart), /ci:publish-snapshot/)
 
   const publish = workflow.slice(publishStart, nextJobStart)
   assert.match(publish, /pull-requests: read/)
@@ -244,7 +294,10 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.match(workflow.slice(validateStart, attestStart), /jobs\?filter=all/)
   assert.match(workflow.slice(validateStart, attestStart), /sort_by\(\.run_attempt\) \| last/)
   assert.match(workflow.slice(validateStart, attestStart), /inputs\.ci_run_id/)
-  assert.match(workflow.slice(validateStart, attestStart), /\.pull_requests\[0\]\.head\.sha/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.head\.repo\.full_name == \$head_repository/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.head\.ref == \$head_branch/)
+  assert.match(workflow.slice(validateStart, attestStart), /\.head\.sha == \$head_sha/)
+  assert.doesNotMatch(workflow.slice(validateStart, attestStart), /\.pull_requests\[0\]/)
   assert.match(workflow, /validated-pr-snapshot-.*release-run-attempt/)
   assert.match(workflow, /promotion-pr-snapshot-.*promotion-attempt/)
 
@@ -257,11 +310,15 @@ test('generated promotion workflow is anchored to trusted main', async () => {
   assert.doesNotMatch(publish, /\[ "\$remote_tag" = "\$SNAPSHOT_VERSION" \]/)
   assert.match(publish, /needs\.validate-pr-snapshot\.outputs\.package-count/)
   assert.match(publish, /Upload trusted verification receipt/)
+  assert.match(publish, /ci:publish-snapshot/)
   assert.match(publish, /verified-pr-snapshot-.*outputs\.head-sha.*outputs\.run-id.*outputs\.run-attempt/s)
   assert.match(publish, /sourceRunAttempt/)
   assert.match(publish, /overwrite: true/)
 
   const ciWorkflow = await readFile(new URL('../workflows/ci.yml', import.meta.url), 'utf8')
+  assert.match(ciWorkflow, /pack-pr-snapshot:\n    if: github\.event_name == 'pull_request'/)
+  assert.doesNotMatch(ciWorkflow, /pack-pr-snapshot:[\s\S]*?head\.repo\.full_name == github\.repository/)
+  assert.doesNotMatch(ciWorkflow, /pull_request_target:/)
   assert.match(
     ciWorkflow,
     /name: 'pr-snapshot-\$\{\{ github\.event\.pull_request\.head\.sha \}\}-\$\{\{ github\.run_attempt \}\}'/,
@@ -311,36 +368,47 @@ test('selects the successful producer attempt when only failed jobs were rerun',
   )
 })
 
-test('selects an exact PR-associated run when multiple PRs share a head SHA', () => {
+test('selects an exact repository, branch, and SHA producer run for forks', () => {
   const headSha = 'a'.repeat(40)
   const artifact = (attempt) => ({ name: `pr-snapshot-${headSha}-${attempt}`, expired: false })
   const runs = [
     {
       id: 100,
-      headSha: 'c'.repeat(40),
+      headRepository: 'other/livestore',
+      headBranch: 'feature',
+      headSha,
       event: 'pull_request',
       conclusion: 'success',
-      pullRequests: [{ number: 41, headSha }],
       packAttempt: 1,
       artifacts: [artifact(1)],
       createdAt: '2026-07-18T10:00:00Z',
     },
     {
       id: 101,
-      headSha: 'd'.repeat(40),
+      headRepository: 'contributor/livestore',
+      headBranch: 'feature',
+      headSha,
       event: 'pull_request',
       conclusion: 'success',
-      pullRequests: [{ number: 42, headSha }],
       packAttempt: 2,
       artifacts: [artifact(2)],
       createdAt: '2026-07-18T09:00:00Z',
     },
   ]
 
-  assert.equal(selectEligibleProducerRun({ runs, prNumber: 42, headSha })?.id, 101)
-  assert.equal(selectEligibleProducerRun({ runs, prNumber: 43, headSha }), null)
+  assert.equal(
+    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'feature', headSha })?.id,
+    101,
+  )
+  assert.equal(
+    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'other', headSha }),
+    null,
+  )
   runs[1].artifacts[0].expired = true
-  assert.equal(selectEligibleProducerRun({ runs, prNumber: 42, headSha }), null)
+  assert.equal(
+    selectEligibleProducerRun({ runs, headRepository: 'contributor/livestore', headBranch: 'feature', headSha }),
+    null,
+  )
 })
 
 test('rejects a tarball changed after manifest creation', async () => {

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -70,9 +70,9 @@ tokens for package publish jobs. Each published `@livestore/*` package must
 trust `livestorejs/livestore` with workflow filename `release.yml` in npm
 package settings.
 
-A successful `ci.yml` run for a repository-owned pull request also publishes
-an immutable candidate for the exact head as
-`0.0.0-snapshot-pr.<number>.<40-character-head-sha>`. Forks are excluded.
+A successful `ci.yml` run for any pull request packs an immutable candidate for
+the exact head as
+`0.0.0-snapshot-pr.<number>.<40-character-head-sha>`.
 The PR job only packs the fixed public package cohort on a GitHub-hosted runner
 without secrets, write permissions, or OIDC. The default-branch `release.yml`
 validation job re-resolves the open PR from the completed run, requires its
@@ -83,12 +83,12 @@ package archives and creates a custom GitHub attestation that binds the package
 and manifest digests to the exact PR head, source CI run, and trusted release
 topology.
 
-npm promotion uses the repository's ordinary required code-review decision as
-its only manual trust boundary. GitHub's authoritative review decision must be
+npm promotion for repository-owned PRs uses the ordinary required code-review
+decision as its manual trust boundary. GitHub's authoritative review decision must be
 `APPROVED`, and a counting approval must name the current head commit. An
 approval for an earlier head, a non-counting approval, or a later changes request
 does not authorize publication. Approval before CI is observed when CI completes.
-For approval after CI, the trusted default-branch workflow polls approved open
+For approval after CI, the trusted default-branch workflow polls authorized open
 PRs every five minutes and dispatches `release.yml` explicitly at `main`; it does
 not grant workflow-write authority to PR-controlled review-event code. The
 dispatched run treats PR and head inputs only as selectors, then resolves and
@@ -104,6 +104,13 @@ verification receipt is uploaded only after every registry integrity matches the
 validated candidate; the scheduler redispatches until that exact PR head, CI run,
 and pack attempt receipt exists. npm provenance identifies this trusted default-branch promotion
 workflow; the custom candidate attestation supplies the separate link back to PR CI.
+
+Fork PRs use the maintainer-managed `ci:publish-snapshot` label instead of
+review approval. The label trusts the PR's mutable head repository and branch,
+including later commits while it remains present. The trusted workflow resolves
+fork producers by exact repository, branch, and SHA and rechecks the live label
+and unchanged head immediately before publication. Removing the label stops
+publication that has not started.
 
 Snapshot DevTools Chrome ZIPs are uploaded as short-lived workflow artifacts,
 not GitHub Releases. Public GitHub Releases are reserved for dev/stable release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
           NODE
         shell: bash
   pack-pr-snapshot:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -133,7 +133,9 @@ export default githubWorkflow({
   jobs: {
     'source-policy': livestoreDefaultRefPolicyJob,
     'pack-pr-snapshot': {
-      if: "github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository",
+      // Fork candidates are untrusted data: this job has no secrets or write
+      // token, and the main-branch release workflow validates every tarball.
+      if: "github.event_name == 'pull_request'",
       'runs-on': 'ubuntu-24.04',
       permissions: { contents: 'read' },
       env: {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,7 +438,7 @@ jobs:
           NODE
         shell: bash
     if: github.event_name != 'schedule'
-  dispatch-approved-pr-snapshots:
+  dispatch-authorized-pr-snapshots:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     permissions:
@@ -459,7 +459,7 @@ jobs:
           sparse-checkout: |
             .github/scripts/pr-snapshot-artifact.mjs
             scripts/src/generated/release-topology.json
-      - name: Dispatch incomplete approved cohorts to trusted main workflow
+      - name: Dispatch incomplete authorized cohorts to trusted main workflow
         run: |
           set -euo pipefail
           test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
@@ -467,7 +467,7 @@ jobs:
           release_workflow_id=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)
           [[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
           scan_failed=false
-          while IFS=$'	' read -r pr_number head_sha head_ref; do
+          while IFS=$'	' read -r pr_number head_sha head_repository head_ref fork_label_present; do
             cohort_failed=false
             verified_receipt=false
             registry_state_file="$RUNNER_TEMP/registry-state-$pr_number.json"
@@ -476,9 +476,14 @@ jobs:
 
             [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
             [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+            test -n "$head_repository"
             test -n "$head_ref"
-            review_json=$(gh api graphql     -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'     -f owner="${GITHUB_REPOSITORY%%/*}"     -f name="${GITHUB_REPOSITORY#*/}"     -F number="$pr_number")
-            if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+            if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+              review_json=$(gh api graphql       -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'       -f owner="${GITHUB_REPOSITORY%%/*}"       -f name="${GITHUB_REPOSITORY#*/}"       -F number="$pr_number")
+              if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+                continue
+              fi
+            elif [ "$fork_label_present" != true ]; then
               continue
             fi
 
@@ -505,7 +510,7 @@ jobs:
               selected_run_id="$candidate_run_id"
               selected_pack_attempt="$pack_attempt"
               break
-            done < <(jq -r --arg sha "$head_sha" --argjson pr_number "$pr_number"     '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == env.GITHUB_REPOSITORY and any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha))] | sort_by(.created_at) | reverse | .[].id'     <<<"$runs_json")
+            done < <(jq -r --arg sha "$head_sha" --arg head_repository "$head_repository" --arg head_ref "$head_ref"     '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == $head_repository and .head_branch == $head_ref and .head_sha == $sha)] | sort_by(.created_at) | reverse | .[].id'     <<<"$runs_json")
             if [ -z "$selected_run_id" ]; then
               echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
               continue
@@ -550,12 +555,12 @@ jobs:
             fi
 
             gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main     -f mode=promote-pr-snapshot     -f npm_tag=latest     -f pr_number="$pr_number"     -f head_sha="$head_sha"     -f ci_run_id="$selected_run_id"
-          done < <(jq -r --arg repository "$GITHUB_REPOSITORY"   '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv'   <<<"$prs_json")
+          done < <(jq -r   '.[][] | select(.draft == false and .base.ref == "main") | [.number, .head.sha, .head.repo.full_name, .head.ref, (any(.labels[]?; .name == "ci:publish-snapshot") | tostring)] | @tsv'   <<<"$prs_json")
           if [ "$scan_failed" = true ]; then
             exit 1
           fi
   validate-pr-snapshot:
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')
     runs-on: ubuntu-24.04
     permissions:
       actions: read
@@ -602,14 +607,21 @@ jobs:
           test "$(jq -r '.event' <<<"$run_json")" = pull_request
           test "$(jq -r '.status' <<<"$run_json")" = completed
           test "$(jq -r '.conclusion' <<<"$run_json")" = success
-          test "$(jq -r '.head_repository.full_name' <<<"$run_json")" = "$GITHUB_REPOSITORY"
           test "$(jq -r '.path' <<<"$run_json")" = .github/workflows/ci.yml
+          run_head_repository=$(jq -r '.head_repository.full_name' <<<"$run_json")
+          run_head_branch=$(jq -r '.head_branch' <<<"$run_json")
+          run_head_sha=$(jq -r '.head_sha' <<<"$run_json")
+          test -n "$run_head_repository"
+          test -n "$run_head_branch"
+          [[ "$run_head_sha" =~ ^[0-9a-f]{40}$ ]]
           if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
-            test "$(jq '.pull_requests | length' <<<"$run_json")" = 1
-            pr_number=$(jq -r '.pull_requests[0].number' <<<"$run_json")
-            head_sha=$(jq -r '.pull_requests[0].head.sha' <<<"$run_json")
+            prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
+            matching_prs=$(jq --arg head_repository "$run_head_repository" --arg head_branch "$run_head_branch" --arg head_sha "$run_head_sha"     '[.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $head_repository and .head.ref == $head_branch and .head.sha == $head_sha)]'     <<<"$prs_json")
+            test "$(jq 'length' <<<"$matching_prs")" = 1
+            pr_number=$(jq -r '.[0].number' <<<"$matching_prs")
+            head_sha="$run_head_sha"
           else
-            jq -e --arg sha "$head_sha" --argjson pr_number "$pr_number"     'any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha)' <<<"$run_json" >/dev/null
+            test "$run_head_sha" = "$head_sha"
           fi
           [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
@@ -623,8 +635,9 @@ jobs:
 
           test "$(jq -r '.state' <<<"$pr_json")" = open
           test "$(jq -r '.base.ref' <<<"$pr_json")" = main
-          test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
           test "$(jq -r '.head.sha' <<<"$pr_json")" = "$head_sha"
+          test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$run_head_repository"
+          test "$(jq -r '.head.ref' <<<"$pr_json")" = "$run_head_branch"
 
           echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
@@ -747,7 +760,7 @@ jobs:
         shell: bash
     steps:
       - id: approval
-        name: Require ordinary approval for the unchanged head
+        name: Require current-head review or fork trust label
         env:
           EXPECTED_HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
           GH_TOKEN: ${{ github.token }}
@@ -755,16 +768,26 @@ jobs:
         run: |
           set -euo pipefail
           pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
-          reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
-          owner="${GITHUB_REPOSITORY%%/*}"
-          name="${GITHUB_REPOSITORY#*/}"
-          review_decision=$(gh api graphql   -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'   -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"   --jq '.data.repository.pullRequest.reviewDecision')
           authorized=false
-          if [ "$(jq -r '.state' <<<"$pr_json")" = open ] &&    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] &&    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] &&    [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] &&    [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] &&    [ "$review_decision" = APPROVED ] &&    jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
-            authorized=true
+          authorized_by='none'
+          if [ "$(jq -r '.state' <<<"$pr_json")" = open ] &&    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] &&    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] &&    [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ]; then
+            head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+            if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+              reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+              owner="${GITHUB_REPOSITORY%%/*}"
+              name="${GITHUB_REPOSITORY#*/}"
+              review_decision=$(gh api graphql       -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'       -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"       --jq '.data.repository.pullRequest.reviewDecision')
+              if [ "$review_decision" = APPROVED ] &&        jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
+                authorized=true
+                authorized_by='current-head review'
+              fi
+            elif jq -e 'any(.labels[]?; .name == "ci:publish-snapshot")' <<<"$pr_json" >/dev/null; then
+              authorized=true
+              authorized_by='ci:publish-snapshot fork trust label'
+            fi
           fi
           echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
-          echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"
+          echo "Snapshot promotion authorized: $authorized ($authorized_by)" >> "$GITHUB_STEP_SUMMARY"
   publish-pr-snapshot:
     if: needs.authorize-pr-snapshot.outputs.authorized == 'true'
     needs: [validate-pr-snapshot, attest-pr-snapshot, authorize-pr-snapshot]
@@ -796,24 +819,28 @@ jobs:
         with:
           name: 'promotion-pr-snapshot-${{ needs.validate-pr-snapshot.outputs.head-sha }}-${{ needs.validate-pr-snapshot.outputs.run-id }}-${{ needs.attest-pr-snapshot.outputs.promotion-attempt }}'
           path: '${{ github.workspace }}/tmp/validated-pr-snapshot'
-      - name: Recheck unchanged-head approval before OIDC publication
+      - name: Recheck current-head authorization before OIDC publication
         env:
           EXPECTED_HEAD_SHA: ${{ needs.validate-pr-snapshot.outputs.head-sha }}
           PR_NUMBER: ${{ needs.validate-pr-snapshot.outputs.pr-number }}
         run: |
           set -euo pipefail
           pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
-          reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
-          owner="${GITHUB_REPOSITORY%%/*}"
-          name="${GITHUB_REPOSITORY#*/}"
-          review_decision=$(gh api graphql   -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'   -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"   --jq '.data.repository.pullRequest.reviewDecision')
           test "$(jq -r '.state' <<<"$pr_json")" = open
           test "$(jq -r '.draft' <<<"$pr_json")" = false
           test "$(jq -r '.base.ref' <<<"$pr_json")" = main
-          test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
           test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
-          test "$review_decision" = APPROVED
-          jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
+          head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+          if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+            reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+            owner="${GITHUB_REPOSITORY%%/*}"
+            name="${GITHUB_REPOSITORY#*/}"
+            review_decision=$(gh api graphql     -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}'     -f owner="$owner" -f name="$name" -F number="$PR_NUMBER"     --jq '.data.repository.pullRequest.reviewDecision')
+            test "$review_decision" = APPROVED
+            jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
+          else
+            jq -e 'any(.labels[]?; .name == "ci:publish-snapshot")' <<<"$pr_json" >/dev/null
+          fi
       - name: Verify promotion handoff
         env:
           EXPECTED_MANIFEST_DIGEST: ${{ needs.validate-pr-snapshot.outputs.manifest-digest }}
@@ -925,7 +952,7 @@ jobs:
           SOURCE_RUN_URL: ${{ needs.validate-pr-snapshot.outputs.source-run-url }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          ## Repository-owned PR snapshot
+          ## PR snapshot
 
           - PR: #$PR_NUMBER
           - Head: `${{ needs.validate-pr-snapshot.outputs.head-sha }}`

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -124,7 +124,7 @@ export default githubWorkflow({
       ...livestoreDefaultRefPolicyJob,
       if: "github.event_name != 'schedule'",
     },
-    'dispatch-approved-pr-snapshots': {
+    'dispatch-authorized-pr-snapshots': {
       if: "github.event_name == 'schedule'",
       'runs-on': 'ubuntu-24.04',
       permissions: {
@@ -146,14 +146,14 @@ scripts/src/generated/release-topology.json`,
           },
         },
         {
-          name: 'Dispatch incomplete approved cohorts to trusted main workflow',
+          name: 'Dispatch incomplete authorized cohorts to trusted main workflow',
           run: `set -euo pipefail
 test "$GITHUB_WORKFLOW_REF" = "$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main"
 prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
 release_workflow_id=$(gh api "/repos/$GITHUB_REPOSITORY/actions/workflows/release.yml" --jq .id)
 [[ "$release_workflow_id" =~ ^[1-9][0-9]*$ ]]
 scan_failed=false
-while IFS=$'\t' read -r pr_number head_sha head_ref; do
+while IFS=$'\t' read -r pr_number head_sha head_repository head_ref fork_label_present; do
   cohort_failed=false
   verified_receipt=false
   registry_state_file="$RUNNER_TEMP/registry-state-$pr_number.json"
@@ -161,13 +161,18 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
 
   [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
   [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+  test -n "$head_repository"
   test -n "$head_ref"
-  review_json=$(gh api graphql \
-    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
-    -f owner="\${GITHUB_REPOSITORY%%/*}" \
-    -f name="\${GITHUB_REPOSITORY#*/}" \
-    -F number="$pr_number")
-  if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+  if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+    review_json=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+      -f owner="\${GITHUB_REPOSITORY%%/*}" \
+      -f name="\${GITHUB_REPOSITORY#*/}" \
+      -F number="$pr_number")
+    if [ "$(jq -r '.data.repository.pullRequest.reviewDecision // ""' <<<"$review_json")" != APPROVED ]; then
+      continue
+    fi
+  elif [ "$fork_label_present" != true ]; then
     continue
   fi
 
@@ -199,8 +204,8 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
     selected_run_id="$candidate_run_id"
     selected_pack_attempt="$pack_attempt"
     break
-  done < <(jq -r --arg sha "$head_sha" --argjson pr_number "$pr_number" \
-    '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == env.GITHUB_REPOSITORY and any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha))] | sort_by(.created_at) | reverse | .[].id' \
+  done < <(jq -r --arg sha "$head_sha" --arg head_repository "$head_repository" --arg head_ref "$head_ref" \
+    '[.[] | .workflow_runs[] | select(.event == "pull_request" and .conclusion == "success" and .head_repository.full_name == $head_repository and .head_branch == $head_ref and .head_sha == $sha)] | sort_by(.created_at) | reverse | .[].id' \
     <<<"$runs_json")
   if [ -z "$selected_run_id" ]; then
     echo "PR #$pr_number has no exact successful pack artifact yet; skipping"
@@ -261,8 +266,8 @@ while IFS=$'\t' read -r pr_number head_sha head_ref; do
     -f pr_number="$pr_number" \
     -f head_sha="$head_sha" \
     -f ci_run_id="$selected_run_id"
-done < <(jq -r --arg repository "$GITHUB_REPOSITORY" \
-  '.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $repository) | [.number, .head.sha, .head.ref] | @tsv' \
+done < <(jq -r \
+  '.[][] | select(.draft == false and .base.ref == "main") | [.number, .head.sha, .head.repo.full_name, .head.ref, (any(.labels[]?; .name == "ci:publish-snapshot") | tostring)] | @tsv' \
   <<<"$prs_json")
 if [ "$scan_failed" = true ]; then
   exit 1
@@ -271,7 +276,7 @@ fi`,
       ],
     },
     'validate-pr-snapshot': {
-      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')",
+      if: "(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.mode == 'promote-pr-snapshot')",
       'runs-on': 'ubuntu-24.04',
       permissions: {
         actions: 'read',
@@ -319,15 +324,23 @@ run_json=$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
 test "$(jq -r '.event' <<<"$run_json")" = pull_request
 test "$(jq -r '.status' <<<"$run_json")" = completed
 test "$(jq -r '.conclusion' <<<"$run_json")" = success
-test "$(jq -r '.head_repository.full_name' <<<"$run_json")" = "$GITHUB_REPOSITORY"
 test "$(jq -r '.path' <<<"$run_json")" = .github/workflows/ci.yml
+run_head_repository=$(jq -r '.head_repository.full_name' <<<"$run_json")
+run_head_branch=$(jq -r '.head_branch' <<<"$run_json")
+run_head_sha=$(jq -r '.head_sha' <<<"$run_json")
+test -n "$run_head_repository"
+test -n "$run_head_branch"
+[[ "$run_head_sha" =~ ^[0-9a-f]{40}$ ]]
 if [ "$GITHUB_EVENT_NAME" = workflow_run ]; then
-  test "$(jq '.pull_requests | length' <<<"$run_json")" = 1
-  pr_number=$(jq -r '.pull_requests[0].number' <<<"$run_json")
-  head_sha=$(jq -r '.pull_requests[0].head.sha' <<<"$run_json")
+  prs_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" --slurp)
+  matching_prs=$(jq --arg head_repository "$run_head_repository" --arg head_branch "$run_head_branch" --arg head_sha "$run_head_sha" \
+    '[.[][] | select(.draft == false and .base.ref == "main" and .head.repo.full_name == $head_repository and .head.ref == $head_branch and .head.sha == $head_sha)]' \
+    <<<"$prs_json")
+  test "$(jq 'length' <<<"$matching_prs")" = 1
+  pr_number=$(jq -r '.[0].number' <<<"$matching_prs")
+  head_sha="$run_head_sha"
 else
-  jq -e --arg sha "$head_sha" --argjson pr_number "$pr_number" \
-    'any(.pull_requests[]?; .number == $pr_number and .head.sha == $sha)' <<<"$run_json" >/dev/null
+  test "$run_head_sha" = "$head_sha"
 fi
 [[ "$pr_number" =~ ^[1-9][0-9]*$ ]]
 [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
@@ -341,8 +354,9 @@ pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number")
 
 test "$(jq -r '.state' <<<"$pr_json")" = open
 test "$(jq -r '.base.ref' <<<"$pr_json")" = main
-test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
 test "$(jq -r '.head.sha' <<<"$pr_json")" = "$head_sha"
+test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$run_head_repository"
+test "$(jq -r '.head.ref' <<<"$pr_json")" = "$run_head_branch"
 
 echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
 echo "pr-number=$pr_number" >> "$GITHUB_OUTPUT"
@@ -496,7 +510,7 @@ jq -n \
       steps: [
         {
           id: 'approval',
-          name: 'Require ordinary approval for the unchanged head',
+          name: 'Require current-head review or fork trust label',
           env: {
             EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
             GH_TOKEN: '${{ github.token }}',
@@ -504,25 +518,33 @@ jq -n \
           },
           run: `set -euo pipefail
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
-reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
-owner="\${GITHUB_REPOSITORY%%/*}"
-name="\${GITHUB_REPOSITORY#*/}"
-review_decision=$(gh api graphql \
-  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
-  -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
-  --jq '.data.repository.pullRequest.reviewDecision')
 authorized=false
+authorized_by='none'
 if [ "$(jq -r '.state' <<<"$pr_json")" = open ] && \
    [ "$(jq -r '.draft' <<<"$pr_json")" = false ] && \
    [ "$(jq -r '.base.ref' <<<"$pr_json")" = main ] && \
-   [ "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY" ] && \
-   [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ] && \
-   [ "$review_decision" = APPROVED ] && \
-   jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
-  authorized=true
+   [ "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA" ]; then
+  head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+  if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+    reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+    owner="\${GITHUB_REPOSITORY%%/*}"
+    name="\${GITHUB_REPOSITORY#*/}"
+    review_decision=$(gh api graphql \
+      -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+      -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewDecision')
+    if [ "$review_decision" = APPROVED ] && \
+       jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null; then
+      authorized=true
+      authorized_by='current-head review'
+    fi
+  elif jq -e 'any(.labels[]?; .name == "ci:publish-snapshot")' <<<"$pr_json" >/dev/null; then
+    authorized=true
+    authorized_by='ci:publish-snapshot fork trust label'
+  fi
 fi
 echo "authorized=$authorized" >> "$GITHUB_OUTPUT"
-echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
+echo "Snapshot promotion authorized: $authorized ($authorized_by)" >> "$GITHUB_STEP_SUMMARY"`,
         },
       ],
     },
@@ -565,27 +587,31 @@ echo "Snapshot promotion authorized: $authorized" >> "$GITHUB_STEP_SUMMARY"`,
           },
         },
         {
-          name: 'Recheck unchanged-head approval before OIDC publication',
+          name: 'Recheck current-head authorization before OIDC publication',
           env: {
             EXPECTED_HEAD_SHA: '${{ needs.validate-pr-snapshot.outputs.head-sha }}',
             PR_NUMBER: '${{ needs.validate-pr-snapshot.outputs.pr-number }}',
           },
           run: `set -euo pipefail
 pr_json=$(gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
-reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
-owner="\${GITHUB_REPOSITORY%%/*}"
-name="\${GITHUB_REPOSITORY#*/}"
-review_decision=$(gh api graphql \
-  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
-  -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
-  --jq '.data.repository.pullRequest.reviewDecision')
 test "$(jq -r '.state' <<<"$pr_json")" = open
 test "$(jq -r '.draft' <<<"$pr_json")" = false
 test "$(jq -r '.base.ref' <<<"$pr_json")" = main
-test "$(jq -r '.head.repo.full_name' <<<"$pr_json")" = "$GITHUB_REPOSITORY"
 test "$(jq -r '.head.sha' <<<"$pr_json")" = "$EXPECTED_HEAD_SHA"
-test "$review_decision" = APPROVED
-jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null`,
+head_repository=$(jq -r '.head.repo.full_name' <<<"$pr_json")
+if [ "$head_repository" = "$GITHUB_REPOSITORY" ]; then
+  reviews_json=$(gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" --slurp | jq -s 'flatten')
+  owner="\${GITHUB_REPOSITORY%%/*}"
+  name="\${GITHUB_REPOSITORY#*/}"
+  review_decision=$(gh api graphql \
+    -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewDecision}}}' \
+    -f owner="$owner" -f name="$name" -F number="$PR_NUMBER" \
+    --jq '.data.repository.pullRequest.reviewDecision')
+  test "$review_decision" = APPROVED
+  jq -e --arg sha "$EXPECTED_HEAD_SHA" 'any(.[]; .state == "APPROVED" and .commit_id == $sha)' <<<"$reviews_json" >/dev/null
+else
+  jq -e 'any(.labels[]?; .name == "ci:publish-snapshot")' <<<"$pr_json" >/dev/null
+fi`,
         },
         {
           name: 'Verify promotion handoff',
@@ -719,7 +745,7 @@ echo "Verified $verified immutable package versions and SHA-512 integrities; tag
             SOURCE_RUN_URL: '${{ needs.validate-pr-snapshot.outputs.source-run-url }}',
           },
           run: `cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-## Repository-owned PR snapshot
+## PR snapshot
 
 - PR: #$PR_NUMBER
 - Head: \`\${{ needs.validate-pr-snapshot.outputs.head-sha }}\`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 For maintainers and contributors:
 
+- **Release tooling:** Pull-request CI now packs exact-head snapshot candidates
+  for forks without secrets. Maintainers can allow npm publication for a fork's
+  current and later PR heads with the revocable `ci:publish-snapshot` label
+  ([#1559](https://github.com/livestorejs/livestore/issues/1559)).
 - **Tooling:** Shell entry no longer runs the full TypeScript build after
   dependency and generated-source setup. The shared Effect-utils
   `otel:profile:setup` task captures the strict setup graph through native

--- a/context/03-delivery/02-release/.decisions/0002-fork-snapshot-trust-label.md
+++ b/context/03-delivery/02-release/.decisions/0002-fork-snapshot-trust-label.md
@@ -1,0 +1,46 @@
+# 0002 — Trust labeled fork PR branches for snapshot publishing
+
+Status: accepted
+
+Evidence: [experiment 0001](../.experiments/0001-label-gated-fork-snapshots.md),
+[experiment 0002](../.experiments/0002-pack-all-fork-candidates.md), and owner
+design interview on 2026-08-18.
+
+## Context
+
+The repository-owned PR snapshot path could not serve fork PRs: fork pack jobs
+were skipped, workflow-run PR associations were absent, and publication required
+a merge-significant approval. PR #1558 demonstrated the gap. Maintainers need a
+separate way to trust a contributor's mutable PR branch for test-only immutable
+npm snapshots without granting merge approval or npm credentials.
+
+## Evidence and Argument
+
+Fork `pull_request` jobs receive a read-only token and no repository secrets.
+The existing main-branch validator treats their artifacts as bounded untrusted
+data and passed 11 adversarial tests. Live PR #1558 evidence showed that neither
+the workflow run nor commit association APIs identify its PR, while exact head
+repository, branch, and SHA do. A representative pack costs about 21 runner
+minutes, which the owner accepted in exchange for the simpler single candidate
+path.
+
+## Options
+
+| Option | Consequence |
+| --- | --- |
+| Package all PRs; label gates fork publication | One candidate path; spends packaging compute on unlabeled forks |
+| Dedicated label-triggered fork pack workflow | Avoids unlabeled compute; adds another workflow/event topology |
+| Keep forks excluded | Preserves the old boundary; fork snapshots remain unavailable |
+
+## Decision
+
+Package every PR head in the existing secretless candidate job. Preserve the
+current-head review gate for repository-owned PRs. For forks, treat the
+maintainer-managed `ci:publish-snapshot` label as a persistent, revocable trust
+grant over the PR head repository and branch, including later commits while the
+label remains. Resolve fork producers by exact repository, branch, and SHA;
+validate artifacts without execution; and recheck the live label and unchanged
+head immediately before npm OIDC publication.
+
+Removing the label stops publication that has not started. It cannot retract an
+immutable version already published to npm.

--- a/context/03-delivery/02-release/.experiments/0001-label-gated-fork-snapshots.md
+++ b/context/03-delivery/02-release/.experiments/0001-label-gated-fork-snapshots.md
@@ -1,0 +1,102 @@
+# 0001 — Label-gated fork snapshot authorization
+
+Date: 2026-08-18
+
+## Question
+
+Can a maintainer-applied pull-request label safely authorize publishing an
+exact-head snapshot from a fork without giving fork code secrets or implicitly
+authorizing later commits?
+
+## Method
+
+- Inspected the generated CI and release workflows at the branch baseline.
+- Queried PR #1558 and its CI run through the GitHub API. The fork CI run had an
+  empty `pull_requests` array and its `pack-pr-snapshot` job was skipped.
+- Queried recent LiveStore label timeline events. Their `commit_id` fields were
+  null, so the issue-event timeline cannot independently bind a label to the PR
+  head that was visible when it was applied.
+- Compared GitHub's `pull_request` and `pull_request_target` security contracts
+  in the official documentation. In particular, `pull_request_target` must not
+  check out and execute untrusted fork code.
+- Built a pure authorization state model with `Label`, `RemoveLabel`, `Push`,
+  and `Publish` actions. A breadth-first driver enumerated all action sequences
+  through depth five and checked that every published SHA had its own
+  authorization receipt.
+- Sketched a two-event workflow and checked its syntax with
+  `nix shell nixpkgs#actionlint -c actionlint`.
+- Ran the existing artifact-boundary tests with
+  `node --test .github/scripts/pr-snapshot-artifact.test.mjs`.
+
+External references:
+
+- [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+- [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Securely using `pull_request_target`](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)
+
+## Result
+
+The persistent-label model failed with the shortest witness:
+
+```text
+Label(head A) -> Push(head B) -> Publish(head B)
+```
+
+The exact-head-receipt model had no invariant violation through depth five.
+
+The viable privilege separation is:
+
+```text
+pull_request_target:labeled
+  -> trusted workflow records { PR, fork repository, head SHA, actor }
+
+pull_request:labeled
+  -> secretless GitHub-hosted runner executes fork packaging
+  -> uploads an untrusted immutable candidate
+
+scheduled or dispatched workflow on main
+  -> requires matching authorization and candidate identities
+  -> re-resolves the open PR and unchanged head
+  -> validates bounded tarballs without executing them
+  -> publishes through npm trusted publishing
+```
+
+The workflow sketch passed `actionlint`. The existing artifact boundary suite
+passed 11/11 tests, including digest mutation, identity drift, unexpected
+files, traversal paths, and lifecycle-script rejection.
+
+## Conclusion
+
+A label can be the maintainer interaction, but label presence cannot itself be
+the durable authorization predicate. The safe design treats the trusted
+`labeled` event as a one-shot authorization for the exact PR head SHA and
+correlates that receipt with a separately produced untrusted artifact.
+
+`pull_request_target` is suitable only for recording authorization metadata;
+it must never check out or execute the fork. Fork packaging belongs in an
+unprivileged `pull_request` run. Publication remains in the main-branch trusted
+workflow and must recheck the unchanged PR head immediately before npm OIDC.
+
+Open design choices include whether the label replaces review approval for the
+authorized SHA, whether repository-owned PRs keep their current automatic path,
+and whether the authorization label is removed after receipt creation.
+
+### 2026-08-18 interpretation amendment
+
+The initial oracle treated authorization as exact-head by definition. The
+owner subsequently clarified that applying the label deliberately trusts the
+contributor-controlled PR head repository and branch, including future commits
+while the label remains present. Under that policy, `Label(A) -> Push(B) ->
+Publish(B)` is intended behavior rather than a violation. Exact head identity
+still binds each candidate and publication, while live label presence grants
+eligibility to the current mutable head.
+
+## VRS Impact
+
+This rules out persistent label presence only when the intended grant is
+exact-head. Under the clarified mutable-head trust policy, the release spec must
+define the label as a revocable grant over the PR head repository and branch,
+keep each candidate exact-SHA and fork packaging unprivileged, and require the
+trusted publisher to revalidate the current head and live label immediately
+before publication. The remaining policy choices are being resolved through
+the design interview before normative requirement or spec text changes.

--- a/context/03-delivery/02-release/.experiments/0002-pack-all-fork-candidates.md
+++ b/context/03-delivery/02-release/.experiments/0002-pack-all-fork-candidates.md
@@ -1,0 +1,84 @@
+# 0002 — Package candidates for every fork PR head
+
+Date: 2026-08-18
+
+## Question
+
+Is it simpler and safe enough to package an immutable snapshot candidate for
+every fork PR update in ordinary CI, while using a persistent maintainer label
+only as the trusted publication gate?
+
+## Method
+
+- Re-read PR #1558, CI run `32037941002`, its jobs, and artifacts through the
+  GitHub API without mutating the PR or workflow.
+- Exercised candidate selection and live-label/head authorization with a local
+  state model, including label removal, head changes, closed PRs, and run
+  attempts.
+- Ran `node --test .github/scripts/pr-snapshot-artifact.test.mjs` against the
+  untrusted artifact boundary.
+- Compared the concrete generated-workflow surfaces required by unconditional
+  fork packaging and a dedicated label-triggered packaging workflow.
+- Measured a successful repository-owned snapshot pack run as a proxy for the
+  incremental compute cost.
+- Checked GitHub's official fork-token, rerun, cache, `pull_request_target`, and
+  `workflow_run` security contracts.
+
+## Result
+
+Verdict: **PARTIAL**. The local and live read-only seams support the design, but
+no disposable hosted fork candidate was created, so upload through trusted
+validation remains unproven end to end.
+
+Evidence established:
+
+- Fork `pull_request` packaging has a read-only token and no secrets. The job
+  further narrows permissions to `contents: read` and clears `CACHIX_AUTH_TOKEN`.
+- PR #1558's successful fork run has `pull_requests: []`; the commit-to-PR API
+  also returns no association. Trusted resolution must match the exact tuple
+  `(head repository, head branch, head SHA)` to one open PR, then re-read it.
+- The existing artifact validator passed 11/11 adversarial tests. It rejects
+  digest and identity drift, unexpected files, traversal, lifecycle scripts,
+  `.npmrc`, hostile `publishConfig`, oversized archives, and topology drift.
+- State enumeration confirmed that a changed head invalidates the old
+  candidate, label removal denies queued publication, and a labeled current
+  head with a matching candidate is eligible.
+- A representative successful pack job took 20m50s; its pack step took 17m34s
+  and produced a 4,282,985-byte artifact. Unconditional packaging pays roughly
+  this runner cost for every fork update, labeled or not.
+- Applying the label cannot backfill PR #1558's old run: its pack job was
+  skipped and no candidate exists. GitHub reruns preserve the original SHA/ref
+  and do not provide a reliable new-workflow backfill.
+
+Implementation-surface comparison:
+
+| Surface | Package every fork | Dedicated labeled packaging |
+| --- | --- | --- |
+| Packaging trigger | Broaden existing CI job | Add one small workflow |
+| Fork identity resolution | Required | Required |
+| Label authorization | Required | Required |
+| Trusted artifact validation | Required | Required |
+| Final revocation/head recheck | Required | Required |
+| Unlabeled fork compute | Every update | None |
+| Existing-PR label backfill | No | Yes |
+
+## Conclusion
+
+Packaging every fork is defensible and removes one workflow trigger, but it is
+not dramatically simpler: almost all trusted identity, authorization,
+validation, scheduling, and revocation changes remain. Its distinct tradeoffs
+are approximately 21 runner-minutes per fork update and no automatic backfill
+for pre-feature runs such as #1558.
+
+A hosted disposable fork test must prove candidate upload, exact tuple
+resolution, trusted validation, and final label/head denial before this option
+receives a full PASS.
+
+## VRS Impact
+
+If adopted, the release contract should state that candidate production is
+unprivileged and unconditional for fork PR heads, while publication authority
+is the live maintainer-applied label on the current PR head ref. It must not use
+Actions `pull_requests` or commit associations as the fork identity source.
+The runbook should disclose that labeling a PR whose earlier run predates the
+feature may require a new PR event before a candidate exists.

--- a/context/03-delivery/02-release/.experiments/0002-pack-all-fork-candidates.md
+++ b/context/03-delivery/02-release/.experiments/0002-pack-all-fork-candidates.md
@@ -21,14 +21,18 @@ only as the trusted publication gate?
   fork packaging and a dedicated label-triggered packaging workflow.
 - Measured a successful repository-owned snapshot pack run as a proxy for the
   incremental compute cost.
+- Created a disposable draft fork PR against `main`, ran the generated fork CI,
+  downloaded its candidate, and exercised the trusted validator locally.
+- Applied and removed the live trust label while re-reading the exact PR tuple
+  to test authorization and revocation without publishing to npm.
 - Checked GitHub's official fork-token, rerun, cache, `pull_request_target`, and
   `workflow_run` security contracts.
 
 ## Result
 
-Verdict: **PARTIAL**. The local and live read-only seams support the design, but
-no disposable hosted fork candidate was created, so upload through trusted
-validation remains unproven end to end.
+Verdict: **PASS** for candidate production, identity resolution, trusted
+validation, and pre-publication revocation. npm publication remains deliberately
+untested until the trusted workflow is merged to the default branch.
 
 Evidence established:
 
@@ -37,7 +41,7 @@ Evidence established:
 - PR #1558's successful fork run has `pull_requests: []`; the commit-to-PR API
   also returns no association. Trusted resolution must match the exact tuple
   `(head repository, head branch, head SHA)` to one open PR, then re-read it.
-- The existing artifact validator passed 11/11 adversarial tests. It rejects
+- The artifact validator passed 12/12 adversarial tests. It rejects
   digest and identity drift, unexpected files, traversal, lifecycle scripts,
   `.npmrc`, hostile `publishConfig`, oversized archives, and topology drift.
 - State enumeration confirmed that a changed head invalidates the old
@@ -46,6 +50,18 @@ Evidence established:
 - A representative successful pack job took 20m50s; its pack step took 17m34s
   and produced a 4,282,985-byte artifact. Unconditional packaging pays roughly
   this runner cost for every fork update, labeled or not.
+- Disposable fork PR #1561 produced candidate
+  `pr-snapshot-b15256f1cb92153260ab35d6290f482666d02760-1` in hosted run
+  `32121765725`. The pack job completed in 20m25s and uploaded a 4,283,167-byte
+  artifact.
+- The trusted validator accepted that downloaded fork artifact as the exact
+  14-package cohort at version
+  `0.0.0-snapshot-pr.1561.b15256f1cb92153260ab35d6290f482666d02760`.
+  Its manifest digest was
+  `c787bfdeb0207460ebb3ffb2c44e8b6b858120b707365bf2252aa70818aea02b`.
+- Exact tuple resolution found only PR #1561. With the live label applied the
+  current head was authorized; after label removal the same current head was
+  denied.
 - Applying the label cannot backfill PR #1558's old run: its pack job was
   skipped and no candidate exists. GitHub reruns preserve the original SHA/ref
   and do not provide a reliable new-workflow backfill.
@@ -70,9 +86,10 @@ validation, scheduling, and revocation changes remain. Its distinct tradeoffs
 are approximately 21 runner-minutes per fork update and no automatic backfill
 for pre-feature runs such as #1558.
 
-A hosted disposable fork test must prove candidate upload, exact tuple
-resolution, trusted validation, and final label/head denial before this option
-receives a full PASS.
+The disposable hosted test proves every seam available before merge. A true npm
+promotion must wait for the trusted `workflow_run` definition to land on the
+default branch; GitHub intentionally runs that workflow from the default branch,
+not from untrusted fork code.
 
 ## VRS Impact
 

--- a/context/03-delivery/02-release/release-workflows-runbook.md
+++ b/context/03-delivery/02-release/release-workflows-runbook.md
@@ -66,6 +66,19 @@ CI=1 mono release snapshot --git-sha=<git-sha> --dry-run --yes
 Local snapshot publishing should be rare; prefer the CI snapshot workflow so npm
 provenance and package identity match the reviewed commit.
 
+Pull-request CI packs an immutable exact-head candidate for repository-owned and
+fork PRs. Repository-owned candidates publish after the ordinary current-head
+approval. Fork candidates publish while a maintainer-managed
+`ci:publish-snapshot` label is present. The label trusts control of that PR's
+head repository and branch, including later commits while it remains present;
+remove it to stop publication that has not started.
+
+The trusted workflow resolves fork producers by exact head repository, branch,
+and SHA because GitHub may omit fork PR associations. It rechecks the open PR,
+unchanged head, and live label immediately before npm OIDC publication. A fork
+PR whose earlier CI run predates this behavior needs a new PR update before a
+candidate exists; applying the label does not backfill a skipped pack job.
+
 ### Stable release groups
 
 Stable releases use Changesets to calculate the next fixed-group version, then

--- a/context/03-delivery/02-release/requirements.md
+++ b/context/03-delivery/02-release/requirements.md
@@ -48,3 +48,13 @@ the normative contract stays here):
   off `workflow_run.conclusion == 'success'`); tracked in
   [.delta/DELTA-001](./.delta/DELTA-001-snapshot-gated-on-ci-conclusion.md).
   Adopted 2026-07-18 (owner-confirmed).
+- **LS.DEL.REL-R08 Fork snapshot trust:** Every pull-request head may produce
+  an untrusted immutable snapshot candidate without secrets or repository write
+  authority. A repository-owned candidate requires the ordinary current-head
+  review decision to publish; a fork candidate requires the maintainer-managed
+  `ci:publish-snapshot` label to remain present through the final live PR/head
+  check immediately before publication. The fork label grants revocable trust
+  to the PR's mutable head repository and branch, including later commits while
+  it remains present. Adopted 2026-08-18 (design interview; evidence:
+  [.experiments/0001](./.experiments/0001-label-gated-fork-snapshots.md) and
+  [.experiments/0002](./.experiments/0002-pack-all-fork-candidates.md)).

--- a/context/03-delivery/02-release/spec.md
+++ b/context/03-delivery/02-release/spec.md
@@ -57,6 +57,40 @@ sequenceDiagram
 Manual contrib release dispatch accepts an explicit version but must use a
 version already published by core (LS.DEL.REL-R05).
 
+## Pull-Request Snapshot Promotion (LS.DEL.REL-R08)
+
+```text
+pull_request CI (untrusted)             release.yml on main (trusted)
+----------------------------------      --------------------------------
+pack exact PR head without secrets ---> resolve exact repo/branch/SHA run
+upload immutable candidate              validate bounded package cohort
+                                        re-read open PR + current head
+same-repo PR: current-head approval ---> authorize
+fork PR: ci:publish-snapshot label ----> authorize while label remains
+                                        recheck immediately before npm OIDC
+                                        publish exact-SHA immutable versions
+```
+
+The `pack-pr-snapshot` job runs for every pull request, including forks, with
+`contents: read`, no npm authority, and no CACHIX credential. Its artifact is
+untrusted data. The trusted main-branch workflow downloads but never executes
+the candidate, validates its exact package topology, version, dependency pins,
+paths, sizes, lifecycle-script absence, and digests, and publishes tarballs with
+scripts disabled.
+
+GitHub Actions may omit fork PR associations from workflow-run records. The
+publisher therefore identifies a producer by the exact tuple of head repository,
+head branch, and head SHA, requires it to resolve to exactly one open non-draft
+PR targeting `main`, and binds the manifest to that PR number and run attempt.
+
+Repository-owned PR authorization remains the authoritative review decision plus
+an approval naming the current head. For a fork PR, the persistent
+`ci:publish-snapshot` label trusts control of that PR's mutable head repository
+and branch: later commits remain eligible while the label is present. Removing
+the label cancels any candidate whose npm publication has not started. Published
+npm versions are immutable and are not revoked by removing the label. Decision
+and rejected alternatives: [.decisions/0002](./.decisions/0002-fork-snapshot-trust-label.md).
+
 ## Breaking-Change Mechanics (LS.DEL.REL-R06)
 
 Beta releases may break in three distinct ways (user-facing promise:


### PR DESCRIPTION
## Problem

The exact-SHA snapshot pipeline excludes fork PRs. PR #1558 has green CI but no
snapshot candidate, leaving maintainers with no supported way to publish a
testable npm cohort without mirroring the branch into the repository.

## Goal

Produce a secretless immutable candidate for every PR head, then let a
maintainer opt a fork's mutable PR branch into trusted snapshot publication with
`ci:publish-snapshot`. Keep the existing review-based path unchanged for
repository-owned PRs.

## Decisions

- Reuse the existing `pack-pr-snapshot` job for forks instead of adding another
  workflow. This costs packaging compute on unlabeled forks but keeps one
  candidate topology.
- Resolve fork producers by exact head repository, branch, and SHA. GitHub omits
  PR associations for the motivating fork run.
- Treat the label as a persistent, revocable grant over the PR head ref. Later
  heads remain eligible while it is present.
- Recheck open/draft/base/head/label state immediately before npm OIDC. Trusted
  jobs validate but never execute fork artifacts.

## Verification

Local gates at `b8a0d91b9`:

- `node --test .github/scripts/pr-snapshot-artifact.test.mjs` - 12/12 pass,
  including identity drift, authorization, traversal, lifecycle scripts, and
  artifact mutation.
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/{ci,release}.yml`
  - pass.
- `devenv tasks run genie:check` - pass.
- `devenv tasks run lint:full` - pass.
- `devenv tasks run ts:check` - pass.
- `devenv tasks run test:unit` - pass.
- `CHANGESET_BASE_REF=origin/main devenv tasks run release:changeset:check-pr`
  - pass.
- New VRS records pass strict shape validation. The repository-wide strict
  checker still reports 117 pre-existing record-shape failures.

Hosted fork E2E:

- Draft fork PR #1561 at exact head `b15256f1c` produced
  `pr-snapshot-b15256f1cb92153260ab35d6290f482666d02760-1` in run
  [32121765725](https://github.com/livestorejs/livestore/actions/runs/32121765725).
- Its pack job completed in 20m25s and uploaded a 4,283,167-byte artifact.
- The downloaded artifact passed the trusted validator as the exact 14-package
  cohort. Manifest digest:
  `c787bfdeb0207460ebb3ffb2c44e8b6b858120b707365bf2252aa70818aea02b`.
- Exact repository/branch/SHA resolution returned only #1561. Applying the live
  label authorized that current head; removing it denied the same head.
- npm publication was intentionally not attempted: `workflow_run` uses the
  default-branch workflow, so promotion becomes safely testable only after this
  PR lands.

## Complexity

No new workflow is added. Complexity is limited to fork run identity resolution
and the second authorization policy in the existing trusted release workflow.

## Concerns

- The hosted E2E candidate consumed 20m25s of runner time on a fork update,
  labeled or not.
- Applying the label cannot backfill a pack job from a run created before this
  change; that PR needs a new update/event.
- npm publication is a package cohort loop. Label removal is guaranteed to stop
  the job before publication starts, not retract packages already published.

## Friction & bottlenecks

- `AGENTS.md` names `devenv tasks run test:run`, but that task does not exist;
  the live aggregate used here is `test:unit` plus focused workflow tests.
- Fork Actions runs expose an empty `pull_requests` array and the commit-to-PR
  API also returns no match, requiring explicit head-ref identity resolution.

## Follow-ups

- Reassess unconditional fork packaging if hosted-runner use becomes material.

## References

Closes #1559.

Extends #1455. Motivated by #1558.
