### PR TITLE
Verify the minimal development image in PR CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.devenv
+.direnv
+**/node_modules
+result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,16 @@ jobs:
           process.exit(1)
           NODE
         shell: bash
+  minimal-dev:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify minimal development setup
+        run: 'docker build --tag livestore-minimal-dev:ci .'
   pack-pr-snapshot:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -135,6 +135,21 @@ export default githubWorkflow({
 
   jobs: {
     'source-policy': livestoreDefaultRefPolicyJob,
+    'minimal-dev': {
+      if: "github.event_name == 'pull_request'",
+      'runs-on': 'ubuntu-latest',
+      steps: [
+        {
+          name: 'Checkout code',
+          uses: 'actions/checkout@v4',
+          with: { ref: PR_HEAD_SHA },
+        },
+        {
+          name: 'Verify minimal development setup',
+          run: 'docker build --tag livestore-minimal-dev:ci .',
+        },
+      ],
+    },
     ...prSnapshotPackJob({
       topologyPath: releaseTopologyPath,
       setupStepsAfterCheckout: livestoreSetupStepsAfterCheckout,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM oven/bun:1.3.13 AS bun
+
+FROM node:24-bookworm-slim
+
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --global "$(node -p "require('./package.json').packageManager")"
+
+COPY . .
+
+RUN node --version \
+  && bun --version \
+  && pnpm --version \
+  && pnpm install --frozen-lockfile \
+  && pnpm exec tsc -b packages/@livestore/livestore --pretty false \
+  && pnpm --filter @livestore/common exec vitest run src/schema/EventSequenceNumber.test.ts


### PR DESCRIPTION
## Problem

The Docker cold-start oracle can drift without detection if it remains only a manual local check.

## Goal

Run the canonical root Dockerfile as an independent pull-request CI job, without first entering Nix/devenv.

## Decisions

- Add the stable `minimal-dev` job without renaming existing gates.
- Use stock `ubuntu-latest`, checkout, and a direct Docker build.
- Keep this layer PR-only and defer required-gate policy to the final stack layer.
- Add no cache, publish step, matrix, or shared environment setup.
- Edit Genie authority and commit the generated workflow together.

## Verification

`devenv tasks run genie:run`, `lint:check:genie`, `genie:check`, `git diff --check`, and commit `check-quick` passed. The unchanged Docker oracle had already passed its uncached build in the parent layer.

## Complexity

One independent two-step generated CI job.

## Concerns

Every PR initially pays for a cold workspace install and image export; caching remains evidence-driven follow-up work.

## Friction & bottlenecks

Repository Genie checks are the focused authority; standalone actionlint also reports unrelated existing custom-runner-label and shellcheck findings.

## Follow-ups

Observe CI timing before adding cache or image-distribution complexity.

## References

- Depends on #1564.
- Layer 2 of stack #1566; followed by #1567, #1568, and #1569.
