### PR TITLE
Define poisoned-event recovery at the last valid canonical head

### DIFF
--- a/context/02-system/01-event-model/requirements.md
+++ b/context/02-system/01-event-model/requirements.md
@@ -63,3 +63,9 @@ and root LS-R04…R06. Code: `packages/@livestore/common/src/schema/EventDef/`,
   sequence number, and client/session identity — decodable without external
   context (sharpens LS.SYS.EVT-R08 to a column-level enumeration; see
   [spec.md](./spec.md) §Eventlog). Adopted 2026-07-16 (interview).
+- **LS.SYS.EVT-R11 Canonical payload validity:** A canonical synced event whose
+  name resolves to a known definition but whose encoded payload does not decode
+  is a poisoned event. The engine must not record it as locally confirmed or
+  skip it to admit later canonical events, because later materializers may
+  depend on the missing state transition. Adopted 2026-08-22 (#732 reproduction
+  and user confirmation). `refines: LS.SYS.EVT-R03, LS.SYS.EVT-R07`

--- a/context/02-system/01-event-model/spec.md
+++ b/context/02-system/01-event-model/spec.md
@@ -61,6 +61,14 @@ Conversions: `toGlobal()` / `EncodedWithMeta.fromGlobal` and
 composite ones via `Client.fromGlobal`). All shapes are Effect Schema
 structs; encoding happens at the boundary (LS.SYS.EVT-R03).
 
+A known canonical event whose encoded payload fails its definition's decoder
+is a **poisoned event** (LS.SYS.EVT-R11). This differs from an event whose name
+is unknown to the current client: unknown-event handling may intentionally
+retain that event as an opaque no-op, whereas a known event declares a state
+transition whose invalid payload cannot be interpreted. The engine fences at
+the preceding valid event. Advancing past the malformed event would create a
+canonical history whose derived state omits a required transition.
+
 ## Sequence Numbers
 
 `EventSequenceNumber.Client.Composite = { global, client, rebaseGeneration }`.

--- a/context/02-system/02-state/requirements.md
+++ b/context/02-system/02-state/requirements.md
@@ -32,11 +32,20 @@ LS-R04…R06, LS-R10, LS-T04. Realization:
   contract; the engine core depends only on the contract. `refines: LS-R10`
 - **LS.SYS.STATE-R06 Read-only queries:** The app query surface cannot mutate
   state.
