### PR TITLE
Require the minimal development CI gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.devenv
+.direnv
+**/node_modules
+result

--- a/.github/repo-settings.json
+++ b/.github/repo-settings.json
@@ -35,6 +35,9 @@
             "context": "changeset-check"
           },
           {
+            "context": "minimal-dev"
+          },
+          {
             "context": "type-check"
           },
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,16 @@ jobs:
           process.exit(1)
           NODE
         shell: bash
+  minimal-dev:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Verify minimal development setup
+        run: 'docker build --tag livestore-minimal-dev:ci .'
   pack-pr-snapshot:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -135,6 +135,21 @@ export default githubWorkflow({
 
   jobs: {
     'source-policy': livestoreDefaultRefPolicyJob,
+    'minimal-dev': {
+      if: "github.event_name == 'pull_request'",
+      'runs-on': 'ubuntu-latest',
+      steps: [
+        {
+          name: 'Checkout code',
+          uses: 'actions/checkout@v4',
+          with: { ref: PR_HEAD_SHA },
+        },
+        {
+          name: 'Verify minimal development setup',
+          run: 'docker build --tag livestore-minimal-dev:ci .',
+        },
+      ],
+    },
     ...prSnapshotPackJob({
       topologyPath: releaseTopologyPath,
       setupStepsAfterCheckout: livestoreSetupStepsAfterCheckout,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,17 @@
 
 ## Setup
 
-This repository uses [`devenv`](https://devenv.sh) for development environment management. Run `devenv shell` to enter the development environment.
+Use the root `compose.yaml` for ordinary TypeScript, core unit-test, Vite,
+local Wrangler, and docs-check work in an exclusive checkout:
+
+```bash
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+```
+
+Run `devenv shell` for browser and full docs tests, generated-source or
+wa-sqlite changes, release and infrastructure work, or repository-wide parity.
+The authoritative boundary is
+[`context/03-delivery/01-composition/01-developer-environment/spec.md`](./context/03-delivery/01-composition/01-developer-environment/spec.md).
 
 ## Intent Layer (`context/`)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM oven/bun:1.3.13 AS bun
+
+FROM node:24-bookworm-slim
+
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --global "$(node -p "require('./package.json').packageManager")"
+
+COPY . .
+
+RUN node --version \
+  && bun --version \
+  && pnpm --version \
+  && pnpm install --frozen-lockfile \
+  && pnpm exec tsc -b packages/@livestore/livestore --pretty false \
+  && pnpm --filter @livestore/common exec vitest run src/schema/EventSequenceNumber.test.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN node --version \
   && pnpm --version \
   && pnpm install --frozen-lockfile \
   && pnpm exec tsc -b packages/@livestore/livestore --pretty false \
-  && pnpm --filter @livestore/common exec vitest run src/schema/EventSequenceNumber.test.ts
+  && pnpm --filter @livestore/common exec vitest run \
+  && pnpm --filter livestore-example-web-todomvc run build \
+  && pnpm --filter livestore-example-cloudflare-todomvc run build \
+  && pnpm --filter @local/docs run check

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  development:
+    build: .
+    working_dir: /workspace
+    user: "${LOCAL_UID:-1000}:${LOCAL_GID:-100}"
+    environment:
+      HOME: /tmp/livestore-home
+    volumes:
+      - .:/workspace
+    command: bash
+    stdin_open: true
+    tty: true

--- a/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.decisions/0003-two-development-lanes.md
@@ -1,0 +1,50 @@
+# 0003 — Support portable and hermetic development lanes
+
+Status: accepted
+
+Evidence: user confirmation on 2026-08-21 and
+[experiment 0002](../.experiments/0002-portable-development-boundary.md).
+
+## Context
+
+The hermetic Nix/devenv environment provides repository-wide parity but makes
+ordinary TypeScript contributions depend on fleet-specific tooling. A
+conventional environment can already exercise a substantial, coherent subset
+of the repository without weakening those checks.
+
+## Evidence and Argument
+
+The clean-container experiment proved frozen installation, reference-aware
+TypeScript, 271 stable core tests, Vite and Wrangler builds, and docs checking
+using only the pinned JavaScript toolchain. Independent failures located a
+clear boundary at browsers, Genie, Nix, Git history, release state, and
+infrastructure tooling. A disposable bind-mounted Compose checkout reproduced
+the portable loop as the non-root checkout owner.
+
+## Options
+
+| Option | Consequence |
+| --- | --- |
+| A. Portable and full lanes with Docker as the executable portable contract (chosen) | Finite measured capability set with explicit escalation |
+| B. Keep devenv as the only supported environment | One tool closure, but Nix and composition admit every contribution |
+| C. Expand Docker until it matches the full environment | Duplicates browsers, Nix, generators, release, and infrastructure tooling |
+| D. Document host commands without an executable oracle | Least configuration, but no failure-capable drift check |
+
+## Decision
+
+Choose A. The root Dockerfile is the cold-start oracle and the root Compose
+service is its bind-mounted interactive form. The full devenv/Nix lane remains
+authoritative beyond the measured portable boundary.
+
+## Consequences
+
+- Ordinary TypeScript, stable core tests, representative Vite and Wrangler
+  builds, and docs source checks do not require Nix or megarepo tooling.
+- The portable promise remains finite; adding a capability requires clean-image
+  evidence and extending the Docker gate.
+- Browser downloads, generated-source tooling, wa-sqlite rebuilds, release
+  state, and infrastructure remain single-owned by the full lane.
+- Compose writes through an exclusively owned checkout and does not attempt to
+  coordinate shared worktree state or application ports.
+- Pull requests cannot drift the portable contract unnoticed because its
+  stable CI context builds the canonical Dockerfile.

--- a/context/03-delivery/01-composition/01-developer-environment/.experiments/0002-portable-development-boundary.md
+++ b/context/03-delivery/01-composition/01-developer-environment/.experiments/0002-portable-development-boundary.md
@@ -1,0 +1,75 @@
+# 0002 — Portable development capability boundary
+
+Date: 2026-08-21
+
+## Question
+
+Which development capabilities work from the canonical Docker environment
+without adding Nix, devenv, megarepo tooling, browsers, Git history, custom
+launchers, or credentials?
+
+## Method
+
+- Built the root Dockerfile from a clean Linux/amd64 context using the official
+  Node 24 and Bun 1.3.13 images and directly installed repository-pinned pnpm
+  11.8.0.
+- Ran each candidate in a disposable container and classified the first
+  boundary failure rather than installing another tool.
+- Exercised Compose against a disposable source copy as UID 1000 and GID 100,
+  including a fresh bind-mounted install and representative checks.
+- Avoided deploy, publish, release mutation, credentials, and external service
+  writes.
+
+## Result
+
+| Capability | Result | Evidence |
+| --- | --- | --- |
+| Frozen install | PASS | 36 workspaces; 2,600 packages; 2,653 supply-chain entries verified |
+| Reference-aware core TypeScript build | PASS | `tsc -b packages/@livestore/livestore` |
+| Stable core unit suite | PASS | 20 files; 271 tests; 1.75s Vitest duration in the expanded oracle |
+| Vite application build | PASS | Worker and client bundles, including committed wa-sqlite WASM |
+| Vite development server | PASS | Ready in 1.557s; HTTP 200 from the container |
+| Local Wrangler build | PASS | Dry-run bundle with Durable Object bindings; no credentials or mutation |
+| Docs source check | PASS | 30 Astro files; zero errors, warnings, or hints; 12.590s standalone |
+| Full docs build | FAIL | 158 snippets rendered, then Puppeteer Chrome was absent after 399.007s |
+| Playwright test | FAIL | Chromium headless-shell absent after 3.297s |
+| Genie regeneration | FAIL | Genie CLI absent after 0.338s |
+| wa-sqlite rebuild | FAIL | Nix/Emscripten build closure absent |
+| Changesets history status | CONDITIONAL | pnpm command present; Git binary and `.git` history absent |
+| Infrastructure check | FAIL | Nix absent |
+| Contrib composition | NO VERDICT | Core experiment did not materialize or build the external contrib checkout |
+
+The initial finite Docker oracle completed an uncached build in 101.8s. The
+expanded oracle, including the full stable core suite, Vite build, Wrangler
+build, and docs check, completed uncached in 115.445s. Image export represented
+roughly 42s of the expanded measurement.
+
+The full docs attempt sampled approximately 3.15 GiB memory and 235% peak CPU
+before failing at the browser boundary. It transferred only kilobytes of
+network traffic before that failure. These are diagnostic observations, not
+portable resource ceilings.
+
+The disposable Compose loop passed a fresh frozen install, reference-aware
+TypeScript build, focused unit test, and docs check through the bind mount as
+the configured non-root owner.
+
+## Conclusion
+
+The portable lane can reliably own frozen installation, ordinary TypeScript
+work, stable core unit tests, representative Vite build/development, local
+Wrangler builds, and docs source checking without another tool layer.
+
+Browser execution, full docs rendering, generated-source regeneration,
+wa-sqlite rebuilding, release-history operations, and infrastructure checks
+cross a material tool or state boundary. They remain full-lane capabilities;
+their absence must stay visible rather than being converted into skipped or
+weakened portable checks. Contrib composition remains unclaimed until it has
+its own clean-checkout evidence.
+
+## VRS Impact
+
+This evidence establishes the portable capability set in
+LS.DEL.COMP.DEV-R03, the escalation boundary in LS.DEL.COMP.DEV-R04, and the
+Docker/Compose mechanics in the developer-environment spec. It does not support
+claiming browser, generation, release, infrastructure, or contrib composition
+as portable capabilities.

--- a/context/03-delivery/01-composition/01-developer-environment/requirements.md
+++ b/context/03-delivery/01-composition/01-developer-environment/requirements.md
@@ -10,3 +10,23 @@ contract for setup work. It refines the broader tooling-composition outcome in
   development shell establishes dependency and generated-source readiness
   without requiring full source validation. TypeScript build and check tasks
   remain explicit developer and CI gates. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R02 Two supported lanes:** A fresh exclusive checkout must
+  offer both a portable development lane that does not require Nix, devenv, or
+  megarepo tooling and a full hermetic lane for repository-wide maintenance.
+  `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R03 Portable TypeScript loop:** The portable lane must
+  perform a frozen dependency install, reference-aware TypeScript build,
+  stable core unit suite, representative Vite application build, local
+  Cloudflare Worker build, and docs source check with repository-pinned
+  JavaScript tooling. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R04 Explicit escalation boundary:** Browser tests, the full
+  docs build, generated-source regeneration, wa-sqlite rebuilding, release
+  operations, and infrastructure validation must direct developers to the
+  full lane rather than silently weakening those checks. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R05 Independent cold-start gate:** Pull-request validation
+  must exercise the portable lane from a stock hosted environment without
+  first preparing Nix, devenv, or megarepo state. `refines: LS.DEL.COMP-R18`
+- **LS.DEL.COMP.DEV-R06 Interactive checkout ownership:** The portable
+  interactive environment must bind one exclusive checkout, preserve the
+  caller's numeric ownership by default, and avoid prescribing application
+  ports that belong to individual examples. `refines: LS.DEL.COMP-R18`

--- a/context/03-delivery/01-composition/01-developer-environment/spec.md
+++ b/context/03-delivery/01-composition/01-developer-environment/spec.md
@@ -1,6 +1,7 @@
 # Developer Environment — Spec
 
-This document specifies shell readiness and setup diagnostics. It builds on
+This document specifies portable and hermetic development lanes, shell
+readiness, and setup diagnostics. It builds on
 [requirements.md](./requirements.md).
 
 ## Status
@@ -9,11 +10,83 @@ Draft.
 
 ## Scope
 
-Defines: automatic shell setup, explicit source-validation gates, setup
-profiling, and local trace handling. Does not define: the shared Effect-utils
-implementation, CI workflow composition, or production observability.
+Defines: portable development, automatic hermetic shell setup, explicit
+source-validation gates, setup profiling, and local trace handling. Does not
+define: individual example ports, the shared Effect-utils implementation, or
+production observability.
 
-## Shell Readiness
+## Development Lanes
+
+```text
+exclusive checkout
+  |
+  +-- portable lane -- Dockerfile -- finite cold-start oracle
+  |                  `- Compose ---- bind-mounted interactive shell
+  |
+  `-- full lane ----- devenv ----- dependencies + generated sources
+                     `- Nix ------- browsers, WASM, release, infrastructure
+```
+
+The portable lane is the default for ordinary TypeScript changes. The full
+lane is an escalation target for capabilities whose correctness depends on the
+hermetic repository toolchain. The two lanes share the committed pnpm lockfile
+and source tree; they do not claim identical tool closures
+([decision 0003](./.decisions/0003-two-development-lanes.md)).
+
+| Capability | Portable lane | Full lane |
+| --- | --- | --- |
+| Frozen workspace install | Required | Required |
+| Reference-aware TypeScript build | Required | Required |
+| Stable core unit tests | Required | Required |
+| Vite application build and development | Required | Required |
+| Local Wrangler build | Required | Required |
+| Docs source check | Required | Required |
+| Browser and Playwright tests | Not provided | Required |
+| Full docs build, including diagrams | Not provided | Required |
+| Genie regeneration | Not provided | Required |
+| wa-sqlite rebuild | Not provided | Required |
+| Release and infrastructure operations | Not provided | Required |
+
+## Portable Lane
+
+The root `Dockerfile` is the executable cold-start contract. It starts from the
+official Node 24 image, copies the Bun binary from the pinned official Bun
+image, installs the pnpm version declared by `package.json#packageManager`
+directly, and runs the finite capability set in the table above. It does not
+install Nix, a browser, Genie, Git history, release credentials, or
+infrastructure tools.
+
+The root `compose.yaml` makes the same image interactive. The `development`
+service bind-mounts the current checkout at `/workspace`, uses the caller's
+`LOCAL_UID` and `LOCAL_GID` when supplied (with repository defaults for the
+standard development host), and keeps package-manager state in a writable
+temporary home. It intentionally declares no application ports. Because tools
+write dependencies and build outputs through the bind mount, the checkout must
+be exclusively owned by that developer or agent.
+
+```bash
+docker compose build
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+pnpm install --frozen-lockfile
+```
+
+The generated pull-request workflow contains an independent `minimal-dev` job
+on a stock hosted Ubuntu runner. Its only preparation is checkout; `docker
+build .` performs the gate. The generated repository ruleset requires the
+stable `minimal-dev` context. The Dockerfile, workflow generator, generated
+workflow, and generated ruleset are reviewed together when the contract
+changes (LS.DEL.COMP.DEV-R03, R05, R06).
+
+## Full Lane
+
+The full lane begins with `devenv shell`. It owns browser installation, full
+docs rendering, Genie and other generated sources, wa-sqlite's Nix/Emscripten
+build, release workflows, infrastructure checks, and repository-wide parity.
+Failing a portable command because one of these capabilities is absent is an
+escalation signal, not permission to skip or approximate the check
+(LS.DEL.COMP.DEV-R04).
+
+## Full-Lane Shell Readiness
 
 Shell entry establishes dependency and generated-source readiness through
 `pnpm:install` and `genie:run`. It does not run the full TypeScript build.

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -13,6 +13,26 @@ Please note that LiveStore is still in active development with many things yet s
 
 Before you start contributing, please check with the maintainers if the changes you'd like to make are likely to be accepted. Please get in touch via the `#contrib` channel on [Discord](https://discord.gg/RbMcjUAPd7).
 
+## Development setup
+
+Most TypeScript, core unit-test, Vite, local Wrangler, and docs-check work can
+use the portable development environment:
+
+```bash
+docker compose build
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+pnpm install --frozen-lockfile
+```
+
+The checkout is bind-mounted into the container, so use an exclusive checkout.
+The container deliberately has no browser, Nix, Genie, release state, or
+infrastructure tooling.
+
+Use `devenv shell` for Playwright and full docs builds, generated-source or
+wa-sqlite changes, releases, infrastructure, and repository-wide parity. The
+exact capability boundary and validation commands are specified in the
+[developer-environment contract](./context/03-delivery/01-composition/01-developer-environment/spec.md).
+
 ## Areas for contribution
 
 There are many ways to contribute to LiveStore.

--- a/docs/src/data/data.ts
+++ b/docs/src/data/data.ts
@@ -1,5 +1,3 @@
-import { execSync } from 'node:child_process'
-
 import { liveStoreVersion } from '@livestore/common'
 import { isNonEmptyString } from '@livestore/utils'
 
@@ -13,7 +11,11 @@ export const officeHours = [
 export const getBranchName = () =>
   isNonEmptyString(process.env.GITHUB_BRANCH_NAME) === true
     ? process.env.GITHUB_BRANCH_NAME
-    : execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+    : isNonEmptyString(process.env.GITHUB_HEAD_REF) === true
+      ? process.env.GITHUB_HEAD_REF
+      : isNonEmptyString(process.env.GITHUB_REF_NAME) === true
+        ? process.env.GITHUB_REF_NAME
+        : 'main'
 
 export const versionNpmSuffix = liveStoreVersion.includes('dev') === true ? `@${liveStoreVersion}` : ''
 

--- a/genie/ci.ts
+++ b/genie/ci.ts
@@ -20,6 +20,7 @@ export const requiredCIJobs = [
   'source-policy',
   'lint',
   'changeset-check',
+  'minimal-dev',
   'type-check',
   'test-unit',
   ...syncProviderMatrix.map((provider) => `test-integration-sync-provider (${provider})`),

--- a/packages/@local/shared/src/CONSTANTS.ts
+++ b/packages/@local/shared/src/CONSTANTS.ts
@@ -8,10 +8,6 @@ export const MIN_NODE_VERSION = '23.0.0'
 
 export const DISCORD_INVITE_URL = 'https://discord.gg/RbMcjUAPd7'
 
-const workspaceRoot = process.env.WORKSPACE_ROOT
-
-if (workspaceRoot === undefined || workspaceRoot === '') {
-  throw new Error('WORKSPACE_ROOT must be set')
-}
+const workspaceRoot = process.env.WORKSPACE_ROOT ?? path.resolve(import.meta.dirname, '../../../..')
 
 export const LIVESTORE_DEVTOOLS_CHROME_DIST_PATH = path.resolve(workspaceRoot, 'tmp/devtools/chrome-extension')


### PR DESCRIPTION
## Problem

The portable cold-start job exists in PR CI, but repository policy does not yet make that contract merge-blocking.

## Goal

Require the stable `minimal-dev` check through the generated repository-settings authority.

## Decisions

- Add `minimal-dev` to the shared `requiredCIJobs` source.
- Regenerate `.github/repo-settings.json` from Genie.
- Do not apply live repository settings from this draft PR; merge and rollout remain maintainer-controlled.

## Verification

`devenv tasks run genie:run`, `genie:check`, `lint:check:genie`, `devenv tasks run lint:full:fix`, `git diff --check`, and commit `check-quick` passed.

## Complexity

One source entry and its generated three-line projection.

## Concerns

The required check should be enabled live only after the preceding CI layer is merged and observed healthy.

## Friction & bottlenecks

None specific to this layer.

## Follow-ups

Apply the generated repository settings through the normal maintainer rollout after the stack lands.

## References

- Depends on #1568 and cumulatively on #1564, #1565, and #1567.
- Layer 5 of stack #1566.
