### PR TITLE
Align wa-sqlite flake-utils with workspace authority

### DIFF
--- a/.changeset/small-chefs-deny.md
+++ b/.changeset/small-chefs-deny.md
@@ -1,0 +1,4 @@
+---
+---
+
+Reuse the workspace-authoritative `flake-utils` input for wa-sqlite Nix build metadata only. This does not change the published package.

--- a/packages/@livestore/wa-sqlite/flake.lock
+++ b/packages/@livestore/wa-sqlite/flake.lock
@@ -18,24 +18,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1769461804,
@@ -54,7 +36,10 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "workspace",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "workspace",
           "nixpkgs"
@@ -77,24 +62,9 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "workspace": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       },
       "locked": {

--- a/packages/@livestore/wa-sqlite/flake.nix
+++ b/packages/@livestore/wa-sqlite/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     workspace.url = "github:overengineeringstudio/effect-utils";
     nixpkgs.follows = "workspace/nixpkgs";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.follows = "workspace/flake-utils";
   };
 
   outputs =


### PR DESCRIPTION
## Problem

The wa-sqlite flake pins `flake-utils` directly even though its `workspace` input already provides the repository-authoritative `flake-utils`. This duplicates both `flake-utils` and `systems` nodes in the adjacent lock file.

## Goal

Make wa-sqlite follow `workspace/flake-utils` and remove only the redundant lock nodes without changing any dependency pins or the published package.

## Decisions

Use a Nix `follows` edge rather than another URL pin so the existing effect-utils workspace remains the explicit authority. Add an empty changeset with an explanatory body because this changes build metadata only and has no package release impact.

## Verification

- Ran `nix flake lock` in `packages/@livestore/wa-sqlite`.
- Inspected the complete lock diff: 7 → 5 nodes and 3,018 → 2,163 bytes. Only `flake-utils_2` and `systems_2` disappeared; no dependency pin changed.
- `CHANGESET_BASE_REF=origin/main devenv tasks run release:changeset:check-pr release:changeset:check-bodies` — passed.
- `devenv tasks run check:quick` — passed.
- `devenv tasks run check:all` — passed.
- Compared wa-sqlite derivations: all dependency derivation inputs are identical. Only the self source store path and its dependent output/unpack strings differ, as expected because `flake.nix` and `flake.lock` are included by `src = ./.`.

## Complexity

No new complexity; this removes redundant lock state.

## Concerns

None.

## Friction & bottlenecks

The installed pre-commit hook initially rejected the first commit because `.pre-commit-config.yaml` was absent before the devenv setup materialized it; `PREK_ALLOW_NO_CONFIG=1` allowed that initial repository state. No resource bottlenecks were encountered.

## Follow-ups

None.

## References

None.

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.be9hj659 |
| `session` | dev3.be9hj659 |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.0.11 |
| `agent_runtime` | OMP 18.0.11 |
| `tooling_profile` | dotfiles@000f2b3 |
</details>
<!-- agent-footer:end -->