### PR TITLE
Keep snapshot OIDC publishing tokenless

### DIFF
--- a/.changeset/empty-oidc-token-guard.md
+++ b/.changeset/empty-oidc-token-guard.md
@@ -1,0 +1,5 @@
+---
+---
+
+No package release impact. Keep the PR snapshot publisher tokenless when using
+npm trusted publishing.

--- a/.github/scripts/pr-snapshot-artifact.test.mjs
+++ b/.github/scripts/pr-snapshot-artifact.test.mjs
@@ -286,6 +286,14 @@ test('generated promotion workflow is anchored to trusted main', async () => {
 
   const publish = workflow.slice(publishStart, nextJobStart)
   assert.match(publish, /pull-requests: read/)
+  const publishNodeSetupStart = publish.indexOf('- name: Use pinned npm trusted-publishing client')
+  const publishNodeSetupEnd = publish.indexOf(
+    '\n      - name: Download validated promotion artifact',
+    publishNodeSetupStart,
+  )
+  assert.notEqual(publishNodeSetupStart, -1)
+  assert.notEqual(publishNodeSetupEnd, -1)
+  assert.doesNotMatch(publish.slice(publishNodeSetupStart, publishNodeSetupEnd), /registry-url:/)
   assert.match(publish, /group: 'pr-snapshot-\$\{\{ needs\.validate-pr-snapshot\.outputs\.head-sha \}\}'/)
   assert.match(publish, /\.base\.ref/)
   assert.match(publish, /\.head\.repo\.full_name/)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -813,7 +813,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.15.0
-          registry-url: 'https://registry.npmjs.org'
       - name: Download validated promotion artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml.genie.ts
+++ b/.github/workflows/release.yml.genie.ts
@@ -575,7 +575,6 @@ echo "Snapshot promotion authorized: $authorized ($authorized_by)" >> "$GITHUB_S
           uses: 'actions/setup-node@v4',
           with: {
             'node-version': '24.15.0',
-            'registry-url': 'https://registry.npmjs.org',
           },
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ For maintainers and contributors:
 - **Release tooling:** Pull-request CI now packs exact-head snapshot candidates
   for forks without secrets. Maintainers can allow npm publication for a fork's
   current and later PR heads with the revocable `ci:publish-snapshot` label
-  ([#1559](https://github.com/livestorejs/livestore/issues/1559)).
+  ([#1559](https://github.com/livestorejs/livestore/issues/1559)). The trusted
+  publisher leaves npm registry configuration unset so `actions/setup-node`
+  does not inject its token-auth placeholder into the OIDC-only job.
 - **Tooling:** Shell entry no longer runs the full TypeScript build after
   dependency and generated-source setup. The shared Effect-utils
   `otel:profile:setup` task captures the strict setup graph through native


### PR DESCRIPTION
## Problem

The first production E2E of labeled fork snapshot publication passed candidate
validation, attestation, and authorization, then failed safely before npm.
`actions/setup-node` exports `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` when its
`registry-url` option is set, and the OIDC-only publisher correctly rejects any
token environment value.

## Goal

Keep the trusted PR snapshot publisher tokenless so npm trusted publishing can
exchange GitHub's OIDC identity without a setup-node token placeholder.

## Decisions

- Remove only `registry-url` from the PR snapshot publisher's setup-node step.
  npm already defaults to `https://registry.npmjs.org`, which is also explicit
  on every `npm publish` and `npm view` command.
- Keep the token guard unchanged. Weakening it to recognize one placeholder
  would make the security invariant depend on an action implementation detail.
- Add a generated-workflow regression assertion preventing `registry-url` from
  returning to this job.

## Verification

- Production failure: [run 32127948131](https://github.com/livestorejs/livestore/actions/runs/32127948131),
  `publish-pr-snapshot / Verify promotion handoff`.
- `node --test .github/scripts/pr-snapshot-artifact.test.mjs` - 12/12 pass.
- `actionlint` on generated `release.yml` - pass with the repository's custom
  runner label ignored.
- `CHANGESET_BASE_REF=origin/main devenv tasks run release:changeset:check-pr`
  - pass.
- `devenv tasks run lint:full:fix` could not complete in the isolated worktree:
  its dependency projection was absent, producing 358 pre-existing missing-type
  errors. Its unrelated formatting edits were discarded.

## Complexity

No new complexity. One setup-node input is removed and its absence is tested.

## Concerns

The failed trusted run cannot be repaired with a rerun because GitHub reruns use
the original default-branch workflow definition. Jamie's green producer run
must be promoted again after this fix reaches `main`.

## Friction & bottlenecks

The E2E surfaced setup-node's masked placeholder only in the live runner
environment; static workflow validation cannot observe action-exported env.

## Follow-ups

None.

## References

Refs #1558 and #1559.
