### PR TITLE
Expand the portable development loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN node --version \
   && pnpm --version \
   && pnpm install --frozen-lockfile \
   && pnpm exec tsc -b packages/@livestore/livestore --pretty false \
-  && pnpm --filter @livestore/common exec vitest run src/schema/EventSequenceNumber.test.ts
+  && pnpm --filter @livestore/common exec vitest run \
+  && pnpm --filter livestore-example-web-todomvc run build \
+  && pnpm --filter livestore-example-cloudflare-todomvc run build \
+  && pnpm --filter @local/docs run check

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  development:
+    build: .
+    working_dir: /workspace
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-100}"
+    environment:
+      HOME: /tmp/livestore-home
+    volumes:
+      - .:/workspace
+    command: bash
+    stdin_open: true
+    tty: true

--- a/docs/src/data/data.ts
+++ b/docs/src/data/data.ts
@@ -1,5 +1,3 @@
-import { execSync } from 'node:child_process'
-
 import { liveStoreVersion } from '@livestore/common'
 import { isNonEmptyString } from '@livestore/utils'
 
@@ -13,7 +11,11 @@ export const officeHours = [
 export const getBranchName = () =>
   isNonEmptyString(process.env.GITHUB_BRANCH_NAME) === true
     ? process.env.GITHUB_BRANCH_NAME
-    : execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+    : isNonEmptyString(process.env.GITHUB_HEAD_REF) === true
+      ? process.env.GITHUB_HEAD_REF
+      : isNonEmptyString(process.env.GITHUB_REF_NAME) === true
+        ? process.env.GITHUB_REF_NAME
+        : 'main'
 
 export const versionNpmSuffix = liveStoreVersion.includes('dev') === true ? `@${liveStoreVersion}` : ''
 

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -8,10 +8,6 @@ export const MIN_NODE_VERSION = '23.0.0'
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
-const workspaceRoot = process.env.WORKSPACE_ROOT
-
-if (workspaceRoot === undefined || workspaceRoot === '') {
-  throw new Error('WORKSPACE_ROOT must be set')
-}
+const workspaceRoot = process.env.WORKSPACE_ROOT ?? path.resolve(import.meta.dirname, '../../../..')
 
 export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(workspaceRoot, 'tmp/devtools/chrome-extension')


### PR DESCRIPTION
## Problem

The cold-start image proves only a narrow batch check and does not yet provide a conventional interactive loop or establish the useful portable capability boundary.

## Goal

Make portable development first-class with a thin Compose entry point and broaden the finite Docker oracle to the representative work that succeeds without adding tools.

## Decisions

- Bind the exclusive checkout into one `development` service; preserve the host UID/GID and use plain Bash as the entry point.
- Add no launcher, devcontainer, named dependency volume, or fixed application-port catalog.
- Derive `WORKSPACE_ROOT` from the shared package location when absent.
- Resolve docs branch links from CI refs, then fall back to `main`, without requiring Git.
- Expand the Docker oracle to TypeScript, the stable common unit suite, a Vite example build, local Wrangler build, and docs check.
- Exclude dev servers, full docs build, Playwright, generators, releases, and Nix from the finite image build.

## Verification

- Uncached expanded Docker build: PASS in 115.445 seconds; 271 common tests plus TypeScript, Vite, Wrangler, and docs check passed.
- `docker compose config`: PASS.
- Disposable checkout Compose shell as UID 1000/GID 100: frozen install, TypeScript, 6 focused tests, and docs check passed.
- `devenv tasks run lint:full:fix`, `git diff --check`, and commit `check-quick`: PASS.

## Complexity

One small Compose service and two local defaulting fixes. Existing commands remain the implementation.

## Concerns

- A bind-mounted checkout has exclusive ownership; simultaneous host/container installs are unsupported.
- Full docs needs a browser, Playwright needs installed browsers, and generator/release/wa-sqlite surfaces remain full-lane work.

## Friction & bottlenecks

The full docs experiment rendered all 158 snippets but failed after 399 seconds because Puppeteer Chrome was absent. That result shaped the portable boundary rather than adding browser installation weight.

## Follow-ups

Image size and caching should be optimized only if observed CI or onboarding costs justify them.

## References

- Depends on #1565.
- Layer 3 of stack #1566; followed by #1568 and #1569.
