### PR TITLE
Recover ServerAhead stalls by restarting backend pull

### DIFF
--- a/.changeset/steady-server-ahead-catchup.md
+++ b/.changeset/steady-server-ahead-catchup.md
@@ -1,0 +1,5 @@
+---
+"@livestore/common": patch
+---
+
+Actively restart backend pull after `ServerAheadError` so a lost publication cannot permanently fence later pending events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Changed
 
+- **Sync recovery:** A leader that receives `ServerAheadError` now actively
+  restarts backend pull from its persisted cursor. Accepted pushes whose live
+  publication was lost can be confirmed or rebased without permanently
+  blocking later pending events
+  ([#1462](https://github.com/livestorejs/livestore/issues/1462)).
 - **Cloudflare sync:** Serialize push admission through pull publication so an
   accepted event cannot advance the backend head without notifying subscribers
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
@@ -1,6 +1,6 @@
 # DELTA-002 — ServerAhead recovery passively waits for pull publication
 
-Status: open
+Status: resolved (2026-08-21)
 
 ## Divergence
 
@@ -38,3 +38,20 @@ replacement. Resume backend pushing only after ordinary pull confirmation or
 rebase has reseeded the FIFO from current pending. Add deterministic fault
 injection that separates backend push admission from pull publication and
 proves recovery without relying on timing or a leader restart.
+
+## Resolution
+
+The leader now sends `ServerAheadError` through a capacity-one restart signal
+and stops the sole backend-push worker. A single pull owner interrupts and
+awaits the current generation before evaluating a replacement pull, whose
+cursor is re-read from the persisted backend head. Normal pull merge then
+confirms or rebases the fenced prefix, rebuilds the push FIFO from live pending,
+and starts pushing again.
+
+The mock backend now allocates a subscriber per evaluated live pull and
+atomically snapshots persisted history when that pull starts. Deterministic
+fault controls can persist a successful push or external advance without live
+publication. The regression composes both faults, obtains a natural
+`ServerAheadError`, observes the replacement pull from the stale persisted
+cursor, and proves one pull generation, one materialization per event, and an
+empty pending suffix after recovery.

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-002-server-ahead-passive-park.md
@@ -42,11 +42,16 @@ proves recovery without relying on timing or a leader restart.
 ## Resolution
 
 The leader now sends `ServerAheadError` through a capacity-one restart signal
-and stops the sole backend-push worker. A single pull owner interrupts and
-awaits the current generation before evaluating a replacement pull, whose
-cursor is re-read from the persisted backend head. Normal pull merge then
-confirms or rebases the fenced prefix, rebuilds the push FIFO from live pending,
-and starts pushing again.
+and stops the sole backend-push worker. A persistent pull owner marks the active
+generation for retirement, waits at a canonical-application fence, and allows
+an application already inside that fence to finish. Pull cleanup then runs
+outside the fence, the owner inspects the generation exit, and a terminal
+application failure wins instead of being masked by replacement. Otherwise the
+owner evaluates one replacement pull whose cursor is re-read from the persisted
+backend head. The same owner remains parked after a finite pull. Normal pull
+merge confirms or rebases the fenced prefix, rebuilds the push FIFO from live
+pending, and starts pushing again. Backend push retry is limited to typed
+connectivity failure; `UnknownError` is terminal.
 
 The mock backend now allocates a subscriber per evaluated live pull and
 atomically snapshots persisted history when that pull starts. Deterministic
@@ -54,4 +59,7 @@ fault controls can persist a successful push or external advance without live
 publication. The regression composes both faults, obtains a natural
 `ServerAheadError`, observes the replacement pull from the stale persisted
 cursor, and proves one pull generation, one materialization per event, and an
-empty pending suffix after recovery.
+empty pending suffix after recovery. Additional regressions pause canonical
+application immediately after cursor advancement to prove retirement cannot
+truncate the chunk, and prove a later `ServerAheadError` restarts a completed
+finite pull.

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -53,11 +53,11 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   leader-side contiguous-chain validation rejects a later suffix that bypasses
   the fence (see resolved
   [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md)).
-- **Backend pushing** (`:647-715`): drains
-  `takeBetween(1, backendPushBatchSize)` (default 50, `:215`), pushes
+- **Backend pushing** (`:667-740`): drains
+  `takeBetween(1, backendPushBatchSize)` (default 50, `:227`), pushes
   `toGlobal()` batches. Retry: `Schedule.exponential(1s)` clamped to 30s,
   no jitter, no attempt cap, and only for positively identified connectivity
-  errors (`IsOfflineError`, `:700-708`). `UnknownError` is terminal.
+  errors (`IsOfflineError`, `:724-733`). `UnknownError` is terminal.
   `ServerAheadError` is NOT
   retried in place: it fences that unresolved prefix and requests a fresh
   backend pull from the persisted cursor. Pull confirmation or rebase then
@@ -65,7 +65,7 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   restarts it. A `ServerAheadError` therefore cannot depend on an already-lost
   live publication to wake the push path (see
   [.decisions/0003](./.decisions/0003-active-server-ahead-catchup.md)).
-- **Backend pulling** (`:400-645`): cursor =
+- **Backend pulling** (`:469-665`): cursor =
   `Eventlog.getSyncBackendCursorInfo(remoteHead)` — the persisted backend
   head (`SYNC_STATUS_TABLE.head`) plus provider-opaque `syncMetadataJson`
   (`eventlog.ts:280-300`). Each chunk merges with
@@ -73,8 +73,8 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   current pending, offers the payload to session pull queues, and persists
   sync metadata for confirmed events; rebase additionally rolls back
   state+eventlog rows and re-seeds pushing from rebased pending
-  (`:466-516`). Backend head advances via `Eventlog.updateBackendHead`
-  (`:462-464`). Normal operation and `ServerAheadError` recovery share one
+  (`:547-615`). Backend head advances via `Eventlog.updateBackendHead`
+  (`:540-545`). Normal operation and `ServerAheadError` recovery share one
   pull owner: recovery retires the current pull generation before starting a
   replacement, so repeated recovery requests coalesce rather than create
   overlapping live pulls. Each replacement derives its cursor anew from the
@@ -83,7 +83,8 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   retirement share an explicit coordination boundary: retirement waits until
   the current canonical application completes, and a terminal application
   failure prevents replacement. After a finite pull completes, the owner stays
-  parked so a later `ServerAheadError` can start a new generation.
+  parked so a later `ServerAheadError` can start a new generation
+  (`:838-915`).
 - **Pull precedence** (`:241, 393, 408-438`): a 1-permit semaphore
   (`localPushBackendPullMutex`) makes local-push application and pull-chunk
   application mutually exclusive; the pull side holds the permit for a

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -53,7 +53,7 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   leader-side contiguous-chain validation rejects a later suffix that bypasses
   the fence (see resolved
   [DELTA-001](./.delta/DELTA-001-session-rejection-prefix-bypass.md)).
-- **Backend pushing** (`:575-637`): drains
+- **Backend pushing** (`:647-715`): drains
   `takeBetween(1, backendPushBatchSize)` (default 50, `:215`), pushes
   `toGlobal()` batches. Retry: `Schedule.exponential(1s)` clamped to 30s,
   no jitter, no attempt cap, and only for positively identified connectivity
@@ -65,7 +65,7 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   restarts it. A `ServerAheadError` therefore cannot depend on an already-lost
   live publication to wake the push path (see
   [.decisions/0003](./.decisions/0003-active-server-ahead-catchup.md)).
-- **Backend pulling** (`:397-573`): cursor =
+- **Backend pulling** (`:400-645`): cursor =
   `Eventlog.getSyncBackendCursorInfo(remoteHead)` — the persisted backend
   head (`SYNC_STATUS_TABLE.head`) plus provider-opaque `syncMetadataJson`
   (`eventlog.ts:280-300`). Each chunk merges with
@@ -98,7 +98,7 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   `../../02-state/01-sqlite/`). Local push acknowledgements are completed only
   after the batch is materialized, published in leader sync state, offered to
   session pull queues, and queued for backend propagation.
-- **Boot** (`:684-755`): initial sync state rehydrates from the eventlog
+- **Boot** (`:758-860`): initial sync state rehydrates from the eventlog
   (`../../04-runtime/spec.md` Leadership Handover); error routing via
   `onError: ignore|shutdown` and `BackendIdMismatchError` handling
   (`reset|shutdown|ignore`; reset clears local databases, `:1060-1123`).

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -10,11 +10,13 @@ import {
   Duration,
   Effect,
   Exit,
+  Fiber,
   FiberHandle,
   Layer,
   Option,
   Predicate,
   Queue,
+  Ref,
   ReadonlyArray,
   References,
   Result,
@@ -200,6 +202,8 @@ interface Options {
     }
     readonly hooks?: {
       readonly localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
+      readonly backendPullCursorAdvanced?: (head: EventSequenceNumber.Client.Composite) => Effect.Effect<void>
+      readonly backendPullRestartRequested?: () => Effect.Effect<void>
     }
   }
 }
