### PR TITLE
fix(common): treat void materializer return as a no-op

### DIFF
--- a/.changeset/fix-void-materializer-noop.md
+++ b/.changeset/fix-void-materializer-noop.md
@@ -1,0 +1,6 @@
+---
+'@livestore/common': patch
+'@livestore/livestore': patch
+---
+
+Treat a materializer that returns `void`/`undefined` as a no-op (same as `[]`) instead of reading `.sql` on `undefined` and shutting down the store. Docs no longer claim materializers can return an `Effect`.

--- a/docs/src/content/docs/building-with-livestore/state/materializers.mdx
+++ b/docs/src/content/docs/building-with-livestore/state/materializers.mdx
@@ -28,15 +28,15 @@ A materializer is always executed in a transaction. This transaction applies to:
 
 Materializers can return:
 - A single database write operation.
-- An array of database write operations.
-- `void` (i.e., no return value) if no database modifications are needed.
-- An `Effect` that resolves to one of the above (e.g., `Effect.succeed(writeOp)` or `Effect.void`).
+- An array of database write operations (use `[]` or `void` if no database modifications are needed).
+
+Materializers are synchronous. Returning an `Effect` is not supported; the function must return one of the values above.
 
 The `context` object passed to each materializer provides `query` for database reads and `event` for the full event details.
 
 ## Error handling
 
-If a materializer function throws an error, or if an `Effect` returned by a materializer fails, the entire transaction for that event will be rolled back. This means any database changes attempted by that materializer for the failing event will not be persisted. The error will be logged, and the system will typically halt or flag the event as problematic, depending on the specific LiveStore setup.
+If a materializer function throws an error, the entire transaction for that event will be rolled back. This means any database changes attempted by that materializer for the failing event will not be persisted. The error will be logged, and the system will typically halt or flag the event as problematic, depending on the specific LiveStore setup.
 
 If the error happens on the client which tries to commit the event, the event will never be committed and pushed to the sync backend.
 

--- a/packages/@livestore/common/src/materializer-helper.ts
+++ b/packages/@livestore/common/src/materializer-helper.ts
@@ -120,12 +120,15 @@ export const hashMaterializerResults = (
 ) => Hash.string(JSON.stringify(materializerResults))
 
 const fromMaterializerResult = (
-  materializerResult: MaterializerResult | ReadonlyArray<MaterializerResult>,
+  materializerResult: MaterializerResult | ReadonlyArray<MaterializerResult> | null | undefined,
 ): ReadonlyArray<{
   sql: string
   bindValues: BindValues
   writeTables: ReadonlySet<string> | undefined
 }> => {
+  if (materializerResult == null) {
+    return []
+  }
   if (ReadonlyArray.isArray<MaterializerResult | ReadonlyArray<MaterializerResult>>(materializerResult) === true) {
     return materializerResult.flatMap(fromMaterializerResult)
   }

--- a/packages/@livestore/common/src/schema/EventDef/materializer.ts
+++ b/packages/@livestore/common/src/schema/EventDef/materializer.ts
@@ -43,6 +43,7 @@ import type { EventDefFacts } from './facts.ts'
  * - A QueryBuilder operation (recommended for type safety)
  * - A raw SQL string
  * - An object with SQL, bind values, and optional write table tracking
+ * - `void` / `undefined` (no-op, same as an empty array)
  */
 export type MaterializerResult =
   | {
@@ -100,7 +101,7 @@ export type Materializer<TEventDef extends EventDef.AnyWithoutFn = EventDef.AnyW
     /** Full event metadata including clientId, sessionId, sequence numbers. */
     event: LiveStoreEvent.Client.Decoded
   },
-) => SingleOrReadonlyArray<MaterializerResult>
+) => SingleOrReadonlyArray<MaterializerResult> | void
 
 /**
  * Type-safe wrapper for defining a single materializer.

--- a/tests/package-common/src/materializer.test.ts
+++ b/tests/package-common/src/materializer.test.ts
@@ -81,6 +81,47 @@ Vitest.describe.each(['raw', 'query-builder'] as const)('materializer', (queryTy
     }).pipe(Vitest.withTestCtx(test)),
   )
 
+  Vitest.live('void materializer is a no-op and does not shut down the store', (test) =>
+    Effect.gen(function* () {
+      const todoNoop = Events.synced({
+        name: 'todoNoop',
+        schema: Schema.Struct({ id: Schema.String }),
+      })
+      const todoCreated = Events.synced({
+        name: 'todoCreatedAfterNoop',
+        schema: Schema.Struct({ id: Schema.String, text: Schema.String }),
+      })
+      const todosTable = State.SQLite.table({
+        name: 'todos',
+        columns: {
+          id: State.SQLite.text({ primaryKey: true }),
+          text: State.SQLite.text({ default: '', nullable: false }),
+        },
+      })
+      const voidSchema = makeSchema({
+        events: { todoNoop, todoCreated },
+        state: State.SQLite.makeState({
+          tables: { todos: todosTable },
+          materializers: State.SQLite.materializers(
+            { todoNoop, todoCreated },
+            {
+              todoNoop: () => undefined,
+              todoCreatedAfterNoop: ({ id, text }) => todosTable.insert({ id, text }),
+            },
+          ),
+        }),
+      })
+      const store = yield* createStore({
+        schema: voidSchema,
+        adapter: makeInMemoryAdapter(),
+        storeId: 'test-void-materializer',
+      })
+      store.commit(todoNoop({ id: 'ghost' }))
+      store.commit(todoCreated({ id: 't1', text: 'after-void' }))
+      expect(store.query(todosTable)).toMatchObject([{ id: 't1', text: 'after-void' }])
+    }).pipe(Vitest.withTestCtx(test)),
+  )
+
   Vitest.live('should pass full event with clientId to materializer', (test) =>
     Effect.gen(function* () {
       const testClientId = 'test-client-123'


### PR DESCRIPTION
## Summary
- Materializers that return `void`/`undefined` are now a no-op (same as `[]`), instead of reading `.sql` on `undefined` and shutting down the store.
- Docs no longer claim materializers can return an `Effect`. Returning an `Effect` is still unsupported.

## Test plan
- [x] `pnpm exec vitest run src/materializer.test.ts` in `tests/package-common` (8 passed)
- [x] Review changeset `.changeset/fix-void-materializer-noop.md`