### PR TITLE
Fix dev release notes by selecting Unreleased content

### DIFF
--- a/context/03-delivery/02-release/release-workflows-runbook.md
+++ b/context/03-delivery/02-release/release-workflows-runbook.md
@@ -130,12 +130,14 @@ automation and then validated by CI before auto-merge.
 
 ### Release notes artifact
 
-Alongside `release/release-plan.json`, the release PR generator extracts the
-current version's `CHANGELOG.md` section into `release/release-notes.md` via
-the `release:notes:extract` task (which calls
-`mono release extract-release-notes`). The extracted file is committed to the
-release-plan PR so reviewers see exactly what will land on the GitHub Release
-page.
+Alongside `release/release-plan.json`, the release PR generator extracts
+reviewable `CHANGELOG.md` content into `release/release-notes.md` via the
+`release:notes:extract` task (which calls
+`mono release extract-release-notes`). Stable releases use the exact promoted
+version section. Prereleases use `Unreleased`, because they intentionally
+preserve pending Changesets and therefore do not promote that content to an
+exact version heading. The extracted file is committed to the release-plan PR
+so reviewers see exactly what will land on the GitHub Release page.
 
 The DevTools artifact publish step then uses that file when it creates or
 updates the GitHub Release tag:
@@ -202,11 +204,11 @@ plus serverless + edge bundling) and the upload in one bounded step. The build
 still spawns Chromium for mermaid, so the `timeout(1)` wrapper around this one
 phase remains the orphan-Chromium backstop.
 
-| Phase          | Task                                  | Purpose                                                                          |
-| -------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| Phase          | Task                                  | Purpose                                                                                             |
+| -------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `build-deploy` | `docs:deploy:prod:phase:build-deploy` | `mono docs deploy --prod --step=upload` (runs `netlify deploy --build`), writes `deploy-state.json` |
-| `verify`       | `docs:deploy:prod:phase:verify`       | `mono docs deploy --prod --step=verify`, posts job summary                       |
-| `purge`        | `docs:deploy:prod:phase:purge`        | `mono docs deploy --prod --step=purge`, purges Netlify CDN                       |
+| `verify`       | `docs:deploy:prod:phase:verify`       | `mono docs deploy --prod --step=verify`, posts job summary                                          |
+| `purge`        | `docs:deploy:prod:phase:purge`        | `mono docs deploy --prod --step=purge`, purges Netlify CDN                                          |
 
 The `build-deploy` phase writes Netlify identifiers to `tmp/ci-docs-prod/deploy-state.json`
 so `verify` and `purge` can run as independent processes (and independent Actions

--- a/scripts/src/commands/release.test.ts
+++ b/scripts/src/commands/release.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { sliceChangelogSection } from './release.ts'
+import { releaseNotesSectionForPlan, sliceChangelogSection } from './release.ts'
+
+describe('releaseNotesSectionForPlan', () => {
+  it('uses the exact promoted section for stable releases', () => {
+    expect(releaseNotesSectionForPlan({ version: '0.5.0', npmTag: 'latest' })).toBe('0.5.0')
+  })
+
+  it('uses Unreleased while prereleases preserve pending Changesets', () => {
+    expect(releaseNotesSectionForPlan({ version: '0.5.0-dev.0', npmTag: 'dev' })).toBe('Unreleased')
+    expect(releaseNotesSectionForPlan({ version: '0.5.0-next.0', npmTag: 'next' })).toBe('Unreleased')
+  })
+})
 
 describe('sliceChangelogSection', () => {
   it('extracts the verbatim block for a stable version with date heading', () => {

--- a/scripts/src/commands/release.ts
+++ b/scripts/src/commands/release.ts
@@ -171,12 +171,20 @@ export const sliceChangelogSection = (changelog: string, version: string): strin
   return `${lines.slice(start, end).join('\n')}\n`
 }
 
-const extractReleaseNotes = ({ cwd, version }: { cwd: string; version: string }) =>
+/**
+ * Stable releases review the changelog section already promoted to their exact
+ * version. Prereleases intentionally preserve pending Changesets, so their
+ * reviewable notes still live under `Unreleased` when the release PR is built.
+ */
+export const releaseNotesSectionForPlan = ({ version, npmTag }: { version: string; npmTag: string }) =>
+  npmTag === 'latest' ? version : 'Unreleased'
+
+const extractReleaseNotes = ({ cwd, version, npmTag }: { cwd: string; version: string; npmTag: string }) =>
   Effect.gen(function* () {
     const fsEffect = yield* FileSystem.FileSystem
     const changelogPath = `${cwd}/CHANGELOG.md`
     const changelog = yield* fsEffect.readFileString(changelogPath)
-    const section = sliceChangelogSection(changelog, version)
+    const section = sliceChangelogSection(changelog, releaseNotesSectionForPlan({ version, npmTag }))
     yield* fsEffect.makeDirectory(`${cwd}/release`, { recursive: true })
     const outPath = releaseNotesPath(cwd)
     yield* fsEffect.writeFileString(outPath, section)
@@ -800,7 +808,7 @@ export const releaseNotesExtractCommand = Cli.Command.make(
   },
   Effect.fn(function* ({ plan: planPath, cwd }) {
     const plan = yield* readReleasePlan(cwd, planPath)
-    const outPath = yield* extractReleaseNotes({ cwd, version: plan.version })
+    const outPath = yield* extractReleaseNotes({ cwd, version: plan.version, npmTag: plan.npmTag })
     yield* Effect.log(`Wrote release notes for ${plan.version} to ${outPath}`)
     console.log(outPath)
   }),


### PR DESCRIPTION
## Problem

The automated dev release path calculates a prerelease version while deliberately preserving pending Changesets under the root `CHANGELOG.md#Unreleased` section. Release-note extraction nevertheless required an exact prerelease heading, so the canonical `0.5.0-dev.0` release run failed before it could open a release-plan PR.

## Solution

- use the exact version changelog section for stable `latest` releases
- use `Unreleased` for dev and other prerelease tags
- retain strict exact-heading matching for stable releases
- document the stable/prerelease release-note contract
- add focused coverage for stable, dev, and next selection

## Validation

- `vitest run scripts/src/commands/release.test.ts`: 9 passed
- scoped `oxfmt` and `oxlint`: pass
- `git diff --check`: pass
- `devenv tasks run lint:full:fix`: attempted, but the minimal setup lacks unrelated workspace type packages and the aggregate stopped on existing cross-workspace tsconfig resolution errors; no scoped error was reported

## Failure evidence

Release workflow run 32669327546 computed `0.5.0-dev.0` and failed with:

```text
No changelog section found for version 0.5.0-dev.0 in CHANGELOG.md
```