@@ -250,6 +254,10 @@ export const make = Effect.fnUntraced(function* ({
   const reservedLocalPushItems = new Set<LocalPushQueueItem>()
   // Ensures mutual exclusion between local push and backend pull processing.
   const localPushBackendPullMutex = yield* Semaphore.make(1)
+  // Pull replacement may interrupt transport work, but never canonical application. This poison-agnostic
+  // boundary also preserves the original application failure when retirement and failure race.
+  const backendPullApplicationFence = yield* Semaphore.make(1)
+  const backendPullRetirementRequested = yield* Ref.make(false)
   // Serializes validation, queue admission, and prefix-fence reconciliation.
   const pushAdmissionSemaphore = yield* Semaphore.make(1)
 
@@ -501,100 +509,113 @@ export const make = Effect.fnUntraced(function* ({
           pullMutexHeld = true
         }
 
-        const chunkExit = yield* Effect.gen(function* () {
-          const syncState = yield* Effect.fromNullishOr(yield* SubscriptionRef.get(syncStateSref)).pipe(
-            Effect.orDieDebugger,
-          )
+        const chunkExit = yield* backendPullApplicationFence
+          .withPermits(1)(
+            Effect.gen(function* () {
+              // Once retirement is requested, no new canonical application may begin. An application
+              // that entered before the flag was set is allowed to finish and retain its real exit.
+              if ((yield* Ref.get(backendPullRetirementRequested)) === true) return yield* Effect.interrupt
 
-          yield* Effect.annotateCurrentSpan({
-            'merge.newEventsCount': newEvents.length,
-            ...(TRACE_VERBOSE === true ? { 'merge.newEvents': jsonStringify(newEvents) } : {}),
-          })
-
-          const mergeResult = yield* SyncState.merge({
-            syncState,
-            payload: SyncState.PayloadUpstreamAdvance.make({ newEvents }),
-            isClientOnlyEvent,
-            isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
-            ignoreClientOnlyEvents: true,
-          })
-
-          if (mergeResult._tag === 'reject') {
-            return yield* Effect.dieDebugger('The leader thread should never reject upstream advances')
-          }
-
-          const newBackendHead = newEvents.at(-1)!.seqNum
-
-          Eventlog.updateBackendHead(dbEventlog, newBackendHead)
-
-          if (mergeResult._tag === 'rebase') {
-            yield* Effect.spanEvent(`pull:rebase[${mergeResult.newSyncState.localHead.rebaseGeneration}]`, {
-              newEventsCount: newEvents.length,
-              ...(TRACE_VERBOSE === true ? { newEvents: jsonStringify(newEvents) } : {}),
-              rollbackCount: mergeResult.rollbackEvents.length,
-              ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-            })
-
-            const globalOrUnknownRebasedPendingEvents = mergeResult.newSyncState.pending.filter(
-              (e) => !isClientOnlyEvent(e),
-            )
-            yield* restartBackendPushing(globalOrUnknownRebasedPendingEvents)
-
-            if (mergeResult.rollbackEvents.length > 0) {
-              yield* rollback({
-                dbState: db,
-                dbEventlog,
-                eventNumsToRollback: mergeResult.rollbackEvents.map((_) => _.seqNum),
-              })
-              yield* stateHead
-                .set(mergeResult.rollbackEvents[0]!.parentSeqNum)
-                .pipe(Effect.mapError((cause) => MaterializeError.make({ cause })))
-            }
-
-            yield* connectedClientSessionPullQueues.offer({
-              payload: SyncState.payloadFromMergeResult(mergeResult),
-              leaderHead: mergeResult.newSyncState.localHead,
-            })
-          } else {
-            yield* Effect.spanEvent(`pull:advance`, {
-              newEventsCount: newEvents.length,
-              ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
-            })
-
-            // Ensure push fiber is active after advance by restarting with current pending (non-client-only) events
-            const globalOrUnknownPendingEvents = mergeResult.newSyncState.pending.filter((e) => !isClientOnlyEvent(e))
-            yield* restartBackendPushing(globalOrUnknownPendingEvents)
-
-            yield* connectedClientSessionPullQueues.offer({
-              payload: SyncState.payloadFromMergeResult(mergeResult),
-              leaderHead: mergeResult.newSyncState.localHead,
-            })
-
-            if (mergeResult.confirmedEvents.length > 0) {
-              // `mergeResult.confirmedEvents` don't contain the correct sync metadata, so we need to use
-              // `newEvents` instead which we filter via `mergeResult.confirmedEvents`
-              const confirmedNewEvents = newEvents.filter((event) =>
-                mergeResult.confirmedEvents.some((confirmedEvent) =>
-                  EventSequenceNumber.Client.isEqual(event.seqNum, confirmedEvent.seqNum),
-                ),
+              const syncState = yield* Effect.fromNullishOr(yield* SubscriptionRef.get(syncStateSref)).pipe(
+                Effect.orDieDebugger,
               )
-              yield* Eventlog.updateSyncMetadata(confirmedNewEvents).pipe(Effect.orDieDebugger)
-            }
-          }
 
-          // Removes the changeset rows which are no longer needed as we'll never have to rollback beyond this point
-          trimChangesetRows(db, newBackendHead)
+              yield* Effect.annotateCurrentSpan({
+                'merge.newEventsCount': newEvents.length,
+                ...(TRACE_VERBOSE === true ? { 'merge.newEvents': jsonStringify(newEvents) } : {}),
+              })
 
-          // The backend merge may advance or rebase the authoritative head. Realign the admission
-          // fence now so newly arriving pushes are validated against that history, not the pre-pull head.
-          yield* reconcilePushHead(mergeResult.newSyncState.localHead)
+              const mergeResult = yield* SyncState.merge({
+                syncState,
+                payload: SyncState.PayloadUpstreamAdvance.make({ newEvents }),
+                isClientOnlyEvent,
+                isEqualEvent: LiveStoreEvent.Client.isEqualEncoded,
+                ignoreClientOnlyEvents: true,
+              })
 
-          // Apply the merged events to storage before publishing the new sync state below, so readers
-          // cannot observe a leader head whose events have not yet been materialized.
-          yield* materializeEventsBatch({ batchItems: mergeResult.newEvents })
+              if (mergeResult._tag === 'reject') {
+                return yield* Effect.dieDebugger('The leader thread should never reject upstream advances')
+              }
 
-          yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
-        }).pipe(Effect.exit)
+              const newBackendHead = newEvents.at(-1)!.seqNum
+
+              Eventlog.updateBackendHead(dbEventlog, newBackendHead)
+              if (testing.hooks?.backendPullCursorAdvanced !== undefined) {
+                yield* testing.hooks.backendPullCursorAdvanced(newBackendHead)
+              }
+
+              if (mergeResult._tag === 'rebase') {
+                yield* Effect.spanEvent(`pull:rebase[${mergeResult.newSyncState.localHead.rebaseGeneration}]`, {
+                  newEventsCount: newEvents.length,
+                  ...(TRACE_VERBOSE === true ? { newEvents: jsonStringify(newEvents) } : {}),
+                  rollbackCount: mergeResult.rollbackEvents.length,
+                  ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+                })
+
+                const globalOrUnknownRebasedPendingEvents = mergeResult.newSyncState.pending.filter(
+                  (e) => !isClientOnlyEvent(e),
+                )
+                yield* restartBackendPushing(globalOrUnknownRebasedPendingEvents)
+
+                if (mergeResult.rollbackEvents.length > 0) {
+                  yield* rollback({
+                    dbState: db,
+                    dbEventlog,
+                    eventNumsToRollback: mergeResult.rollbackEvents.map((_) => _.seqNum),
+                  })
+                  yield* stateHead
+                    .set(mergeResult.rollbackEvents[0]!.parentSeqNum)
+                    .pipe(Effect.mapError((cause) => MaterializeError.make({ cause })))
+                }
+
+                yield* connectedClientSessionPullQueues.offer({
+                  payload: SyncState.payloadFromMergeResult(mergeResult),
+                  leaderHead: mergeResult.newSyncState.localHead,
+                })
+              } else {
+                yield* Effect.spanEvent(`pull:advance`, {
+                  newEventsCount: newEvents.length,
+                  ...(TRACE_VERBOSE === true ? { mergeResult: jsonStringify(mergeResult) } : {}),
+                })
+
+                // Ensure push fiber is active after advance by restarting with current pending (non-client-only) events
+                const globalOrUnknownPendingEvents = mergeResult.newSyncState.pending.filter(
+                  (e) => !isClientOnlyEvent(e),
+                )
+                yield* restartBackendPushing(globalOrUnknownPendingEvents)
+
+                yield* connectedClientSessionPullQueues.offer({
+                  payload: SyncState.payloadFromMergeResult(mergeResult),
+                  leaderHead: mergeResult.newSyncState.localHead,
+                })
+
+                if (mergeResult.confirmedEvents.length > 0) {
+                  // `mergeResult.confirmedEvents` don't contain the correct sync metadata, so we need to use
+                  // `newEvents` instead which we filter via `mergeResult.confirmedEvents`
+                  const confirmedNewEvents = newEvents.filter((event) =>
+                    mergeResult.confirmedEvents.some((confirmedEvent) =>
+                      EventSequenceNumber.Client.isEqual(event.seqNum, confirmedEvent.seqNum),
+                    ),
+                  )
+                  yield* Eventlog.updateSyncMetadata(confirmedNewEvents).pipe(Effect.orDieDebugger)
+                }
+              }
+
+              // Removes the changeset rows which are no longer needed as we'll never have to rollback beyond this point
+              trimChangesetRows(db, newBackendHead)
+
+              // The backend merge may advance or rebase the authoritative head. Realign the admission
+              // fence now so newly arriving pushes are validated against that history, not the pre-pull head.
+              yield* reconcilePushHead(mergeResult.newSyncState.localHead)
+
+              // Apply the merged events to storage before publishing the new sync state below, so readers
+              // cannot observe a leader head whose events have not yet been materialized.
+              yield* materializeEventsBatch({ batchItems: mergeResult.newEvents })
+
+              yield* SubscriptionRef.set(syncStateSref, mergeResult.newSyncState)
+            }),
+          )
+          .pipe(Effect.exit)
 
         if (Exit.isFailure(chunkExit) === true) {
           yield* releasePullMutexIfHeld
@@ -690,6 +711,9 @@ export const make = Effect.fnUntraced(function* ({
             // missing events, so start a fresh pull from our persisted cursor.
             yield* Effect.logDebug('handled backend-push-error (requesting pull restart)', { error })
             yield* TxQueue.offer(backendPullRestartQueue, undefined)
+            if (testing.hooks?.backendPullRestartRequested !== undefined) {
+              yield* testing.hooks.backendPullRestartRequested()
+            }
             return false
           }
 
@@ -703,10 +727,10 @@ export const make = Effect.fnUntraced(function* ({
           schedule: Schedule.exponential(Duration.seconds(1)).pipe(
             Schedule.modifyDelay(({ duration }) => Effect.succeed(Duration.min(duration, Duration.seconds(30)))), // Cap delay at 30s intervals.
           ),
-          while: (error) => error._tag === 'IsOfflineError' || error._tag === 'UnknownError',
+          while: (error) => error._tag === 'IsOfflineError',
         }),
         // This is needed to narrow the Error type. Our retry policy runs indefinitely, but Effect.retry does not narrow the Error type.
-        Effect.catchIf((error) => error._tag === 'IsOfflineError' || error._tag === 'UnknownError', Effect.die),
+        Effect.catchIf((error) => error._tag === 'IsOfflineError', Effect.die),
       )
 
       // Stop pushing so later events cannot skip this rejected batch. Pull reconciliation
@@ -811,7 +835,7 @@ export const make = Effect.fnUntraced(function* ({
         Effect.catchCause(maybeShutdownOnError),
       )
 
-      const backendPullingEffect = backgroundBackendPulling({
+      const backendPullingGenerationEffect = backgroundBackendPulling({
         restartBackendPushing: (filteredRebasedPending) =>
           Effect.gen(function* () {
             // Stop current pushing fiber
@@ -831,23 +855,58 @@ export const make = Effect.fnUntraced(function* ({
           // See https://github.com/Effect-TS/effect/issues/6122
           until: (error): error is Exclude<typeof error, IsOfflineError> => error._tag !== 'IsOfflineError',
         }),
-        Effect.catchTag('BackendIdMismatchError', handleBackendIdMismatchError),
-        Effect.catchCause(maybeShutdownOnError),
         // Needed to avoid `Fiber terminated with an unhandled error` logs which seem to happen because of the `Effect.retry` above.
         // This might be a bug in Effect. Only seems to happen in the browser.
         Effect.provideService(References.UnhandledLogLevel, undefined),
       )
 
-      // A restart request interrupts the current pull before starting another one from
-      // the persisted cursor, so two live pulls can never overlap.
+      const handleTerminalBackendPullExit = (
+        exit: Exit.Exit<void, BackendIdMismatchError | UnknownError | MaterializeError>,
+      ) =>
+        Exit.match(exit, {
+          onSuccess: () => Effect.void,
+          onFailure: (cause) =>
+            Effect.failCause(cause).pipe(
+              Effect.catchTag('BackendIdMismatchError', handleBackendIdMismatchError),
+              Effect.catchCause(maybeShutdownOnError),
+            ),
+        })
+
+      // The owner persists beyond finite generations. Restart retires transport work only after
+      // canonical application leaves its fence, then observes the generation exit before replacement.
       const backgroundBackendPullingSupervised = Effect.gen(function* () {
         while (true) {
+          const pullFiber = yield* backendPullingGenerationEffect.pipe(Effect.forkScoped)
           const outcome = yield* Effect.raceFirst(
-            backendPullingEffect.pipe(Effect.as('pull-ended' as const)),
+            Fiber.await(pullFiber).pipe(Effect.map((exit) => ({ _tag: 'pull-ended' as const, exit }))),
             TxQueue.take(backendPullRestartQueue).pipe(Effect.as('restart-requested' as const)),
           )
 
-          if (outcome === 'pull-ended') return
+          if (outcome !== 'restart-requested') {
+            if (Exit.isFailure(outcome.exit) === true) {
+              yield* handleTerminalBackendPullExit(outcome.exit)
+              return
+            }
+
+            // A finite pull may complete long before ServerAhead reveals missing publication.
+            yield* TxQueue.take(backendPullRestartQueue)
+            continue
+          }
+
+          yield* Ref.set(backendPullRetirementRequested, true)
+          // Wait for an application already inside the fence, then release the fence before
+          // interrupting so pull cleanup cannot deadlock on coordination owned by this processor.
+          yield* backendPullApplicationFence.withPermits(1)(Effect.void)
+          yield* Fiber.interrupt(pullFiber)
+          const retiredExit = yield* Fiber.await(pullFiber)
+          yield* Ref.set(backendPullRetirementRequested, false)
+          // Coalesce any request that arrived while the owner was retiring this generation.
+          yield* TxQueue.poll(backendPullRestartQueue)
+
+          if (Exit.isFailure(retiredExit) === true && Cause.hasInterruptsOnly(retiredExit.cause) === false) {
+            yield* handleTerminalBackendPullExit(retiredExit)
+            return
+          }
         }
       }).pipe(Effect.interruptible)
 

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -217,6 +217,8 @@ export const make = Effect.fnUntraced(function* ({
 }: Options) {
   const stateHead = yield* StateHead.StateHead
   const syncBackendPushQueue = yield* TxQueue.unbounded<LiveStoreEvent.Client.EncodedWithMeta>()
+  // One pending restart request is enough; extra requests can be dropped until it is handled.
+  const backendPullRestartQueue = yield* TxQueue.dropping<void>(1)
   const localPushBatchSize = params.localPushBatchSize ?? 10
   const backendPushBatchSize = params.backendPushBatchSize ?? 50
 
@@ -666,7 +668,7 @@ export const make = Effect.fnUntraced(function* ({
       // - Delay clamped at 30s (continues retrying at 30s)
       // - Resets automatically after successful push
       // TODO(metrics): expose counters/gauges for retry attempts and queue health via devtools/metrics
-      yield* Effect.gen(function* () {
+      const continuePushing = yield* Effect.gen(function* () {
         const iteration = yield* Schedule.CurrentMetadata
 
         const pushResult = yield* syncBackend.push(queueItems.map((_) => _.toGlobal())).pipe(Effect.result)
@@ -684,13 +686,17 @@ export const make = Effect.fnUntraced(function* ({
           })
           const error = pushResult.failure
           if (error._tag === 'ServerAheadError') {
-            // It's a core part of the sync protocol that the sync backend will emit a new pull chunk alongside the ServerAheadError
-            yield* Effect.logDebug('handled backend-push-error (waiting for interupt caused by pull)', { error })
-            return yield* Effect.never
+            // ServerAhead does not guarantee that the current live pull will publish the
+            // missing events, so start a fresh pull from our persisted cursor.
+            yield* Effect.logDebug('handled backend-push-error (requesting pull restart)', { error })
+            yield* TxQueue.offer(backendPullRestartQueue, undefined)
+            return false
           }
 
           return yield* error
         }
+
+        return true
       }).pipe(
         // Retry transient errors
         Effect.retry({
@@ -702,6 +708,10 @@ export const make = Effect.fnUntraced(function* ({
         // This is needed to narrow the Error type. Our retry policy runs indefinitely, but Effect.retry does not narrow the Error type.
         Effect.catchIf((error) => error._tag === 'IsOfflineError' || error._tag === 'UnknownError', Effect.die),
       )
+
+      // Stop pushing so later events cannot skip this rejected batch. Pull reconciliation
+      // will rebase the pending events and restart pushing.
+      if (continuePushing === false) return
     }
   }).pipe(Effect.interruptible)
 
@@ -801,9 +811,7 @@ export const make = Effect.fnUntraced(function* ({
         Effect.catchCause(maybeShutdownOnError),
       )
 
-      yield* FiberHandle.run(backendPushingFiberHandle, backendPushingEffect)
-
-      yield* backgroundBackendPulling({
+      const backendPullingEffect = backgroundBackendPulling({
         restartBackendPushing: (filteredRebasedPending) =>
           Effect.gen(function* () {
             // Stop current pushing fiber
@@ -828,8 +836,24 @@ export const make = Effect.fnUntraced(function* ({
         // Needed to avoid `Fiber terminated with an unhandled error` logs which seem to happen because of the `Effect.retry` above.
         // This might be a bug in Effect. Only seems to happen in the browser.
         Effect.provideService(References.UnhandledLogLevel, undefined),
-        Effect.forkScoped,
       )
+
+      // A restart request interrupts the current pull before starting another one from
+      // the persisted cursor, so two live pulls can never overlap.
+      const backgroundBackendPullingSupervised = Effect.gen(function* () {
+        while (true) {
+          const outcome = yield* Effect.raceFirst(
+            backendPullingEffect.pipe(Effect.as('pull-ended' as const)),
+            TxQueue.take(backendPullRestartQueue).pipe(Effect.as('restart-requested' as const)),
+          )
+
+          if (outcome === 'pull-ended') return
+        }
+      }).pipe(Effect.interruptible)
+
+      // Start pulling before pushing so a stale rehydrated batch can always request a restart.
+      yield* backgroundBackendPullingSupervised.pipe(Effect.forkScoped)
+      yield* FiberHandle.run(backendPushingFiberHandle, backendPushingEffect)
 
       return { initialLeaderHead: initialSyncState.localHead }
     }).pipe(Effect.withSpanScoped('@livestore/common:LeaderSyncProcessor:boot')),

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -72,6 +72,8 @@ export interface MakeLeaderThreadLayerParams {
       }
       hooks?: {
         localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
+        backendPullCursorAdvanced?: (head: EventSequenceNumber.Client.Composite) => Effect.Effect<void>
+        backendPullRestartRequested?: () => Effect.Effect<void>
       }
     }
   }

--- a/packages/@livestore/common/src/sync/mock-sync-backend.test.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.test.ts
@@ -66,6 +66,28 @@ Vitest.describe('makeMockSyncBackend', () => {
       Vitest.expect((yield* Fiber.join(pull)).batch.map((entry) => entry.eventEncoded)).toEqual([next])
     }),
   )
+
+  Vitest.live('a replacement live pull snapshots pushes whose publication was dropped', () =>
+    Effect.gen(function* () {
+      const mockBackend = yield* makeMockSyncBackend({ startConnected: true })
+      const backend = yield* mockBackend.makeSyncBackend
+      const firstPull = yield* backend.pull(Option.none(), { live: true }).pipe(Stream.runDrain, Effect.forkScoped)
+
+      yield* mockBackend.pullRequests.pipe(Stream.runFirstUnsafe)
+      yield* mockBackend.dropNextPushPublications(1)
+      const event = makeEvent(1)
+      yield* backend.push([event])
+      yield* Fiber.interrupt(firstPull)
+
+      const replacementItem = yield* backend.pull(Option.none(), { live: true }).pipe(
+        Stream.filter((item) => item.batch.length > 0),
+        Stream.runFirstUnsafe,
+      )
+
+      Vitest.expect(replacementItem.batch.map((entry) => entry.eventEncoded)).toEqual([event])
+      Vitest.expect(yield* mockBackend.activePulls.maximum).toEqual(1)
+    }),
+  )
 })
 
 const makeEvent = (seqNum: number): LiveStoreEvent.Global.Encoded => ({

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -22,10 +22,14 @@ export interface MockSyncBackend {
   pushAttempts: Stream.Stream<ReadonlyArray<LiveStoreEvent.Global.Encoded>>
   /** Cursor position used by each evaluated pull stream. */
   pullRequests: Stream.Stream<EventSequenceNumber.Global.Type>
+  /** Cursor position of each finite pull after its stream has completed. */
+  completedPulls: Stream.Stream<EventSequenceNumber.Global.Type>
   activePulls: {
     current: Effect.Effect<number>
     maximum: Effect.Effect<number>
   }
+  pullRequestCount: Effect.Effect<number>
+  pushAttemptCount: Effect.Effect<number>
   storedEvents: Effect.Effect<ReadonlyArray<LiveStoreEvent.Global.Encoded>>
   connect: Effect.Effect<void>
   disconnect: Effect.Effect<void>
@@ -71,12 +75,15 @@ export const makeMockSyncBackend = (
     const droppedPushPublicationsRef = yield* Ref.make(0)
     const activePullCountRef = yield* Ref.make(0)
     const maximumActivePullCountRef = yield* Ref.make(0)
+    const pullRequestCountRef = yield* Ref.make(0)
+    const pushAttemptCountRef = yield* Ref.make(0)
 
     // Queues for streaming
     const syncPullQueues = new Set<Queue.Queue<LiveStoreEvent.Global.Encoded>>()
     const pushedEventsQueue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
     const pushAttemptsQueue = yield* Queue.unbounded<ReadonlyArray<LiveStoreEvent.Global.Encoded>>()
     const pullRequestsQueue = yield* Queue.unbounded<EventSequenceNumber.Global.Type>()
+    const completedPullsQueue = yield* Queue.unbounded<EventSequenceNumber.Global.Type>()
 
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
@@ -196,18 +203,30 @@ export const makeMockSyncBackend = (
         connect: SubscriptionRef.set(syncIsConnectedRef, true),
         ping: Effect.void,
         pull: (cursor, pullOptions) =>
-          Stream.fromEffect(Queue.offer(pullRequestsQueue, cursorPosition(cursor))).pipe(
+          Stream.fromEffect(
+            Effect.all([
+              Ref.update(pullRequestCountRef, (count) => count + 1),
+              Queue.offer(pullRequestsQueue, cursorPosition(cursor)),
+            ]),
+          ).pipe(
             Stream.tap(() =>
               checkFailure(
                 failPullRef,
                 new UnknownError({ cause: new Error('MockSyncBackend: simulated pull failure') }),
               ),
             ),
-            Stream.flatMap(() => (pullOptions?.live === true ? pullLive(cursor) : pullNonLive(cursor))),
+            Stream.flatMap(() =>
+              pullOptions?.live === true
+                ? pullLive(cursor)
+                : pullNonLive(cursor).pipe(
+                    Stream.ensuring(Queue.offer(completedPullsQueue, cursorPosition(cursor)).pipe(Effect.asVoid)),
+                  ),
+            ),
             Stream.withSpan('MockSyncBackend:pull', { parent: span }),
           ),
         push: (batch) =>
           Effect.gen(function* () {
+            yield* Ref.update(pushAttemptCountRef, (count) => count + 1)
             yield* Queue.offer(pushAttemptsQueue, batch)
             const currentHead = yield* Ref.get(syncHeadRef)
             yield* validatePushPayload(batch, currentHead)
@@ -281,10 +300,13 @@ export const makeMockSyncBackend = (
       pushedEvents: Stream.fromQueue(pushedEventsQueue),
       pushAttempts: Stream.fromQueue(pushAttemptsQueue),
       pullRequests: Stream.fromQueue(pullRequestsQueue),
+      completedPulls: Stream.fromQueue(completedPullsQueue),
       activePulls: {
         current: Ref.get(activePullCountRef),
         maximum: Ref.get(maximumActivePullCountRef),
       },
+      pullRequestCount: Ref.get(pullRequestCountRef),
+      pushAttemptCount: Ref.get(pushAttemptCountRef),
       storedEvents: Ref.get(allEventsRef),
       connect: SubscriptionRef.set(syncIsConnectedRef, true),
       disconnect: SubscriptionRef.set(syncIsConnectedRef, false),

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -18,10 +18,23 @@ import { validatePushPayload } from './validate-push-payload.ts'
 
 export interface MockSyncBackend {
   pushedEvents: Stream.Stream<LiveStoreEvent.Global.Encoded>
+  /** Every push attempt, including batches rejected before persistence. */
+  pushAttempts: Stream.Stream<ReadonlyArray<LiveStoreEvent.Global.Encoded>>
+  /** Cursor position used by each evaluated pull stream. */
+  pullRequests: Stream.Stream<EventSequenceNumber.Global.Type>
+  activePulls: {
+    current: Effect.Effect<number>
+    maximum: Effect.Effect<number>
+  }
+  storedEvents: Effect.Effect<ReadonlyArray<LiveStoreEvent.Global.Encoded>>
   connect: Effect.Effect<void>
   disconnect: Effect.Effect<void>
   makeSyncBackend: Effect.Effect<SyncBackend.SyncBackend, UnknownError, Scope.Scope>
   advance: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
+  /** Persist backend events without publishing them to currently active pulls. */
+  advanceWithoutPublication: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
+  /** Persist the next N successful pushes but omit their live pull publication. */
+  dropNextPushPublications: (count: number) => Effect.Effect<void>
   /** Fail the next N push calls with an UnknownError, ServerAheadError, BackendIdMismatchError, or custom error */
   failNextPushes: (
     count: number,
@@ -55,10 +68,15 @@ export const makeMockSyncBackend = (
     const syncHeadRef = yield* Ref.make(EventSequenceNumber.Client.ROOT.global)
     const allEventsRef = yield* Ref.make<LiveStoreEvent.Global.Encoded[]>([])
     const syncIsConnectedRef = yield* SubscriptionRef.make(options?.startConnected ?? false)
+    const droppedPushPublicationsRef = yield* Ref.make(0)
+    const activePullCountRef = yield* Ref.make(0)
+    const maximumActivePullCountRef = yield* Ref.make(0)
 
     // Queues for streaming
     const syncPullQueues = new Set<Queue.Queue<LiveStoreEvent.Global.Encoded>>()
     const pushedEventsQueue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
+    const pushAttemptsQueue = yield* Queue.unbounded<ReadonlyArray<LiveStoreEvent.Global.Encoded>>()
+    const pullRequestsQueue = yield* Queue.unbounded<EventSequenceNumber.Global.Type>()
 
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
@@ -124,36 +142,51 @@ export const makeMockSyncBackend = (
       )
 
     const makeSyncBackend = Effect.gen(function* () {
-      // Every backend connection needs its own live cursor. A shared queue would
-      // load-balance events across Clients instead of broadcasting the log.
-      const syncPullQueue = yield* Effect.acquireRelease(
-        Queue.unbounded<LiveStoreEvent.Global.Encoded>(),
-        Queue.shutdown,
-      )
-      yield* semaphore.withPermits(1)(
-        Effect.gen(function* () {
-          const existingEvents = yield* Ref.get(allEventsRef)
-          syncPullQueues.add(syncPullQueue)
-          yield* Queue.offerAll(syncPullQueue, existingEvents)
-        }),
-      )
-      yield* Effect.addFinalizer(() => Effect.sync(() => syncPullQueues.delete(syncPullQueue)))
+      // A live subscription belongs to one evaluated pull, not the backend object. Restarting
+      // pull must therefore allocate a fresh subscriber and replay the cursor-to-head snapshot.
+      const pullLive = (cursor: Option.Option<{ eventSequenceNumber: EventSequenceNumber.Global.Type }>) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const lastSeen = cursorPosition(cursor)
+            const syncPullQueue = yield* Effect.acquireRelease(
+              Effect.gen(function* () {
+                const queue = yield* Queue.unbounded<LiveStoreEvent.Global.Encoded>()
+                yield* semaphore.withPermits(1)(
+                  Effect.gen(function* () {
+                    const existingEvents = yield* Ref.get(allEventsRef)
+                    syncPullQueues.add(queue)
+                    const activePullCount = yield* Ref.updateAndGet(activePullCountRef, (count) => count + 1)
+                    yield* Ref.update(maximumActivePullCountRef, (maximum) => Math.max(maximum, activePullCount))
+                    yield* Queue.offerAll(
+                      queue,
+                      existingEvents.filter((event) => event.seqNum > lastSeen),
+                    )
+                  }),
+                )
+                return queue
+              }),
+              (queue) =>
+                semaphore.withPermits(1)(
+                  Effect.gen(function* () {
+                    syncPullQueues.delete(queue)
+                    yield* Ref.update(activePullCountRef, (count) => count - 1)
+                    yield* Queue.shutdown(queue)
+                  }),
+                ),
+            )
 
-      const pullLive = (cursor: Option.Option<{ eventSequenceNumber: EventSequenceNumber.Global.Type }>) => {
-        const lastSeen = cursorPosition(cursor)
-        return Stream.concat(
-          Stream.make(SyncBackend.pullResItemEmpty()),
-          Stream.fromQueue(syncPullQueue).pipe(
-            Stream.chunks,
-            Stream.map((chunk) => ({
-              batch: [...chunk]
-                .filter((eventEncoded) => eventEncoded.seqNum > lastSeen)
-                .map((eventEncoded) => ({ eventEncoded, metadata: Option.none() })),
-              pageInfo: SyncBackend.pageInfoNoMore,
-            })),
-          ),
+            return Stream.concat(
+              Stream.make(SyncBackend.pullResItemEmpty()),
+              Stream.fromQueue(syncPullQueue).pipe(
+                Stream.chunks,
+                Stream.map((chunk) => ({
+                  batch: [...chunk].map((eventEncoded) => ({ eventEncoded, metadata: Option.none() })),
+                  pageInfo: SyncBackend.pageInfoNoMore,
+                })),
+              ),
+            )
+          }),
         )
-      }
 
       // TODO consider making offline state actively error pull/push.
       // Currently, offline only reflects in `isConnected`, while operations still succeed,
@@ -163,17 +196,19 @@ export const makeMockSyncBackend = (
         connect: SubscriptionRef.set(syncIsConnectedRef, true),
         ping: Effect.void,
         pull: (cursor, pullOptions) =>
-          Stream.fromEffect(
-            checkFailure(
-              failPullRef,
-              new UnknownError({ cause: new Error('MockSyncBackend: simulated pull failure') }),
+          Stream.fromEffect(Queue.offer(pullRequestsQueue, cursorPosition(cursor))).pipe(
+            Stream.tap(() =>
+              checkFailure(
+                failPullRef,
+                new UnknownError({ cause: new Error('MockSyncBackend: simulated pull failure') }),
+              ),
             ),
-          ).pipe(
             Stream.flatMap(() => (pullOptions?.live === true ? pullLive(cursor) : pullNonLive(cursor))),
             Stream.withSpan('MockSyncBackend:pull', { parent: span }),
           ),
         push: (batch) =>
           Effect.gen(function* () {
+            yield* Queue.offer(pushAttemptsQueue, batch)
             const currentHead = yield* Ref.get(syncHeadRef)
             yield* validatePushPayload(batch, currentHead)
 
@@ -185,13 +220,16 @@ export const makeMockSyncBackend = (
 
             yield* Effect.sleep(10).pipe(Effect.withSpan('MockSyncBackend:push:sleep')) // Simulate network latency
 
-            yield* Queue.offerAll(pushedEventsQueue, batch)
-            yield* Effect.forEach(syncPullQueues, (queue) => Queue.offerAll(queue, batch), {
-              concurrency: 'unbounded',
-              discard: true,
-            })
             yield* Ref.update(allEventsRef, (events) => events.concat(batch))
             yield* Ref.set(syncHeadRef, batch.at(-1)!.seqNum)
+            yield* Queue.offerAll(pushedEventsQueue, batch)
+
+            const publish = yield* Ref.modify(droppedPushPublicationsRef, (remaining) =>
+              remaining > 0 ? [false, remaining - 1] : [true, remaining],
+            )
+            if (publish === true) {
+              yield* publishToActivePulls(syncPullQueues, batch)
+            }
           }).pipe(
             Effect.withSpan('MockSyncBackend:push', {
               parent: span,
@@ -210,14 +248,11 @@ export const makeMockSyncBackend = (
       })
     })
 
-    const advance = (...batch: LiveStoreEvent.Global.Encoded[]) =>
+    const advanceBatch = (batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>, publish: boolean) =>
       Effect.gen(function* () {
         yield* Ref.set(syncHeadRef, batch.at(-1)!.seqNum)
         yield* Ref.update(allEventsRef, (events) => events.concat(batch))
-        yield* Effect.forEach(syncPullQueues, (queue) => Queue.offerAll(queue, batch), {
-          concurrency: 'unbounded',
-          discard: true,
-        })
+        if (publish === true) yield* publishToActivePulls(syncPullQueues, batch)
       }).pipe(
         Effect.withSpan('MockSyncBackend:advance', {
           parent: span,
@@ -225,6 +260,12 @@ export const makeMockSyncBackend = (
         }),
         semaphore.withPermits(1),
       )
+
+    const advance = (...batch: LiveStoreEvent.Global.Encoded[]) => advanceBatch(batch, true)
+
+    const advanceWithoutPublication = (...batch: LiveStoreEvent.Global.Encoded[]) => advanceBatch(batch, false)
+
+    const dropNextPushPublications = (count: number) => Ref.set(droppedPushPublicationsRef, Math.max(0, count))
 
     const failNextPushes = (
       count: number,
@@ -238,10 +279,19 @@ export const makeMockSyncBackend = (
 
     return {
       pushedEvents: Stream.fromQueue(pushedEventsQueue),
+      pushAttempts: Stream.fromQueue(pushAttemptsQueue),
+      pullRequests: Stream.fromQueue(pullRequestsQueue),
+      activePulls: {
+        current: Ref.get(activePullCountRef),
+        maximum: Ref.get(maximumActivePullCountRef),
+      },
+      storedEvents: Ref.get(allEventsRef),
       connect: SubscriptionRef.set(syncIsConnectedRef, true),
       disconnect: SubscriptionRef.set(syncIsConnectedRef, false),
       makeSyncBackend,
       advance,
+      advanceWithoutPublication,
+      dropNextPushPublications,
       failNextPushes,
       failNextPulls,
     }
@@ -270,3 +320,12 @@ const chunkEvents = (events: ReadonlyArray<LiveStoreEvent.Global.Encoded>, chunk
   if (chunks.length === 0) chunks.push({ events: [], remaining: 0 })
   return chunks
 }
+
+const publishToActivePulls = (
+  syncPullQueues: ReadonlySet<Queue.Queue<LiveStoreEvent.Global.Encoded>>,
+  batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
+) =>
+  Effect.forEach(syncPullQueues, (queue) => Queue.offerAll(queue, batch), {
+    concurrency: 'unbounded',
+    discard: true,
+  })

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -8,6 +8,7 @@ import {
   makeMockSyncBackend,
   NonContiguousBatchError,
   type RejectedPushError,
+  ServerAheadError,
   StateHead,
   StaleRebaseGenerationError,
   type SyncBackend,
@@ -64,6 +65,8 @@ const withTestCtx = (
     mockBackendOptions?: MockSyncBackendOptions
     seedMockBackend?: (mockBackend: MockSyncBackend) => Effect.Effect<void>
     mockBackendOverride?: (mock: MockSyncBackend) => SyncBackend.SyncBackendConstructor
+    coordinatePullApplication?: boolean
+    failCoordinatedPullApplication?: boolean
   } = {},
 ) =>
   Vitest.makeWithTestCtx({
@@ -743,6 +746,184 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     }).pipe(withTestCtx({ mockBackendOptions: { startConnected: true } })(test)),
   )
 
+  Vitest.live('restarts a completed finite pull after ServerAhead', (test) =>
+    Effect.gen(function* () {
+      const leaderThreadCtx = yield* LeaderThreadCtx
+      const testContext = yield* TestContext
+      const eventFactory = testContext.eventFactory
+      const backendFactory = makeEventFactory({
+        client: EventFactory.clientIdentity('mock-backend', 'static-session-id'),
+        startSeq: 2,
+        initialParent: 1,
+      })
+
+      const completedInitialCursor = yield* testContext.mockSyncBackend.completedPulls.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(completedInitialCursor).toEqual(EventSequenceNumber.Client.ROOT.global)
+      expect(yield* testContext.mockSyncBackend.pullRequests.pipe(Stream.runFirstUnsafe, Effect.timeout(5000))).toEqual(
+        EventSequenceNumber.Client.ROOT.global,
+      )
+
+      yield* testContext.mockSyncBackend.dropNextPushPublications(1)
+      const localA1 = eventFactory.todoCreated.next({ id: 'finite-a1', text: 'finite-a1', completed: false })
+      yield* testContext.pushEncoded(localA1)
+      yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.runFirstUnsafe, Effect.timeout(5000))
+
+      const remoteB2 = backendFactory.todoCreated.next({ id: 'finite-b2', text: 'finite-b2', completed: false })
+      yield* testContext.mockSyncBackend.advanceWithoutPublication(remoteB2)
+
+      const localA2 = eventFactory.todoCreated.next({ id: 'finite-a2', text: 'finite-a2', completed: false })
+      yield* testContext.pushEncoded(localA2)
+
+      const catchUpCursor = yield* testContext.mockSyncBackend.pullRequests.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(catchUpCursor).toEqual(EventSequenceNumber.Client.ROOT.global)
+
+      const rebasedA2 = yield* testContext.mockSyncBackend.pushedEvents.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(rebasedA2.seqNum).toEqual(EventSequenceNumber.Global.make(3))
+      expect(rebasedA2.args).toEqual(localA2.args)
+
+      const syncState = yield* leaderThreadCtx.syncProcessor.syncState.get
+      expect(syncState.upstreamHead.global).toEqual(2)
+      expect(syncState.pending.map((event) => event.args)).toEqual([localA2.args])
+
+      expect(yield* testContext.mockSyncBackend.pullRequestCount).toEqual(2)
+      expect((yield* testContext.mockSyncBackend.storedEvents).map((event) => event.args)).toEqual([
+        localA1.args,
+        remoteB2.args,
+        localA2.args,
+      ])
+    }).pipe(withTestCtx({ mockBackendOptions: { startConnected: true }, syncOptions: { livePull: false } })(test)),
+  )
+
+  Vitest.live('finishes canonical pull application before replacing its generation', (test) =>
+    Effect.gen(function* () {
+      const leaderThreadCtx = yield* LeaderThreadCtx
+      const testContext = yield* TestContext
+      const eventFactory = testContext.eventFactory
+      const backendFactory = makeEventFactory({
+        client: EventFactory.clientIdentity('mock-backend', 'static-session-id'),
+      })
+
+      const pullApplicationControl = testContext.pullApplicationControl
+      assert(pullApplicationControl !== undefined, 'pull application controls were not configured')
+
+      expect(yield* testContext.mockSyncBackend.pullRequests.pipe(Stream.runFirstUnsafe, Effect.timeout(5000))).toEqual(
+        EventSequenceNumber.Client.ROOT.global,
+      )
+
+      // Keep the successful rebased push from publishing into the generation being retired;
+      // this test isolates the retirement/application boundary from a second confirmation chunk.
+      yield* testContext.mockSyncBackend.dropNextPushPublications(1)
+
+      const localA1 = eventFactory.todoCreated.next({ id: 'fenced-local', text: 'local', completed: false })
+      yield* testContext.pushEncoded(localA1)
+      yield* Deferred.await(pullApplicationControl.pushWaiting).pipe(Effect.timeout(5000))
+
+      const remoteB1 = backendFactory.todoCreated.next({ id: 'fenced-remote', text: 'remote', completed: false })
+      yield* testContext.mockSyncBackend.advance(remoteB1)
+      yield* Deferred.await(pullApplicationControl.cursorAdvanced).pipe(Effect.timeout(5000))
+      yield* Deferred.await(pullApplicationControl.restartRequested).pipe(Effect.timeout(5000))
+
+      // Retirement is waiting outside the application fence; no replacement is active yet.
+      expect(yield* testContext.mockSyncBackend.pullRequestCount).toEqual(1)
+      expect(yield* testContext.mockSyncBackend.activePulls.current).toEqual(1)
+
+      yield* Deferred.succeed(pullApplicationControl.allowApplication, undefined)
+
+      const replacementCursor = yield* testContext.mockSyncBackend.pullRequests.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(replacementCursor).toEqual(EventSequenceNumber.Global.make(1))
+
+      const rebasedLocal = yield* testContext.mockSyncBackend.pushedEvents.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(rebasedLocal.seqNum).toEqual(EventSequenceNumber.Global.make(2))
+      expect(rebasedLocal.args).toEqual(localA1.args)
+
+      yield* leaderThreadCtx.syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.upstreamHead.global === 2 && state.pending.length === 0),
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+
+      expect(yield* testContext.mockSyncBackend.activePulls.maximum).toEqual(1)
+      expect((yield* testContext.mockSyncBackend.storedEvents).map((event) => event.args)).toEqual([
+        remoteB1.args,
+        localA1.args,
+      ])
+      expect(
+        leaderThreadCtx.dbState
+          .select<{ id: string }>(tables.todos.asSql().query)
+          .map(({ id }) => id)
+          .toSorted(),
+      ).toEqual(['fenced-local', 'fenced-remote'])
+    }).pipe(
+      withTestCtx({
+        mockBackendOptions: { startConnected: true },
+        coordinatePullApplication: true,
+      })(test),
+    ),
+  )
+
+  Vitest.live('preserves a terminal canonical pull failure instead of replacing its generation', (test) =>
+    Effect.gen(function* () {
+      const testContext = yield* TestContext
+      const backendFactory = makeEventFactory({
+        client: EventFactory.clientIdentity('mock-backend', 'static-session-id'),
+      })
+      const pullApplicationControl = testContext.pullApplicationControl
+      assert(pullApplicationControl !== undefined, 'pull application controls were not configured')
+
+      expect(yield* testContext.mockSyncBackend.pullRequests.pipe(Stream.runFirstUnsafe, Effect.timeout(5000))).toEqual(
+        EventSequenceNumber.Client.ROOT.global,
+      )
+
+      const localA1 = testContext.eventFactory.todoCreated.next({
+        id: 'failed-application-local',
+        text: 'local',
+        completed: false,
+      })
+      yield* testContext.pushEncoded(localA1)
+      yield* Deferred.await(pullApplicationControl.pushWaiting).pipe(Effect.timeout(5000))
+
+      const remoteB1 = backendFactory.todoCreated.next({
+        id: 'failed-application-remote',
+        text: 'remote',
+        completed: false,
+      })
+      yield* testContext.mockSyncBackend.advance(remoteB1)
+      yield* Deferred.await(pullApplicationControl.cursorAdvanced).pipe(Effect.timeout(5000))
+      yield* Deferred.await(pullApplicationControl.restartRequested).pipe(Effect.timeout(5000))
+
+      expect(yield* testContext.mockSyncBackend.pullRequestCount).toEqual(1)
+      yield* Deferred.succeed(pullApplicationControl.allowApplication, undefined)
+
+      const shutdownError = yield* Deferred.await(testContext.shutdownDeferred).pipe(Effect.flip, Effect.timeout(5000))
+      expect(shutdownError._tag).toEqual('UnknownError')
+      expect(yield* testContext.mockSyncBackend.pullRequestCount).toEqual(1)
+      expect(yield* testContext.mockSyncBackend.activePulls.current).toEqual(0)
+    }).pipe(
+      withTestCtx({
+        mockBackendOptions: { startConnected: true },
+        syncOptions: { onSyncError: 'shutdown' },
+        coordinatePullApplication: true,
+        failCoordinatedPullApplication: true,
+        captureShutdown: true,
+      })(test),
+    ),
+  )
+
   // - test for filtering out local push queue items with an older rebase generation
   //   this can happen in a scenario like this
   //   1) local push events are queued (rebase generation 0) + queue is not yet processed (probably requires delay to simulate)
@@ -788,35 +969,21 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     }).pipe(withTestCtx()(test)),
   )
 
-  // Regression test for push fiber stalling when livePull=false and backend push errors occur
-  Vitest.live('recovers from backend push errors without live pull', (test) =>
+  Vitest.live('does not retry an UnknownError from backend push', (test) =>
     Effect.gen(function* () {
-      const leaderThreadCtx = yield* LeaderThreadCtx
       const testContext = yield* TestContext
       const eventFactory = testContext.eventFactory
 
-      // Make next few pushes fail at the mock backend level
-      yield* testContext.mockSyncBackend.failNextPushes(2)
-
-      // Push a few local events; initial push attempts will fail
+      yield* testContext.mockSyncBackend.failNextPushes(1)
       yield* testContext.pushEncoded(
-        eventFactory.todoCreated.next({ id: 'p1', text: 'a', completed: false }),
-        eventFactory.todoCreated.next({ id: 'p2', text: 'b', completed: false }),
-        eventFactory.todoCreated.next({ id: 'p3', text: 'c', completed: false }),
-        eventFactory.todoCreated.next({ id: 'p4', text: 'd', completed: false }),
+        eventFactory.todoCreated.next({ id: 'unknown', text: 'unknown', completed: false }),
       )
 
-      // Expect all 4 to eventually be pushed to the backend (with timeout to catch stalls)
-      yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(4), Stream.runDrain, Effect.timeout(7000))
-
-      // Verify they have been materialized locally as well
-      const result = leaderThreadCtx.dbState.select(tables.todos.asSql().query)
-      expect(result.length).toEqual(4)
-    }).pipe(
-      withTestCtx({ params: { backendPushBatchSize: 2 }, syncOptions: { livePull: false, onSyncError: 'ignore' } })(
-        test,
-      ),
-    ),
+      const shutdownError = yield* Deferred.await(testContext.shutdownDeferred).pipe(Effect.flip, Effect.timeout(3000))
+      expect(shutdownError._tag).toEqual('UnknownError')
+      expect(yield* testContext.mockSyncBackend.pushAttemptCount).toEqual(1)
+      expect(yield* testContext.mockSyncBackend.storedEvents).toEqual([])
+    }).pipe(withTestCtx({ syncOptions: { livePull: false, onSyncError: 'shutdown' }, captureShutdown: true })(test)),
   )
 
   // Should escalate and shutdown on BackendIdMismatchError when onBackendIdMismatch='shutdown' (legacy behavior)
@@ -999,6 +1166,13 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
 type LeaderEventFactory = ReturnType<typeof makeEventFactory>
 
+interface PullApplicationControl {
+  cursorAdvanced: Deferred.Deferred<void>
+  allowApplication: Deferred.Deferred<void>
+  pushWaiting: Deferred.Deferred<void>
+  restartRequested: Deferred.Deferred<void>
+}
+
 class TestContext extends Context.Service<
   TestContext,
   {
@@ -1006,6 +1180,7 @@ class TestContext extends Context.Service<
     shutdownDeferred: Deferred.Deferred<void, typeof Shutdown.All.Type>
     pullQueue: Queue.Queue<{ payload: typeof SyncState.PayloadUpstream.Type }>
     eventFactory: LeaderEventFactory
+    pullApplicationControl: PullApplicationControl | undefined
     /** Equivalent to the ClientSessionSyncProcessor calling `.push` on the LeaderThreadCtx */
     pushEncoded: (
       ...events: ReadonlyArray<LiveStoreEvent.Global.Encoded>
@@ -1021,6 +1196,8 @@ const LeaderThreadCtxLive = ({
   mockBackendOptions,
   seedMockBackend,
   mockBackendOverride,
+  coordinatePullApplication,
+  failCoordinatedPullApplication,
 }: {
   syncProcessor?: NonNullable<MakeLeaderThreadLayerParams['testing']>['syncProcessor']
   params?: MakeLeaderThreadLayerParams['params']
@@ -1030,9 +1207,21 @@ const LeaderThreadCtxLive = ({
   mockBackendOptions?: MockSyncBackendOptions
   seedMockBackend?: (mockBackend: MockSyncBackend) => Effect.Effect<void>
   mockBackendOverride?: (mock: MockSyncBackend) => SyncBackend.SyncBackendConstructor
+  coordinatePullApplication?: boolean
+  failCoordinatedPullApplication?: boolean
 }) =>
   Effect.gen(function* () {
     const mockSyncBackend = yield* makeMockSyncBackend(mockBackendOptions)
+
+    const pullApplicationControl =
+      coordinatePullApplication === true
+        ? {
+            cursorAdvanced: yield* Deferred.make<void>(),
+            allowApplication: yield* Deferred.make<void>(),
+            pushWaiting: yield* Deferred.make<void>(),
+            restartRequested: yield* Deferred.make<void>(),
+          }
+        : undefined
 
     if (seedMockBackend !== undefined) {
       yield* seedMockBackend(mockSyncBackend)
@@ -1049,6 +1238,28 @@ const LeaderThreadCtxLive = ({
 
     const dbState = yield* makeSqliteDb({ _tag: 'in-memory' })
     const dbEventlog = yield* makeSqliteDb({ _tag: 'in-memory' })
+    const syncBackendConstructor =
+      pullApplicationControl === undefined
+        ? (mockBackendOverride?.(mockSyncBackend) ?? syncOptions?.backend ?? (() => mockSyncBackend.makeSyncBackend))
+        : () =>
+            Effect.gen(function* () {
+              const syncBackend = yield* mockSyncBackend.makeSyncBackend
+              let interceptNextPush = true
+              return {
+                ...syncBackend,
+                push: (batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>) =>
+                  Effect.gen(function* () {
+                    if (interceptNextPush === false) return yield* syncBackend.push(batch)
+                    interceptNextPush = false
+                    yield* Deferred.succeed(pullApplicationControl.pushWaiting, undefined)
+                    yield* Deferred.await(pullApplicationControl.cursorAdvanced)
+                    return yield* new ServerAheadError({
+                      minimumExpectedNum: EventSequenceNumber.Global.make(2),
+                      providedNum: EventSequenceNumber.Global.make(1),
+                    })
+                  }),
+              }
+            })
     const leaderContextLayer = makeLeaderThreadLayer({
       schema,
       storeId: 'test',
@@ -1057,8 +1268,7 @@ const LeaderThreadCtxLive = ({
       syncPayloadSchema: undefined,
       makeSqliteDb,
       syncOptions: {
-        backend:
-          mockBackendOverride?.(mockSyncBackend) ?? syncOptions?.backend ?? (() => mockSyncBackend.makeSyncBackend),
+        backend: syncBackendConstructor,
         ...omitUndefineds({
           livePull: syncOptions?.livePull,
           onSyncError: syncOptions?.onSyncError,
@@ -1071,7 +1281,25 @@ const LeaderThreadCtxLive = ({
       devtoolsOptions: { enabled: false },
       shutdownChannel: shutdownProxy?.webChannel ?? (yield* WebChannel.noopChannel<any, any>()),
       testing: {
-        ...omitUndefineds({ syncProcessor }),
+        syncProcessor:
+          pullApplicationControl === undefined
+            ? syncProcessor
+            : {
+                ...syncProcessor,
+                hooks: {
+                  ...syncProcessor?.hooks,
+                  backendPullCursorAdvanced: () =>
+                    Effect.gen(function* () {
+                      yield* Deferred.succeed(pullApplicationControl.cursorAdvanced, undefined)
+                      yield* Deferred.await(pullApplicationControl.allowApplication)
+                      if (failCoordinatedPullApplication === true) {
+                        return yield* Effect.die(new Error('simulated canonical pull application failure'))
+                      }
+                    }),
+                  backendPullRestartRequested: () =>
+                    Deferred.succeed(pullApplicationControl.restartRequested, undefined),
+                },
+              },
       },
       ...omitUndefineds({ params }),
     }).pipe(Layer.provide(StateHead.layer({ dbState })), Layer.provide(FetchHttpClient.layer))
@@ -1113,6 +1341,7 @@ const LeaderThreadCtxLive = ({
           shutdownDeferred,
           pullQueue,
           eventFactory,
+          pullApplicationControl,
           pushEncoded,
         }),
       )

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -8,7 +8,6 @@ import {
   makeMockSyncBackend,
   NonContiguousBatchError,
   type RejectedPushError,
-  ServerAheadError,
   StateHead,
   StaleRebaseGenerationError,
   type SyncBackend,
@@ -665,38 +664,83 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
   // - aborting local pushes
   // - processHead works properly
 
-  Vitest.live('simulate ServerAheadError push error', (test) =>
+  Vitest.live('actively catches up after an accepted push loses its pull publication', (test) =>
     Effect.gen(function* () {
+      const leaderThreadCtx = yield* LeaderThreadCtx
       const testContext = yield* TestContext
       const eventFactory = testContext.eventFactory
       const backendFactory = makeEventFactory({
         client: EventFactory.clientIdentity('mock-backend', 'static-session-id'),
+        startSeq: 2,
+        initialParent: 1,
       })
 
-      // Cause the next push to fail with ServerAheadError so the pushing fiber parks (Effect.never)
-      yield* testContext.mockSyncBackend.failNextPushes(
-        1,
-        () =>
-          new ServerAheadError({
-            minimumExpectedNum: EventSequenceNumber.Global.make(2),
-            providedNum: EventSequenceNumber.Global.make(1),
-          }),
+      const initialPullCursor = yield* testContext.mockSyncBackend.pullRequests.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(initialPullCursor).toEqual(EventSequenceNumber.Client.ROOT.global)
+
+      // Fault point 1: the backend accepts and persists A1, but its active pull never sees A1.
+      yield* testContext.mockSyncBackend.dropNextPushPublications(1)
+      const localA1 = eventFactory.todoCreated.next({ id: 'local-a1', text: 'local-a1', completed: false })
+      yield* testContext.pushEncoded(localA1)
+
+      const firstPushAttempt = yield* testContext.mockSyncBackend.pushAttempts.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(firstPushAttempt).toEqual([localA1])
+      expect(yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.runFirstUnsafe, Effect.timeout(5000))).toEqual(
+        localA1,
       )
 
-      // Enqueue one local event which will attempt a push and hit the simulated error
-      yield* testContext.pushEncoded(eventFactory.todoCreated.next({ id: 'stall', text: 'stall', completed: false }))
+      // Fault point 2: another client advances the backend to B2 without waking the stale pull.
+      const remoteB2 = backendFactory.todoCreated.next({ id: 'remote-b2', text: 'remote-b2', completed: false })
+      yield* testContext.mockSyncBackend.advanceWithoutPublication(remoteB2)
 
-      // Waiting a bit to make sure we've already attempted to push to the backend
-      // TODO replace this sleep with a an API that allows us to wait until the push was processed by the sync backend
-      yield* Effect.sleep(50)
+      // A2 still chains from A1. The mock now derives ServerAheadError naturally from backend head B2.
+      const localA2 = eventFactory.todoCreated.next({ id: 'local-a2', text: 'local-a2', completed: false })
+      yield* testContext.pushEncoded(localA2)
+      const stalePushAttempt = yield* testContext.mockSyncBackend.pushAttempts.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(stalePushAttempt).toEqual([localA2])
 
-      // Sync protocol requires that the sync backend emits a new pull chunk alongside the ServerAheadError
-      yield* testContext.mockSyncBackend.advance(
-        backendFactory.todoCreated.next({ id: '1', text: 't1', completed: false }),
+      // ServerAhead actively replaces pull from the still-persisted root cursor. The fresh
+      // generation snapshots A1+B2, confirms A1, rebases A2 to e3, and resumes pushing.
+      const catchUpCursor = yield* testContext.mockSyncBackend.pullRequests.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(catchUpCursor).toEqual(EventSequenceNumber.Client.ROOT.global)
+
+      const rebasedA2 = yield* testContext.mockSyncBackend.pushedEvents.pipe(
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
+      )
+      expect(rebasedA2.seqNum).toEqual(EventSequenceNumber.Global.make(3))
+      expect(rebasedA2.args).toEqual(localA2.args)
+
+      yield* leaderThreadCtx.syncProcessor.syncState.changes.pipe(
+        Stream.filter((state) => state.upstreamHead.global === 3 && state.pending.length === 0),
+        Stream.runFirstUnsafe,
+        Effect.timeout(5000),
       )
 
-      yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain, Effect.timeout(5000))
-    }).pipe(withTestCtx()(test)),
+      const storedEvents = yield* testContext.mockSyncBackend.storedEvents
+      expect(storedEvents.map(({ seqNum, args }) => ({ seqNum, args }))).toEqual([
+        { seqNum: EventSequenceNumber.Global.make(1), args: localA1.args },
+        { seqNum: EventSequenceNumber.Global.make(2), args: remoteB2.args },
+        { seqNum: EventSequenceNumber.Global.make(3), args: localA2.args },
+      ])
+      expect(yield* testContext.mockSyncBackend.activePulls.current).toEqual(1)
+      expect(yield* testContext.mockSyncBackend.activePulls.maximum).toEqual(1)
+
+      const rows = leaderThreadCtx.dbState.select<{ id: string }>(tables.todos.asSql().query)
+      expect(rows.map(({ id }) => id).toSorted()).toEqual(['local-a1', 'local-a2', 'remote-b2'])
+    }).pipe(withTestCtx({ mockBackendOptions: { startConnected: true } })(test)),
   )
 
   // - test for filtering out local push queue items with an older rebase generation


### PR DESCRIPTION
## Problem

A backend can accept and persist leader event A1 while its pull publication is lost. After another client advances the backend with B2, the leader can locally admit A2 from stale parent A1 and receive `ServerAheadError`. Parking the push worker on the existing pull can wedge the unresolved prefix forever.

This is the remaining core recovery leg tracked by #1462. It is stacked on #1575, which owns processor decision 0003 and the provider-neutral contract.

## Solution

- Convert `ServerAheadError` into a capacity-one catch-up request and stop the sole push worker, preserving the unresolved-prefix fence.
- Keep one persistent pull owner. It remains available after finite pull completion and re-reads the persisted cursor for every replacement.
- Coordinate retirement with a poison-agnostic canonical-application fence and retirement flag. An application already inside the fence completes; later applications self-stop. Pull cleanup runs outside the fence, then the owner inspects the generation exit.
- Give terminal canonical application failure precedence over replacement, so a later poisoned-event implementation can reuse the boundary without having its failure interrupted or masked.
- Coalesce restart requests and start the replacement only after the old generation has terminated, preserving a maximum of one active pull generation.
- Retry backend pushes only for `IsOfflineError`. `UnknownError` is terminal; `ServerAheadError` is reconciliation rather than transport retry.
- Keep ordinary pull merge as the only path that confirms/rebases the fenced prefix, rebuilds the push FIFO, and resumes propagation.

The mock backend exposes deterministic completion, attempt, cursor, stored-event, and active-pull observations while retaining a subscriber per evaluated live pull.

Trade-off: recovery may replay history from the persisted cursor. The merge core already owns idempotent confirmation/rebase; no provider wire contract or Cloudflare adapter behavior changes.

## Deterministic coverage

- accepted push/lost publication plus stale-parent advance produces a natural `ServerAheadError` and converges;
- a normally completed finite pull is restarted by a later catch-up request;
- a catch-up request arriving after cursor advancement cannot truncate the in-flight canonical application;
- a terminal canonical application failure wins the restart race and no replacement starts;
- `UnknownError` receives exactly one push attempt and surfaces through shutdown;
- replacement pulls replay persisted history through a fresh subscription and never overlap.

## Validation

- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check`
- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` — 8 passed
- `pnpm exec vitest run packages/@livestore/common/src/sync/mock-sync-backend.test.ts` — 4 passed
- `pnpm exec vitest run tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts` — 23 passed, 1 existing skip
- `devenv tasks run test:unit` — passed
- `devenv tasks run test:integration:sync-provider:mock` — 19 passed, 9 provider-inapplicable skips

The GitHub matrix is rerunning on commit `572870b2e`.

### Recovery sequence

```text
push A1 accepted --X publication
backend advances B2
push A2 -> ServerAhead -> prefix remains fenced
                         -> request catch-up
in-flight pull apply finishes or fails (failure wins)
old pull generation terminates
replacement pull(persisted cursor) replays A1+B2
ordinary merge rebases A2 -> resumed push
```

## Related issues and foundations

- #1462: accepted-push/lost-confirmation incident and core recovery.
- #1394: stale-parent reconnect deadlock.
- #1365: related WebSocket connection-loss incident; orphaned resume-Ack remains out of scope.
- #1530: prefix fencing and explicit leader push reservations.
- #1537: complementary Cloudflare push/publication atomicity.
- #1545: DO-RPC reconstruction recovery through boot catch-up.
- #1532: separate pull crash/cross-database atomicity work.
