### PR TITLE
Retry interrupted state rebuilds using a completion marker

### DIFF
--- a/.changeset/recover-incomplete-state.md
+++ b/.changeset/recover-incomplete-state.md
@@ -1,0 +1,13 @@
+---
+'@livestore/common': minor
+'@livestore/adapter-web': patch
+---
+
+Retry interrupted state rebuilds from clean derived state. Record completion only
+after replay and all migration hooks succeed, preserving the eventlog and pending
+events. The new fingerprinted system table causes a one-time state rebuild on
+upgrade from a pre-marker version, including Cloudflare replay time and row writes.
+Migration hooks may run again after interruption and must tolerate retries.
+Browser fast-path startup rejects incomplete snapshots and waits for leader recovery.
+
+Fixes https://github.com/livestorejs/livestore/issues/1605.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   Telemetry cleanup runs in the background, and finite WebSocket operations and
   DO-RPC pull streams now emit their sync spans
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
+- **State recovery:** Interrupted rematerialization is retried from clean derived
+  state instead of reopening partial results. Completion is recorded after all
+  migration hooks finish. Browser fast-path startup waits for recovery when its
+  snapshot is incomplete. The eventlog and pending events are preserved
+  ([#1605](https://github.com/livestorejs/livestore/issues/1605)).
 - **Cloudflare sync:** Serialize push admission through pull publication so an
   accepted event cannot advance the backend head without notifying subscribers
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).
@@ -48,6 +53,11 @@
   the undocumented `store.commit(() => [event])` form with `store.commit(event)`
   or `store.commit((commit) => { commit(event) })`
   ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
+- **Rebuild completion tracking:** The first open after upgrading from a version
+  without the completion marker rebuilds derived state once. No application
+  configuration changes are needed. Cloudflare deployments should budget for
+  replay duration and row writes. Migration hooks must tolerate retries after
+  interrupted rebuilds ([#1605](https://github.com/livestorejs/livestore/issues/1605)).
 - **State schema fingerprints:** Replaced Effect-internal AST hashing with a
   LiveStore-owned canonical descriptor and a synchronous full-width SHA-256
   fingerprint. No application schema or configuration changes are required.

--- a/context/02-system/02-state/01-sqlite/02-schema-management/.decisions/0001-rebuild-completion.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/.decisions/0001-rebuild-completion.md
@@ -1,0 +1,56 @@
+# 0001 — Require explicit rebuild completion before reusing state
+
+Status: accepted for the recovery implementation (2026-09-06).
+
+## Context
+
+[#1605](https://github.com/livestorejs/livestore/issues/1605) demonstrates that
+system tables can survive a failed rematerialization. Their existence therefore
+cannot establish that the database is ready. A state head at the eventlog tip is
+also insufficient when a post-migration hook has not finished.
+
+## Decision
+
+Add a fingerprinted state system table whose singleton row is inserted only after
+replay and all migration hooks succeed. Boot without that row replaces derived
+state with an empty SQLite database before rebuilding. Use the existing backup/
+import abstraction, not adapter deletion finalizers or a list of tables to drop.
+The eventlog and its sync metadata are not reset.
+Browser fast-path snapshot loading uses the same completion predicate and falls
+back to the leader snapshot on incomplete state, before queries can observe it.
+
+## Alternatives
+
+- Failure cleanup alone cannot handle runtime termination without finalizers.
+- Continuing replay from a partial head cannot account for partially executed
+  materializers or hook work.
+- Dropping only declared tables can retain hook-created objects and stale data.
+- Trusting old databases without a marker could silently accept partial state.
+
+## Consequences
+
+- The first upgrade from a pre-marker version rebuilds derived state once.
+  Cloudflare deployments incur the associated replay duration and row writes.
+- Successful later boots read the marker but do not rewrite it.
+- Hook side effects outside the state database must tolerate retries.
+- This is not a corruption-repair mechanism or a new storage-durability guarantee.
+  Future buffered persistence needs its own crash-safe flush/publication analysis.
+- No SQL batching, VFS buffering or changes to the asynchronous persistence/sync
+  model are part of this fix.
+
+## Evidence
+
+The real Cloudflare adapter regression first failed against unchanged production
+code: five committed events, failure at event three, then a successful boot with
+only two rows. The fix is exercised by repeated replay failure, hook failure,
+uncatchable DO reset during a post hook, empty eventlog and completed-state reuse.
+The tests also compare persisted eventlog and sync metadata before/after retry.
+The shared WASM regression holds an async post hook open and checks that no
+completion row appears before it finishes. Shared leader boot regressions reopen
+real SQLite files after init/pre/post-hook failure, mid-replay failure and fiber
+interruption. They check that hook-created objects and partial rows are discarded,
+all five pending events survive, and completed state is reused without replay.
+A browser regression reads a real OPFS AccessHandlePoolVFS file and verifies that
+missing/empty completion metadata is rejected while a completed snapshot is loaded.
+It also verifies immediate cleanup of rejected snapshots and scoped cleanup of
+accepted snapshots.

--- a/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
@@ -20,13 +20,13 @@ mismatched tables in place:
    storage-format-versioned directory. The Cloudflare adapter uses
    `state{fingerprint}@{liveStoreStorageFormatVersion}.db`.
 3. A different fingerprint therefore opens a fresh, empty state database.
-   During leader boot, the absence of state system tables causes `recreateDb`
-   to run.
+   During leader boot, missing state system tables or a missing rebuild-complete
+   row causes `recreateDb` to run.
 
 `migrateDb` never drops or clears tables; it uses `create-if-not-exists`.
 Eventlog replay does not clear existing rows either. These operations are safe
-because the fingerprint change has already selected a fresh database. A
-mismatched fingerprint stored inside an existing database does not trigger a
+because boot replaces incomplete derived state with an empty database before
+running them. A mismatched fingerprint stored inside an existing database does not trigger a
 rebuild by itself. The adapter-level database name is the rebuild trigger.
 
 When the web adapter opens the selected state database, it deletes other state
@@ -97,6 +97,33 @@ database:
 3. Run the `pre` migration hook.
 4. Replay the full eventlog through the current materializers.
 5. Run the `post` migration hook.
+6. Insert the singleton completion row (`id = 1`) in `__livestore_rebuild`.
+
+Table existence and the state head alone do not prove completion: a materializer
+can fail partway through replay, or a hook can fail after replay reaches the tip.
+Boot reuses state only when all state system tables and the completion row exist.
+Otherwise it replaces the derived database using SQLite's backup/import operation
+from an empty in-memory database, before creating materializers or running hooks.
+This discards partial application rows, hook-created objects and undo data without
+altering the eventlog or its pending events and sync metadata. Recovery does not
+depend on failure finalizers deleting the state file.
+
+Both browser session variants apply the same check when loading an OPFS snapshot
+for fast-path boot. An incomplete snapshot falls back to the leader's recovered
+snapshot before the session becomes available to application queries.
+
+Completion is recorded only on the successful path, never by a finalizer. Hooks
+can run again after a failed/interrupted rebuild. External hook side effects must
+tolerate retries; the marker does not make them exactly-once. Existing event
+transaction boundaries and asynchronous persistence/sync are unchanged.
+
+The marker table participates in the compound state fingerprint. Upgrading from
+a version without it selects a fresh derived database and causes a one-time
+rebuild, including for previously complete databases. No eventlog schema or
+storage-format version changes. This protocol detects incomplete **readable**
+SQLite databases, not arbitrary file corruption or loss of the eventlog.
+
+See [the completion/recovery decision](./.decisions/0001-rebuild-completion.md).
 
 The rebuild produces a `migrationsReport` surfaced through adapter boot info.
 On the Cloudflare Durable Object adapter, replay writes the newly materialized

--- a/context/02-system/04-runtime/.delta/DELTA-001-fast-path-unvalidated.md
+++ b/context/02-system/04-runtime/.delta/DELTA-001-fast-path-unvalidated.md
@@ -7,10 +7,10 @@ Status: open
 LS.SYS.RT-R15 requires fast-path-derived head/state to be validated against
 what the leader would report. Today the web fast path reads the persisted
 state DB directly from OPFS and derives `leaderHead` from
-`SESSION_CHANGESET_META_TABLE`, while the leader derives its head from the
-eventlog — two sources that can diverge. The snapshot is trusted without
-validation (code TODO, `adapter-web/src/web-worker/client-session/
-persisted-adapter.ts:237`).
+`__livestore_state_head`, while the leader derives its head from the
+eventlog — two sources that can diverge. The snapshot's system tables and
+rebuild-completion row are checked before fast-path use (the #1605 recovery fix),
+but its head and identity are not validated against the leader.
 
 ## VRS
 

--- a/context/02-system/04-runtime/01-web/01-persistence/spec.md
+++ b/context/02-system/04-runtime/01-web/01-persistence/spec.md
@@ -46,10 +46,19 @@ Unless disabled or OPFS is unavailable, a booting session reads the
 persisted state DB directly from OPFS
 (`readPersistedStateDbFromClientSession`) instead of requesting a
 `GetRecreateSnapshot` from the leader, and derives its initial leader head
-from `SESSION_CHANGESET_META_TABLE` rather than the eventlog
-(`persisted-adapter.ts:238-249,464-483`). Any read error falls back to the
-slow path. The snapshot is currently trusted without validation — see
-`LS.SYS.RT-R15` and
+from `__livestore_state_head` rather than the eventlog. Both shared-worker and
+single-tab sessions import the snapshot into their in-memory database and require
+all state system tables plus the rebuild-completion row before using it. A read,
+import or completeness failure falls back to `GetRecreateSnapshot`, so partial
+rebuild state cannot become queryable through the fast path. The successful import
+is reused rather than copied into another database. See the
+[rebuild contract](../../../02-state/01-sqlite/02-schema-management/spec.md).
+
+Rejected snapshot databases close before waiting for leader recovery. Accepted
+snapshot databases and leader fallback databases belong to the session scope.
+
+The completion check does not compare the snapshot's head or identity with the
+leader. That broader validation remains open under `LS.SYS.RT-R15` and
 [../../.delta/DELTA-001-fast-path-unvalidated.md](../../.delta/DELTA-001-fast-path-unvalidated.md).
 
 ## Identity Keys

--- a/context/02-system/04-runtime/spec.md
+++ b/context/02-system/04-runtime/spec.md
@@ -92,10 +92,11 @@ streaming — `worker-schema.ts`); the proxy above is the portable contract.
 Two boot paths produce the session's initial in-memory state:
 
 - **Fast path (web):** the session reads the persisted state DB directly
-  from OPFS and derives `leaderHead` from `SESSION_CHANGESET_META_TABLE` —
+  from OPFS and derives `leaderHead` from `__livestore_state_head` —
   without touching the leader. This is the one sanctioned direct
-  persistence *read*; the snapshot is currently trusted without validation
-  (code TODO), and its head source differs from the leader's
+  persistence *read*. The session requires state system tables and the rebuild
+  completion row before using the snapshot; otherwise it takes the slow path.
+  The snapshot is not compared with the leader, and its head source differs from the leader's
   (eventlog-derived), so the two can in principle diverge — violating
   LS.SYS.RT-R15
   ([DELTA-001](./.delta/DELTA-001-fast-path-unvalidated.md)).

--- a/docs/src/content/docs/building-with-livestore/state/sqlite-schema.mdx
+++ b/docs/src/content/docs/building-with-livestore/state/sqlite-schema.mdx
@@ -61,6 +61,10 @@ You can also provide a custom schema for a column which is used to automatically
 
 LiveStore automatically migrates the database to the newest schema and rematerializes state from the eventlog. A schema change opens a fresh state database and replays the full eventlog, even when only one table changed.
 
+A rebuild is complete only after replay and all migration hooks finish. If a rebuild fails or is interrupted, the next boot discards incomplete derived state and retries from the eventlog. Browser fast-path startup also waits for recovery instead of exposing an incomplete snapshot. Migration hooks may run again, so any external side effects must tolerate retries. The eventlog and pending events are preserved.
+
+Upgrading from a version without rebuild-completion tracking causes a one-time rebuild, even when your application schema is unchanged. On Cloudflare Durable Objects, plan for the corresponding replay time and row writes.
+
 By default, `State.SQLite.json()` does not declare a fixed shape. Changing only the shape of values written to that column therefore does not count as a schema change. Pass a schema when such changes should trigger a rebuild.
 
 ## Client documents

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -15,6 +15,7 @@ import {
   Eventlog,
   LeaderThreadCtx,
   makeLeaderThreadLayer,
+  markStateAsCompleted,
   streamEventsWithSyncState,
 } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
@@ -249,6 +250,7 @@ const makeLeaderThread = ({
       dbState.import(importSnapshot)
 
       const _migrationsReport = yield* migrateDb({ db: dbState, schema })
+      yield* markStateAsCompleted(dbState)
     }
 
     const devtoolsOptions = yield* makeDevtoolsOptions({

--- a/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
+++ b/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
@@ -157,6 +157,7 @@ export const makeSingleTabAdapter =
       yield* Queue.offer(bootStatusQueue, { stage: 'loading' })
 
       const sqlite3 = yield* Effect.promise(() => loadSqlite3())
+      const makeSqliteDb = sqliteDbFactory({ sqlite3 })
 
       const storageOptions = yield* Schema.decodeEffect(WorkerSchema.StorageType)(options.storage)
 
@@ -182,7 +183,7 @@ export const makeSingleTabAdapter =
       const dataFromFile =
         options.experimental?.disableFastPath === true || opfsWarning !== undefined
           ? undefined
-          : yield* readPersistedStateDbFromClientSession({ storageOptions, storeId, schema }).pipe(
+          : yield* readPersistedStateDbFromClientSession({ storageOptions, storeId, schema, makeSqliteDb }).pipe(
               Effect.tapError((error) =>
                 Effect.logDebug('[@livestore/adapter-web:single-tab] Could not read persisted state db', error, {
                   storeId,
@@ -306,31 +307,27 @@ export const makeSingleTabAdapter =
       )
 
       // Get initial snapshot (either from fast-path or from worker)
-      const initialResult =
+      const { sqliteDb, snapshotByteLength, migrationsReport } =
         dataFromFile === undefined
-          ? yield* runInWorker('GetRecreateSnapshot', innerWorker.GetRecreateSnapshot({})).pipe(
-              Effect.map(({ snapshot, migrationsReport }) => ({
-                _tag: 'from-leader-worker' as const,
-                snapshot,
-                migrationsReport,
-              })),
-            )
-          : { _tag: 'fast-path' as const, snapshot: dataFromFile }
-
-      const migrationsReport =
-        initialResult._tag === 'from-leader-worker' ? initialResult.migrationsReport : { migrations: [] }
-
-      const makeSqliteDb = sqliteDbFactory({ sqlite3 })
-      const sqliteDb = yield* makeSqliteDb({ _tag: 'in-memory' })
-
-      sqliteDb.import(initialResult.snapshot)
+          ? yield* Effect.gen(function* () {
+              const { snapshot, migrationsReport } = yield* runInWorker(
+                'GetRecreateSnapshot',
+                innerWorker.GetRecreateSnapshot({}),
+              )
+              const sqliteDb = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+                Effect.sync(() => db.close()),
+              )
+              sqliteDb.import(snapshot)
+              return { sqliteDb, snapshotByteLength: snapshot.byteLength, migrationsReport }
+            })
+          : { ...dataFromFile, migrationsReport: { migrations: [] } }
 
       const numberOfTables =
         sqliteDb.select<{ count: number }>(`select count(*) as count from sqlite_master`)[0]?.count ?? 0
       if (numberOfTables === 0) {
         return yield* UnknownError.make({
           cause: `Encountered empty or corrupted database`,
-          payload: { snapshotByteLength: initialResult.snapshot.byteLength, storageOptions: options.storage },
+          payload: { snapshotByteLength, storageOptions: options.storage },
         })
       }
 

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -203,6 +203,7 @@ export const makePersistedAdapter =
       yield* Queue.offer(bootStatusQueue, { stage: 'loading' })
 
       const sqlite3 = yield* Effect.promise(() => loadSqlite3())
+      const makeSqliteDb = sqliteDbFactory({ sqlite3 })
 
       const LIVESTORE_TAB_LOCK = `livestore-tab-lock-${storeId}`
       const LIVESTORE_SHARED_WORKER_TERMINATION_LOCK = `livestore-shared-worker-termination-lock-${storeId}`
@@ -233,11 +234,10 @@ export const makePersistedAdapter =
       // we're here trying to get the snapshot directly from storage
       // we usually speeds up the boot process by a lot.
       // We need to be extra careful though to not run into any race conditions or inconsistencies.
-      // TODO also verify persisted data
       const dataFromFile =
         options.experimental?.disableFastPath === true || opfsWarning !== undefined
           ? undefined
-          : yield* readPersistedStateDbFromClientSession({ storageOptions, storeId, schema }).pipe(
+          : yield* readPersistedStateDbFromClientSession({ storageOptions, storeId, schema, makeSqliteDb }).pipe(
               Effect.tapError((error) =>
                 Effect.logDebug('[@livestore/adapter-web:client-session] Could not read persisted state db', error, {
                   storeId,
@@ -432,31 +432,27 @@ export const makePersistedAdapter =
 
       // TODO maybe bring back transfering the initially created in-memory db snapshot instead of
       // re-exporting the db
-      const initialResult =
+      const { sqliteDb, snapshotByteLength, migrationsReport } =
         dataFromFile === undefined
-          ? yield* runInWorker('GetRecreateSnapshot', sharedWorker.GetRecreateSnapshot({})).pipe(
-              Effect.map(({ snapshot, migrationsReport }) => ({
-                _tag: 'from-leader-worker' as const,
-                snapshot,
-                migrationsReport,
-              })),
-            )
-          : { _tag: 'fast-path' as const, snapshot: dataFromFile }
-
-      const migrationsReport =
-        initialResult._tag === 'from-leader-worker' ? initialResult.migrationsReport : { migrations: [] }
-
-      const makeSqliteDb = sqliteDbFactory({ sqlite3 })
-      const sqliteDb = yield* makeSqliteDb({ _tag: 'in-memory' })
-
-      sqliteDb.import(initialResult.snapshot)
+          ? yield* Effect.gen(function* () {
+              const { snapshot, migrationsReport } = yield* runInWorker(
+                'GetRecreateSnapshot',
+                sharedWorker.GetRecreateSnapshot({}),
+              )
+              const sqliteDb = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+                Effect.sync(() => db.close()),
+              )
+              sqliteDb.import(snapshot)
+              return { sqliteDb, snapshotByteLength: snapshot.byteLength, migrationsReport }
+            })
+          : { ...dataFromFile, migrationsReport: { migrations: [] } }
 
       const numberOfTables =
         sqliteDb.select<{ count: number }>(`select count(*) as count from sqlite_master`)[0]?.count ?? 0
       if (numberOfTables === 0) {
         return yield* UnknownError.make({
           cause: `Encountered empty or corrupted database`,
-          payload: { snapshotByteLength: initialResult.snapshot.byteLength, storageOptions: options.storage },
+          payload: { snapshotByteLength, storageOptions: options.storage },
         })
       }
 

--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.test-fixture.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.test-fixture.ts
@@ -1,0 +1,68 @@
+import { migrateDb } from '@livestore/common'
+import { configureConnection } from '@livestore/common/leader-thread'
+import { makeSchema, State, SystemTables } from '@livestore/common/schema'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/browser'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { Effect } from '@livestore/utils/effect'
+import { Opfs } from '@livestore/utils/effect/browser'
+
+import { getStateDbFileName, readPersistedStateDbFromClientSession, sanitizeOpfsDir } from './persisted-sqlite.ts'
+
+/** Exercise the browser snapshot reader against a real AccessHandlePoolVFS file. */
+const run = Effect.gen(function* () {
+  const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+  const makeSqliteDb = sqliteDbFactory({ sqlite3 })
+  const services = yield* Effect.context()
+  const storeId = `rebuild-snapshot-${crypto.randomUUID()}`
+  const storageOptions = { type: 'opfs' as const }
+  const todos = State.SQLite.table({ name: 'todos', columns: { id: State.SQLite.text({ primaryKey: true }) } })
+  const schema = makeSchema({ events: [], state: State.SQLite.makeState({ tables: { todos }, materializers: {} }) })
+  const persisted = yield* Effect.acquireRelease(
+    makeSqliteDb({
+      _tag: 'opfs',
+      opfsDirectory: yield* sanitizeOpfsDir(undefined, storeId),
+      fileName: getStateDbFileName(schema),
+      configureDb: (db) => configureConnection(db, { foreignKeys: true }).pipe(Effect.runSyncWith(services)),
+    }),
+    (db) => Effect.sync(() => db.close()),
+  )
+  const closed: boolean[] = []
+  const makeSnapshotDb = (input: { _tag: 'in-memory' }) =>
+    makeSqliteDb(input).pipe(
+      Effect.map((db) => {
+        const index = closed.push(false) - 1
+        return {
+          ...db,
+          close: () => {
+            closed[index] = true
+            db.close()
+          },
+        }
+      }),
+    )
+  yield* migrateDb({ db: persisted, schema })
+  persisted.execute(todos.insert({ id: 'partial' }))
+  const read = readPersistedStateDbFromClientSession({ storeId, storageOptions, schema, makeSqliteDb: makeSnapshotDb })
+  const readStatus = read.pipe(Effect.match({ onSuccess: () => 'accepted', onFailure: (error) => error._tag }))
+  const incomplete = yield* readStatus
+  persisted.execute(`DROP TABLE ${SystemTables.REBUILD_META_TABLE}`)
+  const missingMarkerTable = yield* readStatus
+  yield* migrateDb({ db: persisted, schema })
+  persisted.execute(todos.insert({ id: 'complete' }))
+  persisted.execute(`INSERT INTO ${SystemTables.REBUILD_META_TABLE} (id) VALUES (1)`)
+  const { sqliteDb } = yield* read
+  return {
+    incomplete,
+    missingMarkerTable,
+    complete: 'accepted',
+    rows: sqliteDb.select(todos.orderBy('id', 'asc')),
+    // Check before the outer scope closes: rejection must release memory immediately.
+    closedBeforeScopeExit: [...closed],
+    closedAfterScopeExit: closed,
+  }
+}).pipe(Effect.scoped, Effect.provide(Opfs.layer))
+
+void Effect.runPromise(run).then(
+  (result) => postMessage({ result }),
+  (error) => postMessage({ error: String(error) }),
+)

--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.test-fixture.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.test-fixture.ts
@@ -26,15 +26,15 @@ const run = Effect.gen(function* () {
     }),
     (db) => Effect.sync(() => db.close()),
   )
-  const closed: boolean[] = []
+  const closeCounts: number[] = []
   const makeSnapshotDb = (input: { _tag: 'in-memory' }) =>
     makeSqliteDb(input).pipe(
       Effect.map((db) => {
-        const index = closed.push(false) - 1
+        const index = closeCounts.push(0) - 1
         return {
           ...db,
           close: () => {
-            closed[index] = true
+            closeCounts[index] = (closeCounts[index] ?? 0) + 1
             db.close()
           },
         }
@@ -57,8 +57,8 @@ const run = Effect.gen(function* () {
     complete: 'accepted',
     rows: sqliteDb.select(todos.orderBy('id', 'asc')),
     // Check before the outer scope closes: rejection must release memory immediately.
-    closedBeforeScopeExit: [...closed],
-    closedAfterScopeExit: closed,
+    closeCountsBeforeScopeExit: [...closeCounts],
+    closeCountsAfterScopeExit: closeCounts,
   }
 }).pipe(Effect.scoped, Effect.provide(Opfs.layer))
 

--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
@@ -1,4 +1,5 @@
-import { liveStoreStorageFormatVersion } from '@livestore/common'
+import { liveStoreStorageFormatVersion, type MakeSqliteDb } from '@livestore/common'
+import { hasCompletedState } from '@livestore/common/leader-thread'
 import { getStateDbBaseName, type LiveStoreSchema } from '@livestore/common/schema'
 import {
   decodeAccessHandlePoolFilename,
@@ -34,10 +35,12 @@ export const readPersistedStateDbFromClientSession = Effect.fn(
     storageOptions,
     storeId,
     schema,
+    makeSqliteDb,
   }: {
     storageOptions: WorkerSchema.StorageType
     storeId: string
     schema: LiveStoreSchema
+    makeSqliteDb: (input: { _tag: 'in-memory' }) => ReturnType<MakeSqliteDb>
   }) {
     const accessHandlePoolDirString = yield* sanitizeOpfsDir(storageOptions.directory, storeId)
 
@@ -81,7 +84,27 @@ export const readPersistedStateDbFromClientSession = Effect.fn(
       })
     }
 
-    return new Uint8Array(stateDbBuffer)
+    const snapshot = new Uint8Array(stateDbBuffer)
+    const sqliteDb = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+      Effect.sync(() => db.close()),
+    )
+    yield* Effect.try({
+      try: () => {
+        sqliteDb.import(snapshot)
+        return hasCompletedState(sqliteDb)
+      },
+      catch: (cause) => new PersistedSqliteError({ message: 'Could not load persisted state snapshot', cause }),
+    }).pipe(
+      Effect.filterOrFail(
+        (completed) => completed,
+        () =>
+          new PersistedSqliteError({ message: 'Persisted state rebuild is incomplete; waiting for leader recovery' }),
+      ),
+      // Release rejected snapshots before waiting for recovery, not only when the session scope closes.
+      Effect.onError(() => Effect.sync(() => sqliteDb.close())),
+    )
+
+    return { sqliteDb, snapshotByteLength: snapshot.byteLength }
   },
   Effect.logWarnIfTakesLongerThan({
     duration: 1000,

--- a/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.ts
@@ -85,23 +85,29 @@ export const readPersistedStateDbFromClientSession = Effect.fn(
     }
 
     const snapshot = new Uint8Array(stateDbBuffer)
-    const sqliteDb = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
-      Effect.sync(() => db.close()),
-    )
-    yield* Effect.try({
-      try: () => {
-        sqliteDb.import(snapshot)
-        return hasCompletedState(sqliteDb)
-      },
-      catch: (cause) => new PersistedSqliteError({ message: 'Could not load persisted state snapshot', cause }),
-    }).pipe(
-      Effect.filterOrFail(
-        (completed) => completed,
-        () =>
-          new PersistedSqliteError({ message: 'Persisted state rebuild is incomplete; waiting for leader recovery' }),
+    const sqliteDb = yield* Effect.acquireRelease(
+      makeSqliteDb({ _tag: 'in-memory' }).pipe(
+        Effect.tap((db) =>
+          Effect.try({
+            try: () => {
+              db.import(snapshot)
+              return hasCompletedState(db)
+            },
+            catch: (cause) => new PersistedSqliteError({ message: 'Could not load persisted state snapshot', cause }),
+          }).pipe(
+            Effect.filterOrFail(
+              (completed) => completed,
+              () =>
+                new PersistedSqliteError({
+                  message: 'Persisted state rebuild is incomplete; waiting for leader recovery',
+                }),
+            ),
+            // A failed acquisition has no scope finalizer yet, so release it here.
+            Effect.onError(() => Effect.sync(() => db.close())),
+          ),
+        ),
       ),
-      // Release rejected snapshots before waiting for recovery, not only when the session scope closes.
-      Effect.onError(() => Effect.sync(() => sqliteDb.close())),
+      (db) => Effect.sync(() => db.close()),
     )
 
     return { sqliteDb, snapshotByteLength: snapshot.byteLength }

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -31,11 +31,12 @@ import type * as StateHead from '../StateHead.ts'
 import type { SyncBackend, SyncOptions } from '../sync/sync.ts'
 import { SyncState } from '../sync/syncstate.ts'
 import { sql } from '../util.ts'
+import { configureConnection } from './connection.ts'
 import * as Eventlog from './eventlog.ts'
 import { bootDevtools } from './leader-worker-devtools.ts'
 import * as LeaderSyncProcessor from './LeaderSyncProcessor.ts'
 import { makeMaterializeEvent } from './materialize-event.ts'
-import { recreateDb } from './recreate-db.ts'
+import { hasCompletedState, recreateDb } from './recreate-db.ts'
 import type { ShutdownChannel } from './shutdown-channel.ts'
 import type {
   DevtoolsContext,
@@ -112,8 +113,20 @@ export const makeLeaderThreadLayer = ({
 
     const dbEventlogMissing = !hasEventlogTables(dbEventlog)
 
-    // Either happens on initial boot or if schema changes
-    const dbStateMissing = !hasStateTables(dbState)
+    const dbStateMissing = !hasCompletedState(dbState)
+
+    if (dbStateMissing === true) {
+      // Import also clears hook-created objects while preserving the open connection.
+      yield* Effect.acquireUseRelease(
+        makeSqliteDb({ _tag: 'in-memory' }),
+        (emptyDb) =>
+          configureConnection(emptyDb, { foreignKeys: false }).pipe(
+            Effect.andThen(Effect.sync(() => dbState.import(emptyDb))),
+            UnknownError.mapToUnknownError,
+          ),
+        (emptyDb) => Effect.sync(() => emptyDb.close()),
+      )
+    }
 
     yield* Eventlog.initEventlogDb(dbEventlog)
 
@@ -264,11 +277,6 @@ export const makeLeaderThreadLayer = ({
 const hasEventlogTables = (db: SqliteDb) => {
   const tableNames = new Set(db.select<{ name: string }>(sql`select name from sqlite_master`).map((_) => _.name))
   return ReadonlyArray.every(SystemTables.eventlogSystemTables, (_) => tableNames.has(_.sqliteDef.name))
-}
-
-const hasStateTables = (db: SqliteDb) => {
-  const tableNames = new Set(db.select<{ name: string }>(sql`select name from sqlite_master`).map((_) => _.name))
-  return ReadonlyArray.every(SystemTables.stateSystemTables, (_) => tableNames.has(_.sqliteDef.name))
 }
 
 const getInitialSyncState = ({

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -113,9 +113,9 @@ export const makeLeaderThreadLayer = ({
 
     const dbEventlogMissing = !hasEventlogTables(dbEventlog)
 
-    const dbStateMissing = !hasCompletedState(dbState)
+    const stateNeedsRebuild = !hasCompletedState(dbState)
 
-    if (dbStateMissing === true) {
+    if (stateNeedsRebuild === true) {
       // Import also clears hook-created objects while preserving the open connection.
       yield* Effect.acquireUseRelease(
         makeSqliteDb({ _tag: 'in-memory' }),
@@ -184,7 +184,7 @@ export const makeLeaderThreadLayer = ({
     // Recreate state database if needed BEFORE creating sync processor
     // This ensures all system tables exist before any queries are made
     const { migrationsReport } =
-      dbStateMissing === true
+      stateNeedsRebuild === true
         ? yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
         : { migrationsReport: { migrations: [] } }
 

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -11,8 +11,17 @@ import {
   UnknownError,
 } from '../index.ts'
 import type { LiveStoreSchema } from '../schema/mod.ts'
-import { configureConnection } from './connection.ts'
+import { SystemTables } from '../schema/mod.ts'
+import { configureConnection, execSql } from './connection.ts'
 import type { MaterializeEvent } from './types.ts'
+
+export const hasCompletedState = (db: SqliteDb): boolean => {
+  const tableNames = new Set(db.select<{ name: string }>('SELECT name FROM sqlite_master').map((_) => _.name))
+  return (
+    SystemTables.stateSystemTables.every((table) => tableNames.has(table.sqliteDef.name)) &&
+    db.select(`SELECT id FROM ${SystemTables.REBUILD_META_TABLE} WHERE id = 1`).length === 1
+  )
+}
 
 export const recreateDb = ({
   dbState,
@@ -36,27 +45,21 @@ export const recreateDb = ({
       }),
     )
 
-    // NOTE to speed up the operations below, we're creating a temporary in-memory database
-    // and later we'll overwrite the persisted database with the new data
-    // TODO bring back this optimization
-    // const tmpDb = yield* makeSqliteDb({ _tag: 'in-memory' })
-    const tmpDb = dbState
-    yield* configureConnection(tmpDb, { foreignKeys: true })
+    yield* configureConnection(dbState, { foreignKeys: true })
 
     // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user hook errors are immediately normalized to LiveStore UnknownError
-    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.init?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
+    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.init?.(dbState)).pipe(UnknownError.mapToUnknownError)
 
     const migrationsReport = yield* migrateDb({
-      db: tmpDb,
+      db: dbState,
       schema,
       onProgress: ({ done, total }) => Queue.offer(bootStatusQueue, { stage: 'migrating', progress: { done, total } }),
     })
 
     // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user hook errors are immediately normalized to LiveStore UnknownError
-    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.pre?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
+    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.pre?.(dbState)).pipe(UnknownError.mapToUnknownError)
 
     yield* rematerializeFromEventlog({
-      // db: tmpDb,
       dbEventlog,
       schema,
       materializeEvent,
@@ -65,21 +68,10 @@ export const recreateDb = ({
     })
 
     // @effect-diagnostics-next-line anyUnknownInErrorContext:off -- user hook errors are immediately normalized to LiveStore UnknownError
-    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.post?.(tmpDb)).pipe(UnknownError.mapToUnknownError)
+    yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.post?.(dbState)).pipe(UnknownError.mapToUnknownError)
 
-    // TODO bring back
-    // Import the temporary in-memory database into the persistent database
-    // yield* Effect.sync(() => db.import(tmpDb)).pipe(
-    //   Effect.withSpan('@livestore/common:leader-thread:recreateDb:import'),
-    // )
-
-    // TODO maybe bring back re-using this initial snapshot to avoid calling `.export()` again
-    // We've disabled this for now as it made the code too complex, as we often run syncing right after
-    // so the snapshot is no longer up to date
-    // const snapshotFromTmpDb = tmpDb.export()
-
-    // TODO bring back
-    // tmpDb.close()
+    // Keep this out of finalizers, which also run on failure and interruption.
+    yield* execSql(dbState, `INSERT INTO ${SystemTables.REBUILD_META_TABLE} (id) VALUES (1)`, {})
 
     return { migrationsReport }
   }).pipe(

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -23,6 +23,10 @@ export const hasCompletedState = (db: SqliteDb): boolean => {
   )
 }
 
+/** Marks a successfully prepared state database as safe to use without rebuilding it. */
+export const markStateAsCompleted = (db: SqliteDb): Effect.Effect<void, SqliteError> =>
+  execSql(db, `INSERT OR IGNORE INTO ${SystemTables.REBUILD_META_TABLE} (id) VALUES (1)`, {})
+
 export const recreateDb = ({
   dbState,
   dbEventlog,
@@ -71,7 +75,7 @@ export const recreateDb = ({
     yield* Effect.trySyncOrPromiseOrEffect(() => hooks?.post?.(dbState)).pipe(UnknownError.mapToUnknownError)
 
     // Keep this out of finalizers, which also run on failure and interruption.
-    yield* execSql(dbState, `INSERT INTO ${SystemTables.REBUILD_META_TABLE} (id) VALUES (1)`, {})
+    yield* markStateAsCompleted(dbState)
 
     return { migrationsReport }
   }).pipe(

--- a/packages/@livestore/common/src/schema/state/sqlite/db-schema/ast/fingerprint.test.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/db-schema/ast/fingerprint.test.ts
@@ -4,6 +4,7 @@ import { Schema } from '@livestore/utils/effect'
 
 import { liveStoreStorageFormatVersion } from '../../../../../version.ts'
 import { makeState } from '../../mod.ts'
+import { REBUILD_META_TABLE } from '../../system-tables/state-tables.ts'
 import { SqliteDsl } from '../mod.ts'
 import { digestToFingerprint } from './fingerprint-digest.ts'
 import { fingerprint } from './fingerprint.ts'
@@ -14,7 +15,17 @@ describe('SQLite storage fingerprints', () => {
     expect(fingerprint(makeJsonTable('documents', representativeJsonSchema).ast)).toBe(
       'kUzaurzV2rcXYLljHOZ64TDR9c_RebqD7y5ZUM_nPBE',
     )
-    expect(makeState({ tables: [], materializers: {} }).sqlite.hash).toBe('H5Uktp6Ffp84WDj_RWPnfDnaQEu_E61AMl7ieZ9Zn8k')
+    expect(makeState({ tables: [], materializers: {} }).sqlite.hash).toBe('o8mmnRDnhXhkgDpBybM3FK7S-PkaLEj_pKcnbzgg3TU')
+  })
+
+  test('isolates pre-completion-marker state databases without changing the hash algorithm', () => {
+    const state = makeState({ tables: [], materializers: {} })
+    const legacyTables = [...state.sqlite.tables.values()]
+      .filter((table) => table.sqliteDef.name !== REBUILD_META_TABLE)
+      .map((table) => table.sqliteDef.ast)
+    const legacyHash = fingerprint({ _tag: 'dbSchema', tables: legacyTables })
+    expect(legacyHash).toBe('H5Uktp6Ffp84WDj_RWPnfDnaQEu_E61AMl7ieZ9Zn8k')
+    expect(state.sqlite.hash).not.toBe(legacyHash)
   })
 
   test('matches the standard SHA-256 vector', () => {

--- a/packages/@livestore/common/src/schema/state/sqlite/system-tables/state-tables.ts
+++ b/packages/@livestore/common/src/schema/state/sqlite/system-tables/state-tables.ts
@@ -64,6 +64,16 @@ export const stateHeadMetaTable = table({
 
 export type StateHeadMetaRow = typeof stateHeadMetaTable.Type
 
+export const REBUILD_META_TABLE = '__livestore_rebuild'
+
+/** Only a completed replay and successful migration hooks may insert the marker row. */
+export const rebuildMetaTable = table({
+  name: REBUILD_META_TABLE,
+  columns: {
+    id: SqliteDsl.integer({ primaryKey: true }),
+  },
+})
+
 /**
  * Table which stores SQLite changeset blobs which is used for rolling back
  * read-model state during rebasing.
@@ -104,6 +114,7 @@ export const stateSystemTables = [
   schemaEventDefsMetaTable,
   stateHeadMetaTable,
   sessionChangesetMetaTable,
+  rebuildMetaTable,
 ] as const
 
 export const isStateSystemTable = (tableName: string) => stateSystemTables.some((_) => _.sqliteDef.name === tableName)

--- a/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
@@ -54,16 +54,37 @@ const ResetPersistenceSnapshotSchema = Schema.Struct({
   after: PersistenceSnapshotSchema,
 })
 
+const RebuildResponseSchema = Schema.Struct({
+  todos: Schema.Array(Schema.Struct({ id: Schema.String, title: Schema.String })),
+  attemptedEvents: Schema.Array(Schema.String),
+  attemptedHooks: Schema.Array(Schema.String),
+  instanceId: Schema.String,
+})
+
+const readRebuildResponse = HttpClientResponse.schemaBodyJson(RebuildResponseSchema)
+
 const makeStoreHelpers = (serverUrl: string, storeId: string) =>
   Effect.gen(function* () {
-    const client = (yield* HttpClient.HttpClient).pipe(
+    const rawClient = (yield* HttpClient.HttpClient).pipe(
       HttpClient.mapRequest((req) =>
         req.pipe(HttpClientRequest.prependUrl(serverUrl), HttpClientRequest.setUrlParam('storeId', storeId)),
       ),
-      HttpClient.filterStatusOk,
     )
+    const client = HttpClient.filterStatusOk(rawClient)
 
     return {
+      // Recovery tests deliberately inspect failed boot responses.
+      rebuild: (params: Record<string, string>) => rawClient.post('/store/rebuild', { urlParams: params }),
+      rebuildEventlog: () =>
+        client
+          .get('/store/rebuild/eventlog')
+          .pipe(
+            Effect.flatMap(
+              HttpClientResponse.schemaBodyJson(
+                Schema.Struct({ events: Schema.Array(Schema.Json), sync: Schema.Array(Schema.Json) }),
+              ),
+            ),
+          ),
       createTodo: (id: string, title: string) =>
         HttpClientRequest.post('/store/todos').pipe(
           HttpClientRequest.bodyJson({ id, title }),
@@ -131,6 +152,110 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
   })
 
 Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
+  Vitest.live('retries an interrupted schema rebuild instead of serving partial state (#1605)', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServer.WranglerDevServer
+      const storeId = `cf-rebuild-${nanoid(6)}`
+      const { rebuild: request, rebuildEventlog: eventlog } = yield* makeStoreHelpers(server.url, storeId)
+      const expected = Array.from({ length: 5 }, (_, i) => ({ id: `todo-${i + 1}`, title: `item ${i + 1}` }))
+
+      const seeded = yield* request({ seed: 'true' })
+      expect(seeded.status).toBe(200)
+      const seededBody = yield* readRebuildResponse(seeded)
+      expect(seededBody).toMatchObject({ todos: expected })
+
+      const before = yield* eventlog()
+      expect(before.events).toHaveLength(5)
+
+      // The table rename forces replay into a new persisted state database.
+      const failed = yield* request({ failAt: 'todo-3' })
+      expect(failed.status).toBe(500)
+      expect(yield* failed.json).toMatchObject({
+        attemptedEvents: ['todo-1', 'todo-2', 'todo-3'],
+      })
+
+      const failedAgain = yield* request({ failAt: 'todo-3' })
+      expect(failedAgain.status).toBe(500)
+      expect(yield* failedAgain.json).toMatchObject({
+        attemptedEvents: ['todo-1', 'todo-2', 'todo-3'],
+      })
+
+      const recovered = yield* request({})
+      expect(recovered.status).toBe(200)
+      expect(yield* recovered.json).toMatchObject({ todos: expected })
+      expect(yield* eventlog()).toEqual(before)
+
+      const reused = yield* request({ failAt: 'todo-1' })
+      expect(reused.status).toBe(200)
+      expect(yield* reused.json).toMatchObject({ todos: expected, attemptedEvents: [] })
+    }).pipe(withTestCtx(test)),
+  )
+
+  for (const post of ['fail', 'abort'] as const) {
+    Vitest.live(`retries a rebuild after post-hook ${post}, without publishing partial state (#1605)`, (test) =>
+      Effect.gen(function* () {
+        const server = yield* WranglerDevServer.WranglerDevServer
+        const storeId = `cf-rebuild-post-${nanoid(6)}`
+        const { rebuild: request } = yield* makeStoreHelpers(server.url, storeId)
+        const seeded = yield* request({ seed: 'true' })
+        expect(seeded.status).toBe(200)
+        const seedBody = yield* readRebuildResponse(seeded)
+
+        const failed = yield* request({ post })
+        expect(failed.status).toBe(500)
+        if (post === 'fail') {
+          expect(yield* failed.json).toMatchObject({
+            attemptedEvents: ['todo-1', 'todo-2', 'todo-3', 'todo-4', 'todo-5'],
+            attemptedHooks: ['init', 'pre', 'post'],
+          })
+        } else {
+          expect(yield* failed.text).toContain('Rebuild fixture aborted during post hook')
+        }
+
+        const recovered = yield* request({ post: 'complete' })
+        expect(recovered.status).toBe(200)
+        const recoveredBody = yield* readRebuildResponse(recovered)
+        expect(recoveredBody).toMatchObject({
+          todos: [{ id: 'post-hook', title: 'completed' }, ...seedBody.todos],
+          attemptedEvents: ['todo-1', 'todo-2', 'todo-3', 'todo-4', 'todo-5'],
+          attemptedHooks: ['init', 'pre', 'post'],
+        })
+        if (post === 'abort') expect(recoveredBody.instanceId).not.toBe(seedBody.instanceId)
+
+        const reused = yield* request({ post: 'fail' })
+        expect(reused.status).toBe(200)
+        expect(yield* reused.json).toMatchObject({
+          todos: recoveredBody.todos,
+          attemptedEvents: [],
+          attemptedHooks: [],
+        })
+      }).pipe(withTestCtx(test)),
+    )
+  }
+
+  Vitest.live('records completion for an empty eventlog and does not repeat hooks (#1605)', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServer.WranglerDevServer
+      const storeId = `cf-rebuild-empty-${nanoid(6)}`
+      const { rebuild: request } = yield* makeStoreHelpers(server.url, storeId)
+      const first = yield* request({ post: 'complete' })
+      expect(first.status).toBe(200)
+      const firstBody = yield* readRebuildResponse(first)
+      expect(firstBody).toMatchObject({
+        todos: [{ id: 'post-hook', title: 'completed' }],
+        attemptedEvents: [],
+        attemptedHooks: ['init', 'pre', 'post'],
+      })
+      const reused = yield* request({ post: 'fail' })
+      expect(reused.status).toBe(200)
+      expect(yield* reused.json).toMatchObject({
+        todos: firstBody.todos,
+        attemptedEvents: [],
+        attemptedHooks: [],
+      })
+    }).pipe(withTestCtx(test)),
+  )
+
   Vitest.live('keeps Durable Object state when resetPersistence is not requested', (test) =>
     Effect.gen(function* () {
       const server = yield* WranglerDevServer.WranglerDevServer
@@ -244,6 +369,9 @@ Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
       const preShutdownTodos = yield* listTodos()
       expect(preShutdownTodos).toHaveLength(todos.length)
 
+      // Let blocking sync acknowledge seeded events before measuring an idle reopen.
+      yield* shutdownStore()
+      expect(yield* listTodos()).toEqual(preShutdownTodos)
       yield* shutdownStore()
       yield* resetMetrics()
 

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -2,9 +2,9 @@
 
 import { DurableObject } from 'cloudflare:workers'
 
-import { type ClientDoWithRpcCallback, createStoreDoPromise } from '@livestore/adapter-cloudflare'
+import { type ClientDoWithRpcCallback, createStoreDoPromise, makeAdapter } from '@livestore/adapter-cloudflare'
 import { CfDeclare } from '@livestore/common-cf/declare'
-import type { Store } from '@livestore/livestore'
+import { createStorePromise, type Store } from '@livestore/livestore'
 import {
   type CfTypes,
   handleSyncRequest,
@@ -15,6 +15,7 @@ import {
 import { handleSyncUpdateRpc } from '@livestore/sync-cf/client'
 import { shouldNeverHappen } from '@livestore/utils'
 
+import { makeRebuildSchema } from '../rebuild-schema.ts'
 import { events, schema, tables } from '../schema.ts'
 
 /**
@@ -99,6 +100,7 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
   /** Captures the VFS counts immediately before/after a reset so tests can assert the deletion actually happened. */
   private lastResetSnapshot: ResetPersistenceSnapshot | undefined
   private trackedSql: ReturnType<typeof wrapSqlForTracking> | undefined
+  private readonly rebuildInstanceId = crypto.randomUUID()
 
   override async fetch(request: CfTypes.Request): Promise<CfTypes.Response> {
     const url = new URL(request.url)
@@ -106,6 +108,83 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
 
     if (storeId === null) {
       return makeCfResponse('storeId is required', { status: 400 })
+    }
+
+    if (url.pathname === '/store/rebuild/eventlog') {
+      return makeCfResponse(
+        JSON.stringify({
+          events: this.ctx.storage.sql.exec('SELECT * FROM eventlog ORDER BY seqNumGlobal, seqNumClient').toArray(),
+          sync: this.ctx.storage.sql.exec('SELECT * FROM __livestore_sync_status').toArray(),
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    }
+
+    if (url.pathname === '/store/rebuild' && request.method === 'POST') {
+      const seed = url.searchParams.get('seed') === 'true'
+      const fixture = makeRebuildSchema({
+        upgraded: seed === false,
+        ...(url.searchParams.has('failAt') === true ? { failAt: url.searchParams.get('failAt')! } : {}),
+        ...(url.searchParams.has('post') === true
+          ? {
+              post: async () => {
+                if (url.searchParams.get('post') === 'fail') throw new Error('Rebuild fixture post hook failed')
+                if (url.searchParams.get('post') === 'abort') {
+                  // Persist before aborting without running LiveStore finalizers.
+                  await this.ctx.storage.sync()
+                  this.ctx.abort('Rebuild fixture aborted during post hook')
+                }
+              },
+            }
+          : {}),
+      })
+      try {
+        // A sync backend could refill missing rows and hide a recovery failure.
+        const store = await createStorePromise({
+          schema: fixture.schema,
+          storeId,
+          disableDevtools: true,
+          adapter: makeAdapter({
+            storage: this.ctx.storage,
+            clientId: 'rebuild-client',
+            sessionId: crypto.randomUUID(),
+            syncOptions: {},
+          }),
+        })
+        try {
+          if (seed === true) {
+            for (let i = 1; i <= 5; i++) {
+              store.commit(fixture.events.created({ id: `todo-${i}`, title: `item ${i}` }))
+            }
+          }
+          const todos = store.query(fixture.todos.orderBy('id', 'asc'))
+          return makeCfResponse(
+            JSON.stringify({
+              todos,
+              attemptedEvents: fixture.attemptedEvents,
+              attemptedHooks: fixture.attemptedHooks,
+              instanceId: this.rebuildInstanceId,
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          )
+        } finally {
+          // Orderly shutdown drains admitted events to the persisted leader eventlog.
+          await store.shutdownPromise()
+        }
+      } catch (error) {
+        return makeCfResponse(
+          JSON.stringify({
+            error: String(error),
+            cause: error,
+            attemptedEvents: fixture.attemptedEvents,
+            attemptedHooks: fixture.attemptedHooks,
+          }),
+          {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+          },
+        )
+      }
     }
 
     if (url.pathname === '/store/todos') {

--- a/tests/integration/src/tests/adapter-cloudflare/rebuild-schema.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/rebuild-schema.ts
@@ -1,0 +1,64 @@
+import { Events, makeSchema, State } from '@livestore/common/schema'
+import { Schema } from '@livestore/utils/effect'
+
+/** A table rename selects a fresh state file through the normal schema fingerprint. */
+export const makeRebuildSchema = ({
+  upgraded,
+  failAt,
+  post,
+}: {
+  upgraded: boolean
+  failAt?: string
+  post?: () => Promise<void>
+}) => {
+  const attemptedEvents: string[] = []
+  const attemptedHooks: string[] = []
+  const todos = State.SQLite.table({
+    name: upgraded === true ? 'rebuild_todos_v2' : 'rebuild_todos_v1',
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      title: State.SQLite.text(),
+    },
+  })
+  const events = {
+    created: Events.synced({
+      name: 'created',
+      schema: Schema.Struct({ id: Schema.String, title: Schema.String }),
+    }),
+  }
+  const materializers = State.SQLite.materializers(events, {
+    created: ({ id, title }) => {
+      attemptedEvents.push(id)
+      if (id === failAt) throw new Error(`Rebuild fixture rejected ${id}`)
+      return todos.insert({ id, title })
+    },
+  })
+  const state = State.SQLite.makeState({
+    tables: { todos },
+    materializers,
+    migrations: {
+      hooks:
+        post === undefined
+          ? undefined
+          : {
+              init: (db) => {
+                attemptedHooks.push('init')
+                // Not a declared table: recovery must discard hook-created objects too.
+                db.execute('CREATE TABLE rebuild_scratch (id INTEGER PRIMARY KEY)')
+                db.execute('INSERT INTO rebuild_scratch VALUES (1)')
+              },
+              pre: (db) => {
+                attemptedHooks.push('pre')
+                db.execute('INSERT INTO rebuild_scratch VALUES (2)')
+              },
+              post: async (db) => {
+                attemptedHooks.push('post')
+                db.execute('INSERT INTO rebuild_scratch VALUES (3)')
+                await post()
+                db.execute(todos.insert({ id: 'post-hook', title: 'completed' }))
+              },
+            },
+    },
+  })
+  return { schema: makeSchema({ events, state }), events, todos, attemptedEvents, attemptedHooks }
+}

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -31,6 +31,51 @@ const withTestCtx = Vitest.makeWithTestCtx({
 })
 
 Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
+  Vitest.live('rejects incomplete OPFS snapshots before fast-path boot (#1605)', (test) =>
+    Effect.gen(function* () {
+      const port = yield* getFreePort.pipe(Effect.map(String))
+      yield* cmd(`./node_modules/.bin/vite --config ${viteConfigRel} dev --port ${port}`, {
+        env: { TEST_LIVESTORE_SCHEMA_PATH_JSON: undefined, LSD_DEVTOOLS_LOCAL_PREVIEW: undefined },
+      }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)), Effect.forkScoped)
+      const url = `http://localhost:${port}`
+      const httpClient = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
+      yield* httpClient.head(url).pipe(
+        Effect.retry(Schedule.exponentialBackoff10Sec),
+        Effect.mapError((error) => new DevServerNotReadyError({ cause: error })),
+      )
+      const { browserContext } = yield* BrowserContext
+      const page = yield* Effect.promise(() => browserContext.newPage())
+      yield* Effect.promise(() => page.goto(url))
+      const response = yield* Effect.promise(() =>
+        page.evaluate(
+          (workerUrl) =>
+            new Promise((resolve, reject) => {
+              const worker = new Worker(workerUrl, { type: 'module' })
+              worker.onmessage = (event) => {
+                worker.terminate()
+                resolve(event.data)
+              }
+              worker.onerror = (event) => {
+                worker.terminate()
+                reject(new Error(event.message))
+              }
+            }),
+          `/@fs/${path.resolve(integrationRoot, '../../packages/@livestore/adapter-web/src/web-worker/common/persisted-sqlite.test-fixture.ts')}`,
+        ),
+      )
+      expect(response).toEqual({
+        result: {
+          incomplete: 'PersistedSqliteError',
+          missingMarkerTable: 'PersistedSqliteError',
+          complete: 'accepted',
+          rows: [{ id: 'complete' }, { id: 'partial' }],
+          closedBeforeScopeExit: [true, true, false],
+          closedAfterScopeExit: [true, true, true],
+        },
+      })
+    }).pipe(withTestCtx(test)),
+  )
+
   /**
    * SharedWorker boot/leader race can stall startup when two tabs boot concurrently.
    * Issue: https://github.com/livestorejs/livestore/issues/763

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -69,8 +69,8 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
           missingMarkerTable: 'PersistedSqliteError',
           complete: 'accepted',
           rows: [{ id: 'complete' }, { id: 'partial' }],
-          closedBeforeScopeExit: [true, true, false],
-          closedAfterScopeExit: [true, true, true],
+          closeCountsBeforeScopeExit: [1, 1, 0],
+          closeCountsAfterScopeExit: [1, 1, 1],
         },
       })
     }).pipe(withTestCtx(test)),

--- a/tests/package-common/src/in-memory-adapter.test.ts
+++ b/tests/package-common/src/in-memory-adapter.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'vitest'
+
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { migrateDb } from '@livestore/common'
+import { makeSchema, State, SystemTables } from '@livestore/common/schema'
+import { createStore } from '@livestore/livestore'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect } from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+Vitest.live('preserves imported snapshots without a rebuild completion marker (#1605)', (test) =>
+  Effect.gen(function* () {
+    const todos = State.SQLite.table({
+      name: 'todos',
+      columns: { id: State.SQLite.text({ primaryKey: true }) },
+    })
+    const schema = makeSchema({
+      events: [],
+      state: State.SQLite.makeState({ tables: { todos }, materializers: {} }),
+    })
+    const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+    const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+    const sourceDb = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+      Effect.sync(() => db.close()),
+    )
+
+    yield* migrateDb({ db: sourceDb, schema })
+    sourceDb.execute(todos.insert({ id: 'imported' }))
+    sourceDb.execute(`DROP TABLE ${SystemTables.REBUILD_META_TABLE}`)
+
+    const store = yield* createStore({
+      schema,
+      adapter: makeInMemoryAdapter({ importSnapshot: sourceDb.export() }),
+      storeId: 'import-snapshot-without-completion-marker',
+    })
+
+    expect(store.query(todos)).toEqual([{ id: 'imported' }])
+  }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+)

--- a/tests/package-common/src/leader-thread/recreate-db.test.ts
+++ b/tests/package-common/src/leader-thread/recreate-db.test.ts
@@ -1,0 +1,236 @@
+import { expect } from 'vitest'
+
+import { type BootStatus, StateHead } from '@livestore/common'
+import {
+  configureConnection,
+  Eventlog,
+  LeaderThreadCtx,
+  makeLeaderThreadLayer,
+  makeMaterializeEvent,
+  recreateDb,
+  ShutdownChannel,
+} from '@livestore/common/leader-thread'
+import { Events, LiveStoreEvent, makeSchema, State, SystemTables } from '@livestore/common/schema'
+import { EventFactory } from '@livestore/common/testing'
+import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
+import { sqliteDbFactory } from '@livestore/sqlite-wasm/node'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import {
+  Deferred,
+  Effect,
+  Exit,
+  FetchHttpClient,
+  Fiber,
+  FileSystem,
+  Layer,
+  Queue,
+  Schema,
+  WebChannel,
+} from '@livestore/utils/effect'
+import { PlatformNode } from '@livestore/utils/node'
+
+for (const failure of ['init', 'pre', 'replay', 'post', 'interrupt'] as const) {
+  Vitest.live(`rebuilds surviving partial state after ${failure} failure on common leader boot (#1605)`, (test) =>
+    Effect.gen(function* () {
+      const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+      const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+      const fs = yield* FileSystem.FileSystem
+      const directory = yield* fs.makeTempDirectoryScoped()
+      const services = yield* Effect.context()
+      const dbEventlog = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+        Effect.sync(() => db.close()),
+      )
+      const openState = Effect.acquireRelease(
+        makeSqliteDb({
+          _tag: 'fs',
+          directory,
+          fileName: 'state.db',
+          configureDb: (db) => configureConnection(db, { foreignKeys: true }).pipe(Effect.runSyncWith(services)),
+        }),
+        (db) => Effect.sync(() => db.close()),
+      )
+      const todos = State.SQLite.table({
+        name: 'rebuild_todos',
+        columns: { id: State.SQLite.text({ primaryKey: true }) },
+      })
+      const events = { created: Events.synced({ name: 'created', schema: Schema.Struct({ id: Schema.String }) }) }
+      const factory = EventFactory.makeFactory(events)({ client: EventFactory.clientIdentity('test') })
+      yield* Eventlog.initEventlogDb(dbEventlog)
+      for (let i = 1; i <= 5; i++) {
+        const event = new LiveStoreEvent.Client.EncodedWithMeta({
+          ...LiveStoreEvent.Global.toClientEncoded(factory.created.next({ id: `todo-${i}` })),
+        })
+        yield* Eventlog.insertIntoEventlog(
+          event,
+          dbEventlog,
+          Schema.hash(events.created.schema),
+          event.clientId,
+          event.sessionId,
+        )
+      }
+      const readEventlog = () => ({
+        events: dbEventlog.select(SystemTables.eventlogMetaTable),
+        sync: dbEventlog.select(SystemTables.syncStatusTable),
+      })
+      const before = readEventlog()
+      const enteredPost = yield* Deferred.make<void>()
+      let shouldFail = true
+      const attemptedEvents: string[] = []
+      const attemptedHooks: string[] = []
+      const failHook = (stage: string) => {
+        attemptedHooks.push(stage)
+        if (shouldFail === true && failure === stage) throw new Error(`Injected ${stage} failure`)
+      }
+      const schema = makeSchema({
+        events,
+        state: State.SQLite.makeState({
+          tables: { todos },
+          materializers: State.SQLite.materializers(events, {
+            created: ({ id }) => {
+              attemptedEvents.push(id)
+              if (shouldFail === true && failure === 'replay' && id === 'todo-3') {
+                throw new Error('Injected replay failure')
+              }
+              return todos.insert({ id })
+            },
+          }),
+          migrations: {
+            hooks: {
+              init: (db) => {
+                // Objects outside the declared schema must also disappear before retry.
+                db.execute('CREATE TABLE scratch (id INTEGER PRIMARY KEY)')
+                db.execute('INSERT INTO scratch VALUES (1)')
+                failHook('init')
+              },
+              pre: (db) => {
+                db.execute('INSERT INTO scratch VALUES (2)')
+                failHook('pre')
+              },
+              post: (db) =>
+                Effect.gen(function* () {
+                  db.execute('INSERT INTO scratch VALUES (3)')
+                  yield* Effect.sync(() => failHook('post'))
+                  if (shouldFail === true && failure === 'interrupt') {
+                    yield* Deferred.succeed(enteredPost, undefined)
+                    return yield* Effect.never
+                  }
+                  db.execute(todos.insert({ id: 'post-hook' }))
+                }),
+            },
+          },
+        }),
+      })
+      const boot = Effect.gen(function* () {
+        const persistedState = yield* openState
+        // Model adapters whose failure cleanup leaves the persisted file intact.
+        const dbState = { ...persistedState, destroy: () => persistedState.close() }
+        const shutdown = yield* WebChannel.queueChannelProxy({ schema: ShutdownChannel.All })
+        return yield* Effect.gen(function* () {
+          const leader = yield* LeaderThreadCtx
+          return {
+            todos: dbState.select(todos.orderBy('id', 'asc')),
+            pending: (yield* leader.syncProcessor.syncState.get).pending.length,
+            marker: dbState.select(SystemTables.rebuildMetaTable),
+          }
+        }).pipe(
+          Effect.provide(
+            makeLeaderThreadLayer({
+              schema,
+              storeId: 'rebuild-test',
+              clientId: 'test',
+              syncPayloadEncoded: undefined,
+              syncPayloadSchema: undefined,
+              makeSqliteDb,
+              syncOptions: undefined,
+              dbState,
+              dbEventlog,
+              devtoolsOptions: { enabled: false },
+              shutdownChannel: shutdown.webChannel,
+            }).pipe(Layer.provide(StateHead.layer({ dbState })), Layer.provide(FetchHttpClient.layer)),
+          ),
+        )
+      }).pipe(Effect.scoped)
+
+      if (failure === 'interrupt') {
+        const fiber = yield* boot.pipe(Effect.forkScoped)
+        yield* Deferred.await(enteredPost)
+        yield* Fiber.interrupt(fiber)
+      } else {
+        expect(Exit.isFailure(yield* boot.pipe(Effect.exit))).toBe(true)
+      }
+      yield* Effect.gen(function* () {
+        const partial = yield* openState
+        expect(partial.select('SELECT * FROM scratch')).not.toEqual([])
+        if (failure !== 'init') expect(partial.select(SystemTables.rebuildMetaTable)).toEqual([])
+        if (failure === 'replay') expect(partial.select(todos)).toHaveLength(2)
+        if (failure === 'post' || failure === 'interrupt') expect(partial.select(todos)).toHaveLength(5)
+      }).pipe(Effect.scoped)
+      expect(readEventlog()).toEqual(before)
+
+      shouldFail = false
+      attemptedEvents.length = 0
+      attemptedHooks.length = 0
+      const recovered = yield* boot
+      expect(recovered).toEqual({
+        todos: [{ id: 'post-hook' }, ...Array.from({ length: 5 }, (_, i) => ({ id: `todo-${i + 1}` }))],
+        pending: 5,
+        marker: [{ id: 1 }],
+      })
+      expect(attemptedEvents).toEqual(['todo-1', 'todo-2', 'todo-3', 'todo-4', 'todo-5'])
+      expect(attemptedHooks).toEqual(['init', 'pre', 'post'])
+      expect(readEventlog()).toEqual(before)
+
+      shouldFail = true
+      attemptedEvents.length = 0
+      attemptedHooks.length = 0
+      expect(yield* boot).toEqual(recovered)
+      expect(attemptedEvents).toEqual([])
+      expect(attemptedHooks).toEqual([])
+      expect(readEventlog()).toEqual(before)
+    }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+  )
+}
+
+Vitest.live('publishes rebuild completion only after an async post hook finishes (#1605)', (test) =>
+  Effect.gen(function* () {
+    const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
+    const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
+    const dbState = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+      Effect.sync(() => db.close()),
+    )
+    const dbEventlog = yield* Effect.acquireRelease(makeSqliteDb({ _tag: 'in-memory' }), (db) =>
+      Effect.sync(() => db.close()),
+    )
+    const enteredPost = yield* Deferred.make<void>()
+    const releasePost = yield* Deferred.make<void>()
+    const schema = makeSchema({
+      events: [],
+      state: State.SQLite.makeState({
+        tables: {},
+        materializers: {},
+        migrations: {
+          hooks: {
+            post: () =>
+              Effect.gen(function* () {
+                yield* Deferred.succeed(enteredPost, undefined)
+                yield* Deferred.await(releasePost)
+              }),
+          },
+        },
+      }),
+    })
+    yield* Eventlog.initEventlogDb(dbEventlog)
+    const bootStatusQueue = yield* Effect.acquireRelease(Queue.unbounded<BootStatus>(), Queue.shutdown)
+    const materializeEvent = yield* makeMaterializeEvent({ schema, dbState, dbEventlog }).pipe(
+      Effect.provide(StateHead.layer({ dbState })),
+    )
+    const rebuild = yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent }).pipe(
+      Effect.forkScoped,
+    )
+    yield* Deferred.await(enteredPost)
+    expect(dbState.select(SystemTables.rebuildMetaTable)).toEqual([])
+    yield* Deferred.succeed(releasePost, undefined)
+    yield* Fiber.join(rebuild)
+    expect(dbState.select(SystemTables.rebuildMetaTable)).toEqual([{ id: 1 }])
+  }).pipe(Effect.provide(PlatformNode.NodeFileSystem.layer), Vitest.withTestCtx(test)),
+)


### PR DESCRIPTION
## Problem

If event replay or a migration hook fails, the next boot can mistake an existing partial state database for a completed rebuild. Queries then return only the replayed prefix even though the eventlog still contains every event. Runtime termination can leave this state behind without running failure finalizers, and browser fast-path loading can bypass leader recovery.

The same completion check can discard a snapshot supplied to the in-memory adapter by an older release or custom setup: after importing and migrating the snapshot, leader boot sees no completion marker and rebuilds from the adapter's new, empty eventlog.

## Solution

Record a completion row only after replay and all migration hooks succeed. Leader boot checks it before reusing state; incomplete state is cleared through the existing SQLite import operation and rebuilt from the preserved eventlog. Both browser adapters validate the same condition before accepting an OPFS snapshot and otherwise wait for leader recovery. Snapshot import and validation are part of the database acquisition: rejected databases close exactly once immediately, while accepted databases remain owned by the session scope.

Snapshots explicitly supplied to `makeInMemoryAdapter` are marked complete after their migration succeeds, preserving their imported rows instead of rebuilding them from an unrelated empty eventlog. The marker write is idempotent, so current snapshots that already contain it remain valid.

The marker uses the existing system-table and fingerprint machinery. Schema metadata and the state head cannot replace it because they are written before rebuild completion. Intent specs, derived docs, the changelog, and a changeset describe the same contract.

**Upgrade trade-off:** the fingerprint change causes a one-time state rebuild on upgrade. Cloudflare deployments should budget for replay time and row writes, and migration hooks must tolerate retries. The eventlog, pending events, and sync metadata are preserved. This does not add arbitrary SQLite corruption repair or validate snapshot identity/head against the leader.

## Validation

- `devenv tasks run lint:full:fix` and `devenv tasks run ts:check` pass, including Effect diagnostics.
- `devenv tasks run test:unit` passes, including common recovery regressions, fingerprint checks, intent-layer invariants, and an in-memory adapter regression for imported pre-marker snapshots.
- All 10 Cloudflare adapter integration tests pass: repeated replay failure, post-hook failure, runtime abort, empty replay, completed-state reuse, and existing persistence/write checks.
- Three focused browser tests pass, including real OPFS rejection/acceptance. The snapshot regression verifies that rejected databases close exactly once immediately and an accepted database closes exactly once with its session scope.
- Docs `astro sync` and `astro-check` pass with zero checker errors, warnings, or hints. `git diff --check` passes.

The documented `devenv tasks run test:run` command was attempted but that task does not exist in this checkout. Validation above covers the available full unit lane and affected integration tests, not the entire CI matrix. The unchanged browser test `single-tab mode: tabs operate independently` also fails on baseline `583bf8420`; #1609 tracks its shared-store fixture problem. It is excluded from the focused browser run and remains unquarantined.

The Cloudflare zero-write test now finishes startup sync acknowledgements in a preparatory restart before measuring an idle reopen. Its zero-write assertion is unchanged; the first reopen also produced acknowledgement writes on baseline.

### Demo

```text
Replay events 1–2 → event 3 fails → no completion marker
Restart          → discard partial state → replay all events
Hooks succeed    → record completion     → serve complete state
Next restart     → reuse completed state → no replay

Import snapshot  → migrate successfully → record/reuse completion marker
Leader boot      → keep imported rows    → do not replay an empty eventlog
```

## Related issues

- Fixes #1605.
- Follow-up for the existing browser test failure: #1609.