-- **LS.SYS.STATE-R07 Error classification:** Materializer failures are
-  recoverable tagged errors (`MaterializeError`, materializer-hash
-  mismatch); contract violations (unknown event on write, missing event
+- **LS.SYS.STATE-R07 Error classification:** Materializer failures are tagged
+  errors (`MaterializeError`, materializer-hash mismatch), not defects;
+  canonical occurrences become supervised poisoned-event failures under
+  LS.SYS.STATE-R08. Contract violations (unknown event on write, missing event
   definition during materialization) are defects (see [spec.md](./spec.md)
-  §Error classification). Adopted 2026-07-16 (interview).
+  §Error classification). Adopted 2026-07-16 (interview); canonical
+  classification sharpened 2026-08-22 (#732).
+- **LS.SYS.STATE-R08 Deterministic failure atomicity:** Payload decoding,
+  materializer evaluation, determinism validation, and mutation execution form
+  one deterministic application boundary. If any step fails, no mutation,
+  changeset, eventlog row, state head, or canonical cursor from that batch may
+  remain committed. When the input is canonical, the failing event is poisoned
+  rather than skipped. Adopted 2026-08-22 (#732 reproduction and user
+  confirmation). `refines: LS.SYS.STATE-R02, LS.SYS.STATE-R03`
 
 ## Open Design Questions
 

--- a/context/02-system/02-state/spec.md
+++ b/context/02-system/02-state/spec.md
@@ -59,12 +59,20 @@ The classification is contract (LS.SYS.STATE-R07):
 
 | Failure | Kind |
 | --- | --- |
-| `MaterializeError` (materializer threw / bad SQL) | recoverable tagged error |
-| `MaterializerHashMismatchError` (dev determinism check) | recoverable tagged error |
+| `MaterializeError` (materializer threw / bad SQL) | tagged error; poisoned when applying canonical input |
+| `MaterializerHashMismatchError` (dev determinism check) | tagged error; poisoned when applying canonical input |
 | Unknown event definition on **write** (`eventlog.ts:228`) | defect (`shouldNeverHappen`) |
 | Missing event definition during materialization (`materialize-event.ts:133`) | defect (`shouldNeverHappen`) |
 
 Unknown events on **read** are tolerated (`../01-event-model/spec.md`).
+
+Payload decode failures for known events, materializer evaluation failures,
+materializer-hash mismatches, and SQLite mutation failures are deterministic
+for the same event, schema, and pre-event state. A canonical event that reaches
+one of these failures is poisoned. Applying a batch containing it rolls back
+the complete batch, including state-head, eventlog, changeset, and cursor
+bookkeeping (LS.SYS.STATE-R08). The processor reports the failing event and the
+last valid head; it does not classify an unchanged retry as transient.
 
 ## Realization Contract
 

--- a/context/02-system/03-sync/02-processors/.decisions/0005-fence-poisoned-canonical-events.md
+++ b/context/02-system/03-sync/02-processors/.decisions/0005-fence-poisoned-canonical-events.md
@@ -1,0 +1,67 @@
+# 0005 — Fence poisoned canonical events at the last valid head
+
+Status: accepted (#732 reproduction and user confirmation, 2026-08-22).
+
+## Context
+
+Issue #732 expected `onSyncError: 'ignore'` to log a malformed known event and
+continue pulling. Reproduction on `upstream/main` showed two distinct failures:
+a payload decode defect terminated backend pulling at `e0`, while a SQLite
+materialization failure left published sync state at `e0` but persisted the
+backend cursor as `e1`.
+
+Continuing at `e2` is unsafe. The materializer for `e2` may read state that only
+`e1` creates, so skipping `e1` would make derived state disagree with canonical
+history on every client that encountered the malformed payload. Retrying the
+same payload or deterministic materializer against the same pre-event state
+cannot recover it either.
+
+## Options
+
+- **(a) Fence at the last valid canonical head and fail Store lifecycle —
+  chosen.** Roll back the complete attempted pull batch, preserve cursor and
+  heads, stop later propagation, and surface a structured failure through the
+  existing adapter/Store lifecycle delivery path. A restart retries only after an
+  operator, schema, materializer, state rebuild, or canonical-data repair has
+  changed the inputs.
+- **(b) Skip the poisoned event and continue pulling.** Rejected because later
+  materializers can depend on its absent state transition. The resulting state
+  would no longer be a deterministic derivation of the canonical eventlog.
+- **(c) Retry the poisoned event indefinitely in the pull worker.** Rejected
+  because unchanged deterministic inputs produce the same failure and a live
+  but permanently retrying Store misrepresents its health.
+- **(d) Leave recovery to each application commit call.** Rejected because the
+  poisoned event is canonical remote input, not the application's current
+  commit, and every session sharing the leader needs one coordinated fence.
+
+## Failure classification
+
+- Automatic retry requires positive retryability evidence. A classified
+  connectivity failure such as `IsOfflineError` retries from the persisted
+  last-valid cursor without publishing a new head.
+- `ServerAheadError` requests cooperative replacement from that cursor rather
+  than retrying the rejected push in place. Provider-specific and backend
+  identity failures retain their dedicated recovery policies. `UnknownError`
+  remains the unclassified terminal family and reaches worker supervision;
+  failure phase alone does not make it transient.
+- Known-event payload decode failures, materializer evaluation failures,
+  materializer-hash mismatches, and SQLite mutation failures are deterministic
+  for the same event, schema, and pre-event state. On canonical input they
+  produce a poisoned event.
+- Unknown events remain governed by the schema's explicit unknown-event
+  strategy. They are not reclassified as malformed known events.
+
+## Consequences
+
+- Pull application must delay cursor persistence and session publication until
+  state and eventlog application succeeds.
+- Rebase rollback and replacement materialization share the same error rollback
+  boundary. A failed replacement cannot discard the previous valid local tail.
+- Backend pushing pauses before canonical application and resumes only after a
+  successful commit, preventing local suffixes from crossing a poison fence.
+- Cooperative pull retirement waits until canonical application has completed;
+  an application failure reaches lifecycle supervision before a queued restart
+  can replace its pull generation.
+- `onSyncError: 'ignore'` cannot suppress poisoned-event lifecycle failure.
+- Crash and cross-database atomicity remain outside this decision. The boundary
+  guarantees rollback for in-process errors and interruption.

--- a/context/02-system/03-sync/02-processors/requirements.md
+++ b/context/02-system/03-sync/02-processors/requirements.md
@@ -80,6 +80,30 @@ Builds on [../requirements.md](../requirements.md) and
   state machine or per-commit receipt API. Adopted 2026-08-22 (#1577, [decision
   0004](./.decisions/0004-supervised-sync-failures.md)).
   `refines: LS.SYS.SYNC-R03, LS.SYS.SYNC.PROC-R04`
+- **LS.SYS.SYNC.PROC-R06 Poisoned canonical prefix:** Pull application commits
+  state, eventlog, changesets, persisted backend cursor, and published sync
+  heads as one error boundary. A deterministic application failure preserves
+  the last valid cursor and heads, rolls back the complete attempted batch,
+  stops backend propagation, and fences every later local or canonical event
+  behind the poisoned event. The processor emits a structured poisoned-event
+  failure to Store lifecycle supervision even when generic sync-error handling
+  is configured to ignore errors. Adopted 2026-08-22 (#732 reproduction and
+  user confirmation); see
+  [decision 0005](./.decisions/0005-fence-poisoned-canonical-events.md).
+  `refines: LS.SYS.EVT-R11, LS.SYS.STATE-R08, LS.SYS.SYNC.PROC-R04, LS.SYS.STORE-R07`
+- **LS.SYS.SYNC.PROC-R07 Recovery by classified failure:** Automatic retry
+  requires positive evidence that the failure is retryable. A classified
+  connectivity failure (`IsOfflineError` today) retries from the persisted
+  last-valid cursor. `ServerAheadError` requests cooperative backend-pull
+  replacement rather than in-place retry; provider-specific and backend
+  identity failures retain their dedicated policies. An unclassified
+  `UnknownError` is terminal and reaches R05 supervision. Deterministic
+  canonical payload or materialization failure is poison under R06: it is not
+  retried unchanged, takes precedence over generic ignore-mode parking, and
+  fails Store lifecycle so recovery can occur only after schema, materializer,
+  local state, or canonical data repair. Merely occurring before canonical
+  application does not make a provider failure transient. Adopted 2026-08-22
+  (#732 reproduction and user confirmation). `refines: LS.SYS.SYNC-R03`
 
 Further processor requirements (e.g. the crash-atomicity contract of batch
 materialization) remain open pending `LS.SYS.STATE-DQ2`;

--- a/context/02-system/03-sync/02-processors/spec.md
+++ b/context/02-system/03-sync/02-processors/spec.md
@@ -85,6 +85,19 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   failure prevents replacement. After a finite pull completes, the owner stays
   parked so a later `ServerAheadError` can start a new generation
   (`:838-915`).
+- **Poison fence:** applying a non-empty pull chunk first pauses backend
+  pushing. State rollback/materialization, eventlog writes, changesets, sync
+  metadata, and the persisted backend cursor then share one rollback boundary.
+  Only after that boundary commits does the processor publish sync state,
+  notify sessions, and resume backend pushing. A known-payload decode failure,
+  materializer evaluation/hash failure, or SQLite mutation failure wraps the
+  failing canonical event and last-valid head in a structured poisoned-event
+  diagnostic. The pull worker does not retry the unchanged event, backend
+  pushing remains fenced, and Store lifecycle supervision shuts the Store down
+  regardless of `onSyncError: 'ignore'` (LS.SYS.SYNC.PROC-R06/R07). A queued
+  `ServerAheadError` retirement waits outside the canonical-application
+  boundary; if application fails, poison reaches lifecycle supervision before
+  any replacement can interrupt or mask it.
 - **Pull precedence** (`:241, 393, 408-438`): a 1-permit semaphore
   (`localPushBackendPullMutex`) makes local-push application and pull-chunk
   application mutually exclusive; the pull side holds the permit for a
@@ -103,6 +116,9 @@ backend ──pull stream──▶ onNewPullChunk (precedence via semaphore)
   (`../../04-runtime/spec.md` Leadership Handover); error routing via
   `onError: ignore|shutdown` and `BackendIdMismatchError` handling
   (`reset|shutdown|ignore`; reset clears local databases, `:1060-1123`).
+  Generic terminal failures use the R05 parking policy, but a poisoned
+  canonical event is never ignored: it is a lifecycle-fatal supervised failure
+  so no Store remains apparently healthy with dead sync workers.
 
 ### Worker supervision
 
@@ -112,8 +128,8 @@ stay inside their operation loop. `ServerAheadError` stays inside
 reconciliation. A more-specific lifecycle-fatal family may take precedence;
 otherwise terminal failures reach the generic supervision boundary:
 
-- `onSyncError: 'shutdown'` sends the failure through the shutdown channel and
-  terminates the Store.
+- `onSyncError: 'shutdown'` sends a generic terminal failure through Store
+  lifecycle delivery and terminates the Store.
 - `onSyncError: 'ignore'` logs a generic terminal failure and parks the affected
   worker rather than letting its fiber return. Its in-flight prefix remains
   unresolved.
@@ -123,8 +139,11 @@ otherwise terminal failures reach the generic supervision boundary:
   also retire and replace a parked backend pull from the persisted cursor.
   Replacement is not acknowledgement of the failed attempt and is not a reason
   to retry `UnknownError` in place.
+- A deterministic materialization failure or `PoisonedEventError` takes
+  precedence over both generic branches, reaches central Store lifecycle
+  delivery regardless of `onSyncError`, and remains fenced until teardown.
 
-Local-apply failures retain their deferred acknowledgements and reservations;
+Local-apply failures retain their deferred acknowledgements and admitted prefix;
 backend-push failures retain the pending prefix as the source for later
 reconciliation. Local apply has no equivalent independent recovery path and
 remains parked until scope shutdown unless a future, more-specific policy owns

--- a/context/02-system/04-runtime/01-web/requirements.md
+++ b/context/02-system/04-runtime/01-web/requirements.md
@@ -23,3 +23,7 @@ Re-homed 2026-07-16: `LS.SYS.RT.WEB-R01` → `LS.SYS.RT.WEB.TOPO-R01`,
 - **LS.SYS.RT.WEB-R05 Devtools channel:** The adapter exposes a devtools web
   channel (webmesh) so browser devtools can attach to sessions and leader.
   `refines: LS-R13`
+- **LS.SYS.RT.WEB-R06 In-process lifecycle delivery:** The in-memory variant
+  routes leader terminal failures directly to the Store lifecycle callback;
+  the absence of a worker-side shutdown-channel listener must not leave a
+  queryable Store with a terminal sync worker. `refines: LS.SYS.RT-R06`

--- a/context/02-system/04-runtime/01-web/spec.md
+++ b/context/02-system/04-runtime/01-web/spec.md
@@ -31,6 +31,11 @@ The worker adapter falls back to single-tab automatically when
 `SharedWorker` is unavailable (e.g. Android Chrome). Single-tab warns that
 multiple tabs on one `storeId` can conflict.
 
+The worker and single-tab variants transport leader failures over their
+shutdown channels. The in-memory variant has no lifecycle receiver in another
+worker, so its inline leader invokes the adapter-provided Store shutdown
+callback directly (LS.SYS.RT.WEB-R06).
+
 ## Devtools Wiring
 
 The adapter exports `./devtools-web-channel` (webmesh `direct` mode) and

--- a/context/02-system/04-runtime/02-cloudflare/requirements.md
+++ b/context/02-system/04-runtime/02-cloudflare/requirements.md
@@ -31,3 +31,8 @@ a Cloudflare Durable Object as a headless client. Refines
   flush (see
   [.reference/cloudflare-do-durability.md](./.reference/cloudflare-do-durability.md)).
   Decided 2026-07-16 (interview).
+- **LS.SYS.RT.CF-R07 In-process lifecycle delivery:** The colocated leader
+  routes terminal failures directly to the Store lifecycle callback. The
+  realization may omit cross-context shutdown transport, but a no-op channel
+  must not leave a queryable Store with a terminal sync worker.
+  `refines: LS.SYS.RT-R06`

--- a/context/02-system/04-runtime/02-cloudflare/spec.md
+++ b/context/02-system/04-runtime/02-cloudflare/spec.md
@@ -40,8 +40,10 @@ place.
 Colocation and the `SqlStorage` API force several degenerate or adapted
 behaviors versus the portable contract:
 
-- **No shutdown channel** — `WebChannel.noopChannel`; with a single context
-  there is nothing to broadcast to (degenerate case of LS.SYS.RT-R06).
+- **No shutdown broadcast channel** — there is no second context to notify.
+  The colocated leader delivers terminal failures directly through the
+  adapter-provided Store lifecycle callback; the no-op channel remains only as
+  a transport placeholder (LS.SYS.RT.CF-R07).
 - **Devtools disabled** — `devtoolsOptions.enabled` is hardcoded false; the
   websocket webmesh connect is commented out (stub). `webmeshMode` is
   `'proxy'` (web adapters use `'direct'`).

--- a/context/02-system/04-runtime/requirements.md
+++ b/context/02-system/04-runtime/requirements.md
@@ -76,9 +76,11 @@ contrib-owned — see [realizations.md](./realizations.md), decision
   leader-thread proxy, lock status, shutdown handling, and devtools
   connectivity (where supported). `refines: LS-R07`
 - **LS.SYS.RT-R06 Shutdown-cause propagation:** Shutdown and terminal failure
-  causes propagate to all contexts of a client (shutdown channel); sessions
-  distinguish intentional shutdown from failure. Single-context realizations
-  may degenerate to no channel.
+  causes reach central Store lifecycle and propagate to every context of a
+  client; sessions distinguish intentional shutdown from failure.
+  Worker-backed realizations transport causes through the shutdown channel.
+  A single-context realization may omit that transport, but must invoke the
+  existing Store lifecycle callback directly before a terminal worker parks.
 - **LS.SYS.RT-R07 Storage-mode transparency:** Persistence may degrade to
   in-memory (e.g. private browsing); the adapter must surface the effective
   storage mode and a boot warning instead of failing silently.

--- a/context/02-system/04-runtime/spec.md
+++ b/context/02-system/04-runtime/spec.md
@@ -63,7 +63,9 @@ An `Adapter` is a function from adapter args to a booted `ClientSession`
 
 The leader side is assembled by `makeLeaderThreadLayer`
 (`common/src/leader-thread/`): eventlog init, materializer wiring, optional
-sync backend, devtools hooks, shutdown channel.
+sync backend, devtools hooks, and topology-aware lifecycle delivery. Worker
+leaders send through the shutdown channel; an in-process leader uses the
+adapter's existing Store shutdown callback directly.
 
 ## Proxy Contract
 
@@ -168,13 +170,16 @@ The session ⇄ leader boundary has a typed failure contract:
   `StaleRebaseGenerationError` (`leader-thread/RejectedPushError.ts`).
   The session responds by rebasing and retrying; events are never dropped
   (LS.SYS.RT-R10). Semantics: [../03-sync/](../03-sync/spec.md).
-- **Shutdown broadcast:** the shutdown channel carries
+- **Lifecycle failure delivery:** the shutdown channel carries
   `IntentionalShutdownCause` (reasons: `devtools-reset`, `devtools-import`,
   `adapter-reset`, `manual`, `backend-id-mismatch`) *and* terminal failure
   causes (`UnknownError`, `BackendIdMismatchError`, `MaterializeError`) —
   it is a failure broadcast, not an intentional-only signal. Sessions map
   intentional causes to a successful exit and everything else to a failed
-  exit. Cloudflare has no channel (noop; single-context).
+  exit. In-process leaders, including the in-memory web and Cloudflare
+  realizations, deliver the same cause directly to the adapter's Store
+  lifecycle callback; a no-op cross-context channel never makes lifecycle
+  delivery itself a no-op.
 - **Boot defect:** leader boot asserts `backendHead <= localHead` and dies
   otherwise (LS.SYS.RT-R13) — the sole handover safety check; there is no
   cross-source reconciliation beyond it.

--- a/context/02-system/05-store/requirements.md
+++ b/context/02-system/05-store/requirements.md
@@ -48,3 +48,10 @@ former `LS.SYS.STORE-R03`/`-R05` were re-homed there (2026-07-16) as
 - **LS.SYS.STORE-R12 Storage mode surfaced:** The store exposes whether its
   state is persisted or in-memory (`storageMode`). Adopted 2026-07-16
   (interview).
+- **LS.SYS.STORE-R13 Supervised poisoned-event failure:** A poisoned canonical
+  event is a Store lifecycle failure, not an application commit result. The
+  Store shuts down through central lifecycle delivery and exposes structured
+  diagnostics containing the event and last valid head, so applications cannot
+  continue against a Store whose sync workers have terminated. Adopted
+  2026-08-22 (#732 reproduction and user confirmation).
+  `refines: LS.SYS.STORE-R01, LS.SYS.STORE-R07`

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -82,6 +82,14 @@ per-commit root span with links.
 ## Lifecycle
 
 - Every public operation guards on `isShutdown` (`checkShutdown`).
+- A poisoned canonical event reaches the adapter's central lifecycle path as a
+  structured failure carrying the event identity, deterministic application
+  cause, and last valid head. Worker-backed leaders use their shutdown channel;
+  in-process leaders invoke the existing Store shutdown callback directly.
+  Lifecycle supervision marks the Store failed and closes its lifetime scope
+  regardless of `onSyncError: 'ignore'`; recovery is a Store restart after the
+  schema, materializer, state, or canonical data has been repaired. Application
+  commit sites do not handle this per event (LS.SYS.STORE-R13).
 - `shutdown` first drains admitted client-session events to the leader, then
   closes the store's `lifetimeScope`. **Durability contract (Q2, see
   [`.decisions/0001-client-session-shutdown-drain.md`](./.decisions/0001-client-session-shutdown-drain.md)):

--- a/context/ontology.md
+++ b/context/ontology.md
@@ -19,6 +19,10 @@
   carrying an older generation.
 - **Pending event** — An event committed locally but not yet confirmed by
   the sync backend.
+- **Poisoned event** — A canonical synced event that the current schema and
+  read model cannot apply deterministically, for example because its known
+  payload does not decode or its materializer fails. It fences the canonical
+  prefix at the preceding valid event until the data or code is repaired.
 - **Upstream head** — The latest backend-confirmed eventlog position
   (persisted leader-side as `backendHead`).
 - **Local head** — The latest locally committed eventlog position, including
@@ -126,7 +130,7 @@ in their name:
 
 - **Event family** (leitwort "event") — anchor **Event**; followers Event
   definition, Eventlog, Event sequence number, Synced event, Client-only
-  event, Pending event, Derived event.
+  event, Pending event, Poisoned event, Derived event.
 - **Client family** (leitwort "client") — anchor **Client**; followers
   Client session, Client document.
 - **Sync family** (leitwort "sync") — no single anchor noun; Sync provider,


### PR DESCRIPTION
## Problem

Issue #732 reports that a malformed known canonical event terminates backend pulling. Reproduction also showed a deterministic materialization failure could persist backend cursor `e1` while sync and state remained at `e0`.

The issue expectation to ignore the malformed event and continue is unsafe: a later materializer may depend on the state transition that the malformed event should have produced.

## Solution

Define a poisoned event as a known canonical event that the current schema/read model cannot apply deterministically. The contract now requires LiveStore to:

- preserve the last valid cursor and heads;
- roll back the complete attempted application;
- fence later local and canonical propagation;
- retry only positively classified connectivity failures such as `IsOfflineError`;
- keep `UnknownError` terminal, `ServerAheadError` in active pull replacement, and provider/identity failures in their dedicated policies;
- fail poison through central Store lifecycle delivery even when generic sync errors are ignored.

This converges with the predecessor contracts: ServerAhead owns decision 0003, supervision owns decision 0004 and LS.SYS.SYNC.PROC-R05, and poison owns decision 0005 plus R06/R07. Cooperative pull retirement waits outside canonical application so an in-flight poison failure wins over a queued restart.

Worker-backed leaders retain shutdown-channel transport. In-process web and Cloudflare leaders must invoke the existing Store lifecycle callback directly; no public health API or application recovery callback is introduced.

Crash/cross-database atomicity, receipts, command replay, and public recovery state machines remain out of scope.

This is the intent layer above #1580 and the bottom layer for implementation PR #1583.

## Validation

- `pnpm exec vitest run tests/package-common/src/intent-layer/intent-layer.test.ts` (8 passed)
- `devenv tasks run lint:full:fix`
- `git diff --check`

### Demo

```text
canonical: e0 -> e1(poisoned) -> e2
local:     e0 | fence
cursor:    e0
lifecycle: structured failure -> Store shutdown
```

## Related issues

- Relates to #732
- Builds on #1580
- Implementation: #1583
