### PR TITLE
Expose backend-confirmed delivery in SyncStatus

### DIFF
--- a/.changeset/backend-confirmed-sync-status.md
+++ b/.changeset/backend-confirmed-sync-status.md
@@ -1,0 +1,5 @@
+---
+"@livestore/livestore": minor
+---
+
+Add backend confirmation fields to `SyncStatus` while preserving the existing session-to-leader fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   accepted event cannot advance the backend head without notifying subscribers
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).
 - Removed redundant devenv package entries now owned by the task guard modules.
+- **Sync status API:** Added `backendHead`, `backendPendingCount`, and
+  `isBackendSynced` to `SyncStatus`, allowing sessions to distinguish leader
+  acceptance from sync-backend confirmation while preserving the existing
+  session-to-leader fields ([#1553](https://github.com/livestorejs/livestore/issues/1553)).
 - **Sync correctness:** Prevented later client-session events from crossing an
   older rejected pending prefix, and made leader admission retain explicit
   reservation ownership through queue drain until apply, rejection, or stale

--- a/context/02-system/05-store/.delta/DELTA-001-backend-confirmation-status-missing.md
+++ b/context/02-system/05-store/.delta/DELTA-001-backend-confirmation-status-missing.md
@@ -1,6 +1,6 @@
 # DELTA-001 — Store sync status omits backend confirmation
 
-Status: open
+Status: resolved (2026-08-21)
 
 ## Divergence
 
@@ -19,3 +19,15 @@ Close when `SyncStatus` exposes `backendHead`, `backendPendingCount`, and
 `isBackendSynced`; synchronous snapshots and subscriptions combine session and
 leader observations conservatively; and regression tests cover a session that
 is synced to its leader while the leader still awaits backend confirmation.
+
+## Resolution
+
+`SyncStatus` now combines the session processor's state with a Store-local cache
+of the leader processor's state. The cache is seeded during Store boot and kept
+current through the existing leader sync-state stream, so synchronous reads do
+not add an on-demand RPC. `isBackendSynced` requires both pending counts to be
+zero and the cached leader head to cover the leader head already observed by the
+session. Regression tests cover backend-pending delivery and a deliberately
+stale leader observation. The aggregate has no worker-lifecycle input: it
+reports latest-observed delivery convergence and may remain converged while a
+terminal sync worker is parked.

--- a/docs/src/content/docs/building-with-livestore/store.mdx
+++ b/docs/src/content/docs/building-with-livestore/store.mdx
@@ -92,18 +92,25 @@ You can create and use multiple stores in the same app. This can be useful when 
 
 ## Sync Status
 
-LiveStore provides APIs to monitor the synchronization status between the client session and the leader thread. This is useful for displaying sync indicators or performing health checks.
+LiveStore provides one sync status spanning both propagation boundaries: client session to leader, and leader to sync backend. The status distinguishes leader acceptance from backend confirmation without classifying why delivery remains pending.
 
 ### SyncStatus type
 
 ```ts
 type SyncStatus = {
-  localHead: string      // e.g., "e5.2" or "e5.2r1"
-  upstreamHead: string   // e.g., "e3"
-  pendingCount: number   // Number of events pending sync
-  isSynced: boolean      // true when pendingCount === 0
+  localHead: string            // Latest session head
+  upstreamHead: string         // Latest leader head observed by the session
+  pendingCount: number         // Events pending from session to leader
+  isSynced: boolean            // true when pendingCount === 0
+  backendHead: string          // Latest backend-confirmed head observed through the leader
+  backendPendingCount: number  // Synced events accepted by the leader, awaiting backend confirmation
+  isBackendSynced: boolean     // true when the latest observed state has converged across both boundaries
 }
 ```
+
+`isSynced` retains its session-to-leader meaning. `isBackendSynced` reports whether the latest observed state has converged across both boundaries. Because `syncStatus()` is synchronous, backend fields represent the latest leader state observed by the session and may briefly lag behind confirmation.
+
+This is a delivery-convergence snapshot, not a sync-worker health signal. `isBackendSynced` can remain `true` while the observed heads are converged even if a terminal backend worker is parked, and it does not guarantee that future delivery attempts can make progress.
 
 ### `store.syncStatus()`
 
@@ -111,8 +118,8 @@ Returns the current sync status synchronously.
 
 ```ts
 const status = store.syncStatus()
-if (!status.isSynced) {
-  console.log(`${status.pendingCount} events pending sync`)
+if (status.isSynced && !status.isBackendSynced) {
+  console.log(`${status.backendPendingCount} events awaiting backend confirmation`)
 }
 ```
 
@@ -122,7 +129,7 @@ Subscribes to sync status changes. The callback is invoked immediately with the 
 
 ```ts
 const unsubscribe = store.subscribeSyncStatus((status) => {
-  updateUI(status.isSynced ? 'Synced' : 'Syncing...')
+  updateUI(status.isBackendSynced ? 'Backend confirmed' : 'Awaiting backend confirmation...')
 })
 
 // Later, stop listening
@@ -137,7 +144,7 @@ Returns an Effect Stream of sync status updates. For Effect-based workflows.
 import { Effect, Stream } from 'effect'
 
 store.syncStatusStream().pipe(
-  Stream.tap((status) => Effect.log(`Sync: ${status.isSynced}`)),
+  Stream.tap((status) => Effect.log(`Backend confirmed: ${status.isBackendSynced}`)),
   Stream.runDrain,
 )
 ```

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -187,9 +187,12 @@ function SyncIndicator() {
   const store = useStore(storeOptions)
   const status = store.useSyncStatus()
   
-  return <span>{status.isSynced ? '✓ Synced' : `Syncing (${status.pendingCount} pending)...`}</span>
+  return <span>{status.isBackendSynced ? '✓ Backend confirmed' : 'Awaiting confirmation...'}</span>
 }
 ```
+
+This hook exposes latest-observed delivery convergence, not sync-worker health
+or a guarantee of future progress.
 
 For the `SyncStatus` type and non-React APIs (`syncStatus()`, `subscribeSyncStatus()`, `syncStatusStream()`), see the [Store documentation](/building-with-livestore/store#sync-status).
 

--- a/packages/@livestore/livestore/src/store/store-sync-status.test.ts
+++ b/packages/@livestore/livestore/src/store/store-sync-status.test.ts
@@ -1,0 +1,114 @@
+import { expect } from 'vitest'
+
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { ClientSessionLeaderThreadProxy, makeMockSyncBackend } from '@livestore/common'
+import { createStore } from '@livestore/livestore'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect, FetchHttpClient, Layer, References, Stream, Subscribable } from '@livestore/utils/effect'
+import { nanoid } from '@livestore/utils/nanoid'
+import { PlatformNode } from '@livestore/utils/node'
+
+import { events, schema } from '../utils/tests/fixture.ts'
+import type { SyncStatus } from './store-types.ts'
+
+const withTestCtx = Vitest.makeWithTestCtx({
+  makeLayer: () =>
+    Layer.mergeAll(
+      PlatformNode.NodeFileSystem.layer,
+      FetchHttpClient.layer,
+      Layer.succeed(References.MinimumLogLevel, 'Debug'),
+    ),
+})
+
+Vitest.describe('Store sync status API', () => {
+  Vitest.live('distinguishes leader acceptance from backend confirmation', (test) =>
+    Effect.gen(function* () {
+      const mockSyncBackend = yield* makeMockSyncBackend()
+      const store = yield* createStore({
+        schema,
+        storeId: nanoid(),
+        adapter: makeInMemoryAdapter({
+          sync: { backend: () => mockSyncBackend.makeSyncBackend, onSyncError: 'shutdown' },
+        }),
+      })
+
+      expect(store.syncStatus()).toMatchObject({
+        pendingCount: 0,
+        isSynced: true,
+        backendHead: 'e0',
+        backendPendingCount: 0,
+        isBackendSynced: true,
+      })
+
+      store.commit(events.todoCreated({ id: '1', text: 't1', completed: false }))
+
+      const awaitingBackend = yield* waitForStatus(
+        store.syncStatusStream(),
+        (status) => status.isSynced === true && status.backendPendingCount === 1,
+      )
+      expect(awaitingBackend).toMatchObject({
+        pendingCount: 0,
+        isSynced: true,
+        backendHead: 'e0',
+        backendPendingCount: 1,
+        isBackendSynced: false,
+      })
+
+      yield* mockSyncBackend.connect
+
+      const backendConfirmed = yield* waitForStatus(
+        store.syncStatusStream(),
+        (status) => status.isBackendSynced === true,
+      )
+      expect(backendConfirmed).toMatchObject({
+        pendingCount: 0,
+        isSynced: true,
+        backendHead: 'e1',
+        backendPendingCount: 0,
+        isBackendSynced: true,
+      })
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('does not report backend confirmation from a stale leader observation', (test) =>
+    Effect.gen(function* () {
+      const mockSyncBackend = yield* makeMockSyncBackend()
+      const baseAdapter = makeInMemoryAdapter({
+        sync: { backend: () => mockSyncBackend.makeSyncBackend, onSyncError: 'shutdown' },
+      })
+      const store = yield* createStore({
+        schema,
+        storeId: nanoid(),
+        adapter: (args) =>
+          baseAdapter(args).pipe(
+            Effect.map((clientSession) => ({
+              ...clientSession,
+              leaderThread: ClientSessionLeaderThreadProxy.of(clientSession.leaderThread, {
+                overrides: (original) => ({
+                  syncState: Subscribable.make({ get: original.syncState, changes: Stream.never }),
+                }),
+              }),
+            })),
+          ),
+      })
+
+      store.commit(events.todoCreated({ id: '1', text: 't1', completed: false }))
+
+      const sessionCaughtUp = yield* waitForStatus(
+        store.syncStatusStream(),
+        (status) => status.isSynced === true && status.upstreamHead !== 'e0',
+      )
+
+      expect(sessionCaughtUp).toMatchObject({
+        pendingCount: 0,
+        isSynced: true,
+        backendHead: 'e0',
+        backendPendingCount: 0,
+        isBackendSynced: false,
+      })
+    }).pipe(withTestCtx(test)),
+  )
+})
+
+const waitForStatus = (stream: Stream.Stream<SyncStatus>, predicate: (status: SyncStatus) => boolean) =>
+  stream.pipe(Stream.filter(predicate), Stream.runHead, Effect.flatMap(Effect.fromOption), Effect.timeout('5 seconds'))

--- a/packages/@livestore/livestore/src/store/store-types.ts
+++ b/packages/@livestore/livestore/src/store/store-types.ts
@@ -374,17 +374,18 @@ export const isQueryable = (value: unknown): value is Queryable<unknown> =>
 /**
  * Represents the current synchronization status of the store.
  *
- * This provides visibility into the sync state between the client session
- * and the leader thread, allowing applications to show sync indicators
- * or determine backend health.
+ * This provides visibility into both propagation boundaries: client session
+ * to leader thread, and leader thread to sync backend. It reports
+ * latest-observed delivery convergence, not sync-worker health or whether
+ * future delivery attempts can make progress.
  *
  * @example
  * ```ts
  * const status = store.syncStatus()
- * if (status.isSynced) {
- *   console.log('All changes synced')
+ * if (status.isBackendSynced) {
+ *   console.log('All changes confirmed by the sync backend')
  * } else {
- *   console.log(`${status.pendingCount} events pending sync`)
+ *   console.log(`${status.backendPendingCount} events awaiting backend confirmation`)
  * }
  * ```
  */
@@ -395,7 +396,7 @@ export type SyncStatus = {
    */
   localHead: string
   /**
-   * The upstream head sequence number (what the leader thread has confirmed).
+   * The latest leader head observed by the client session.
    * Represented as a string in the format "e{global}" (e.g., "e3").
    */
   upstreamHead: string
@@ -408,4 +409,21 @@ export type SyncStatus = {
    * True when there are no pending events (pendingCount === 0).
    */
   isSynced: boolean
+  /**
+   * Latest backend-confirmed head observed through the leader thread.
+   */
+  backendHead: string
+  /**
+   * Number of synced events accepted by the leader but not yet confirmed by the backend.
+   */
+  backendPendingCount: number
+  /**
+   * Whether the latest observed state has no pending events at either boundary.
+   *
+   * This conservative synchronous value may briefly remain false while a newer
+   * leader observation is in transit, but stale leader state cannot produce true.
+   * It may remain true while observed heads are converged even if a terminal
+   * sync worker is parked; worker health is not part of this status.
+   */
+  isBackendSynced: boolean
 }

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -39,6 +39,7 @@ import {
   Result,
   Schema,
   Stream,
+  SubscriptionRef,
 } from '@livestore/utils/effect'
 import { nanoid } from '@livestore/utils/nanoid'
 
@@ -185,6 +186,11 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * Store internals. Not part of the public API — shapes and semantics may change without notice.
    */
   readonly [StoreInternalsSymbol]: StoreInternals
+
+  /** Latest leader sync state observed by this session; populated before Store boot completes. */
+  private readonly leaderSyncStateRef = SubscriptionRef.make<SyncState.SyncState | undefined>(undefined).pipe(
+    Effect.runSync,
+  )
 
   //#region constructor
   constructor({
@@ -382,6 +388,14 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
           commitsSpan.end()
           queriesSpan.end()
         }),
+      )
+
+      yield* clientSession.leaderThread.syncState.pipe(
+        Effect.flatMap((syncState) => SubscriptionRef.set(this.leaderSyncStateRef, syncState)),
+      )
+      yield* clientSession.leaderThread.syncState.changes.pipe(
+        Stream.runForEach((syncState) => SubscriptionRef.set(this.leaderSyncStateRef, syncState)),
+        Effect.forkScoped,
       )
 
       yield* syncProcessor.boot
@@ -1026,43 +1040,38 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   /**
    * Returns the current synchronization status of the store.
    *
-   * This is a synchronous operation that returns the sync state between the
-   * client session and the leader thread. Use this to display sync indicators
-   * or check if local changes have been pushed to the leader.
+   * This is a synchronous operation that returns the latest observed sync state
+   * across the session-to-leader and leader-to-backend boundaries. It does not
+   * report sync-worker health or guarantee that future delivery can make progress.
    *
    * @example
    * ```ts
    * const status = store.syncStatus()
-   * console.log(status.isSynced ? 'Synced' : `${status.pendingCount} pending`)
+   * console.log(status.isBackendSynced ? 'Backend confirmed' : 'Awaiting backend confirmation')
    * ```
    *
    * @example
    * ```ts
-   * // Health check for backend connectivity
+   * // The session can be caught up with its leader while backend confirmation is pending.
    * const status = store.syncStatus()
-   * if (!status.isSynced && status.pendingCount > 100) {
-   *   console.warn('Large backlog of unsynced events')
+   * if (status.isSynced && !status.isBackendSynced) {
+   *   console.log(`${status.backendPendingCount} events awaiting backend confirmation`)
    * }
    * ```
    */
   syncStatus = (): SyncStatus => {
     this.checkShutdown('syncStatus')
 
-    const syncState = this[StoreInternalsSymbol].syncProcessor.syncState.pipe(Effect.runSync)
-    const pendingCount = syncState.pending.length
+    const sessionSyncState = this[StoreInternalsSymbol].syncProcessor.syncState.pipe(Effect.runSync)
+    const leaderSyncState = this.getLeaderSyncState()
 
-    return {
-      localHead: EventSequenceNumber.Client.toString(syncState.localHead),
-      upstreamHead: EventSequenceNumber.Client.toString(syncState.upstreamHead),
-      pendingCount,
-      isSynced: pendingCount === 0,
-    }
+    return this.makeSyncStatus(sessionSyncState, leaderSyncState)
   }
 
   /**
    * Returns an Effect Stream of sync status updates.
    *
-   * Emits the current status immediately and then whenever the sync state changes.
+   * Emits the current status immediately and then whenever either boundary changes.
    * Use this for Effect-based workflows or when you need more control over the stream.
    *
    * @example
@@ -1074,11 +1083,17 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * ```
    */
   syncStatusStream = (): Stream.Stream<SyncStatus> => {
-    const syncStateSubscribable = this[StoreInternalsSymbol].syncProcessor.syncState
+    const sessionSyncState = this[StoreInternalsSymbol].syncProcessor.syncState
+    const leaderSyncStateChanges = SubscriptionRef.changes(this.leaderSyncStateRef).pipe(
+      Stream.filter((syncState): syncState is SyncState.SyncState => syncState !== undefined),
+    )
 
-    return Stream.concat(
-      Stream.fromEffect(syncStateSubscribable.pipe(Effect.map(this.makeSyncStatus))),
-      syncStateSubscribable.changes.pipe(Stream.map(this.makeSyncStatus)),
+    return Stream.merge(sessionSyncState.changes, leaderSyncStateChanges).pipe(
+      Stream.mapEffect(() =>
+        Effect.all([sessionSyncState, SubscriptionRef.get(this.leaderSyncStateRef)]).pipe(
+          Effect.map(([session, leader]) => this.makeSyncStatus(session, this.requireLeaderSyncState(leader))),
+        ),
+      ),
     )
   }
 
@@ -1115,20 +1130,32 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     }
   }
 
-  private makeSyncStatus = (syncState: {
-    localHead: EventSequenceNumber.Client.Composite
-    upstreamHead: EventSequenceNumber.Client.Composite
-    pending: readonly any[]
-  }): SyncStatus => {
-    const pendingCount = syncState.pending.length
+  private makeSyncStatus = (session: SyncState.SyncState, leader: SyncState.SyncState): SyncStatus => {
+    const pendingCount = session.pending.length
+    const backendPendingCount = leader.pending.filter(
+      (event) => this.schema.eventsDefsMap.get(event.name)?.options.clientOnly !== true,
+    ).length
+    const leaderObservationCoversSession = EventSequenceNumber.Client.isGreaterThanOrEqual(
+      leader.localHead,
+      session.upstreamHead,
+    )
 
     return {
-      localHead: EventSequenceNumber.Client.toString(syncState.localHead),
-      upstreamHead: EventSequenceNumber.Client.toString(syncState.upstreamHead),
+      localHead: EventSequenceNumber.Client.toString(session.localHead),
+      upstreamHead: EventSequenceNumber.Client.toString(session.upstreamHead),
       pendingCount,
       isSynced: pendingCount === 0,
+      backendHead: EventSequenceNumber.Client.toString(leader.upstreamHead),
+      backendPendingCount,
+      isBackendSynced: pendingCount === 0 && backendPendingCount === 0 && leaderObservationCoversSession,
     }
   }
+
+  private getLeaderSyncState = (): SyncState.SyncState =>
+    this.leaderSyncStateRef.pipe(SubscriptionRef.get, Effect.runSync, this.requireLeaderSyncState)
+
+  private requireLeaderSyncState = (syncState: SyncState.SyncState | undefined): SyncState.SyncState =>
+    syncState ?? shouldNeverHappen('Leader sync state was not initialized before Store use')
 
   /**
    * This can be used in combination with `skipRefresh` when committing events.

--- a/packages/@livestore/react/src/useSyncStatus.ts
+++ b/packages/@livestore/react/src/useSyncStatus.ts
@@ -5,14 +5,16 @@ import type { Store, SyncStatus } from '@livestore/livestore'
 /**
  * React hook that subscribes to sync status changes.
  *
- * Returns the current synchronization status between the client session and
- * the leader thread. The component re-renders whenever the sync status changes.
+ * Returns the current synchronization status across the session-to-leader and
+ * leader-to-backend boundaries. The component re-renders whenever either
+ * boundary changes. The status describes latest-observed delivery convergence,
+ * not sync-worker health or future progress.
  *
  * @example
  * ```tsx
  * function SyncIndicator() {
  *   const status = store.useSyncStatus()
- *   return <span>{status.isSynced ? '✓ Synced' : `Syncing (${status.pendingCount} pending)...`}</span>
+ *   return <span>{status.isBackendSynced ? '✓ Backend confirmed' : 'Awaiting confirmation...'}</span>
  * }
  * ```
  *
@@ -28,7 +30,7 @@ export const useSyncStatus = (options: { store: Store<any> }): SyncStatus => {
     return store.subscribeSyncStatus(setStatus)
   }, [store])
 
-  React.useDebugValue(`LiveStore:useSyncStatus:${status.isSynced === true ? 'synced' : 'pending'}`)
+  React.useDebugValue(`LiveStore:useSyncStatus:${status.isBackendSynced === true ? 'backend-synced' : 'pending'}`)
 
   return status
 }


### PR DESCRIPTION
## Problem

`SyncStatus.isSynced` only reports session-to-leader delivery. A session can therefore report synced while the leader still has events awaiting sync-backend confirmation.

## Solution

Add three flat fields to the existing synchronous status:

- `backendHead`: latest backend-confirmed head observed through the leader
- `backendPendingCount`: leader events still awaiting backend confirmation
- `isBackendSynced`: latest-observed convergence across both propagation boundaries

The Store seeds and maintains a local cache from the leader's existing sync-state getter and stream, so this adds no transport protocol. A session watermark prevents stale cached leader state from producing a false positive. `syncStatusStream()` reacts to changes at either boundary.

The first commit contains deterministic regression tests; the second contains the implementation, derived docs, changelog, changeset, and delta resolution.

## Trade-offs

This is a latest-observed synchronous delivery snapshot. It may briefly remain false while a newer leader observation is in transit, but it must not report true from stale leader state. It is not sync-worker health: converged observed heads may leave `isBackendSynced` true while a terminal worker is parked, and the field does not guarantee future progress.

This PR does not add worker-health state, per-event receipts, or backend delivery-failure classification.

## Validation

- `pnpm exec vitest run packages/@livestore/livestore/src/store/store-sync-status.test.ts` (2 passed)
- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` (8 passed)
- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check`
- `devenv tasks run test:unit`
- `devenv tasks run test:integration:sync-provider:mock`
- `DEVENV_TASK_PASSTHROUGH=1 devenv tasks run docs:build`

## Stack

- Layer 1: #1554 — synchronous Store contract
- Layer 2: this PR — regression tests and implementation

Depends on #1554.
Closes #1553.

Related clarification: #1580.
