### PR TITLE
Document host-native Minimal Setup and full devenv setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,27 @@
 
 ## Setup
 
-This repository uses [`devenv`](https://devenv.sh) for development environment management. Run `devenv shell` to enter the development environment.
+### Minimal Setup
+
+For ordinary TypeScript, core unit-test, Vite, local Wrangler, and docs-check
+work, provide Node.js 24, Bun, and the exact pnpm version declared by
+`package.json#packageManager`, then run:
+
+```bash
+./scripts/bootstrap-minimal.sh
+```
+
+The script verifies prerequisites and performs a frozen install; it never
+installs tools globally. Bun 1.3.13 is the known-good Docker realization.
+The optional root `compose.yaml` supplies that toolchain in an exclusive
+bind-mounted checkout.
+
+### Full setup
+
+Run `devenv shell` for Playwright and full docs builds, generated-source or
+wa-sqlite changes, release and infrastructure work, or repository-wide parity.
+The authoritative boundary is
+[`context/03-delivery/01-composition/01-developer-environment/spec.md`](./context/03-delivery/01-composition/01-developer-environment/spec.md).
 
 ## Intent Layer (`context/`)
 

--- a/docs/src/content/docs/sustainable-open-source/contributing/info.md
+++ b/docs/src/content/docs/sustainable-open-source/contributing/info.md
@@ -13,6 +13,42 @@ Please note that LiveStore is still in active development with many things yet s
 
 Before you start contributing, please check with the maintainers if the changes you'd like to make are likely to be accepted. Please get in touch via the `#contrib` channel on [Discord](https://discord.gg/RbMcjUAPd7).
 
+## Development setup
+
+### Minimal Setup
+
+Most TypeScript, core unit-test, Vite, local Wrangler, and docs-check work uses
+the host-native Minimal Setup. Install Node.js 24 and Bun, and provide the exact
+pnpm version declared by `package.json#packageManager`. Then run:
+
+```bash
+./scripts/bootstrap-minimal.sh
+```
+
+The script verifies those prerequisites and performs a frozen dependency
+install. It does not install or upgrade tools globally.
+
+#### Docker (optional)
+
+The repository also provides the known-good Node 24, pnpm 11.8.0, and Bun
+1.3.13 toolchain as a container:
+
+```bash
+docker compose build
+LOCAL_UID="$(id -u)" LOCAL_GID="$(id -g)" docker compose run --rm development
+./scripts/bootstrap-minimal.sh
+```
+
+Compose bind-mounts the source tree, so use an exclusive checkout and do not run
+host and container installs concurrently.
+
+### Full setup with Nix and devenv
+
+Use `devenv shell` for Playwright and full docs builds, generated-source or
+wa-sqlite changes, releases, infrastructure, and repository-wide parity. The
+exact boundary is maintained in the
+[developer-environment contract](https://github.com/livestorejs/livestore/tree/main/context/03-delivery/01-composition/01-developer-environment/spec.md).
+
 ## Areas for contribution
 
 There are many ways to contribute to LiveStore.


### PR DESCRIPTION
## Problem

Contributor setup guidance presented only the full devenv path and did not distinguish the host-native default from the optional Docker realization or the full hermetic environment.

## Goal

Provide separate, concise Minimal Setup and full Nix/devenv guides derived from the authoritative developer-environment contract.

## Decisions

- Present host-native Minimal Setup first: install Node.js 24 and Bun, provide the exact pnpm declared by the repository, then run the shared bootstrap.
- State that bootstrap verifies prerequisites and performs a frozen install without globally installing or upgrading tools.
- Put Docker in an optional subsection with its known-good Node 24, pnpm 11.8.0, and Bun 1.3.13 realization and exclusive-checkout warning.
- Keep the full Nix/devenv setup separate and name the capabilities that require escalation.
- Update both the agent-facing canonical setup and the contributor guide without duplicating the underlying contract.

## Verification

- Docs check with `GITHUB_BRANCH_NAME`, `GITHUB_HEAD_REF`, and `GITHUB_REF_NAME` all unset: PASS, deriving the current Git branch; 30 files with zero errors, warnings, or hints.
- `devenv tasks run lint:full:fix`, `git diff --check`, and commit `check-quick`: PASS.

## Complexity

Two existing setup documents only; no new guide hierarchy or launcher.

## Concerns

The host-native guide deliberately does not prescribe a global tool installer. Contributors retain control of installation while the bootstrap enforces versions.

## Friction & bottlenecks

Direct `pnpm` inside the devenv shell is policy-wrapped; focused verification used the documented `DEVENV_TASK_PASSTHROUGH=1` path.

## Follow-ups

None required for core. Contrib guidance is handled in its corresponding repository stack.

## References

- Depends on #1568 and cumulatively on #1564.
- Layer 3 of stack #1571.
