### PR TITLE
Allow booleans in raw SQL bind values

### DIFF
--- a/.changeset/bright-booleans-bind.md
+++ b/.changeset/bright-booleans-bind.md
@@ -1,0 +1,7 @@
+---
+'@livestore/common': patch
+'@livestore/livestore': patch
+'@livestore/wa-sqlite': patch
+---
+
+Allow raw SQL queries to bind JavaScript booleans by normalizing them to SQLite integers, and distinguish SQLite bind input types from result value types.

--- a/packages/@livestore/common/src/session-id-symbol.ts
+++ b/packages/@livestore/common/src/session-id-symbol.ts
@@ -8,7 +8,7 @@
  */
 import { Predicate } from '@livestore/utils/effect'
 
-import type { Bindable, SqlValue } from './util.ts'
+import type { Bindable, SqlBindValue } from './util.ts'
 
 /**
  * Can be used in queries to refer to the current session id.
@@ -36,8 +36,8 @@ export const SessionIdSymbol = Symbol.for('@livestore/session-id')
 export type SessionIdSymbol = typeof SessionIdSymbol
 
 export type BindableWithSessionIdSymbol =
-  | ReadonlyArray<SqlValue | SessionIdSymbol>
-  | Record<string, SqlValue | SessionIdSymbol>
+  | ReadonlyArray<SqlBindValue | SessionIdSymbol>
+  | Record<string, SqlBindValue | SessionIdSymbol>
 
 export const resolveSessionIdSymbolInBindValues = (
   bindValues: BindableWithSessionIdSymbol,
@@ -47,7 +47,7 @@ export const resolveSessionIdSymbolInBindValues = (
     ? bindValues.map((value) => (value === SessionIdSymbol ? sessionId : value))
     : (Object.fromEntries(
         Object.entries(bindValues).map(([key, value]) => [key, value === SessionIdSymbol ? sessionId : value]),
-      ) as Record<string, SqlValue>)
+      ) as Record<string, SqlBindValue>)
 }
 
 export const resolveSessionIdSymbolInEventArgs = (args: unknown, sessionId: string): unknown => {

--- a/packages/@livestore/common/src/util.ts
+++ b/packages/@livestore/common/src/util.ts
@@ -2,10 +2,14 @@
 
 import { type Brand, Schema } from '@livestore/utils/effect'
 
-export type ParamsObject = Record<string, SqlValue>
 export type SqlValue = string | number | Uint8Array<ArrayBuffer> | null
+export type SqlBindValue = SqlValue | boolean
 
-export type Bindable = ReadonlyArray<SqlValue> | ParamsObject
+export type ParamsObject = Record<string, SqlBindValue>
+
+export type Bindable = ReadonlyArray<SqlBindValue> | ParamsObject
+type PreparedParamsObject = Record<string, SqlValue>
+type PreparedBindable = ReadonlyArray<SqlValue> | PreparedParamsObject
 
 /**
  * Numeric schema for the SQLite `REAL` domain. Unlike `Schema.Finite` it accepts
@@ -24,12 +28,14 @@ export const SqlValueSchema = Schema.Union([
   Schema.Null,
 ])
 
+export const SqlBindValueSchema = Schema.Union([SqlValueSchema, Schema.Boolean])
+
 export const PreparedBindValues = Schema.Union([
   Schema.Array(SqlValueSchema),
   Schema.Record(Schema.String, SqlValueSchema),
 ]).pipe(Schema.brand('PreparedBindValues'))
 
-export type PreparedBindValues = Brand.Branded<Bindable, 'PreparedBindValues'>
+export type PreparedBindValues = Brand.Branded<PreparedBindable, 'PreparedBindValues'>
 
 /**
  * This is a tag function for tagged literals.
@@ -47,6 +53,11 @@ export const sql = (template: TemplateStringsArray, ...args: unknown[]): string 
   return str + template[template.length - 1]
 }
 
+const normalizeBindValue = (value: SqlBindValue): SqlValue => {
+  if (typeof value !== 'boolean') return value
+  return value ? 1 : 0
+}
+
 /**
  * Prepare bind values to send to SQLite
  * Add $ to the beginning of keys; which we use as our interpolation syntax
@@ -56,12 +67,14 @@ export const sql = (template: TemplateStringsArray, ...args: unknown[]): string 
  * TODO: Also make sure that the SQLite binding limit of 1000 is respected
  */
 export const prepareBindValues = (values: Bindable, statement: string): PreparedBindValues => {
-  if (Array.isArray(values) === true) return values as any as PreparedBindValues
+  if (Array.isArray(values) === true) {
+    return values.map(normalizeBindValue) as unknown as PreparedBindValues
+  }
 
-  const result: ParamsObject = {}
+  const result: PreparedParamsObject = {}
   for (const [key, value] of Object.entries(values)) {
     if (statement.includes(key) === true) {
-      result[`$${key}`] = value
+      result[`$${key}`] = normalizeBindValue(value)
     }
   }
 

--- a/packages/@livestore/livestore/src/live-queries/db-query.test.ts
+++ b/packages/@livestore/livestore/src/live-queries/db-query.test.ts
@@ -475,3 +475,29 @@ Vitest.describe('otel', () => {
     ),
   )
 })
