### PR TITLE
Define and document Minimal and Full development setups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ installs tools globally. Bun 1.3.13 is the known-good Docker realization.
 The optional root `compose.yaml` supplies that toolchain in an exclusive
 bind-mounted checkout.
 
-### Full setup
+### Full Setup (Nix + devenv)
 
 Run `devenv shell` for Playwright and full docs builds, generated-source or
 wa-sqlite changes, release and infrastructure work, or repository-wide parity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,9 @@ bind-mounted checkout.
 
 Run `devenv shell` for Playwright and full docs builds, generated-source or
 wa-sqlite changes, release and infrastructure work, or repository-wide parity.
+Before final handoff, escalate to this lane whenever the relevant validation
+extends beyond the finite Minimal Setup checks; setup success never substitutes
+for the full required CI bar.
 The authoritative boundary is
 [`context/03-delivery/01-composition/01-developer-environment/spec.md`](./context/03-delivery/01-composition/01-developer-environment/spec.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,27 @@
 
 ## Setup
 
-This repository uses [`devenv`](https://devenv.sh) for development environment management. Run `devenv shell` to enter the development environment.
+### Minimal Setup
+
+For ordinary TypeScript, core unit-test, Vite, local Wrangler, and docs-check
+work, provide Node.js 24, Bun, and the exact pnpm version declared by
+`package.json#packageManager`, then run:
+
+```bash
+./scripts/bootstrap-minimal.sh
+```
+
+The script verifies prerequisites and performs a frozen install; it never
+installs tools globally. Bun 1.3.13 is the known-good Docker realization.
+The optional root `compose.yaml` supplies that toolchain in an exclusive
+bind-mounted checkout.
+
+### Full setup
+
+Run `devenv shell` for Playwright and full docs builds, generated-source or
+wa-sqlite changes, release and infrastructure work, or repository-wide parity.
+The authoritative boundary is
+[`context/03-delivery/01-composition/01-developer-environment/spec.md`](./context/03-delivery/01-composition/01-developer-environment/spec.md).
 
 ## Intent Layer (`context/`)
 

--- a/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
@@ -1,4 +1,4 @@
-# 0003 — Support portable and hermetic development lanes
+# 0003 — Support Minimal Setup and Full Setup (Nix + devenv)
 
 Status: accepted
 
@@ -10,13 +10,13 @@ and [experiment 0003](../.experiments/0003-portable-development-boundary.md).
 
 The hermetic Nix/devenv environment provides repository-wide parity but makes
 ordinary TypeScript contributions depend on fleet-specific tooling. A
-conventional environment can already exercise a substantial, coherent subset
+Minimal Setup can already exercise a substantial, coherent subset
 of the repository without weakening those checks.
 
 The discussion identified a long first Nix setup and large download as a
 material admission cost, especially when Nix feels unfamiliar or intrusive on
 macOS. Its directional goal was to cover the TypeScript-heavy majority of
-contributions conventionally while retaining Nix/devenv as the holistic
+contributions through Minimal Setup while retaining Full Setup (Nix + devenv) as the holistic
 dependency and final-validation authority. The stated proportion was an
 estimate, not measured coverage.
 
@@ -37,7 +37,7 @@ boundary instead of adding tools one failure at a time.
 
 | Option | Consequence |
 | --- | --- |
-| A. Minimal and full lanes with a shared bootstrap and Docker oracle (chosen) | Host-native default plus a finite measured gate and explicit escalation |
+| A. Minimal Setup and Full Setup (Nix + devenv) with a shared bootstrap and Docker oracle (chosen) | Host-native default plus a finite measured gate and explicit escalation |
 | B. Keep devenv as the only supported environment | One tool closure, but Nix and composition admit every contribution |
 | C. Expand Docker until it matches the full environment | Duplicates browsers, Nix, generators, release, and infrastructure tooling |
 | D. Document host commands without an executable oracle | Least configuration, but no failure-capable drift check |
@@ -46,7 +46,7 @@ boundary instead of adding tools one failure at a time.
 
 Choose A. A non-installing bootstrap is the host-native Minimal Setup entry
 point. The root Dockerfile is its cold-start oracle and the root Compose
-service is an optional bind-mounted form. The full devenv/Nix lane remains
+service is an optional bind-mounted form. Full Setup (Nix + devenv) remains
 authoritative beyond the measured portable boundary.
 
 ## Consequences
@@ -61,10 +61,10 @@ authoritative beyond the measured portable boundary.
   readiness and installs dependencies without globally installing tools; it is
   not a validation umbrella.
 - Browser downloads, generated-source tooling, wa-sqlite rebuilds, release
-  state, and infrastructure remain single-owned by the full lane.
+  state, and infrastructure remain single-owned by Full Setup (Nix + devenv).
 - Compose writes through an exclusively owned checkout and does not attempt to
   coordinate shared worktree state or application ports.
 - Pull requests cannot drift the portable contract unnoticed because its
   stable CI context builds the canonical Dockerfile.
-- Contributor feedback is reviewed as boundary evidence so the two lanes do
+- Contributor feedback is reviewed as boundary evidence so the two setups do
   not decay into recurring setup exceptions.

--- a/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
@@ -2,8 +2,9 @@
 
 Status: accepted
 
-Evidence: user confirmation on 2026-08-21 and
-[experiment 0003](../.experiments/0003-portable-development-boundary.md).
+Evidence: the 2026-08-20
+[developer setup discussion](https://app.notion.com/p/schickling/3c2e3d41f4a380b58b07daa038191f3e)
+and [experiment 0003](../.experiments/0003-portable-development-boundary.md).
 
 ## Context
 
@@ -11,6 +12,13 @@ The hermetic Nix/devenv environment provides repository-wide parity but makes
 ordinary TypeScript contributions depend on fleet-specific tooling. A
 conventional environment can already exercise a substantial, coherent subset
 of the repository without weakening those checks.
+
+The discussion identified a long first Nix setup and large download as a
+material admission cost, especially when Nix feels unfamiliar or intrusive on
+macOS. Its directional goal was to cover the TypeScript-heavy majority of
+contributions conventionally while retaining Nix/devenv as the holistic
+dependency and final-validation authority. The stated proportion was an
+estimate, not measured coverage.
 
 ## Evidence and Argument
 
@@ -20,6 +28,10 @@ using only the pinned JavaScript toolchain. Independent failures located a
 clear boundary at browsers, Genie, Nix, Git history, release state, and
 infrastructure tooling. A disposable bind-mounted Compose checkout reproduced
 the portable loop as the non-root checkout owner.
+
+Committed SQLite distribution artifacts make ordinary use portable, while a
+rebuild requires the full Nix/Emscripten closure. This supplies a principled
+boundary instead of adding tools one failure at a time.
 
 ## Options
 
@@ -45,9 +57,14 @@ authoritative beyond the measured portable boundary.
   Docker pins Bun 1.3.13 as its known-good realization.
 - The portable promise remains finite; adding a capability requires clean-image
   evidence and extending the Docker gate.
+- The bootstrap is an optional diagnostic for people and agents. It verifies
+  readiness and installs dependencies without globally installing tools; it is
+  not a validation umbrella.
 - Browser downloads, generated-source tooling, wa-sqlite rebuilds, release
   state, and infrastructure remain single-owned by the full lane.
 - Compose writes through an exclusively owned checkout and does not attempt to
   coordinate shared worktree state or application ports.
 - Pull requests cannot drift the portable contract unnoticed because its
   stable CI context builds the canonical Dockerfile.
+- Contributor feedback is reviewed as boundary evidence so the two lanes do
+  not decay into recurring setup exceptions.

--- a/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
@@ -1,0 +1,53 @@
+# 0003 — Support portable and hermetic development lanes
+
+Status: accepted
+
+Evidence: user confirmation on 2026-08-21 and
+[experiment 0003](../.experiments/0003-portable-development-boundary.md).
+
+## Context
+
+The hermetic Nix/devenv environment provides repository-wide parity but makes
+ordinary TypeScript contributions depend on fleet-specific tooling. A
+conventional environment can already exercise a substantial, coherent subset
+of the repository without weakening those checks.
+
+## Evidence and Argument
+
+The clean-container experiment proved frozen installation, reference-aware
+TypeScript, 271 stable core tests, Vite and Wrangler builds, and docs checking
+using only the pinned JavaScript toolchain. Independent failures located a
+clear boundary at browsers, Genie, Nix, Git history, release state, and
+infrastructure tooling. A disposable bind-mounted Compose checkout reproduced
+the portable loop as the non-root checkout owner.
+
+## Options
+
+| Option | Consequence |
+| --- | --- |
+| A. Minimal and full lanes with a shared bootstrap and Docker oracle (chosen) | Host-native default plus a finite measured gate and explicit escalation |
+| B. Keep devenv as the only supported environment | One tool closure, but Nix and composition admit every contribution |
+| C. Expand Docker until it matches the full environment | Duplicates browsers, Nix, generators, release, and infrastructure tooling |
+| D. Document host commands without an executable oracle | Least configuration, but no failure-capable drift check |
+
+## Decision
+
+Choose A. A non-installing bootstrap is the host-native Minimal Setup entry
+point. The root Dockerfile is its cold-start oracle and the root Compose
+service is an optional bind-mounted form. The full devenv/Nix lane remains
+authoritative beyond the measured portable boundary.
+
+## Consequences
+
+- Ordinary TypeScript, stable core tests, representative Vite and Wrangler
+  builds, and docs source checks do not require Nix or megarepo tooling.
+- Minimal Setup admits Node.js major 24, exact repository-pinned pnpm, and Bun;
+  Docker pins Bun 1.3.13 as its known-good realization.
+- The portable promise remains finite; adding a capability requires clean-image
+  evidence and extending the Docker gate.
+- Browser downloads, generated-source tooling, wa-sqlite rebuilds, release
+  state, and infrastructure remain single-owned by the full lane.
+- Compose writes through an exclusively owned checkout and does not attempt to
+  coordinate shared worktree state or application ports.
+- Pull requests cannot drift the portable contract unnoticed because its
+  stable CI context builds the canonical Dockerfile.

--- a/context/03-delivery/01-composition/01-developer-environment/.experiments/0003-portable-development-boundary.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.experiments/0003-portable-development-boundary.md
@@ -1,0 +1,80 @@
+# 0003 — Portable development capability boundary
+
+Date: 2026-08-21
+
+## Question
+
+Which development capabilities work from the canonical Docker environment
+without adding Nix, devenv, megarepo tooling, browsers, Git history, custom
+launchers, or credentials?
+
+## Method
+
+- Built the root Dockerfile from a clean Linux/amd64 context using the official
+  Node 24 and Bun 1.3.13 images and directly installed repository-pinned pnpm
+  11.8.0.
+- Ran each candidate in a disposable container and classified the first
+  boundary failure rather than installing another tool.
+- Exercised Compose against a disposable source copy as UID 1000 and GID 100,
+  including a fresh bind-mounted install and representative checks.
+- Avoided deploy, publish, release mutation, credentials, and external service
+  writes.
+
+## Result
+
+| Capability | Result | Evidence |
+| --- | --- | --- |
+| Frozen install | PASS | 36 workspaces; 2,600 packages; 2,653 supply-chain entries verified |
+| Reference-aware core TypeScript build | PASS | `tsc -b packages/@livestore/livestore` |
+| Stable core unit suite | PASS | 20 files; 271 tests; 1.75s Vitest duration in the expanded oracle |
+| Vite application build | PASS | Worker and client bundles, including committed wa-sqlite WASM |
+| Vite development server | PASS | Ready in 1.557s; HTTP 200 from the container |
+| Local Wrangler build | PASS | Dry-run bundle with Durable Object bindings; no credentials or mutation |
+| Docs source check | PASS | 30 Astro files; zero errors, warnings, or hints; 12.590s standalone |
+| Full docs build | FAIL | 158 snippets rendered, then Puppeteer Chrome was absent after 399.007s |
+| Playwright test | FAIL | Chromium headless-shell absent after 3.297s |
+| Genie regeneration | FAIL | Genie CLI absent after 0.338s |
+| wa-sqlite rebuild | FAIL | Nix/Emscripten build closure absent |
+| Changesets history status | CONDITIONAL | pnpm command present; Git binary and `.git` history absent |
+| Infrastructure check | FAIL | Nix absent |
+| Contrib composition | NO VERDICT | Core experiment did not materialize or build the external contrib checkout |
+
+The initial finite Docker oracle completed an uncached build in 101.8s. The
+expanded oracle, including the full stable core suite, Vite build, Wrangler
+build, and docs check, completed uncached in 115.445s. Image export represented
+roughly 42s of the expanded measurement.
+
+The full docs attempt sampled approximately 3.15 GiB memory and 235% peak CPU
+before failing at the browser boundary. It transferred only kilobytes of
+network traffic before that failure. These are diagnostic observations, not
+portable resource ceilings.
+
+The disposable Compose loop passed a fresh frozen install, reference-aware
+TypeScript build, focused unit test, and docs check through the bind mount as
+the configured non-root owner.
+
+A subsequent oracle run invoked the shared admission bootstrap and completed
+the same finite bar with Node v24.19.0, pnpm 11.8.0, and Bun 1.3.13. The build
+steps completed in 53.1s and image export in 32.8s on the sampled warm-host
+container cache; these timings are evidence, not performance requirements.
+
+## Conclusion
+
+The portable lane can reliably own frozen installation, ordinary TypeScript
+work, stable core unit tests, representative Vite build/development, local
+Wrangler builds, and docs source checking without another tool layer.
+
+Browser execution, full docs rendering, generated-source regeneration,
+wa-sqlite rebuilding, release-history operations, and infrastructure checks
+cross a material tool or state boundary. They remain full-lane capabilities;
+their absence must stay visible rather than being converted into skipped or
+weakened portable checks. Contrib composition remains unclaimed until it has
+its own clean-checkout evidence.
+
+## VRS Impact
+
+This evidence establishes the portable capability set in
+LS.DEL.COMP.DEV-R03, the escalation boundary in LS.DEL.COMP.DEV-R04, and the
+Docker/Compose mechanics in the developer-environment spec. It does not support
+claiming browser, generation, release, infrastructure, or contrib composition
+as portable capabilities.

--- a/context/03-delivery/01-composition/01-developer-environment/.experiments/0003-portable-development-boundary.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.experiments/0003-portable-development-boundary.md
@@ -10,6 +10,12 @@ launchers, or credentials?
 
 ## Method
 
+- Used the 2026-08-20
+  [developer setup discussion](https://app.notion.com/p/schickling/3c2e3d41f4a380b58b07daa038191f3e)
+  as qualitative admission evidence. It reported roughly an hour for an
+  initial Nix setup with a large download and proposed conventional coverage
+  for the TypeScript-heavy majority. These are participant observations and a
+  directional estimate, not benchmark measurements.
 - Built the root Dockerfile from a clean Linux/amd64 context using the official
   Node 24 and Bun 1.3.13 images and directly installed repository-pinned pnpm
   11.8.0.
@@ -38,6 +44,12 @@ launchers, or credentials?
 | Changesets history status | CONDITIONAL | pnpm command present; Git binary and `.git` history absent |
 | Infrastructure check | FAIL | Nix absent |
 | Contrib composition | NO VERDICT | Core experiment did not materialize or build the external contrib checkout |
+
+The discussion also identified unfamiliarity and perceived host intrusion on
+macOS, concern that a portable path could become tool-by-tool whack-a-mole, and
+the need to use contributor feedback to revisit the boundary. These findings
+shape admission and maintenance policy; they are not container performance
+results.
 
 The initial finite Docker oracle completed an uncached build in 101.8s. The
 expanded oracle, including the full stable core suite, Vite build, Wrangler

--- a/context/03-delivery/01-composition/01-developer-environment/.experiments/0003-portable-development-boundary.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.experiments/0003-portable-development-boundary.md
@@ -1,4 +1,4 @@
-# 0003 — Portable development capability boundary
+# 0003 — Minimal Setup capability boundary
 
 Date: 2026-08-21
 
@@ -13,7 +13,7 @@ launchers, or credentials?
 - Used the 2026-08-20
   [developer setup discussion](https://app.notion.com/p/schickling/3c2e3d41f4a380b58b07daa038191f3e)
   as qualitative admission evidence. It reported roughly an hour for an
-  initial Nix setup with a large download and proposed conventional coverage
+  initial Nix setup with a large download and proposed Minimal Setup coverage
   for the TypeScript-heavy majority. These are participant observations and a
   directional estimate, not benchmark measurements.
 - Built the root Dockerfile from a clean Linux/amd64 context using the official
@@ -72,13 +72,13 @@ container cache; these timings are evidence, not performance requirements.
 
 ## Conclusion
 
-The portable lane can reliably own frozen installation, ordinary TypeScript
+Minimal Setup can reliably own frozen installation, ordinary TypeScript
 work, stable core unit tests, representative Vite build/development, local
 Wrangler builds, and docs source checking without another tool layer.
 
 Browser execution, full docs rendering, generated-source regeneration,
 wa-sqlite rebuilding, release-history operations, and infrastructure checks
-cross a material tool or state boundary. They remain full-lane capabilities;
+cross a material tool or state boundary. They remain Full Setup (Nix + devenv) capabilities;
 their absence must stay visible rather than being converted into skipped or
 weakened portable checks. Contrib composition remains unclaimed until it has
 its own clean-checkout evidence.

--- a/context/03-delivery/01-composition/01-developer-environment/requirements.md
+++ b/context/03-delivery/01-composition/01-developer-environment/requirements.md
@@ -10,13 +10,13 @@ contract for setup work. It refines the broader tooling-composition outcome in
   development shell establishes dependency and generated-source readiness
   without requiring full source validation. TypeScript build and check tasks
   remain explicit developer and CI gates. `refines: LS.DEL.COMP-R18`
-- **LS.DEL.COMP.DEV-R02 Two supported lanes:** A fresh exclusive checkout must
-  offer both a conventional lane for the common TypeScript-heavy contribution
-  path without Nix, devenv, or megarepo tooling and a full hermetic lane for
-  repository-wide maintenance. Nix/devenv remains the holistic authority for
+- **LS.DEL.COMP.DEV-R02 Two supported setups:** A fresh exclusive checkout must
+  offer both Minimal Setup for the common TypeScript-heavy contribution path
+  without Nix, devenv, or megarepo tooling and Full Setup (Nix + devenv) for
+  repository-wide maintenance. Full Setup (Nix + devenv) remains the holistic authority for
   runtime, build, development dependencies, and final CI parity.
   `refines: LS.DEL.COMP-R18`
-- **LS.DEL.COMP.DEV-R03 Portable TypeScript loop:** The portable lane must
+- **LS.DEL.COMP.DEV-R03 Minimal Setup TypeScript loop:** Minimal Setup must
   perform a frozen dependency install, reference-aware TypeScript build,
   stable core unit suite, representative Vite application build, local
   Cloudflare Worker build, and docs source check with repository-pinned
@@ -25,11 +25,11 @@ contract for setup work. It refines the broader tooling-composition outcome in
 - **LS.DEL.COMP.DEV-R04 Explicit escalation boundary:** Browser tests, the full
   docs build, generated-source regeneration, wa-sqlite rebuilding, release
   operations, and infrastructure validation must direct developers to the
-  full lane rather than silently weakening those checks. `refines: LS.DEL.COMP-R18`
+  Full Setup (Nix + devenv) rather than silently weakening those checks. `refines: LS.DEL.COMP-R18`
 - **LS.DEL.COMP.DEV-R05 Independent cold-start gate:** Pull-request validation
-  must exercise the portable lane from a stock hosted environment without
+  must exercise Minimal Setup from a stock hosted environment without
   first preparing Nix, devenv, or megarepo state. `refines: LS.DEL.COMP-R18`
-- **LS.DEL.COMP.DEV-R06 Interactive checkout ownership:** The portable
+- **LS.DEL.COMP.DEV-R06 Interactive checkout ownership:** The Minimal Setup
   interactive environment must bind one exclusive checkout, preserve the
   caller's numeric ownership by default, and avoid prescribing application
   ports that belong to individual examples. `refines: LS.DEL.COMP-R18`
@@ -37,7 +37,7 @@ contract for setup work. It refines the broader tooling-composition outcome in
   and diagnose prerequisites and dependency readiness without implying that
   source validation or the full CI bar has passed. Its bootstrap must remain
   optional and must not install tools globally. `refines: LS.DEL.COMP-R18`
-- **LS.DEL.COMP.DEV-R08 Evidence-led boundary:** The portable capability set
+- **LS.DEL.COMP.DEV-R08 Evidence-led boundary:** The Minimal Setup capability set
   must expand only after a clean-environment experiment proves the added work
   without accumulating another parallel toolchain. Contributor feedback must
   remain an input to revising the boundary. `refines: LS.DEL.COMP-R18`

--- a/context/03-delivery/01-composition/01-developer-environment/requirements.md
+++ b/context/03-delivery/01-composition/01-developer-environment/requirements.md
@@ -11,8 +11,10 @@ contract for setup work. It refines the broader tooling-composition outcome in
   without requiring full source validation. TypeScript build and check tasks
   remain explicit developer and CI gates. `refines: LS.DEL.COMP-R18`
 - **LS.DEL.COMP.DEV-R02 Two supported lanes:** A fresh exclusive checkout must
-  offer both a portable development lane that does not require Nix, devenv, or
-  megarepo tooling and a full hermetic lane for repository-wide maintenance.
+  offer both a conventional lane for the common TypeScript-heavy contribution
+  path without Nix, devenv, or megarepo tooling and a full hermetic lane for
+  repository-wide maintenance. Nix/devenv remains the holistic authority for
+  runtime, build, development dependencies, and final CI parity.
   `refines: LS.DEL.COMP-R18`
 - **LS.DEL.COMP.DEV-R03 Portable TypeScript loop:** The portable lane must
   perform a frozen dependency install, reference-aware TypeScript build,
@@ -31,3 +33,11 @@ contract for setup work. It refines the broader tooling-composition outcome in
   interactive environment must bind one exclusive checkout, preserve the
   caller's numeric ownership by default, and avoid prescribing application
   ports that belong to individual examples. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R07 Setup before validation:** Minimal Setup must establish
+  and diagnose prerequisites and dependency readiness without implying that
+  source validation or the full CI bar has passed. Its bootstrap must remain
+  optional and must not install tools globally. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R08 Evidence-led boundary:** The portable capability set
+  must expand only after a clean-environment experiment proves the added work
+  without accumulating another parallel toolchain. Contributor feedback must
+  remain an input to revising the boundary. `refines: LS.DEL.COMP-R18`

--- a/context/03-delivery/01-composition/01-developer-environment/requirements.md
+++ b/context/03-delivery/01-composition/01-developer-environment/requirements.md
@@ -31,8 +31,10 @@ contract for setup work. It refines the broader tooling-composition outcome in
   first preparing Nix, devenv, or megarepo state. `refines: LS.DEL.COMP-R18`
 - **LS.DEL.COMP.DEV-R06 Interactive checkout ownership:** The Minimal Setup
   interactive environment must bind one exclusive checkout, preserve the
-  caller's numeric ownership by default, and avoid prescribing application
-  ports that belong to individual examples. `refines: LS.DEL.COMP-R18`
+  caller's numeric ownership when the caller supplies `LOCAL_UID` and
+  `LOCAL_GID` (repository defaults cover the standard development host), and
+  avoid prescribing application ports that belong to individual examples.
+  `refines: LS.DEL.COMP-R18`
 - **LS.DEL.COMP.DEV-R07 Setup before validation:** Minimal Setup must establish
   and diagnose prerequisites and dependency readiness without implying that
   source validation or the full CI bar has passed. Its bootstrap must remain

--- a/context/03-delivery/01-composition/01-developer-environment/requirements.md
+++ b/context/03-delivery/01-composition/01-developer-environment/requirements.md
@@ -10,3 +10,24 @@ contract for setup work. It refines the broader tooling-composition outcome in
   development shell establishes dependency and generated-source readiness
   without requiring full source validation. TypeScript build and check tasks
   remain explicit developer and CI gates. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R02 Two supported lanes:** A fresh exclusive checkout must
+  offer both a portable development lane that does not require Nix, devenv, or
+  megarepo tooling and a full hermetic lane for repository-wide maintenance.
+  `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R03 Portable TypeScript loop:** The portable lane must
+  perform a frozen dependency install, reference-aware TypeScript build,
+  stable core unit suite, representative Vite application build, local
+  Cloudflare Worker build, and docs source check with repository-pinned
+  JavaScript tooling. It must admit Node.js major 24, the exact pnpm version
+  declared by `package.json#packageManager`, and Bun. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R04 Explicit escalation boundary:** Browser tests, the full
+  docs build, generated-source regeneration, wa-sqlite rebuilding, release
+  operations, and infrastructure validation must direct developers to the
+  full lane rather than silently weakening those checks. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R05 Independent cold-start gate:** Pull-request validation
+  must exercise the portable lane from a stock hosted environment without
+  first preparing Nix, devenv, or megarepo state. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R06 Interactive checkout ownership:** The portable
+  interactive environment must bind one exclusive checkout, preserve the
+  caller's numeric ownership by default, and avoid prescribing application
+  ports that belong to individual examples. `refines: LS.DEL.COMP-R18`

--- a/context/03-delivery/01-composition/01-developer-environment/spec.md
+++ b/context/03-delivery/01-composition/01-developer-environment/spec.md
@@ -27,10 +27,12 @@ exclusive checkout
                      `- Nix ------- browsers, WASM, release, infrastructure
 ```
 
-Minimal Setup is the default for ordinary TypeScript changes. The full
-lane is an escalation target for capabilities whose correctness depends on the
-hermetic repository toolchain. The two lanes share the committed pnpm lockfile
-and source tree; they do not claim identical tool closures
+Minimal Setup is the conventional path for the TypeScript-heavy majority of
+contributions. This is a design target informed by contributor experience, not
+a measured coverage percentage. The full lane remains the holistic authority
+for runtime, build and development dependencies, and the final CI bar. The two
+lanes share the committed pnpm lockfile and source tree; they do not claim
+identical tool closures
 ([decision 0003](./.decisions/0003-two-development-lanes.md)).
 
 | Capability | Portable lane | Full lane |
@@ -41,6 +43,7 @@ and source tree; they do not claim identical tool closures
 | Vite application build and development | Required | Required |
 | Local Wrangler build | Required | Required |
 | Docs source check | Required | Required |
+| Use committed SQLite distribution | Required | Required |
 | Browser and Playwright tests | Not provided | Required |
 | Full docs build, including diagrams | Not provided | Required |
 | Genie regeneration | Not provided | Required |
@@ -49,14 +52,23 @@ and source tree; they do not claim identical tool closures
 
 ## Minimal Setup
 
-The host-native entry point is `scripts/bootstrap-minimal.sh`. It verifies
+The optional host-native diagnostic is `scripts/bootstrap-minimal.sh`. It verifies
 Node.js major 24, Bun, and the exact pnpm version declared by
 `package.json#packageManager`, then runs a frozen workspace install. It never
 installs or upgrades tools globally. Bun 1.3.13 is the known-good version in
 the Docker oracle; the host admission contract requires Bun to be present but
 does not impose that exact version.
 
-The root `Dockerfile` is the executable cold-start contract. It starts from the
+Developers may run the equivalent install directly after checking the same
+prerequisites. The bootstrap establishes dependency readiness only; it does
+not claim that TypeScript, tests, docs, or the full CI bar have passed.
+
+Committed SQLite distribution artifacts make ordinary use and TypeScript
+changes portable. Rebuilding those artifacts crosses into the full lane
+because Nix/Emscripten owns that build closure.
+
+The optional root `Dockerfile` is the executable cold-start contract and a
+familiar alternative when host tooling is undesirable. It starts from the
 official Node 24 image, copies the Bun binary from the pinned official Bun
 image, installs the pnpm version declared by `package.json#packageManager`
 directly, invokes the shared bootstrap, and runs the finite capability set in
@@ -91,6 +103,11 @@ build .` performs the gate. The generated repository ruleset requires the
 stable `minimal-dev` context. The Dockerfile, workflow generator, generated
 workflow, and generated ruleset are reviewed together when the contract
 changes (LS.DEL.COMP.DEV-R03, R05, R06).
+
+The boundary is intentionally finite. Requests to add another tool or special
+case first become clean-environment experiments; recurring contributor friction
+is evidence for revising the boundary rather than triggering ad hoc expansion
+(LS.DEL.COMP.DEV-R08).
 
 ## Full Lane
 

--- a/context/03-delivery/01-composition/01-developer-environment/spec.md
+++ b/context/03-delivery/01-composition/01-developer-environment/spec.md
@@ -1,6 +1,6 @@
 # Developer Environment — Spec
 
-This document specifies portable and hermetic development lanes, shell
+This document specifies Minimal Setup and Full Setup (Nix + devenv), shell
 readiness, and setup diagnostics. It builds on
 [requirements.md](./requirements.md).
 
@@ -10,12 +10,12 @@ Draft.
 
 ## Scope
 
-Defines: portable development, automatic hermetic shell setup, explicit
+Defines: the two development setups, automatic full-shell setup, explicit
 source-validation gates, setup profiling, and local trace handling. Does not
 define: individual example ports, the shared Effect-utils implementation, or
 production observability.
 
-## Development Lanes
+## Development Setups
 
 ```text
 exclusive checkout
@@ -23,19 +23,19 @@ exclusive checkout
   +-- Minimal Setup -- bootstrap -- host-native default
   |                  `- Docker ---- finite oracle + optional Compose shell
   |
-  `-- full lane ----- devenv ----- dependencies + generated sources
-                     `- Nix ------- browsers, WASM, release, infrastructure
+  `-- Full Setup (Nix + devenv) -- dependencies + generated sources
+                                  `- browsers, WASM, release, infrastructure
 ```
 
-Minimal Setup is the conventional path for the TypeScript-heavy majority of
+Minimal Setup targets the TypeScript-heavy majority of
 contributions. This is a design target informed by contributor experience, not
-a measured coverage percentage. The full lane remains the holistic authority
+a measured coverage percentage. Full Setup (Nix + devenv) remains the holistic authority
 for runtime, build and development dependencies, and the final CI bar. The two
-lanes share the committed pnpm lockfile and source tree; they do not claim
+setups share the committed pnpm lockfile and source tree; they do not claim
 identical tool closures
 ([decision 0003](./.decisions/0003-two-development-lanes.md)).
 
-| Capability | Portable lane | Full lane |
+| Capability | Minimal Setup | Full Setup (Nix + devenv) |
 | --- | --- | --- |
 | Frozen workspace install | Required | Required |
 | Reference-aware TypeScript build | Required | Required |
@@ -64,7 +64,7 @@ prerequisites. The bootstrap establishes dependency readiness only; it does
 not claim that TypeScript, tests, docs, or the full CI bar have passed.
 
 Committed SQLite distribution artifacts make ordinary use and TypeScript
-changes portable. Rebuilding those artifacts crosses into the full lane
+changes possible. Rebuilding those artifacts crosses into Full Setup (Nix + devenv)
 because Nix/Emscripten owns that build closure.
 
 The optional root `Dockerfile` is the executable cold-start contract and a
@@ -109,16 +109,16 @@ case first become clean-environment experiments; recurring contributor friction
 is evidence for revising the boundary rather than triggering ad hoc expansion
 (LS.DEL.COMP.DEV-R08).
 
-## Full Lane
+## Full Setup (Nix + devenv)
 
-The full lane begins with `devenv shell`. It owns browser installation, full
+Full Setup (Nix + devenv) begins with `devenv shell`. It owns browser installation, full
 docs rendering, Genie and other generated sources, wa-sqlite's Nix/Emscripten
 build, release workflows, infrastructure checks, and repository-wide parity.
 Failing a portable command because one of these capabilities is absent is an
 escalation signal, not permission to skip or approximate the check
 (LS.DEL.COMP.DEV-R04).
 
-## Full-Lane Shell Readiness
+## Full Setup (Nix + devenv) Shell Readiness
 
 Shell entry establishes dependency and generated-source readiness through
 `pnpm:install` and `genie:run`. It does not run the full TypeScript build.
@@ -154,5 +154,5 @@ material inputs
 
 Setup captures are local diagnostic artifacts under the ignored `tmp/` tree.
 They are not uploaded automatically. This keeps machine-local paths and command
-metadata in a private-by-default evidence lane while stable task names,
+metadata in a private-by-default evidence path while stable task names,
 outcomes, cache decisions, and durations remain queryable.

--- a/context/03-delivery/01-composition/01-developer-environment/spec.md
+++ b/context/03-delivery/01-composition/01-developer-environment/spec.md
@@ -40,7 +40,7 @@ identical tool closures
 | Frozen workspace install | Required | Required |
 | Reference-aware TypeScript build | Required | Required |
 | Stable core unit tests | Required | Required |
-| Vite application build and development | Required | Required |
+| Vite application build | Required | Required |
 | Local Wrangler build | Required | Required |
 | Docs source check | Required | Required |
 | Use committed SQLite distribution | Required | Required |

--- a/context/03-delivery/01-composition/01-developer-environment/spec.md
+++ b/context/03-delivery/01-composition/01-developer-environment/spec.md
@@ -1,6 +1,7 @@
 # Developer Environment — Spec
 
-This document specifies shell readiness and setup diagnostics. It builds on
+This document specifies portable and hermetic development lanes, shell
+readiness, and setup diagnostics. It builds on
 [requirements.md](./requirements.md).
 
 ## Status
@@ -9,11 +10,98 @@ Draft.
 
 ## Scope
 
-Defines: automatic shell setup, explicit source-validation gates, setup
-profiling, and local trace handling. Does not define: the shared Effect-utils
-implementation, CI workflow composition, or production observability.
+Defines: portable development, automatic hermetic shell setup, explicit
+source-validation gates, setup profiling, and local trace handling. Does not
+define: individual example ports, the shared Effect-utils implementation, or
+production observability.
 
-## Shell Readiness
+## Development Lanes
+
+```text
+exclusive checkout
+  |
+  +-- Minimal Setup -- bootstrap -- host-native default
+  |                  `- Docker ---- finite oracle + optional Compose shell
+  |
+  `-- full lane ----- devenv ----- dependencies + generated sources
+                     `- Nix ------- browsers, WASM, release, infrastructure
+```
+
+Minimal Setup is the default for ordinary TypeScript changes. The full
+lane is an escalation target for capabilities whose correctness depends on the
+hermetic repository toolchain. The two lanes share the committed pnpm lockfile
+and source tree; they do not claim identical tool closures
+([decision 0003](./.decisions/0003-two-development-lanes.md)).
+
+| Capability | Portable lane | Full lane |
+| --- | --- | --- |
+| Frozen workspace install | Required | Required |
+| Reference-aware TypeScript build | Required | Required |
+| Stable core unit tests | Required | Required |
+| Vite application build and development | Required | Required |
+| Local Wrangler build | Required | Required |
+| Docs source check | Required | Required |
+| Browser and Playwright tests | Not provided | Required |
+| Full docs build, including diagrams | Not provided | Required |
+| Genie regeneration | Not provided | Required |
+| wa-sqlite rebuild | Not provided | Required |
+| Release and infrastructure operations | Not provided | Required |
+
+## Minimal Setup
+
+The host-native entry point is `scripts/bootstrap-minimal.sh`. It verifies
+Node.js major 24, Bun, and the exact pnpm version declared by
+`package.json#packageManager`, then runs a frozen workspace install. It never
+installs or upgrades tools globally. Bun 1.3.13 is the known-good version in
+the Docker oracle; the host admission contract requires Bun to be present but
+does not impose that exact version.
+
+The root `Dockerfile` is the executable cold-start contract. It starts from the
+official Node 24 image, copies the Bun binary from the pinned official Bun
+image, installs the pnpm version declared by `package.json#packageManager`
+directly, invokes the shared bootstrap, and runs the finite capability set in
+the table above. It does not
+install Nix, a browser, Genie, Git history, release credentials, or
+infrastructure tools.
+
+Documentation source links resolve branch authority in this order:
+`GITHUB_BRANCH_NAME`, `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`, then the current
+Git branch. Resolution fails with an actionable error when none is available.
+Because the Docker context intentionally excludes Git metadata, the Dockerfile
+explicitly sets `GITHUB_BRANCH_NAME=main`; it does not hide that authority in a
+source-code default.
+
+The optional root `compose.yaml` makes the same image interactive. The `development`
+service bind-mounts the current checkout at `/workspace`, uses the caller's
+`LOCAL_UID` and `LOCAL_GID` when supplied (with repository defaults for the
+standard development host), and keeps package-manager state in a writable
+temporary home. It intentionally declares no application ports. Because tools
+write dependencies and build outputs through the bind mount, the checkout must
+be exclusively owned by that developer or agent.
+
+```bash
+docker compose build
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+./scripts/bootstrap-minimal.sh
+```
+
+The generated pull-request workflow contains an independent `minimal-dev` job
+on a stock hosted Ubuntu runner. Its only preparation is checkout; `docker
+build .` performs the gate. The generated repository ruleset requires the
+stable `minimal-dev` context. The Dockerfile, workflow generator, generated
+workflow, and generated ruleset are reviewed together when the contract
+changes (LS.DEL.COMP.DEV-R03, R05, R06).
+
+## Full Lane
+
+The full lane begins with `devenv shell`. It owns browser installation, full
+docs rendering, Genie and other generated sources, wa-sqlite's Nix/Emscripten
+build, release workflows, infrastructure checks, and repository-wide parity.
+Failing a portable command because one of these capabilities is absent is an
+escalation signal, not permission to skip or approximate the check
+(LS.DEL.COMP.DEV-R04).
+
+## Full-Lane Shell Readiness
 
 Shell entry establishes dependency and generated-source readiness through
 `pnpm:install` and `genie:run`. It does not run the full TypeScript build.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -89,7 +89,8 @@ const docsRedirects = Object.fromEntries([
 
   ...docsRedirect('/contributing/contributing', '/sustainable-open-source/contributing/info'),
   ...docsRedirect('/contributing/docs', '/sustainable-open-source/contributing/docs'),
-  ...docsRedirect('/contributing/monorepo', '/sustainable-open-source/contributing/monorepo'),
+  ...docsRedirect('/contributing/monorepo', '/sustainable-open-source/contributing/full-setup'),
+  ...docsRedirect('/sustainable-open-source/contributing/monorepo', '/sustainable-open-source/contributing/full-setup'),
 ]) satisfies Record<string, string>
 
 // Netlify preview domain (see https://docs.netlify.com/configure-builds/environment-variables/#build-metadata)

--- a/docs/src/content/docs/sustainable-open-source/contributing/full-setup.mdx
+++ b/docs/src/content/docs/sustainable-open-source/contributing/full-setup.mdx
@@ -1,6 +1,6 @@
 ---
-title: Monorepo
-description: Notes on the monorepo setup of LiveStore.
+title: Full setup with Nix and devenv
+description: The complete development environment and validation path for LiveStore.
 ---
 
 import { REACT_VERSION, EFFECT_VERSION } from '../../../../../../packages/@local/shared/src/CONSTANTS'
@@ -20,20 +20,23 @@ experience is recommended:
 - Experience with TypeScript monorepo setups
 - Experience with distributed systems
 
-### Required tooling: Nix + devenv
+### Nix and devenv
 
-LiveStore requires [Nix](https://nixos.org/) with [devenv](https://devenv.sh)
-to manage all development dependencies (Node.js, Bun, pnpm, oxlint, OTEL stack,
-Playwright browsers, etc.). Enter the development shell with `devenv shell`.
+The full setup uses [Nix](https://nixos.org/) with
+[devenv](https://devenv.sh) to manage the complete development dependency set,
+including oxlint plugins, generated-source tooling, telemetry, browsers, and
+SQLite distribution rebuilds. Enter it with `devenv shell`.
 
-#### Why this is a hard requirement
+#### Why the full lane remains authoritative
 
 LiveStore is developed alongside a family of projects that share tooling
 through [`effect-utils`](https://github.com/overengineeringstudio/effect-utils)
 — a Nix flake that provides the exact oxlint (with custom plugins),
 `genie` config generator, `megarepo` CLI, OTEL dashboards, and
-Playwright integration used here. Standing this up outside of Nix/devenv
-means reimplementing a moving target and drifting from CI.
+Playwright integration used here. Standing up this complete closure outside
+Nix/devenv means reimplementing a moving target and drifting from CI. The
+separate [Minimal setup](./minimal-setup/) is supported for its deliberately
+smaller capability set.
 
 By requiring Nix + devenv we get:
 
@@ -59,13 +62,6 @@ After installing Nix, install
 into the repo, also install [direnv](https://direnv.net) — the repo ships
 an `.envrc` that wires devenv into direnv. Not required.
 
-### Manual setup (discouraged)
-
-It is technically possible to set up the toolchain manually (Node.js, Bun,
-pnpm, etc.), but this path is **not supported**: you'll diverge from CI,
-miss linter plugins, and have to track tool versions by hand. Use Nix +
-devenv unless you have a very specific reason not to.
-
 ## Initial setup
 
 ```bash
@@ -76,8 +72,8 @@ devenv shell
 
 Entering the shell builds the Nix environment, puts the full toolchain
 (Node.js, Bun, pnpm, `mono`, oxlint, oxfmt, etc.) on `$PATH`, and
-runs the project `setup` task (which installs pnpm deps, regenerates
-`genie` outputs, and builds TypeScript).
+runs setup tasks that install dependencies and regenerate managed sources.
+Source validation remains explicit; setup completion is not a passing build.
 
 ## Working with devenv
 

--- a/docs/src/content/docs/sustainable-open-source/contributing/full-setup.mdx
+++ b/docs/src/content/docs/sustainable-open-source/contributing/full-setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: Full setup with Nix and devenv
+title: Full Setup (Nix + devenv)
 description: The complete development environment and validation path for LiveStore.
 ---
 
@@ -22,12 +22,12 @@ experience is recommended:
 
 ### Nix and devenv
 
-The full setup uses [Nix](https://nixos.org/) with
+Full Setup (Nix + devenv) uses [Nix](https://nixos.org/) with
 [devenv](https://devenv.sh) to manage the complete development dependency set,
 including oxlint plugins, generated-source tooling, telemetry, browsers, and
 SQLite distribution rebuilds. Enter it with `devenv shell`.
 
-#### Why the full lane remains authoritative
+#### Why Full Setup (Nix + devenv) remains authoritative
 
 LiveStore is developed alongside a family of projects that share tooling
 through [`effect-utils`](https://github.com/overengineeringstudio/effect-utils)
@@ -35,7 +35,7 @@ through [`effect-utils`](https://github.com/overengineeringstudio/effect-utils)
 `genie` config generator, `megarepo` CLI, OTEL dashboards, and
 Playwright integration used here. Standing up this complete closure outside
 Nix/devenv means reimplementing a moving target and drifting from CI. The
-separate [Minimal setup](./minimal-setup/) is supported for its deliberately
+separate [Minimal Setup](./minimal-setup/) is supported for its deliberately
 smaller capability set.
 
 By requiring Nix + devenv we get:

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -15,39 +15,17 @@ Before you start contributing, please check with the maintainers if the changes 
 
 ## Development setup
 
-### Minimal Setup
+Choose the smallest environment that covers your contribution:
 
-Most TypeScript, core unit-test, Vite, local Wrangler, and docs-check work uses
-the host-native Minimal Setup. Install Node.js 24 and Bun, and provide the exact
-pnpm version declared by `package.json#packageManager`. Then run:
+- [Minimal setup](./minimal-setup/) is the conventional path for most
+  TypeScript, core unit-test, Vite, local Wrangler, and docs-check work. Docker
+  is available there as an optional alternative.
+- [Full setup with Nix and devenv](./full-setup/) owns browser tests, generated
+  sources, SQLite distribution rebuilds, releases, infrastructure, and final
+  repository-wide validation.
 
-```bash
-./scripts/bootstrap-minimal.sh
-```
-
-The script verifies those prerequisites and performs a frozen dependency
-install. It does not install or upgrade tools globally.
-
-#### Docker (optional)
-
-The repository also provides the known-good Node 24, pnpm 11.8.0, and Bun
-1.3.13 toolchain as a container:
-
-```bash
-docker compose build
-LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
-./scripts/bootstrap-minimal.sh
-```
-
-Compose bind-mounts the source tree, so use an exclusive checkout and do not run
-host and container installs concurrently.
-
-### Full setup with Nix and devenv
-
-Use `devenv shell` for Playwright and full docs builds, generated-source or
-wa-sqlite changes, releases, infrastructure, and repository-wide parity. The
-exact boundary is maintained in the
-[developer-environment contract](https://github.com/livestorejs/livestore/tree/main/context/03-delivery/01-composition/01-developer-environment/spec.md).
+Setup makes dependencies ready. It does not replace the validation appropriate
+to your change or the full CI bar.
 
 ## Areas for contribution
 

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -13,6 +13,42 @@ Please note that LiveStore is still in active development with many things yet s
 
 Before you start contributing, please check with the maintainers if the changes you'd like to make are likely to be accepted. Please get in touch via the `#contrib` channel on [Discord](https://discord.gg/RbMcjUAPd7).
 
+## Development setup
+
+### Minimal Setup
+
+Most TypeScript, core unit-test, Vite, local Wrangler, and docs-check work uses
+the host-native Minimal Setup. Install Node.js 24 and Bun, and provide the exact
+pnpm version declared by `package.json#packageManager`. Then run:
+
+```bash
+./scripts/bootstrap-minimal.sh
+```
+
+The script verifies those prerequisites and performs a frozen dependency
+install. It does not install or upgrade tools globally.
+
+#### Docker (optional)
+
+The repository also provides the known-good Node 24, pnpm 11.8.0, and Bun
+1.3.13 toolchain as a container:
+
+```bash
+docker compose build
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+./scripts/bootstrap-minimal.sh
+```
+
+Compose bind-mounts the source tree, so use an exclusive checkout and do not run
+host and container installs concurrently.
+
+### Full setup with Nix and devenv
+
+Use `devenv shell` for Playwright and full docs builds, generated-source or
+wa-sqlite changes, releases, infrastructure, and repository-wide parity. The
+exact boundary is maintained in the
+[developer-environment contract](https://github.com/livestorejs/livestore/tree/main/context/03-delivery/01-composition/01-developer-environment/spec.md).
+
 ## Areas for contribution
 
 There are many ways to contribute to LiveStore.

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -17,10 +17,10 @@ Before you start contributing, please check with the maintainers if the changes 
 
 Choose the smallest environment that covers your contribution:
 
-- [Minimal setup](./minimal-setup/) is the conventional path for most
+- [Minimal Setup](./minimal-setup/) is the path for most
   TypeScript, core unit-test, Vite, local Wrangler, and docs-check work. Docker
   is available there as an optional alternative.
-- [Full setup with Nix and devenv](./full-setup/) owns browser tests, generated
+- [Full Setup (Nix + devenv)](./full-setup/) owns browser tests, generated
   sources, SQLite distribution rebuilds, releases, infrastructure, and final
   repository-wide validation.
 

--- a/docs/src/content/docs/sustainable-open-source/contributing/minimal-setup.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/minimal-setup.md
@@ -41,6 +41,8 @@ Setup only makes dependencies ready. Run the checks that match your work:
 | ----------------- | --------------------------------------------------------------- |
 | Core TypeScript   | `pnpm exec tsc -b packages/@livestore/livestore --pretty false` |
 | Stable core units | `pnpm --filter @livestore/common exec vitest run`               |
+| Vite example      | `pnpm --filter livestore-example-web-todomvc run build`         |
+| Cloudflare Worker | `pnpm --filter livestore-example-cloudflare-todomvc run build`  |
 | Docs source       | `pnpm --filter @local/docs run check`                           |
 
 Before a maintainer-ready handoff, use the full setup for any required checks
@@ -54,6 +56,14 @@ regression oracle for this lane:
 ```bash
 docker compose build
 LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+```
+
+The image ships its install under `/app`, while Compose bind-mounts your fresh
+checkout at `/workspace`. Prepare the mounted checkout once inside the container
+before working in it:
+
+```bash
+./scripts/bootstrap-minimal.sh
 ```
 
 Compose bind-mounts the source tree. Use an exclusive checkout and do not run

--- a/docs/src/content/docs/sustainable-open-source/contributing/minimal-setup.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/minimal-setup.md
@@ -1,11 +1,11 @@
 ---
-title: Minimal setup
-description: A conventional setup for TypeScript-heavy LiveStore contributions.
+title: Minimal Setup
+description: The lightweight setup for TypeScript-heavy LiveStore contributions.
 ---
 
-Minimal setup covers most TypeScript changes, stable core unit tests,
+Minimal Setup covers most TypeScript changes, stable core unit tests,
 representative Vite and local Wrangler builds, and docs source checks. Use the
-[full Nix and devenv setup](./full-setup/) when your work needs browsers,
+[Full Setup (Nix + devenv)](./full-setup/) when your work needs browsers,
 generated sources, a SQLite distribution rebuild, releases, infrastructure, or
 final repository-wide validation.
 

--- a/docs/src/content/docs/sustainable-open-source/contributing/minimal-setup.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/minimal-setup.md
@@ -1,0 +1,62 @@
+---
+title: Minimal setup
+description: A conventional setup for TypeScript-heavy LiveStore contributions.
+---
+
+Minimal setup covers most TypeScript changes, stable core unit tests,
+representative Vite and local Wrangler builds, and docs source checks. Use the
+[full Nix and devenv setup](./full-setup/) when your work needs browsers,
+generated sources, a SQLite distribution rebuild, releases, infrastructure, or
+final repository-wide validation.
+
+## Install the toolchain
+
+Install [Node.js 24](https://nodejs.org/en/download),
+[Bun](https://bun.sh/docs/installation), and the pnpm version declared by
+`package.json#packageManager` using the
+[official pnpm installation options](https://pnpm.io/installation). Confirm the
+tools resolved from your shell:
+
+```bash
+node --version
+bun --version
+pnpm --version
+```
+
+Run a frozen install from the repository root:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+`./scripts/bootstrap-minimal.sh` is an optional diagnostic for people and
+agents. It checks the same prerequisites and runs the frozen install, without
+installing or upgrading tools globally.
+
+## Validate your change
+
+Setup only makes dependencies ready. Run the checks that match your work:
+
+| Work              | Command                                                         |
+| ----------------- | --------------------------------------------------------------- |
+| Core TypeScript   | `pnpm exec tsc -b packages/@livestore/livestore --pretty false` |
+| Stable core units | `pnpm --filter @livestore/common exec vitest run`               |
+| Docs source       | `pnpm --filter @local/docs run check`                           |
+
+Before a maintainer-ready handoff, use the full setup for any required checks
+outside this table and rely on the complete CI bar.
+
+## Docker (optional)
+
+Docker provides a familiar, known-good realization and is also the CI
+regression oracle for this lane:
+
+```bash
+docker compose build
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+```
+
+Compose bind-mounts the source tree. Use an exclusive checkout and do not run
+host and container installs concurrently. The image intentionally omits
+browsers, generated-source tooling, Nix, release state, and infrastructure
+tools.


### PR DESCRIPTION
## Problem

The repository did not authoritatively define the Minimal Setup path, its boundary with the holistic Nix/devenv environment, or present those paths as distinct public guides. Existing monorepo documentation also contradicted the supported Minimal Setup.

## Goal

Define the two development setups from contributor evidence and provide a chooser plus focused Minimal and Full Setup (Nix + devenv) guides without weakening the final CI bar.

## Decisions

- Treat Minimal Setup coverage of the TypeScript-heavy majority as a design target informed by the 2026-08-20 setup discussion, not a measured percentage.
- Retain Nix/devenv as the holistic runtime, build, development-dependency, and final-validation authority.
- Make the bootstrap an optional readiness diagnostic for people and agents. It installs no tools globally and does not imply validation passed.
- Define Docker as an optional familiar realization and the CI regression oracle, not the only human workflow.
- Use committed SQLite distribution artifacts in Minimal Setup; rebuilding them crosses into the full Nix/Emscripten lane.
- Admit new portable capabilities only through clean-environment evidence, with contributor feedback informing boundary revisions.
- Split public guidance into an Info chooser, dedicated Minimal Setup page, and renamed Full Setup (Nix + devenv) with Nix and devenv page. Preserve the old monorepo URL with a redirect.
- Use neutral official installation links and version-check commands; derive pnpm authority from `package.json#packageManager` rather than prose.
- Keep setup and validation distinct, with explicit escalation before final handoff.
- Update the protected requirements with explicit maintainer authorization.

## Verification

- Intent-layer Vitest: PASS, 1 file / 8 tests in 235 ms.
- Docs check with all GitHub branch variables unset: PASS via Git fallback; 30 files with zero errors, warnings, or hints.
- Markdown-import/link policy, Genie generation/drift, full lint/fix, `git diff --check`, and all commit `check-quick` hooks: PASS.
- New decision 0003 and experiment 0003 satisfy strict VRS shape.
- `devenv tasks run check:all`: BLOCKED on both this stack and current `origin/main` at `otel:verify:setup`; the child exits 0 but the stale Effect-utils pin captures only one span. Overriding to current Effect-utils main passes with 21 spans, but adopting that pin regenerates nine unrelated CI/snapshot surfaces and remains a separate rollout. This PR remains draft.

## Complexity

Four reviewable commits: initial VRS, initial guides, evidence refinement, and the public guide split. The docs reuse existing navigation and redirect conventions; no launcher or duplicate toolchain was added.

## Concerns

- Strict VRS checking still reports inherited shape errors in decisions 0001/0002 and experiment 0001; the new records are conformant.
- Open PR #1515 also edits the developer-environment spec for setup tracing. The experiment-number collision was removed by using 0003; merge order may still require a textual rebase.
- Contributor experience is qualitative evidence. Setup duration and the proposed coverage ratio are not promoted to performance or coverage guarantees.

## Friction & bottlenecks

`axe vrs review` remains unavailable because this node's referenced review-prompt asset is absent. The full pre-flip check remains blocked by the existing setup telemetry assertion.

## Follow-ups

Review contributor feedback after the path is used in practice. Repair inherited VRS shapes, the missing review asset, and the setup telemetry gate separately before readiness unless maintainers explicitly waive inherited failures.

## References

- Depends on #1564.
- Layer 2 of stack #1572.
- Evidence source: [developer setup discussion, 2026-08-20](https://app.notion.com/p/schickling/3c2e3d41f4a380b58b07daa038191f3e).
- Supersedes the former guide-only draft #1570 while preserving its commit in this branch.
