### PR TITLE
Define terminal sync failures through supervised recovery

### DIFF
--- a/context/02-system/03-sync/02-processors/.decisions/0004-supervised-sync-failures.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0004-supervised-sync-failures.md
@@ -1,0 +1,66 @@
+# 0004 — Classify sync failures by recovery and supervise terminal workers
+
+Status: accepted (issue #1577 analysis and explicit user authorization,
+2026-08-22).
+
+This decision follows [0003](./0003-active-server-ahead-catchup.md), which owns
+active `ServerAheadError` catch-up and pull-generation retirement.
+
+## Context
+
+The sync boundary classifies `UnknownError` as a defect to surface, while the
+processor requirement and backend-push implementation treat the same family as
+transient and retry it forever. Backend pull retries only `IsOfflineError`.
+Providers also use `UnknownError` for failures as different as malformed
+responses, storage defects, authorization failures, and native transport
+rejections, so the catch-all carries no evidence that replay is safe or useful.
+
+The leader starts backend push, backend pull, and local-apply as separate scoped
+fibers. Their common `onSyncError: 'ignore'` handler returns after an error (and
+logs only in development), which completes that worker while the Store and its
+sibling workers keep running. Queue items, reservations, or stale read state can
+then remain unresolved with no lifecycle owner.
+
+## Options
+
+- **(a) Classify by recovery evidence and park terminal workers under
+  supervision — chosen.** Retry only positively identified retryable failures.
+  Keep `ServerAheadError` in reconciliation and backend identity mismatches in
+  their dedicated policy. Treat `UnknownError` as terminal. Under ignore mode,
+  log and park the affected worker with its prefix intact until scope shutdown
+  or an existing protocol recovery path reconstructs it from authoritative
+  state. A more-specific lifecycle-fatal family may take precedence over this
+  generic ignore policy.
+- **(b) Retry every `UnknownError`.** Rejected because the family includes
+  deterministic defects and permanent semantic failures. An infinite loop can
+  hide the root cause and repeatedly execute an operation whose outcome is
+  uncertain.
+- **(c) Let ignore mode complete only the failed worker.** Rejected because a
+  partially live processor looks healthy while silently losing one direction
+  of progress or leaving local acknowledgements unresolved.
+- **(d) Expose retry schedules, per-commit receipts, or an application recovery
+  state machine.** Rejected for this change. The processor owns recovery
+  mechanics; configurability (#1111) and confirmation APIs are separate public
+  contracts.
+- **(e) Fold `ServerAheadError` liveness into this decision.** Rejected because
+  stale-parent catch-up is owned by [decision
+  0003](./0003-active-server-ahead-catchup.md), #1462, and PRs #1575/#1576.
+
+## Consequences
+
+- `IsOfflineError` is the only current automatic-retry signal. Providers must
+  positively identify connectivity loss before using it.
+- `UnknownError` never enters an operation retry schedule. This is a semantic
+  correction to existing backend-push behavior, not a new public error type.
+- Ignore mode still lets the Store continue for generic terminal failures,
+  preserving the public option, but it no longer means a worker may return
+  unnoticed. Those errors are logged in every build and the worker stays parked
+  with its unresolved work owned. A more-specific lifecycle-fatal family may
+  override generic parking.
+- Pull-driven reconciliation may replace parked backend pushing from current
+  pending state. Active `ServerAheadError` catch-up may replace a parked backend
+  pull from the persisted cursor. Local apply has no equivalent independent
+  recovery trigger and stays terminal until shutdown if no more-specific policy
+  applies.
+- No provider wire shape, application callback, receipt API, retry
+  configurability, ServerAhead catch-up, or crash-atomicity contract changes.

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-003-unsupervised-sync-worker-exit.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-003-unsupervised-sync-worker-exit.md
@@ -1,0 +1,48 @@
+# DELTA-003 — Unknown failures retry forever or silently terminate sync workers
+
+Status: open
+
+This delta follows
+[DELTA-002](./DELTA-002-server-ahead-passive-park.md), which owns active
+`ServerAheadError` catch-up drift.
+
+## Divergence
+
+LS.SYS.SYNC-R03 and LS.SYS.SYNC.PROC-R01 classify `UnknownError` as an
+unclassified terminal defect that must not be retried automatically.
+`LeaderSyncProcessor` instead retries backend-push `UnknownError` indefinitely
+alongside `IsOfflineError`.
+
+LS.SYS.SYNC.PROC-R05 requires every background worker to retain lifecycle
+ownership after a terminal failure. The shared ignore handler currently returns
+`void`, so backend push, backend pull, or local-apply can complete permanently
+while the Store continues. Its diagnostic is guarded by `LS_DEV`, making this
+silent in production.
+
+Code:
+`packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts` (backend
+push retry predicate and the boot-time `maybeShutdownOnError` handler).
+
+## VRS
+
+Violates [../requirements.md](../requirements.md)
+LS.SYS.SYNC.PROC-R01 and LS.SYS.SYNC.PROC-R05, plus parent
+[../../requirements.md](../../requirements.md) LS.SYS.SYNC-R03.
+
+## Implementation Contract
+
+Remove `UnknownError` from backend-push retry and retain only positively
+identified connectivity failures. Route generic terminal causes from backend
+push, backend pull, and local apply through one named supervision policy, after
+any more-specific lifecycle-fatal policy. In ignore mode, emit an unconditional
+error log and park rather than returning. Keep the failed operation's
+acknowledgement/prefix unresolved so an existing protocol recovery path can
+reconstruct work from current sync state without claiming that the terminal
+attempt succeeded. Active `ServerAheadError` catch-up must be able to replace a
+parked backend pull from the persisted cursor without weakening cooperative
+pull retirement or the single-owner invariant.
+
+Add deterministic tests that distinguish retryable recovery from terminal
+parking, prove an `UnknownError` causes one push attempt rather than a retry
+loop, cover terminal handling for all three worker roles under ignore mode, and
+compose parked-pull supervision with active `ServerAheadError` replacement.

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -17,9 +17,9 @@ Builds on [../requirements.md](../requirements.md) and
 
 - **LS.SYS.SYNC.PROC-R01 Bounded transient-only retry:** Backend pushes are
   batch-bounded and retried with capped exponential backoff only on
-  positively identified connectivity errors. `UnknownError` surfaces as a
-  terminal failure, and `ServerAheadError` is never retried in place. The
-  unresolved backend prefix remains fenced while the processor actively
+  positively identified connectivity failures (`IsOfflineError` today).
+  `UnknownError` is terminal, and `ServerAheadError` is never retried in place.
+  The unresolved backend prefix remains fenced while the processor actively
   replaces its backend pull from the persisted cursor. Replacement retires the
   current generation only between canonical pull applications; an in-flight
   application finishes or fails first, and its terminal failure takes
@@ -27,12 +27,15 @@ Builds on [../requirements.md](../requirements.md) and
   finite pull so a later catch-up request can start another generation. Only
   pull confirmation or rebase may reseed backend pushing from current pending
   and resume it. At most one backend-pull generation may be active during this
-  recovery. Adopted 2026-07-16 (interview); active catch-up clarified
-  2026-08-21 from [#1462](https://github.com/livestorejs/livestore/issues/1462)
-  reduction evidence and maintainer direction; retirement precedence and
-  terminal-error classification clarified 2026-08-22 from convergence review
-  (see
-  [decision 0003](./.decisions/0003-active-server-ahead-catchup.md)).
+  recovery. Retry schedules remain owned by the processor rather than
+  application configuration. Adopted 2026-07-16 (interview); active catch-up
+  clarified 2026-08-21 from
+  [#1462](https://github.com/livestorejs/livestore/issues/1462) reduction
+  evidence and maintainer direction; retirement precedence and terminal-error
+  classification clarified 2026-08-22 from convergence review (see [decision
+  0003](./.decisions/0003-active-server-ahead-catchup.md)); recovery taxonomy
+  clarified 2026-08-22 (#1577, [decision
+  0004](./.decisions/0004-supervised-sync-failures.md)).
   `refines: LS.SYS.SYNC-R03`
 - **LS.SYS.SYNC.PROC-R02 Pull precedence:** Backend-pull application and
   local-push application are mutually exclusive, and the pull side takes
@@ -63,6 +66,20 @@ Builds on [../requirements.md](../requirements.md) and
   evidence and maintainer review; see
   [decision 0001](./.decisions/0001-prefix-fence-unresolved-upstream.md).
   `refines: LS.SYS.SYNC.SS-R03, LS.SYS.STORE-R04`
+- **LS.SYS.SYNC.PROC-R05 Supervised worker termination:** The leader's backend
+  push, backend pull, and local-apply workers never return unnoticed after a
+  terminal failure. A more-specific lifecycle-fatal failure family may take
+  precedence over the generic sync-error policy. Otherwise, with
+  `onSyncError: 'shutdown'`, the failure terminates the Store; with
+  `onSyncError: 'ignore'`, the processor logs the cause and holds the affected
+  worker in an explicit terminal parked state until scope shutdown or an
+  existing protocol recovery path replaces it. Recovery reconstructs work from
+  authoritative processor state; it never acknowledges or drops an uncertain
+  prefix and never converts a terminal failure into an implicit retry.
+  This supervision is internal and does not require an application-facing sync
+  state machine or per-commit receipt API. Adopted 2026-08-22 (#1577, [decision
+  0004](./.decisions/0004-supervised-sync-failures.md)).
+  `refines: LS.SYS.SYNC-R03, LS.SYS.SYNC.PROC-R04`
 
 Further processor requirements (e.g. the crash-atomicity contract of batch
 materialization) remain open pending `LS.SYS.STATE-DQ2`;

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -57,7 +57,7 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   `takeBetween(1, backendPushBatchSize)` (default 50, `:227`), pushes
   `toGlobal()` batches. Retry: `Schedule.exponential(1s)` clamped to 30s,
   no jitter, no attempt cap, and only for positively identified connectivity
-  errors (`IsOfflineError`, `:724-733`). `UnknownError` is terminal.
+  failures (`IsOfflineError`, `:724-733`). `UnknownError` is terminal.
   `ServerAheadError` is NOT
   retried in place: it fences that unresolved prefix and requests a fresh
   backend pull from the persisted cursor. Pull confirmation or rebase then
@@ -103,6 +103,33 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   (`../../04-runtime/spec.md` Leadership Handover); error routing via
   `onError: ignore|shutdown` and `BackendIdMismatchError` handling
   (`reset|shutdown|ignore`; reset clears local databases, `:1060-1123`).
+
+### Worker supervision
+
+(LS.SYS.SYNC.PROC-R05) Backend push, backend pull, and local-apply each run
+under the same generic terminal-failure policy. Retryable connectivity failures
+stay inside their operation loop. `ServerAheadError` stays inside
+reconciliation. A more-specific lifecycle-fatal family may take precedence;
+otherwise terminal failures reach the generic supervision boundary:
+
+- `onSyncError: 'shutdown'` sends the failure through the shutdown channel and
+  terminates the Store.
+- `onSyncError: 'ignore'` logs a generic terminal failure and parks the affected
+  worker rather than letting its fiber return. Its in-flight prefix remains
+  unresolved.
+- An existing protocol recovery path may interrupt and replace a parked worker
+  from authoritative state. In particular, a later pull reconciliation clears,
+  reseeds, and replaces backend pushing. Active `ServerAheadError` catch-up may
+  also retire and replace a parked backend pull from the persisted cursor.
+  Replacement is not acknowledgement of the failed attempt and is not a reason
+  to retry `UnknownError` in place.
+
+Local-apply failures retain their deferred acknowledgements and reservations;
+backend-push failures retain the pending prefix as the source for later
+reconciliation. Local apply has no equivalent independent recovery path and
+remains parked until scope shutdown unless a future, more-specific policy owns
+the failure. No application callback, receipt, retry schedule, public
+worker-health surface, or recovery state machine is introduced.
 
 ## Client Session Sync Processor
 
@@ -166,3 +193,5 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
 - Per-event `materializerHashLeader` beyond the first item of a pull chunk
   is unknown (TODO, `:555-556`, issue #503).
 - Metrics for retry/queue health are an acknowledged TODO (`:599`).
+- Terminal worker state is internal and observable through logs but has no
+  first-class public status surface; adding one requires a separate contract.

--- a/context/02-system/03-sync/requirements.md
+++ b/context/02-system/03-sync/requirements.md
@@ -29,10 +29,13 @@ ID note: former LS.SYS.SYNC-R02…R05 moved to LS.SYS.SYNC.SS-R01…R04 when
   `connect/pull/push/ping` plus connectivity signal, capability flags, and
   metadata against the schema-defined event encoding — nothing else about
   the engine. `refines: LS-R08`
-- **LS.SYS.SYNC-R03 Typed failure taxonomy:** Push rejection and backend
-  failures are tagged error families with a uniform recovery rule (rebase
-  and retry); defects stay distinguishable from expected sync conditions
-  like being offline. `refines: LS.SYS-R03`
+- **LS.SYS.SYNC-R03 Recovery-classified failure taxonomy:** Sync failures are
+  tagged by the recovery the processor can justify. Only positively identified
+  retryable failures are retried automatically; reconciliation signals,
+  backend-identity mismatches, terminal payload failures, and unclassified
+  defects remain distinguishable and follow their own recovery paths.
+  `UnknownError` is the unclassified terminal family, never evidence that an
+  operation is safe to retry. `refines: LS.SYS-R03`
 - **LS.SYS.SYNC-R04 Bounded transport batches:** Providers bound push/pull
   batches (≤100 events per message at the Cloudflare transports) and chunk
   oversized payloads below the transport frame limit; batches are strictly

--- a/context/02-system/03-sync/spec.md
+++ b/context/02-system/03-sync/spec.md
@@ -68,9 +68,17 @@ SyncBackend = {
 | Family | Members | Recovery |
 | --- | --- | --- |
 | `RejectedPushError` (leader push validation) | `NonMonotonicBatchError`, `StaleRebaseGenerationError`, `LeaderAheadError` | rebase and retry |
-| Backend | `IsOfflineError`, `BackendIdMismatchError`, `ServerAheadError` | wait/reconnect; `ServerAheadError` fences the push and actively replaces pull from the persisted cursor until confirmation or rebase ([02-processors](./02-processors/spec.md)) |
+| Retryable connectivity | `IsOfflineError` | retry with the processor-owned reconnect schedule |
+| Reconciliation | `ServerAheadError` | fence the stale push and actively replace pull from the persisted cursor until confirmation or rebase; never retry the stale batch in place ([02-processors](./02-processors/spec.md)) |
+| Backend identity | `BackendIdMismatchError` | apply the configured reset, shutdown, or terminal-ignore policy |
 | Transport | `OversizeChunkItemError` | surface (payload cannot be chunked) |
-| Defects | `UnknownError` | surface, don't retry |
+| Unclassified defect | `UnknownError` | terminal; surface or park according to `onSyncError`, never retry automatically |
+
+The taxonomy is recovery evidence, not a provider convenience. A transport may
+map a failure to `IsOfflineError` only when it can positively identify lost
+connectivity. Authorization, rate-limit, protocol, malformed-response, storage,
+and unexpected failures must not be collapsed into the retryable family.
+Providers that cannot classify a failure preserve it as `UnknownError`.
 
 ## Next-Gen Sync
 


### PR DESCRIPTION
## Problem

LiveStore's sync intent contradicted itself about `UnknownError`: the parent taxonomy treated it as a defect to surface while the processor contract permitted indefinite backend-push retry. The processor could also let backend push, backend pull, or local apply return permanently under `onSyncError: 'ignore'` while the Store and sibling workers continued.

Without one recovery-based taxonomy, permanent semantic failures can loop forever and terminal worker exits can leave unresolved prefixes or stale reads without a lifecycle owner.

This is PR 3 of 4 in native GitHub Stack #1578. It follows the active ServerAhead contract and implementation in #1575/#1576; the runtime supervision implementation is stacked above in #1580.

## Solution

Define the contract before changing runtime behavior:

- preserve decision 0003's active `ServerAheadError` catch-up from the persisted cursor, cooperative between-application retirement, persistent single pull owner, prefix fence, and one-generation invariant;
- retry only positively identified connectivity failures (`IsOfflineError` today);
- treat `UnknownError` as an unclassified terminal defect, never retry evidence;
- assign this stack decision 0004, DELTA-003, and `LS.SYS.SYNC.PROC-R05`;
- under `onSyncError: 'ignore'`, log and park generic terminal workers unless a more-specific lifecycle-fatal family takes precedence;
- allow authoritative protocol recovery to replace parked work: pull reconciliation replaces backend push, and active ServerAhead catch-up can replace a parked backend pull;
- keep local apply parked when no independent recovery path exists;
- keep worker health/status, callbacks, receipts, retry configuration, and application recovery state machines out of scope.

Recovery reconstructs work from authoritative processor state and never acknowledges or drops an uncertain prefix. Decision 0003/DELTA-002 remain owned by #1575/#1576; decision 0004/DELTA-003 and R05 are introduced here.

This PR is intent-only relative to its base. It contains no runtime or release implementation.

## Validation

Converged stack validation:

- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` (8 passed)
- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check`
- `devenv tasks run test:unit`
- `devenv tasks run test:integration:sync-provider:mock`

### Recovery taxonomy

```text
IsOfflineError ---------> processor-owned retry
ServerAheadError -------> active persisted-cursor pull replacement
UnknownError -----------> generic terminal supervision
lifecycle-fatal family -> higher-priority policy
```

## Related issues

- #1577
- Retry schedule configurability remains in #1111.
- ServerAhead catch-up is owned by #1462 and #1575/#1576.
- Crash atomicity remains in #1532.
