### PR TITLE
Establish a portable Minimal Setup with a verified Docker lane

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 .direnv
 **/node_modules
 result
+# Local secret files must never enter the image via the broad COPY.
+.envrc.local
+**/.envrc.local
+.env*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.devenv
+.direnv
+**/node_modules
+result

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@ tsconfig.json linguist-generated=true
 tsconfig.*.json linguist-generated=true
 pnpm-install-contract.json linguist-generated=true
 .github/workflows/*.yml linguist-generated=true
+.github/repo-settings.json linguist-generated=true
 
 # Lock files - collapse in GitHub PR diffs
 *.lock linguist-generated=true

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -35,6 +35,9 @@
             "context": "changeset-check"
           },
           {
+            "context": "minimal-dev"
+          },
+          {
             "context": "type-check"
           },
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -643,6 +644,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -822,6 +824,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1008,6 +1011,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1186,6 +1190,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1374,6 +1379,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1568,6 +1574,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1775,6 +1782,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1967,6 +1975,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -2168,6 +2177,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -2389,6 +2399,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -2598,6 +2609,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,16 @@ jobs:
           process.exit(1)
           NODE
         shell: bash
+  minimal-dev:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify minimal development setup
+        run: 'docker build --tag livestore-minimal-dev:ci .'
   pack-pr-snapshot:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -135,6 +135,21 @@ export default githubWorkflow({
 
   jobs: {
     'source-policy': livestoreDefaultRefPolicyJob,
+    'minimal-dev': {
+      if: "github.event_name == 'pull_request'",
+      'runs-on': 'ubuntu-latest',
+      steps: [
+        {
+          name: 'Checkout code',
+          uses: 'actions/checkout@v4',
+          with: { ref: PR_HEAD_SHA },
+        },
+        {
+          name: 'Verify minimal development setup',
+          run: 'docker build --tag livestore-minimal-dev:ci .',
+        },
+      ],
+    },
     ...prSnapshotPackJob({
       topologyPath: releaseTopologyPath,
       setupStepsAfterCheckout: livestoreSetupStepsAfterCheckout,

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -442,6 +442,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -659,6 +660,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -852,6 +854,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/.github/workflows/devtools-artifact.yml
+++ b/.github/workflows/devtools-artifact.yml
@@ -476,6 +476,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/.github/workflows/infra-drift.yml
+++ b/.github/workflows/infra-drift.yml
@@ -50,6 +50,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1020,6 +1020,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1263,6 +1264,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1513,6 +1515,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -1806,6 +1809,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/.github/workflows/repo-settings.yml
+++ b/.github/workflows/repo-settings.yml
@@ -62,6 +62,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -247,6 +248,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -56,6 +56,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |
@@ -239,6 +240,7 @@ jobs:
             extra-substituters = https://cache.nixos.org
             extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           summarize: true
+          source-tag: v3.21.9
       - name: Provide cachix CLI from nixpkgs
         shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM oven/bun:1.3.13 AS bun
+
+# Node 24 and Bun 1.3.13 are the known-good portable toolchain.
+FROM node:24-bookworm-slim
+
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --global "$(node -p "require('./package.json').packageManager")"
+
+COPY . .
+
+# The image has no Git metadata, so docs links intentionally target main.
+ENV GITHUB_BRANCH_NAME=main
+
+RUN ./scripts/bootstrap-minimal.sh \
+  # Keep this finite oracle representative; interactive and full-lane work runs outside the build.
+  && pnpm exec tsc -b packages/@livestore/livestore --pretty false \
+  && pnpm --filter @livestore/common exec vitest run \
+  && pnpm --filter livestore-example-web-todomvc run build \
+  && pnpm --filter livestore-example-cloudflare-todomvc run build \
+  && pnpm --filter @local/docs run check

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM oven/bun:1.3.13 AS bun
 # Node 24 and Bun 1.3.13 are the known-good portable toolchain.
 FROM node:24-bookworm-slim
 
+# bunx is a symlink to the same binary; recreate it so `bunx ...` commands work.
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+RUN ln -s bun /usr/local/bin/bunx
 
 WORKDIR /app
 
@@ -12,10 +14,12 @@ RUN npm install --global "$(node -p "require('./package.json').packageManager")"
 
 COPY . .
 
-# The image has no Git metadata, so docs links intentionally target main.
-ENV GITHUB_BRANCH_NAME=main
-
-RUN ./scripts/bootstrap-minimal.sh \
+# The image build has no Git metadata (see .dockerignore), so docs links during the
+# oracle run intentionally target main. `export` scopes the override to this single
+# RUN (an env prefix would only cover the first command): interactive Compose users
+# keep their real branch, resolved from the bind-mounted checkout's Git.
+RUN export GITHUB_BRANCH_NAME=main \
+  && ./scripts/bootstrap-minimal.sh \
   # Keep this finite oracle representative; interactive and full-lane work runs outside the build.
   && pnpm exec tsc -b packages/@livestore/livestore --pretty false \
   && pnpm --filter @livestore/common exec vitest run \

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  development:
+    # Build the same known-good toolchain that CI verifies.
+    build: .
+    working_dir: /workspace
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-100}"
+    environment:
+      HOME: /tmp/livestore-home
+    volumes:
+      # The checkout is bind-mounted and must have one active install owner at a time.
+      - .:/workspace
+    command: bash
+    stdin_open: true
+    tty: true

--- a/docs/src/data/data.ts
+++ b/docs/src/data/data.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 
 import { liveStoreVersion } from '@livestore/common'
 import { isNonEmptyString } from '@livestore/utils'
@@ -10,10 +10,20 @@ export const officeHours = [
   'https://www.youtube.com/embed/2GYKgI1GU8k', // 1
 ]
 
-export const getBranchName = () =>
-  isNonEmptyString(process.env.GITHUB_BRANCH_NAME) === true
-    ? process.env.GITHUB_BRANCH_NAME
-    : execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+export const getBranchName = () => {
+  for (const value of [process.env.GITHUB_BRANCH_NAME, process.env.GITHUB_HEAD_REF, process.env.GITHUB_REF_NAME]) {
+    if (isNonEmptyString(value) === true) return value
+  }
+
+  try {
+    const branchName = execFileSync('git', ['branch', '--show-current'], { encoding: 'utf8' }).trim()
+    if (isNonEmptyString(branchName) === true) return branchName
+  } catch {}
+
+  throw new Error(
+    'Unable to determine the documentation branch. Set GITHUB_BRANCH_NAME, GITHUB_HEAD_REF, or GITHUB_REF_NAME.',
+  )
+}
 
 export const versionNpmSuffix = liveStoreVersion.includes('dev') === true ? `@${liveStoreVersion}` : ''
 

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -20,6 +20,7 @@ export const requiredCIJobs = [
   'source-policy',
   'lint',
   'changeset-check',
+  'minimal-dev',
   'type-check',
   'test-unit',
   ...syncProviderMatrix.map((provider) => `test-integration-sync-provider (${provider})`),

--- a/genie/repo.ts
+++ b/genie/repo.ts
@@ -387,10 +387,17 @@ export const livestoreSetupStepsAfterCheckout = [
   // scripts dir before any retry-wrapped command runs, and before any alternate
   // checkout can replace the workspace. Required by the genie CI workflow validator.
   prepareCiScriptsStep,
-  installNixStep({
-    extraConf:
-      'extra-substituters = https://cache.nixos.org\nextra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=',
-  }),
+  (() => {
+    const base = installNixStep({
+      extraConf:
+        'extra-substituters = https://cache.nixos.org\nextra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=',
+    })
+    // Pin the nix-installer (and with it Determinate Nix) to the last Nix 2.34-based
+    // release. Nix 2.35 validates `github:` flake-ref parameters, which rejects
+    // Effect-TS/tsgo's `typescript-go-src = github:...?submodules=1` declaration while
+    // resolving megarepo sync inputs. Unpin once upstream tsgo drops that parameter.
+    return { ...base, with: { ...base.with, 'source-tag': 'v3.21.9' } }
+  })(),
   cachixCliBuildStep,
   (() => {
     const base = cachixStep({ name: 'livestore', authToken: '${{ env.CACHIX_AUTH_TOKEN }}' })

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -8,10 +8,6 @@ export const MIN_NODE_VERSION = '23.0.0'
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
-const workspaceRoot = process.env.WORKSPACE_ROOT
-
-if (workspaceRoot === undefined || workspaceRoot === '') {
-  throw new Error('WORKSPACE_ROOT must be set')
-}
+const workspaceRoot = process.env.WORKSPACE_ROOT ?? path.resolve(import.meta.dirname, '../../../..')
 
 export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(workspaceRoot, 'tmp/devtools/chrome-extension')

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -8,6 +8,8 @@ export const MIN_NODE_VERSION = '23.0.0'
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
-const workspaceRoot = process.env.WORKSPACE_ROOT ?? path.resolve(import.meta.dirname, '../../../..')
+// An exported-but-empty WORKSPACE_ROOT is treated as unset so the path stays
+// repo-root-relative instead of silently resolving against process.cwd().
+const workspaceRoot = process.env.WORKSPACE_ROOT || path.resolve(import.meta.dirname, '../../../..')
 
 export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(workspaceRoot, 'tmp/devtools/chrome-extension')

--- a/scripts/bootstrap-minimal.sh
+++ b/scripts/bootstrap-minimal.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+workspace_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$workspace_root"
+
+# Fail before touching dependency state when the portable toolchain is incomplete.
+command -v node >/dev/null 2>&1 || { echo 'Minimal Setup requires Node.js 24.' >&2; exit 1; }
+node_major=$(node -p "process.versions.node.split('.')[0]")
+[ "$node_major" = '24' ] || { echo "Minimal Setup requires Node.js 24; found $(node --version)." >&2; exit 1; }
+
+command -v bun >/dev/null 2>&1 || { echo 'Minimal Setup requires Bun (known-good version: 1.3.13).' >&2; exit 1; }
+command -v pnpm >/dev/null 2>&1 || { echo 'Minimal Setup requires the pnpm version declared by package.json#packageManager.' >&2; exit 1; }
+
+package_manager=$(node -p "require('./package.json').packageManager")
+required_pnpm=${package_manager#pnpm@}
+[ "$required_pnpm" != "$package_manager" ] || { echo "Unsupported packageManager: $package_manager" >&2; exit 1; }
+actual_pnpm=$(pnpm --version)
+# Exact pnpm parity keeps the committed lockfile interpretation deterministic.
+[ "$actual_pnpm" = "$required_pnpm" ] || {
+  echo "Minimal Setup requires pnpm $required_pnpm; found $actual_pnpm." >&2
+  exit 1
+}
+
+echo "Minimal Setup: Node $(node --version), pnpm $actual_pnpm, Bun $(bun --version)"
+pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

LiveStore's ordinary TypeScript contribution loop was coupled to the full Nix/devenv environment, and no executable gate proved that a conventional checkout remained usable.

## Goal

Establish one self-contained Minimal Setup layer: host admission and frozen install, an optional Docker/Compose realization, representative cold-start CI, and its required-gate policy.

## Decisions

- Add `scripts/bootstrap-minimal.sh` as the shared host/container entry point. It requires Node.js major 24, the exact pnpm from `package.json#packageManager`, and Bun, then performs a frozen install; it never installs tools globally.
- Pin the known-good container realization to Node 24, pnpm 11.8.0, and Bun 1.3.13. Docker installs its own exact pnpm directly, without Corepack.
- Keep Compose thin: one bind-mounted interactive shell, caller UID/GID, no launcher, named dependency volume, or application-port catalog.
- Make docs branch authority explicit: `GITHUB_BRANCH_NAME`, `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`, then Git; fail clearly if none exists. Docker explicitly declares `main` because its context excludes Git metadata.
- Keep the finite Docker oracle at frozen install, reference-aware TypeScript, stable core units, representative Vite and local Wrangler builds, and docs checking.
- Generate the independent PR-only `minimal-dev` CI job and require that stable context through generated repository settings.

## Verification

- `docker build --no-cache --progress=plain -t livestore-minimal-refined:verify .`: PASS. Node v24.19.0, pnpm 11.8.0, Bun 1.3.13; 20 files / 271 tests; TypeScript, Vite, Wrangler dry-run, and docs check passed. Build step 53.1s; export 32.8s.
- `devenv shell -- env DEVENV_TASK_PASSTHROUGH=1 ./scripts/bootstrap-minimal.sh`: PASS with Node v24.18.1, pnpm 11.8.0, Bun 1.3.13 and frozen install.
- `docker compose config`: PASS. The earlier disposable checkout Compose proof also passed install, TypeScript, focused tests, and docs check as UID 1000/GID 100.
- Genie generation/drift checks, generated-file review marking for CI and repository settings, full lint, `git diff --check`, and commit `check-quick`: PASS.

## Complexity

One small handwritten bootstrap, one Dockerfile, one 14-line Compose service, two tiny source defaults, and their generated CI/ruleset projections. Existing commands remain the implementation.

## Concerns

- Bind-mounted development requires an exclusively owned checkout; host and container installs must not run concurrently.
- The image remains about 4 GB. Browser, full docs, generators, wa-sqlite, releases, and infrastructure deliberately remain outside this lane.
- Live repository settings are not applied by this draft; rollout remains maintainer-controlled after the CI job is observed healthy.
- Pre-existing repo-wide CI breakage (unrelated to this stack): since Aug 21 the floating `determinate-nix-action@v3` ships Nix 2.35, which validates `github:` flake-ref parameters and rejects Effect-TS/tsgo's `typescript-go-src = github:...?submodules=1` declaration during megarepo sync. Every branch's cold CI run failed at that step. Fixed here by pinning the nix-installer to `v3.21.9` (last Nix 2.34-based release) via `source-tag`; unpin once upstream tsgo drops the unsupported parameter.

## Friction & bottlenecks

Image export remains a material part of a cold build. Full docs rendered 158 snippets but then required absent Puppeteer Chrome, which established the boundary instead of prompting another tool layer.

## Follow-ups

Observe real CI timing and reliability before adding caching or image publication.

## References

- Layer 1 of stack #1571.
- Followed by #1568 and #1570.
- Supersedes the review scopes previously split across #1565, #1567, and #1569.

