### PR TITLE
Stop masking CloudflareWorkerVFS timeout after stability checks

### DIFF
--- a/.changeset/empty-cf-vfs-retry.md
+++ b/.changeset/empty-cf-vfs-retry.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release impact. Removes a test-only retry workaround after repeated local and CI validation.

--- a/packages/@livestore/sqlite-wasm/src/cf/test/async-storage/cloudflare-worker-vfs-advanced.test.ts
+++ b/packages/@livestore/sqlite-wasm/src/cf/test/async-storage/cloudflare-worker-vfs-advanced.test.ts
@@ -158,8 +158,7 @@ describe('CloudflareWorkerVFS - Advanced Features', () => {
       expect(vfs.jClose(fileId)).toBe(VFS.SQLITE_OK)
     })
 
-    // TODO: Remove retry once flaky timeout is investigated (https://github.com/livestorejs/livestore/issues/1020)
-    it('should handle large files that exceed cache capacity', { retry: 3, timeout: 10000 }, async () => {
+    it('should handle large files that exceed cache capacity', async () => {
       const path = '/test/cache-overflow.db'
       const fileId = 1
       const flags = VFS.SQLITE_OPEN_CREATE | VFS.SQLITE_OPEN_READWRITE


### PR DESCRIPTION
## Problem

The CloudflareWorkerVFS cache-capacity test still retries up to three times and uses an extended timeout after an old CI flake. Successful CI can therefore hide a first-attempt timeout, leaving the regression guard weaker than intended.

## Solution

Remove the retry workaround and the explicit extended timeout. The test now uses Vitest’s normal timeout and any recurrence fails CI on its first attempt.

The trade-off is intentional: if the environment-specific timeout returns, CI will expose it instead of masking it. An empty changeset records that this test-only change has no release impact.

## Validation

**CI stability result: 5/5 independent GitHub Actions Linux `test-unit` runs passed with the retry-free test.** Each run used the same test-change commit (`ea9392042`) and a separate CI job/environment:

1. [CI confirmation 1](https://github.com/livestorejs/livestore/actions/runs/33987681749/job/101364152870)
2. [CI confirmation 2](https://github.com/livestorejs/livestore/actions/runs/33988272112/job/101365740908)
3. [CI confirmation 3](https://github.com/livestorejs/livestore/actions/runs/33988271101/job/101365737729)
4. [CI confirmation 4](https://github.com/livestorejs/livestore/actions/runs/33988270282/job/101365735760)
5. [CI confirmation 5](https://github.com/livestorejs/livestore/actions/runs/33988271172/job/101365737955)

Local validation:

- `CI=true ./scripts/bootstrap-minimal.sh`
- `pnpm exec vitest run packages/@livestore/sqlite-wasm/src/cf/test/async-storage/cloudflare-worker-vfs-advanced.test.ts --testNamePattern "should handle large files that exceed cache capacity"`
- `pnpm exec vitest run packages/@livestore/sqlite-wasm/src/cf/test/async-storage/cloudflare-worker-vfs-advanced.test.ts` (11 tests passed)
- 30 consecutive targeted runs with retries disabled during investigation
- `devenv tasks run lint:full:fix`

## Related issues

Closes #1020