### PR TITLE
Prevent passive ServerAhead stalls with an active catch-up contract

### DIFF
--- a/context/02-system/03-sync/02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0001-prefix-fence-unresolved-upstream.md
@@ -53,7 +53,9 @@ transaction spanning the session, leader, and backend.
 - Upstream admission must accept or reject a batch as a unit and acknowledge
   only after admission completes. Defensive generation/session fencing at the
   receiver prevents a buggy downstream from bypassing its prefix.
-- The existing leader→backend `ServerAheadError` path already approximates the
-  chosen state machine by parking until pull interrupts and reseeds it. The
-  client-session path now uses the same park, reconcile, reseed, and resume
-  transition; the leader additionally rejects non-contiguous pushed batches.
+- The leader→backend `ServerAheadError` path uses the same fence, reconcile,
+  reseed, and resume transition. Decision
+  [0003](./0003-active-server-ahead-catchup.md) supersedes its passive wake-up
+  mechanism by requiring the processor to replace backend pull actively. The
+  client-session path retains pull-driven recovery; the leader additionally
+  rejects non-contiguous pushed batches.

--- a/context/02-system/03-sync/02-processors/.decisions/0003-active-server-ahead-catchup.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0003-active-server-ahead-catchup.md
@@ -1,0 +1,52 @@
+# 0003 — Actively replace backend pull after ServerAhead
+
+Status: accepted ([#1462](https://github.com/livestorejs/livestore/issues/1462)
+reduction evidence and maintainer direction, 2026-08-21).
+
+## Context
+
+The backend can durably accept a push while the corresponding pull publication
+never reaches that leader. If another client then advances the backend, the
+original leader's next push starts from a stale parent and receives
+`ServerAheadError`. The push processor correctly preserves its unresolved
+prefix, but passive parking assumes that its existing pull will eventually
+deliver the missing history. That assumption is not guaranteed after a lost
+publication, so an otherwise healthy leader can stop propagating later pending
+events permanently.
+
+The processor already persists an authoritative backend cursor and can rebuild
+its backend-push FIFO after pull confirmation or rebase. The missing transition
+is an active way to obtain history after `ServerAheadError` without weakening
+the prefix fence or depending on provider-specific server state.
+
+## Options
+
+- **(a) Replace the processor-owned backend pull from its persisted cursor —
+  chosen.** `ServerAheadError` requests catch-up, the current pull generation is
+  retired, and one replacement pull is started from the newly read persisted
+  cursor. The rejected push remains fenced until pull confirms or rebases it.
+- **(b) Keep parking until the current pull publishes something.** Rejected:
+  the publication that would wake the processor may be the event already lost,
+  leaving no future traffic guaranteed to arrive.
+- **(c) Ask the provider to replay from the rejected push's reported backend
+  head.** Rejected as the core recovery mechanism: the reported head is not
+  event history, provider metadata is opaque, and provider-targeted replay
+  would expand the wire contract and adapter responsibilities.
+- **(d) Treat an exact duplicate push as an acknowledgement.** Deferred as
+  independent protocol hardening. It can reduce ambiguity for a retried
+  accepted batch, but it does not recover intervening history or replace
+  pull-based confirmation of the complete pending prefix.
+
+## Consequences
+
+- The processor, not a specific sync-provider adapter, owns recovery from the
+  shared `ServerAheadError` contract.
+- The persisted backend cursor remains authoritative. A server-head value in
+  the error is only evidence that catch-up is required.
+- Pull replacement has a single owner: the old generation is retired before
+  the next starts, and concurrent replacement requests coalesce.
+- Backend pushing remains fenced until normal pull merge confirms or rebases
+  the unresolved prefix; catch-up never skips the merge core.
+- Provider publication guarantees, typed transport outcomes, and duplicate
+  acceptance can be strengthened separately without being prerequisites for
+  forward progress here.

--- a/context/02-system/03-sync/02-processors/.decisions/0003-active-server-ahead-catchup.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0003-active-server-ahead-catchup.md
@@ -1,7 +1,8 @@
 # 0003 — Actively replace backend pull after ServerAhead
 
 Status: accepted ([#1462](https://github.com/livestorejs/livestore/issues/1462)
-reduction evidence and maintainer direction, 2026-08-21).
+reduction evidence and maintainer direction, 2026-08-21; convergence review,
+2026-08-22).
 
 ## Context
 
@@ -23,8 +24,11 @@ the prefix fence or depending on provider-specific server state.
 
 - **(a) Replace the processor-owned backend pull from its persisted cursor —
   chosen.** `ServerAheadError` requests catch-up, the current pull generation is
-  retired, and one replacement pull is started from the newly read persisted
-  cursor. The rejected push remains fenced until pull confirms or rebases it.
+  retired at the next between-application boundary, and one replacement pull is
+  started from the newly read persisted cursor. The rejected push remains
+  fenced until pull confirms or rebases it. A finite generation may already be
+  absent when catch-up is requested; the same persistent owner starts its
+  replacement.
 - **(b) Keep parking until the current pull publishes something.** Rejected:
   the publication that would wake the processor may be the event already lost,
   leaving no future traffic guaranteed to arrive.
@@ -44,9 +48,16 @@ the prefix fence or depending on provider-specific server state.
 - The persisted backend cursor remains authoritative. A server-head value in
   the error is only evidence that catch-up is required.
 - Pull replacement has a single owner: the old generation is retired before
-  the next starts, and concurrent replacement requests coalesce.
+  the next starts, and concurrent replacement requests coalesce. Retirement
+  waits for an in-flight canonical pull application. If that application fails,
+  its terminal failure wins and no replacement masks it.
+- The pull owner outlives a normally completed finite generation and remains
+  parked for later catch-up requests.
 - Backend pushing remains fenced until normal pull merge confirms or rebases
   the unresolved prefix; catch-up never skips the merge core.
+- Only positively identified connectivity failures are retried. `UnknownError`
+  remains terminal; `ServerAheadError` is a reconciliation signal rather than a
+  retryable transport failure.
 - Provider publication guarantees, typed transport outcomes, and duplicate
   acceptance can be strengthened separately without being prerequisites for
   forward progress here.

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
@@ -1,0 +1,37 @@
+# DELTA-002 — ServerAhead recovery passively waits for pull publication
+
+Status: open
+
+## Divergence
+
+LS.SYS.SYNC.PROC-R01 requires `ServerAheadError` to trigger an active backend
+pull replacement while preserving the unresolved prefix fence. The current
+leader push processor instead parks on `Effect.never` and can only resume when
+the existing pull path happens to reconcile and restart it
+(`packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts`).
+
+If the backend accepted and persisted the preceding push but its pull
+publication was lost, another client can advance the backend before the
+original leader pushes again. That retry receives `ServerAheadError`, yet the
+publication needed to reconcile its stale cursor may never arrive on the
+existing pull. Later pending events remain locally materialized but cannot
+cross the fenced backend boundary.
+
+Evidence: deterministic incident model and reduction in
+[#1462](https://github.com/livestorejs/livestore/issues/1462).
+
+## VRS
+
+Violates [requirements.md](../requirements.md) LS.SYS.SYNC.PROC-R01 and the
+active catch-up transition in
+[decision 0003](../.decisions/0003-active-server-ahead-catchup.md).
+
+## Implementation Contract
+
+On `ServerAheadError`, keep the rejected backend prefix fenced and request a
+fresh pull from the persisted backend cursor. Retire the current pull
+generation before starting its replacement, coalesce concurrent requests, and
+resume backend pushing only after ordinary pull confirmation or rebase has
+reseeded the FIFO from current pending. Add deterministic fault injection that
+separates backend push admission from pull publication and proves recovery
+without relying on timing or a leader restart.

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
@@ -30,8 +30,11 @@ active catch-up transition in
 
 On `ServerAheadError`, keep the rejected backend prefix fenced and request a
 fresh pull from the persisted backend cursor. Retire the current pull
-generation before starting its replacement, coalesce concurrent requests, and
-resume backend pushing only after ordinary pull confirmation or rebase has
-reseeded the FIFO from current pending. Add deterministic fault injection that
-separates backend push admission from pull publication and proves recovery
-without relying on timing or a leader restart.
+generation at an explicit between-application boundary before starting its
+replacement, coalesce concurrent requests, and keep the single owner available
+after finite pull completion. An in-flight canonical application completes or
+fails before retirement; a terminal application failure must not be masked by
+replacement. Resume backend pushing only after ordinary pull confirmation or
+rebase has reseeded the FIFO from current pending. Add deterministic fault
+injection that separates backend push admission from pull publication and
+proves recovery without relying on timing or a leader restart.

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -18,9 +18,15 @@ Builds on [../requirements.md](../requirements.md) and
 - **LS.SYS.SYNC.PROC-R01 Bounded transient-only retry:** Backend pushes are
   batch-bounded and retried with capped exponential backoff only on
   transient errors (offline/unknown); `ServerAheadError` is never retried in
-  place — the push fiber parks and yields to the pull-driven rebase restart
-  (spec: [Leader Sync Processor](./spec.md#leader-sync-processor)). Adopted
-  2026-07-16 (interview). `refines: LS.SYS.SYNC-R03`
+  place. The unresolved backend prefix remains fenced while the processor
+  actively replaces its backend pull from the persisted cursor. Only pull
+  confirmation or rebase may reseed backend pushing from current pending and
+  resume it. At most one backend-pull generation may be active during this
+  recovery. Adopted 2026-07-16 (interview); active catch-up clarified
+  2026-08-21 from [#1462](https://github.com/livestorejs/livestore/issues/1462)
+  reduction evidence and maintainer direction (see
+  [decision 0003](./.decisions/0003-active-server-ahead-catchup.md)).
+  `refines: LS.SYS.SYNC-R03`
 - **LS.SYS.SYNC.PROC-R02 Pull precedence:** Backend-pull application and
   local-push application are mutually exclusive, and the pull side takes
   precedence when both contend (spec: [Leader Sync

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -17,14 +17,21 @@ Builds on [../requirements.md](../requirements.md) and
 
 - **LS.SYS.SYNC.PROC-R01 Bounded transient-only retry:** Backend pushes are
   batch-bounded and retried with capped exponential backoff only on
-  transient errors (offline/unknown); `ServerAheadError` is never retried in
-  place. The unresolved backend prefix remains fenced while the processor
-  actively replaces its backend pull from the persisted cursor. Only pull
-  confirmation or rebase may reseed backend pushing from current pending and
-  resume it. At most one backend-pull generation may be active during this
+  positively identified connectivity errors. `UnknownError` surfaces as a
+  terminal failure, and `ServerAheadError` is never retried in place. The
+  unresolved backend prefix remains fenced while the processor actively
+  replaces its backend pull from the persisted cursor. Replacement retires the
+  current generation only between canonical pull applications; an in-flight
+  application finishes or fails first, and its terminal failure takes
+  precedence over restart. The single pull owner remains available after a
+  finite pull so a later catch-up request can start another generation. Only
+  pull confirmation or rebase may reseed backend pushing from current pending
+  and resume it. At most one backend-pull generation may be active during this
   recovery. Adopted 2026-07-16 (interview); active catch-up clarified
   2026-08-21 from [#1462](https://github.com/livestorejs/livestore/issues/1462)
-  reduction evidence and maintainer direction (see
+  reduction evidence and maintainer direction; retirement precedence and
+  terminal-error classification clarified 2026-08-22 from convergence review
+  (see
   [decision 0003](./.decisions/0003-active-server-ahead-catchup.md)).
   `refines: LS.SYS.SYNC-R03`
 - **LS.SYS.SYNC.PROC-R02 Pull precedence:** Backend-pull application and

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -58,9 +58,12 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   `toGlobal()` batches. Retry: `Schedule.exponential(1s)` clamped to 30s,
   no jitter, no attempt cap, and only for transient errors
   (`IsOfflineError`/`UnknownError`, `:627-631`). `ServerAheadError` is NOT
-  retried in place: the push fiber parks on `Effect.never` (`:617-621`)
-  and the pull side interrupts it — `restartBackendPushing` (`:729-741`)
-  clears the fiber, re-seeds the queue from rebased pending, restarts.
+  retried in place: it fences that unresolved prefix and requests a fresh
+  backend pull from the persisted cursor. Pull confirmation or rebase then
+  interrupts the fenced push, re-seeds its queue from current pending, and
+  restarts it. A `ServerAheadError` therefore cannot depend on an already-lost
+  live publication to wake the push path (see
+  [.decisions/0003](./.decisions/0003-active-server-ahead-catchup.md)).
 - **Backend pulling** (`:397-573`): cursor =
   `Eventlog.getSyncBackendCursorInfo(remoteHead)` — the persisted backend
   head (`SYNC_STATUS_TABLE.head`) plus provider-opaque `syncMetadataJson`
@@ -70,7 +73,12 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   sync metadata for confirmed events; rebase additionally rolls back
   state+eventlog rows and re-seeds pushing from rebased pending
   (`:466-516`). Backend head advances via `Eventlog.updateBackendHead`
-  (`:462-464`).
+  (`:462-464`). Normal operation and `ServerAheadError` recovery share one
+  pull owner: recovery retires the current pull generation before starting a
+  replacement, so repeated recovery requests coalesce rather than create
+  overlapping live pulls. Each replacement derives its cursor anew from the
+  persisted backend head; the error's reported head is a catch-up signal, not
+  event data and not a cursor substitute.
 - **Pull precedence** (`:241, 393, 408-438`): a 1-permit semaphore
   (`localPushBackendPullMutex`) makes local-push application and pull-chunk
   application mutually exclusive; the pull side holds the permit for a

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -56,8 +56,9 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 - **Backend pushing** (`:575-637`): drains
   `takeBetween(1, backendPushBatchSize)` (default 50, `:215`), pushes
   `toGlobal()` batches. Retry: `Schedule.exponential(1s)` clamped to 30s,
-  no jitter, no attempt cap, and only for transient errors
-  (`IsOfflineError`/`UnknownError`, `:627-631`). `ServerAheadError` is NOT
+  no jitter, no attempt cap, and only for positively identified connectivity
+  errors (`IsOfflineError`, `:700-708`). `UnknownError` is terminal.
+  `ServerAheadError` is NOT
   retried in place: it fences that unresolved prefix and requests a fresh
   backend pull from the persisted cursor. Pull confirmation or rebase then
   interrupts the fenced push, re-seeds its queue from current pending, and
@@ -78,7 +79,11 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   replacement, so repeated recovery requests coalesce rather than create
   overlapping live pulls. Each replacement derives its cursor anew from the
   persisted backend head; the error's reported head is a catch-up signal, not
-  event data and not a cursor substitute.
+  event data and not a cursor substitute. Pull application and generation
+  retirement share an explicit coordination boundary: retirement waits until
+  the current canonical application completes, and a terminal application
+  failure prevents replacement. After a finite pull completes, the owner stays
+  parked so a later `ServerAheadError` can start a new generation.
 - **Pull precedence** (`:241, 393, 408-438`): a 1-permit semaphore
   (`localPushBackendPullMutex`) makes local-push application and pull-chunk
   application mutually exclusive; the pull side holds the permit for a

--- a/context/02-system/03-sync/spec.md
+++ b/context/02-system/03-sync/spec.md
@@ -68,7 +68,7 @@ SyncBackend = {
 | Family | Members | Recovery |
 | --- | --- | --- |
 | `RejectedPushError` (leader push validation) | `NonMonotonicBatchError`, `StaleRebaseGenerationError`, `LeaderAheadError` | rebase and retry |
-| Backend | `IsOfflineError`, `BackendIdMismatchError`, `ServerAheadError` | wait/reconnect; `ServerAheadError` yields to the pull-driven rebase ([02-processors](./02-processors/spec.md)) |
+| Backend | `IsOfflineError`, `BackendIdMismatchError`, `ServerAheadError` | wait/reconnect; `ServerAheadError` fences the push and actively replaces pull from the persisted cursor until confirmation or rebase ([02-processors](./02-processors/spec.md)) |
 | Transport | `OversizeChunkItemError` | surface (payload cannot be chunked) |
 | Defects | `UnknownError` | surface, don't retry |
 


### PR DESCRIPTION
## Problem

A backend push can be accepted and persisted while its pull echo is lost. If another client advances the backend, the original leader then pushes from a stale parent and receives `ServerAheadError`. Passive parking cannot guarantee progress because the publication needed to wake reconciliation may never arrive.

## Solution

Define the provider-neutral processor contract before changing runtime behavior:

- treat `ServerAheadError` as reconciliation, never as an `UnknownError` retry;
- retry only positively identified connectivity failures; `UnknownError` remains terminal;
- keep the unresolved prefix fenced until ordinary pull confirmation or rebase reseeds current pending;
- retain one persistent pull owner, including after a finite pull completes;
- replace from the persisted cursor, coalescing requests and never overlapping pull generations;
- retire only at a between-application boundary: an in-flight canonical application finishes or fails first, and its terminal failure prevents replacement.

Decision 0003 remains the owning processor decision. The contract is provider-neutral: #1537's Cloudflare atomic publication reduces one failure window, but does not replace core recovery. Provider receipts, general retry configuration, duplicate acceptance, and crash/cross-database atomicity remain separate work.

The stacked implementation PR #1576 resolves the recorded delta.

## Validation

- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` — 8 passed
- The stacked implementation additionally passes repository lint, TypeScript, unit, and mock-provider integration gates.

### Recovery invariant

```text
accepted push --X pull publication
       backend advances elsewhere
stale next push -> ServerAhead
                   -> fence prefix + request catch-up
                   -> finish/fail in-flight canonical application
                   -> replace one pull from persisted cursor
                   -> confirm/rebase before resuming push
```

## Related issues and foundations

- #1462 records the accepted-push/lost-confirmation production incident addressed by this contract.
- #1394 records the stale-parent reconnect deadlock that exposes the same passive-wait mismatch.
- #1365 records a related WebSocket connection-loss deadlock; orphaned RPC resume remains separate.
- #1530 supplies the unresolved-prefix fence and explicit leader reservations preserved here.
- #1537 supplies complementary Cloudflare push/publication atomicity.
- #1545 supplies reconstructed DO-RPC client boot catch-up.
- #1532 tracks separate pull crash-atomicity work.