+
+Vitest.describe('raw query bind values', () => {
+  Vitest.live(
+    'supports boolean bind values',
+    () =>
+      Effect.gen(function* () {
+        const store = yield* makeTodoMvc()
+
+        store.commit(events.todoCreated({ id: 'completed', text: 'done', completed: true }))
+        store.commit(events.todoCreated({ id: 'active', text: 'todo', completed: false }))
+
+        const completedTodos$ = queryDb({
+          query: 'SELECT id, completed FROM todos WHERE completed = ?',
+          bindValues: [true],
+          schema: Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              completed: Schema.BooleanFromBit,
+            }),
+          ),
+        })
+
+        expect(store.query(completedTodos$)).toEqual([{ id: 'completed', completed: true }])
+      }).pipe(Effect.scoped),
+  )
+})

--- a/packages/@livestore/livestore/src/mod.ts
+++ b/packages/@livestore/livestore/src/mod.ts
@@ -13,6 +13,8 @@ export {
   type QueryBuilderAst,
   type RowQuery,
   SessionIdSymbol,
+  type SqlBindValue,
+  SqlBindValueSchema,
   type SqliteDb,
   StoreInterrupted,
   type SyncState,

--- a/packages/@livestore/wa-sqlite/src/types/index.d.ts
+++ b/packages/@livestore/wa-sqlite/src/types/index.d.ts
@@ -16,6 +16,8 @@
  * `Uint8Array<ArrayBuffer>`
  */
 type SQLiteCompatibleType = number | string | Uint8Array<ArrayBuffer> | Array<number> | bigint | null
+type SQLiteBindValue = SQLiteCompatibleType | boolean
+type SQLiteResultValue = Exclude<SQLiteCompatibleType, Array<number>>
 
 /** https://sqlite.org/session/c_changeset_conflict.html */
 type SQLiteChangesetConflictType =
@@ -200,7 +202,7 @@ interface SQLiteAPI {
    */
   bind_collection(
     stmt: number,
-    bindings: { [index: string]: SQLiteCompatibleType | null } | Array<SQLiteCompatibleType | null>,
+    bindings: { [index: string]: SQLiteBindValue } | Array<SQLiteBindValue>,
   ): number
 
   /**
@@ -213,7 +215,7 @@ interface SQLiteAPI {
    * @param value
    * @returns `SQLITE_OK` (throws exception on error)
    */
-  bind(stmt: number, i: number, value: SQLiteCompatibleType | null): number
+  bind(stmt: number, i: number, value: SQLiteBindValue): number
 
   /**
    * Bind blob to prepared statement parameter
@@ -403,7 +405,7 @@ interface SQLiteAPI {
    * @param i column index
    * @returns column value
    */
-  column(stmt: number, i: number): SQLiteCompatibleType
+  column(stmt: number, i: number): SQLiteResultValue
 
   /**
    * Extract a column value from a row after a prepared statment {@link step}
@@ -564,7 +566,7 @@ interface SQLiteAPI {
   exec(
     db: number,
     zSQL: string,
-    callback?: (row: Array<SQLiteCompatibleType | null>, columns: string[]) => void,
+    callback?: (row: Array<SQLiteResultValue>, columns: string[]) => void,
     // ): Promise<number>;
   ): number
 
@@ -719,7 +721,7 @@ interface SQLiteAPI {
    * @param stmt prepared statement pointer
    * @returns row data
    */
-  row(stmt: number): Array<SQLiteCompatibleType | null>
+  row(stmt: number): Array<SQLiteResultValue>
 
   /**
    * Register a callback function that is invoked to authorize certain SQL statement actions.
@@ -833,7 +835,7 @@ interface SQLiteAPI {
    * @param pValue `sqlite3_value` pointer
    * @returns value
    */
-  value(pValue: number): SQLiteCompatibleType
+  value(pValue: number): SQLiteResultValue
 
   /**
    * Extract a value from `sqlite3_value`


### PR DESCRIPTION
<!-- Use a title that captures the problem and the approach, e.g. "Fix backlog replay flake by stabilizing event helper" -->

## Problem

Raw `queryDb` parameters cannot use JavaScript booleans because `Bindable` only accepts `SqlValue`, which excludes `boolean`.

This causes TypeScript to reject otherwise valid queries:

```ts
queryDb({
  query: 'SELECT * FROM todos WHERE completed = ?',
  bindValues: [true],
  schema,
})
```

The declared API is inconsistent with `wa-sqlite`, whose runtime binder already accepts booleans and represents them as SQLite integers.

## Solution

- Introduced `SqlBindValue = SqlValue | boolean` for bind inputs.
- Kept `SqlValue` limited to values SQLite returns.
- Normalized boolean parameters in `prepareBindValues`:
  - `true` → `1`
  - `false` → `0`
- Added support for booleans in positional and named bindings.
- Updated session-ID bind-value types.
- Distinguished `SQLiteBindValue` from `SQLiteResultValue` in the `wa-sqlite` declarations.
- Added regression coverage for the raw `queryDb` reproduction.

Boolean conversion is limited to input binding. SQLite results remain numbers and can be decoded with schemas such as `Schema.BooleanFromBit`.

## Validation

Ran the regression test:

```bash
pnpm --filter @livestore/livestore test --run \
  src/live-queries/db-query.test.ts \
  --testNamePattern "supports boolean bind values"
```

## Related issues

- Closes #1547