### PR TITLE
Prevent silent sync exits by parking terminal failures

### DIFF
--- a/.changeset/quiet-sync-workers.md
+++ b/.changeset/quiet-sync-workers.md
@@ -1,0 +1,8 @@
+---
+'@livestore/common': patch
+---
+
+Retry backend sync operations only after positively identified offline
+failures. `UnknownError` now enters a logged terminal worker state instead of
+being retried indefinitely or letting one sync worker terminate silently under
+`onSyncError: 'ignore'` (#1577).

--- a/.changeset/quiet-sync-workers.md
+++ b/.changeset/quiet-sync-workers.md
@@ -3,6 +3,6 @@
 ---
 
 Retry backend sync operations only after positively identified offline
-failures. `UnknownError` now enters a logged terminal worker state instead of
-being retried indefinitely or letting one sync worker terminate silently under
-`onSyncError: 'ignore'` (#1577).
+failures. `UnknownError` now enters a logged generic terminal worker state
+instead of being retried indefinitely or letting one sync worker terminate
+silently under `onSyncError: 'ignore'` (#1577).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   rebase generation while stale epochs remain checked separately, avoiding
   duplicate materialization and ghost fences during multi-writer rebases
   ([#1530](https://github.com/livestorejs/livestore/pull/1530)).
+- **Sync recovery:** Sync processors now retry only positively identified
+  offline failures. Unclassified failures park the affected supervised worker
+  instead of retrying forever or terminating silently while the Store remains
+  open ([#1577](https://github.com/livestorejs/livestore/issues/1577)).
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@
   duplicate materialization and ghost fences during multi-writer rebases
   ([#1530](https://github.com/livestorejs/livestore/pull/1530)).
 - **Sync recovery:** Sync processors now retry only positively identified
-  offline failures. Unclassified failures park the affected supervised worker
-  instead of retrying forever or terminating silently while the Store remains
-  open ([#1577](https://github.com/livestorejs/livestore/issues/1577)).
+  offline failures. Generic unclassified failures park the affected supervised
+  worker instead of retrying forever or terminating silently while the Store
+  remains open ([#1577](https://github.com/livestorejs/livestore/issues/1577)).
 
 ### Internal Changes
 

--- a/context/02-system/03-sync/02-processors/.delta/DELTA-003-unsupervised-sync-worker-exit.md
+++ b/context/02-system/03-sync/02-processors/.delta/DELTA-003-unsupervised-sync-worker-exit.md
@@ -1,6 +1,6 @@
 # DELTA-003 — Unknown failures retry forever or silently terminate sync workers
 
-Status: open
+Status: resolved (2026-08-22)
 
 This delta follows
 [DELTA-002](./DELTA-002-server-ahead-passive-park.md), which owns active
@@ -46,3 +46,19 @@ Add deterministic tests that distinguish retryable recovery from terminal
 parking, prove an `UnknownError` causes one push attempt rather than a retry
 loop, cover terminal handling for all three worker roles under ignore mode, and
 compose parked-pull supervision with active `ServerAheadError` replacement.
+
+## Resolution
+
+Backend push now retries only `IsOfflineError`; `UnknownError` reaches the
+generic terminal supervision boundary after one attempt. Backend push, backend
+pull, and local apply all use the named supervision policy. Ignore mode logs at
+error level in every build and parks generic terminal work, while
+interrupt-only causes still end normally during scope shutdown. Pull
+reconciliation can clear and replace a parked backend-push worker from current
+pending state; active `ServerAheadError` catch-up can replace a parked backend
+pull from the persisted cursor without overlapping pull generations.
+
+Deterministic tests observe the supervision boundary for all three roles and
+use an injected immediate retry schedule and deferred barriers to distinguish
+`IsOfflineError` from `UnknownError`. Combined coverage proves a parked backend
+pull remains replaceable through the persistent ServerAhead pull owner.

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -202,6 +202,9 @@ interface Options {
     readonly delays?: {
       readonly localPushProcessing?: Effect.Effect<void>
     }
+    readonly schedules?: {
+      readonly backendPushRetry?: Schedule.Schedule<unknown>
+    }
     readonly hooks?: {
       readonly localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
       readonly backendPullCursorAdvanced?: (head: EventSequenceNumber.Client.Composite) => Effect.Effect<void>
@@ -728,9 +731,11 @@ export const make = Effect.fnUntraced(function* ({
       }).pipe(
         // Retry transient errors
         Effect.retry({
-          schedule: Schedule.exponential(Duration.seconds(1)).pipe(
-            Schedule.modifyDelay(({ duration }) => Effect.succeed(Duration.min(duration, Duration.seconds(30)))), // Cap delay at 30s intervals.
-          ),
+          schedule:
+            testing.schedules?.backendPushRetry ??
+            Schedule.exponential(Duration.seconds(1)).pipe(
+              Schedule.modifyDelay(({ duration }) => Effect.succeed(Duration.min(duration, Duration.seconds(30)))), // Cap delay at 30s intervals.
+            ),
           while: (error) => error._tag === 'IsOfflineError',
         }),
         // This is needed to narrow the Error type. Our retry policy runs indefinitely, but Effect.retry does not narrow the Error type.

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -57,6 +57,8 @@ import { LeaderThreadCtx } from './types.ts'
 export const TypeId = '~@livestore/common/LeaderSyncProcessor' as const
 export type TypeId = typeof TypeId
 
+export type SyncWorker = 'local-apply' | 'backend-push' | 'backend-pull'
+
 /**
  * The LeaderSyncProcessor manages synchronization of events between
  * the local state and the sync backend, ensuring efficient and orderly processing.
@@ -204,6 +206,8 @@ interface Options {
       readonly localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
       readonly backendPullCursorAdvanced?: (head: EventSequenceNumber.Client.Composite) => Effect.Effect<void>
       readonly backendPullRestartRequested?: () => Effect.Effect<void>
+      /** Test-only observation of a worker reaching the terminal supervision boundary. */
+      readonly workerTerminal?: (args: { worker: SyncWorker; cause: Cause.Cause<unknown> }) => Effect.Effect<void>
     }
   }
 }
@@ -730,7 +734,7 @@ export const make = Effect.fnUntraced(function* ({
           while: (error) => error._tag === 'IsOfflineError',
         }),
         // This is needed to narrow the Error type. Our retry policy runs indefinitely, but Effect.retry does not narrow the Error type.
-        Effect.catchIf((error) => error._tag === 'IsOfflineError', Effect.die),
+        Effect.catchTag('IsOfflineError', Effect.die),
       )
 
       // Stop pushing so later events cannot skip this rejected batch. Pull reconciliation
@@ -808,16 +812,26 @@ export const make = Effect.fnUntraced(function* ({
       const handleBackendIdMismatchError = (error: BackendIdMismatchError) =>
         handleBackendIdMismatch({ error, onBackendIdMismatch, shutdownChannel })
 
-      const maybeShutdownOnError = (cause: Cause.Cause<UnknownError | MaterializeError>) =>
+      /**
+       * Terminal worker failures remain owned by the processor. Ignore mode parks the worker instead
+       * of completing its fiber, leaving its uncertain prefix available to an existing recovery path.
+       */
+      const superviseTerminalWorker =
+        (worker: SyncWorker) =>
+        (cause: Cause.Cause<BackendIdMismatchError | UnknownError | MaterializeError>) =>
         Effect.gen(function* () {
+          if (Cause.hasInterruptsOnly(cause) === true) return
+
+          if (testing.hooks?.workerTerminal !== undefined) {
+            yield* testing.hooks.workerTerminal({ worker, cause })
+          }
+
           if (onError === 'ignore') {
-            if (LS_DEV === true) {
-              yield* Effect.logDebug(
-                `Ignoring sync error (${Option.getOrUndefined(Cause.findErrorOption(cause))?._tag ?? cause.toString()})`,
-                Cause.pretty(cause),
-              )
-            }
-            return
+            yield* Effect.logError(
+              `Sync ${worker} worker parked after terminal failure (${Option.getOrUndefined(Cause.findErrorOption(cause))?._tag ?? cause.toString()})`,
+              Cause.pretty(cause),
+            )
+            return yield* Effect.never
           }
 
           const error = Option.getOrUndefined(Cause.findErrorOption(cause))
@@ -827,12 +841,15 @@ export const make = Effect.fnUntraced(function* ({
           return yield* Effect.failCause(cause).pipe(Effect.orDie)
         })
 
-      yield* backgroundApplyLocalPushes.pipe(Effect.catchCause(maybeShutdownOnError), Effect.forkScoped)
+      yield* backgroundApplyLocalPushes.pipe(
+        Effect.catchCause(superviseTerminalWorker('local-apply')),
+        Effect.forkScoped,
+      )
 
       const backendPushingFiberHandle = yield* FiberHandle.make<void, never>()
       const backendPushingEffect = backgroundBackendPushing.pipe(
         Effect.catchTag('BackendIdMismatchError', handleBackendIdMismatchError),
-        Effect.catchCause(maybeShutdownOnError),
+        Effect.catchCause(superviseTerminalWorker('backend-push')),
       )
 
       const backendPullingGenerationEffect = backgroundBackendPulling({
@@ -860,17 +877,21 @@ export const make = Effect.fnUntraced(function* ({
         Effect.provideService(References.UnhandledLogLevel, undefined),
       )
 
-      const handleTerminalBackendPullExit = (
-        exit: Exit.Exit<void, BackendIdMismatchError | UnknownError | MaterializeError>,
-      ) =>
-        Exit.match(exit, {
-          onSuccess: () => Effect.void,
-          onFailure: (cause) =>
-            Effect.failCause(cause).pipe(
-              Effect.catchTag('BackendIdMismatchError', handleBackendIdMismatchError),
-              Effect.catchCause(maybeShutdownOnError),
-            ),
-        })
+      /** Generic pull parking remains owned by the persistent pull owner so ServerAhead can replace it. */
+      const handleTerminalBackendPullCause = (
+        cause: Cause.Cause<BackendIdMismatchError | UnknownError | MaterializeError>,
+      ) => {
+        const error = Option.getOrUndefined(Cause.findErrorOption(cause))
+
+        if (error?._tag === 'BackendIdMismatchError') {
+          return handleBackendIdMismatchError(error).pipe(Effect.as('terminal-policy-ended' as const))
+        }
+
+        return Effect.raceFirst(
+          superviseTerminalWorker('backend-pull')(cause).pipe(Effect.as('terminal-policy-ended' as const)),
+          TxQueue.take(backendPullRestartQueue).pipe(Effect.as('restart-requested' as const)),
+        )
+      }
 
       // The owner persists beyond finite generations. Restart retires transport work only after
       // canonical application leaves its fence, then observes the generation exit before replacement.
@@ -884,7 +905,8 @@ export const make = Effect.fnUntraced(function* ({
 
           if (outcome !== 'restart-requested') {
             if (Exit.isFailure(outcome.exit) === true) {
-              yield* handleTerminalBackendPullExit(outcome.exit)
+              const terminalOutcome = yield* handleTerminalBackendPullCause(outcome.exit.cause)
+              if (terminalOutcome === 'restart-requested') continue
               return
             }
 
@@ -904,7 +926,8 @@ export const make = Effect.fnUntraced(function* ({
           yield* TxQueue.poll(backendPullRestartQueue)
 
           if (Exit.isFailure(retiredExit) === true && Cause.hasInterruptsOnly(retiredExit.cause) === false) {
-            yield* handleTerminalBackendPullExit(retiredExit)
+            const terminalOutcome = yield* handleTerminalBackendPullCause(retiredExit.cause)
+            if (terminalOutcome === 'restart-requested') continue
             return
           }
         }
@@ -1292,13 +1315,12 @@ const handleBackendIdMismatch = Effect.fn('@livestore/common:LeaderSyncProcessor
     return yield* Effect.die(error)
   }
 
-  // ignore mode
-  if (LS_DEV === true) {
-    yield* Effect.logDebug(
-      'Ignoring BackendIdMismatchError (sync backend was reset but client continues with stale data)',
-      error,
-    )
-  }
+  // Ignore mode deliberately leaves this worker terminal while the Store continues.
+  yield* Effect.logError(
+    'Sync worker parked after BackendIdMismatchError (backend was reset but client continues with stale data)',
+    error,
+  )
+  return yield* Effect.never
 })
 
 /**

--- a/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
+++ b/packages/@livestore/common/src/leader-thread/LeaderSyncProcessor.ts
@@ -822,29 +822,28 @@ export const make = Effect.fnUntraced(function* ({
        * of completing its fiber, leaving its uncertain prefix available to an existing recovery path.
        */
       const superviseTerminalWorker =
-        (worker: SyncWorker) =>
-        (cause: Cause.Cause<BackendIdMismatchError | UnknownError | MaterializeError>) =>
-        Effect.gen(function* () {
-          if (Cause.hasInterruptsOnly(cause) === true) return
+        (worker: SyncWorker) => (cause: Cause.Cause<BackendIdMismatchError | UnknownError | MaterializeError>) =>
+          Effect.gen(function* () {
+            if (Cause.hasInterruptsOnly(cause) === true) return
 
-          if (testing.hooks?.workerTerminal !== undefined) {
-            yield* testing.hooks.workerTerminal({ worker, cause })
-          }
+            if (testing.hooks?.workerTerminal !== undefined) {
+              yield* testing.hooks.workerTerminal({ worker, cause })
+            }
 
-          if (onError === 'ignore') {
-            yield* Effect.logError(
-              `Sync ${worker} worker parked after terminal failure (${Option.getOrUndefined(Cause.findErrorOption(cause))?._tag ?? cause.toString()})`,
-              Cause.pretty(cause),
-            )
-            return yield* Effect.never
-          }
+            if (onError === 'ignore') {
+              yield* Effect.logError(
+                `Sync ${worker} worker parked after terminal failure (${Option.getOrUndefined(Cause.findErrorOption(cause))?._tag ?? cause.toString()})`,
+                Cause.pretty(cause),
+              )
+              return yield* Effect.never
+            }
 
-          const error = Option.getOrUndefined(Cause.findErrorOption(cause))
-          const errorToSend = error === undefined ? UnknownError.make({ cause }) : error
-          yield* shutdownChannel.send(errorToSend).pipe(Effect.orDie)
+            const error = Option.getOrUndefined(Cause.findErrorOption(cause))
+            const errorToSend = error === undefined ? UnknownError.make({ cause }) : error
+            yield* shutdownChannel.send(errorToSend).pipe(Effect.orDie)
 
-          return yield* Effect.failCause(cause).pipe(Effect.orDie)
-        })
+            return yield* Effect.failCause(cause).pipe(Effect.orDie)
+          })
 
       yield* backgroundApplyLocalPushes.pipe(
         Effect.catchCause(superviseTerminalWorker('local-apply')),

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -11,6 +11,7 @@ import {
   Option,
   Queue,
   ReadonlyArray,
+  type Schedule,
   Schema,
   Stream,
   Subscribable,
@@ -70,6 +71,9 @@ export interface MakeLeaderThreadLayerParams {
     syncProcessor?: {
       delays?: {
         localPushProcessing?: Effect.Effect<void>
+      }
+      schedules?: {
+        backendPushRetry?: Schedule.Schedule<unknown>
       }
       hooks?: {
         localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
@@ -197,7 +201,11 @@ export const makeLeaderThreadLayer = ({
         }),
       },
       testing: {
-        ...omitUndefineds({ delays: testing?.syncProcessor?.delays, hooks: testing?.syncProcessor?.hooks }),
+        ...omitUndefineds({
+          delays: testing?.syncProcessor?.delays,
+          schedules: testing?.syncProcessor?.schedules,
+          hooks: testing?.syncProcessor?.hooks,
+        }),
       },
     })
 

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -1,5 +1,6 @@
 import { omitUndefineds, shouldNeverHappen } from '@livestore/utils'
 import {
+  type Cause,
   type HttpClient,
   type Scope,
   Deferred,
@@ -74,6 +75,10 @@ export interface MakeLeaderThreadLayerParams {
         localPushAdmitted?: (events: ReadonlyArray<LiveStoreEvent.Client.EncodedWithMeta>) => Effect.Effect<void>
         backendPullCursorAdvanced?: (head: EventSequenceNumber.Client.Composite) => Effect.Effect<void>
         backendPullRestartRequested?: () => Effect.Effect<void>
+        workerTerminal?: (args: {
+          worker: LeaderSyncProcessor.SyncWorker
+          cause: Cause.Cause<unknown>
+        }) => Effect.Effect<void>
       }
     }
   }

--- a/packages/@livestore/common/src/sync/mock-sync-backend.ts
+++ b/packages/@livestore/common/src/sync/mock-sync-backend.ts
@@ -12,7 +12,7 @@ import {
 
 import { UnknownError } from '../errors.ts'
 import { EventSequenceNumber, type LiveStoreEvent } from '../schema/mod.ts'
-import type { BackendIdMismatchError, ServerAheadError } from './errors.ts'
+import type { BackendIdMismatchError, IsOfflineError, ServerAheadError } from './errors.ts'
 import * as SyncBackend from './sync-backend.ts'
 import { validatePushPayload } from './validate-push-payload.ts'
 
@@ -39,17 +39,17 @@ export interface MockSyncBackend {
   advanceWithoutPublication: (...batch: LiveStoreEvent.Global.Encoded[]) => Effect.Effect<void>
   /** Persist the next N successful pushes but omit their live pull publication. */
   dropNextPushPublications: (count: number) => Effect.Effect<void>
-  /** Fail the next N push calls with an UnknownError, ServerAheadError, BackendIdMismatchError, or custom error */
+  /** Fail the next N push calls with a supported sync error or custom error. */
   failNextPushes: (
     count: number,
     error?: (
       batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-    ) => Effect.Effect<never, UnknownError | ServerAheadError | BackendIdMismatchError>,
+    ) => Effect.Effect<never, UnknownError | IsOfflineError | ServerAheadError | BackendIdMismatchError>,
   ) => Effect.Effect<void>
-  /** Fail the next N pull calls with an UnknownError, BackendIdMismatchError, or custom error */
+  /** Fail the next N pull calls with a supported sync error or custom error. */
   failNextPulls: (
     count: number,
-    error?: () => Effect.Effect<never, UnknownError | BackendIdMismatchError>,
+    error?: () => Effect.Effect<never, UnknownError | IsOfflineError | BackendIdMismatchError>,
   ) => Effect.Effect<void>
 }
 
@@ -95,11 +95,11 @@ export const makeMockSyncBackend = (
     // Failure simulation state
     const failPushRef = yield* Ref.make<
       FailureState<
-        UnknownError | ServerAheadError | BackendIdMismatchError,
+        UnknownError | IsOfflineError | ServerAheadError | BackendIdMismatchError,
         [ReadonlyArray<LiveStoreEvent.Global.Encoded>]
       >
     >({ remaining: 0, error: undefined })
-    const failPullRef = yield* Ref.make<FailureState<UnknownError | BackendIdMismatchError, []>>({
+    const failPullRef = yield* Ref.make<FailureState<UnknownError | IsOfflineError | BackendIdMismatchError, []>>({
       remaining: 0,
       error: undefined,
     })
@@ -290,11 +290,13 @@ export const makeMockSyncBackend = (
       count: number,
       error?: (
         batch: ReadonlyArray<LiveStoreEvent.Global.Encoded>,
-      ) => Effect.Effect<never, UnknownError | ServerAheadError | BackendIdMismatchError>,
+      ) => Effect.Effect<never, UnknownError | IsOfflineError | ServerAheadError | BackendIdMismatchError>,
     ) => Ref.set(failPushRef, { remaining: count, error })
 
-    const failNextPulls = (count: number, error?: () => Effect.Effect<never, UnknownError | BackendIdMismatchError>) =>
-      Ref.set(failPullRef, { remaining: count, error })
+    const failNextPulls = (
+      count: number,
+      error?: () => Effect.Effect<never, UnknownError | IsOfflineError | BackendIdMismatchError>,
+    ) => Ref.set(failPullRef, { remaining: count, error })
 
     return {
       pushedEvents: Stream.fromQueue(pushedEventsQueue),

--- a/packages/@livestore/common/src/sync/sync.ts
+++ b/packages/@livestore/common/src/sync/sync.ts
@@ -11,13 +11,14 @@ export type SyncOptions<TPayload = Schema.Json> = {
   /** @default { _tag: 'Skip' } */
   initialSyncOptions?: InitialSyncOptions
   /**
-   * What to do if there is an error during sync.
+   * What to do for a generic terminal error during sync. More-specific failure
+   * families may define a higher-priority lifecycle policy.
    *
    * Options:
    * `shutdown` will stop the sync processor and cause the app to crash.
-   * `ignore` will log the error, park the affected sync worker with its unresolved work intact,
-   * and let the app continue running. An existing protocol recovery path may replace the worker;
-   * the terminal failure itself is not retried automatically.
+   * `ignore` will log the generic error, park the affected sync worker with its unresolved work
+   * intact, and let the app continue running. An existing protocol recovery path may replace the
+   * worker; the terminal failure itself is not retried automatically.
    *
    * @default 'ignore'
    * */

--- a/packages/@livestore/common/src/sync/sync.ts
+++ b/packages/@livestore/common/src/sync/sync.ts
@@ -15,7 +15,9 @@ export type SyncOptions<TPayload = Schema.Json> = {
    *
    * Options:
    * `shutdown` will stop the sync processor and cause the app to crash.
-   * `ignore` will log the error and let the app continue running acting as if it was offline.
+   * `ignore` will log the error, park the affected sync worker with its unresolved work intact,
+   * and let the app continue running. An existing protocol recovery path may replace the worker;
+   * the terminal failure itself is not retried automatically.
    *
    * @default 'ignore'
    * */
@@ -34,8 +36,8 @@ export type SyncOptions<TPayload = Schema.Json> = {
    *   This is the recommended option for development.
    * - `'shutdown'`: Shutdown without clearing local storage.
    *   On restart, the client will still have stale data and hit the same error.
-   * - `'ignore'`: Log the error and continue running.
-   *   The client will show stale data but keep running (effectively offline mode).
+   * - `'ignore'`: Log the error, park the affected sync worker, and continue running.
+   *   The client will show stale data (effectively offline mode).
    *
    * @default 'reset'
    */

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'vitest'
 
 import {
   BackendIdMismatchError,
+  IsOfflineError,
   type IntentionalShutdownCause,
   type MockSyncBackend,
   type MockSyncBackendOptions,
@@ -37,6 +38,7 @@ import {
   Result,
   type Scope,
   Stream,
+  TestClock,
   WebChannel,
 } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
@@ -985,6 +987,207 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
       expect(yield* testContext.mockSyncBackend.storedEvents).toEqual([])
     }).pipe(withTestCtx({ syncOptions: { livePull: false, onSyncError: 'shutdown' }, captureShutdown: true })(test)),
   )
+
+  {
+    const firstAttempt = Deferred.makeUnsafe<void>()
+    let pushAttempts = 0
+
+    Vitest.it.effect('retries positively identified offline push failures', (test) =>
+      Effect.gen(function* () {
+        const testContext = yield* TestContext
+
+        yield* testContext.pushEncoded(
+          testContext.eventFactory.todoCreated.next({ id: 'offline-retry', text: 'offline', completed: false }),
+        )
+        yield* Deferred.await(firstAttempt)
+        expect(pushAttempts).toBe(1)
+
+        yield* TestClock.adjust('2 seconds')
+        yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain)
+
+        expect(pushAttempts).toBe(2)
+      }).pipe(
+        withTestCtx({
+          syncOptions: { livePull: false, onSyncError: 'ignore' },
+          mockBackendOverride: (mockBackend) => () =>
+            Effect.gen(function* () {
+              const syncBackend = yield* mockBackend.makeSyncBackend
+              return {
+                ...syncBackend,
+                push: (batch) =>
+                  Effect.sync(() => ++pushAttempts).pipe(
+                    Effect.tap(() => Deferred.succeed(firstAttempt, undefined)),
+                    Effect.flatMap((attempt) =>
+                      attempt === 1
+                        ? Effect.fail(new IsOfflineError({ cause: new Error('simulated offline backend') }))
+                        : syncBackend.push(batch),
+                    ),
+                  ),
+              }
+            }),
+        })(test),
+      ),
+    )
+  }
+
+  {
+    const terminalWorker = Deferred.makeUnsafe<string>()
+    let pushAttempts = 0
+
+    Vitest.it.effect('parks backend push after one UnknownError attempt', (test) =>
+      Effect.gen(function* () {
+        const testContext = yield* TestContext
+
+        yield* testContext.pushEncoded(
+          testContext.eventFactory.todoCreated.next({ id: 'unknown-terminal', text: 'terminal', completed: false }),
+        )
+
+        expect(yield* Deferred.await(terminalWorker)).toBe('backend-push')
+        expect(pushAttempts).toBe(1)
+
+        // Crossing the first two exponential retry delays proves UnknownError did not enter the schedule.
+        yield* TestClock.adjust('5 seconds')
+        expect(pushAttempts).toBe(1)
+        expect(yield* Deferred.isDone(testContext.shutdownDeferred)).toBe(false)
+      }).pipe(
+        withTestCtx({
+          syncOptions: { livePull: false, onSyncError: 'ignore' },
+          captureShutdown: true,
+          testing: {
+            syncProcessor: {
+              hooks: {
+                workerTerminal: ({ worker }) => Deferred.succeed(terminalWorker, worker),
+              },
+            },
+          },
+          mockBackendOverride: (mockBackend) => () =>
+            Effect.gen(function* () {
+              const syncBackend = yield* mockBackend.makeSyncBackend
+              return {
+                ...syncBackend,
+                push: () =>
+                  Effect.sync(() => ++pushAttempts).pipe(
+                    Effect.andThen(
+                      Effect.fail(new UnknownError({ cause: new Error('simulated unclassified push failure') })),
+                    ),
+                  ),
+              }
+            }),
+        })(test),
+      ),
+    )
+  }
+
+  {
+    const terminalWorker = Deferred.makeUnsafe<string>()
+    let pullAttempts = 0
+
+    Vitest.it.effect('parks backend pull after terminal failure', (test) =>
+      Effect.gen(function* () {
+        const testContext = yield* TestContext
+
+        expect(yield* Deferred.await(terminalWorker)).toBe('backend-pull')
+        expect(pullAttempts).toBe(1)
+
+        yield* TestClock.adjust('5 seconds')
+        expect(pullAttempts).toBe(1)
+        expect(yield* Deferred.isDone(testContext.shutdownDeferred)).toBe(false)
+      }).pipe(
+        withTestCtx({
+          syncOptions: { livePull: true, onSyncError: 'ignore' },
+          captureShutdown: true,
+          testing: {
+            syncProcessor: {
+              hooks: {
+                workerTerminal: ({ worker }) => Deferred.succeed(terminalWorker, worker),
+              },
+            },
+          },
+          mockBackendOverride: (mockBackend) => () =>
+            Effect.gen(function* () {
+              const syncBackend = yield* mockBackend.makeSyncBackend
+              return {
+                ...syncBackend,
+                pull: () => {
+                  pullAttempts++
+                  return Stream.fail(new UnknownError({ cause: new Error('simulated unclassified pull failure') }))
+                },
+              }
+            }),
+        })(test),
+      ),
+    )
+  }
+
+  {
+    const terminalWorker = Deferred.makeUnsafe<string>()
+
+    Vitest.live('replaces a parked backend push after pull reconciliation', (test) =>
+      Effect.gen(function* () {
+        const testContext = yield* TestContext
+        const backendFactory = makeEventFactory({
+          client: EventFactory.clientIdentity('recovery-backend', 'recovery-session'),
+        })
+
+        yield* testContext.mockSyncBackend.failNextPushes(
+          1,
+          () => new UnknownError({ cause: new Error('simulated uncertain push outcome') }),
+        )
+        yield* testContext.pushEncoded(
+          testContext.eventFactory.todoCreated.next({ id: 'local-recovered', text: 'local', completed: false }),
+        )
+        expect(yield* Deferred.await(terminalWorker)).toBe('backend-push')
+
+        // An authoritative pull rebases current pending and replaces the parked push worker.
+        yield* testContext.mockSyncBackend.advance(
+          backendFactory.todoCreated.next({ id: 'remote', text: 'remote', completed: false }),
+        )
+
+        const recoveredPush = yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runHead)
+        assert(recoveredPush._tag === 'Some')
+        expect(recoveredPush.value.args).toMatchObject({ id: 'local-recovered' })
+      }).pipe(
+        withTestCtx({
+          syncOptions: { livePull: true, onSyncError: 'ignore' },
+          testing: {
+            syncProcessor: {
+              hooks: {
+                workerTerminal: ({ worker }) => Deferred.succeed(terminalWorker, worker),
+              },
+            },
+          },
+        })(test),
+      ),
+    )
+  }
+
+  {
+    const terminalWorker = Deferred.makeUnsafe<string>()
+
+    Vitest.live('parks local apply after terminal failure', (test) =>
+      Effect.gen(function* () {
+        const testContext = yield* TestContext
+
+        expect(yield* Deferred.await(terminalWorker)).toBe('local-apply')
+        expect(yield* Deferred.isDone(testContext.shutdownDeferred)).toBe(false)
+      }).pipe(
+        withTestCtx({
+          syncOptions: { livePull: false, onSyncError: 'ignore' },
+          captureShutdown: true,
+          testing: {
+            syncProcessor: {
+              delays: {
+                localPushProcessing: Effect.die(new Error('simulated local-apply defect')),
+              },
+              hooks: {
+                workerTerminal: ({ worker }) => Deferred.succeed(terminalWorker, worker),
+              },
+            },
+          },
+        })(test),
+      ),
+    )
+  }
 
   // Should escalate and shutdown on BackendIdMismatchError when onBackendIdMismatch='shutdown' (legacy behavior)
   Vitest.live('shutdowns on BackendIdMismatchError push', (test) =>

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -1123,6 +1123,78 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
   {
     const terminalWorker = Deferred.makeUnsafe<string>()
 
+    Vitest.live('ServerAhead catch-up replaces a parked backend pull', (test) =>
+      Effect.gen(function* () {
+        const leaderThreadCtx = yield* LeaderThreadCtx
+        const testContext = yield* TestContext
+
+        expect(yield* Deferred.await(terminalWorker)).toBe('backend-pull')
+        expect(
+          yield* testContext.mockSyncBackend.pullRequests.pipe(Stream.runFirstUnsafe, Effect.timeout(5000)),
+        ).toEqual(EventSequenceNumber.Client.ROOT.global)
+
+        const localEvent = testContext.eventFactory.todoCreated.next({
+          id: 'local-after-park',
+          text: 'local-after-park',
+          completed: false,
+        })
+        yield* testContext.pushEncoded(localEvent)
+
+        // The backend already contains e1, so the stale e1 push requests ServerAhead catch-up.
+        // The persistent pull owner replaces the parked generation from its still-authoritative root cursor.
+        expect(
+          yield* testContext.mockSyncBackend.pullRequests.pipe(Stream.runFirstUnsafe, Effect.timeout(5000)),
+        ).toEqual(EventSequenceNumber.Client.ROOT.global)
+
+        const recoveredPush = yield* testContext.mockSyncBackend.pushedEvents.pipe(
+          Stream.runFirstUnsafe,
+          Effect.timeout(5000),
+        )
+        expect(recoveredPush.args).toEqual(localEvent.args)
+
+        yield* leaderThreadCtx.syncProcessor.syncState.changes.pipe(
+          Stream.filter((state) => state.upstreamHead.global === 2 && state.pending.length === 0),
+          Stream.runFirstUnsafe,
+          Effect.timeout(5000),
+        )
+
+        expect(yield* testContext.mockSyncBackend.pullRequestCount).toBe(2)
+        expect(yield* testContext.mockSyncBackend.activePulls.maximum).toBe(1)
+        expect(yield* Deferred.isDone(testContext.shutdownDeferred)).toBe(false)
+      }).pipe(
+        withTestCtx({
+          mockBackendOptions: { startConnected: true },
+          syncOptions: { livePull: true, onSyncError: 'ignore' },
+          captureShutdown: true,
+          seedMockBackend: (mockBackend) => {
+            const backendFactory = makeEventFactory({
+              client: EventFactory.clientIdentity('parked-pull-backend', 'recovery-session'),
+            })
+            return Effect.gen(function* () {
+              yield* mockBackend.advanceWithoutPublication(
+                backendFactory.todoCreated.next({ id: 'remote', text: 'remote', completed: false }),
+              )
+              yield* mockBackend.failNextPulls(
+                1,
+                () => new UnknownError({ cause: new Error('simulated unclassified pull failure') }),
+              )
+            })
+          },
+          testing: {
+            syncProcessor: {
+              hooks: {
+                workerTerminal: ({ worker }) => Deferred.succeed(terminalWorker, worker),
+              },
+            },
+          },
+        })(test),
+      ),
+    )
+  }
+
+  {
+    const terminalWorker = Deferred.makeUnsafe<string>()
+
     Vitest.live('replaces a parked backend push after pull reconciliation', (test) =>
       Effect.gen(function* () {
         const testContext = yield* TestContext
@@ -1356,7 +1428,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
   // NOTE: Pull path test is skipped because the MockSyncBackend's failNextPulls works on the
   // initial pull, not on live pulls after advance. The core functionality for handling
-  // BackendIdMismatchError is shared with the push path via maybeShutdownOnError.
+  // BackendIdMismatchError is shared with the push path via the dedicated backend-identity policy.
   // The real pull scenario is tested in integration tests with actual sync providers.
   Vitest.live.skip('clears databases on BackendIdMismatchError pull with reset', (test) =>
     Effect.gen(function* () {

--- a/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
+++ b/tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts
@@ -36,9 +36,9 @@ import {
   Queue,
   References,
   Result,
+  Schedule,
   type Scope,
   Stream,
-  TestClock,
   WebChannel,
 } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
@@ -990,9 +990,10 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
 
   {
     const firstAttempt = Deferred.makeUnsafe<void>()
+    const secondAttempt = Deferred.makeUnsafe<void>()
     let pushAttempts = 0
 
-    Vitest.it.effect('retries positively identified offline push failures', (test) =>
+    Vitest.live('retries positively identified offline push failures', (test) =>
       Effect.gen(function* () {
         const testContext = yield* TestContext
 
@@ -1002,25 +1003,29 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         yield* Deferred.await(firstAttempt)
         expect(pushAttempts).toBe(1)
 
-        yield* TestClock.adjust('2 seconds')
-        yield* testContext.mockSyncBackend.pushedEvents.pipe(Stream.take(1), Stream.runDrain)
+        yield* Deferred.await(secondAttempt)
 
         expect(pushAttempts).toBe(2)
       }).pipe(
         withTestCtx({
           syncOptions: { livePull: false, onSyncError: 'ignore' },
+          testing: {
+            syncProcessor: {
+              schedules: { backendPushRetry: Schedule.recurs(1) },
+            },
+          },
           mockBackendOverride: (mockBackend) => () =>
             Effect.gen(function* () {
               const syncBackend = yield* mockBackend.makeSyncBackend
               return {
                 ...syncBackend,
-                push: (batch) =>
+                push: () =>
                   Effect.sync(() => ++pushAttempts).pipe(
                     Effect.tap(() => Deferred.succeed(firstAttempt, undefined)),
                     Effect.flatMap((attempt) =>
                       attempt === 1
                         ? Effect.fail(new IsOfflineError({ cause: new Error('simulated offline backend') }))
-                        : syncBackend.push(batch),
+                        : Deferred.succeed(secondAttempt, undefined),
                     ),
                   ),
               }
@@ -1034,7 +1039,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     const terminalWorker = Deferred.makeUnsafe<string>()
     let pushAttempts = 0
 
-    Vitest.it.effect('parks backend push after one UnknownError attempt', (test) =>
+    Vitest.live('parks backend push after one UnknownError attempt', (test) =>
       Effect.gen(function* () {
         const testContext = yield* TestContext
 
@@ -1045,9 +1050,6 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
         expect(yield* Deferred.await(terminalWorker)).toBe('backend-push')
         expect(pushAttempts).toBe(1)
 
-        // Crossing the first two exponential retry delays proves UnknownError did not enter the schedule.
-        yield* TestClock.adjust('5 seconds')
-        expect(pushAttempts).toBe(1)
         expect(yield* Deferred.isDone(testContext.shutdownDeferred)).toBe(false)
       }).pipe(
         withTestCtx({
@@ -1055,6 +1057,7 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
           captureShutdown: true,
           testing: {
             syncProcessor: {
+              schedules: { backendPushRetry: Schedule.recurs(1) },
               hooks: {
                 workerTerminal: ({ worker }) => Deferred.succeed(terminalWorker, worker),
               },
@@ -1082,15 +1085,13 @@ Vitest.describe.concurrent('LeaderSyncProcessor', { timeout: 60000 }, () => {
     const terminalWorker = Deferred.makeUnsafe<string>()
     let pullAttempts = 0
 
-    Vitest.it.effect('parks backend pull after terminal failure', (test) =>
+    Vitest.live('parks backend pull after terminal failure', (test) =>
       Effect.gen(function* () {
         const testContext = yield* TestContext
 
         expect(yield* Deferred.await(terminalWorker)).toBe('backend-pull')
         expect(pullAttempts).toBe(1)
 
-        yield* TestClock.adjust('5 seconds')
-        expect(pullAttempts).toBe(1)
         expect(yield* Deferred.isDone(testContext.shutdownDeferred)).toBe(false)
       }).pipe(
         withTestCtx({


### PR DESCRIPTION
## Problem

Backend push retried `UnknownError` forever even though it carries no evidence that replay is safe. Separately, the shared `onSyncError: 'ignore'` handler returned after a terminal cause, so backend push, backend pull, or local apply could lose its background worker while the Store remained open.

This is PR 4 of 4 in native GitHub Stack #1578. It implements the intent-only contract in #1579 on top of #1576's active ServerAhead pull owner.

## Solution

- Retry backend push only for positively classified connectivity failures such as `IsOfflineError`; `UnknownError` reaches terminal supervision after one attempt.
- Preserve #1576's active `ServerAheadError` path: fence the stale push, request persisted-cursor catch-up, retire only between canonical applications, keep one persistent pull owner, and never overlap generations.
- Route generic terminal causes from backend push, backend pull, and local apply through one named supervision policy.
- Under `onSyncError: 'ignore'`, log at error level and park generic terminal work with its unresolved prefix intact. Interrupt-only scope shutdown still completes normally, and a more-specific lifecycle-fatal policy may be inserted ahead of generic parking.
- Keep generic backend-pull parking inside the persistent pull owner, allowing a later ServerAhead request to replace it from authoritative state.
- Retain pull reconciliation's ability to clear, reseed, and replace a parked backend-push worker.
- Preserve the dedicated backend-identity policy and add no public worker-health/status API, callback, receipt, retry configuration, or application recovery state machine.

The combined deterministic regression parks backend pull on `UnknownError`, derives `ServerAheadError` naturally from a stale push, proves exactly one replacement pull starts from the persisted root cursor, proves at most one pull generation is active, and observes processing resume through the rebased push.

Trade-off: generic ignore mode keeps the Store open while terminal local apply remains parked when no independent recovery signal exists. A specialized lifecycle-fatal family may override this generic policy in its owning stack.

## Validation

- `devenv tasks run lint:full:fix`
- `devenv tasks run ts:check`
- `devenv tasks run test:unit`
- `devenv tasks run test:integration:sync-provider:mock`
- `pnpm exec vitest run packages/@livestore/common/src/sync/mock-sync-backend.test.ts tests/package-common/src/leader-thread/LeaderSyncProcessor.test.ts tests/package-common/src/client-session/ClientSessionSyncProcessor.test.ts tests/package-common/src/intent-layer/intent-layer.test.ts` (72 passed, 1 skipped)
- `pnpm exec changeset status`

### Recovery flow

```text
parked backend pull
        ^
        | UnknownError (generic ignore)
stale push -> ServerAhead -> persisted-cursor restart request
                              |
                              v
                 one replacement pull generation
                              |
                              v
                    reconcile + resume push
```

## Related issues

- #1577
- ServerAhead liveness is owned by #1462 and #1575/#1576.
- Retry schedule configurability (#1111), crash atomicity (#1532), public receipts, and worker-health APIs remain out of scope.
