### PR TITLE
Batch schema rebuild writes: 93% average reduction in benchmarks

### DIFF
--- a/.changeset/batch-state-replay.md
+++ b/.changeset/batch-state-replay.md
@@ -1,5 +1,8 @@
 ---
+'@livestore/adapter-cloudflare': patch
+'@livestore/adapter-web': patch
 '@livestore/common': patch
+'@livestore/livestore': patch
 ---
 
-Batch schema-rebuild replay to reduce repeated SQLite page writes while preserving event order and recovery from incomplete rebuilds.
+Batch schema-rebuild replay to reduce repeated SQLite page writes while preserving event order and recovery from incomplete rebuilds. Clients can tune future rebuilds with `createStore.params.stateRebuildBatchSize` (positive integers, default 100).

--- a/.changeset/batch-state-replay.md
+++ b/.changeset/batch-state-replay.md
@@ -1,0 +1,5 @@
+---
+'@livestore/common': patch
+---
+
+Batch schema-rebuild replay to reduce repeated SQLite page writes while preserving event order and recovery from incomplete rebuilds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
 - **Schema rebuilds:** Batched eventlog replay to reduce repeated SQLite page
   writes, including billed row writes on Cloudflare Durable Objects. Replay order
-  and recovery from incomplete rebuilds are preserved
+  and recovery from incomplete rebuilds are preserved. Clients can tune the
+  event-count batch per runtime with `params.stateRebuildBatchSize` (a positive
+  integer, default 100); lower values trade more queries and writes for smaller batches
   ([#1555](https://github.com/livestorejs/livestore/issues/1555)).
 - **State recovery:** Interrupted rematerialization is retried from clean derived
   state instead of reopening partial results. Completion is recorded after all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   Telemetry cleanup runs in the background, and finite WebSocket operations and
   DO-RPC pull streams now emit their sync spans
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
+- **Schema rebuilds:** Batched eventlog replay to reduce repeated SQLite page
+  writes, including billed row writes on Cloudflare Durable Objects. Replay order
+  and recovery from incomplete rebuilds are preserved
+  ([#1555](https://github.com/livestorejs/livestore/issues/1555)).
 - **State recovery:** Interrupted rematerialization is retried from clean derived
   state instead of reopening partial results. Completion is recorded after all
   migration hooks finish. Browser fast-path startup waits for recovery when its

--- a/context/02-system/02-state/01-sqlite/02-schema-management/.decisions/0002-batch-replay-writes.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/.decisions/0002-batch-replay-writes.md
@@ -1,0 +1,66 @@
+# 0002 — Batch replay writes using existing eventlog pages
+
+Status: accepted for the replay implementation (2026-09-06), supported by the
+Cloudflare write-budget and common leader recovery regressions described below.
+
+## Context
+
+Full replay after a schema change repeatedly writes shared SQLite pages. The
+Cloudflare adapter bills these writes. The regression fixture for
+[#1555](https://github.com/livestorejs/livestore/issues/1555) measured 2,586 writes
+for 250 events and 10,140 writes for 1,000 events before batching.
+
+## Decision
+
+Consume each existing 100-event stream chunk inside the shared `withSavepoint`
+helper. Keep materialization sequential and retain per-event progress. Commit
+application rows, the state head and undo metadata together. Keep hooks and the
+completion marker outside replay batches, in their existing order.
+
+Prioritize memory headroom over further write savings. Retaining 100 limits the
+batch's contribution; it is not evidence that full boot fits a Cloudflare isolate.
+
+## Alternatives
+
+- One transaction for the whole eventlog would retain transaction state across
+  an unbounded number of events.
+- Rebuilding a second in-memory database would duplicate state and require a
+  separate persistence/publication protocol.
+- VFS buffering would broaden the change into persistence durability.
+
+## Consequences
+
+The current batch rolls back on failure or interruption. Earlier batches may
+survive, but the completion protocol still requires a clean rebuild before reuse.
+Batch size bounds event count, not bytes or materializer work. No application
+configuration, live-event transaction changes or new transaction helper is needed.
+
+## Evidence
+
+`tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts`
+passes budgets of 1,250 and 5,000 writes for the same 250/1,000-event fixtures.
+The tests also verify replay order, hooks, unchanged eventlog/sync metadata and
+zero-write completed-state reuse. The common leader regression in
+`tests/package-common/src/leader-thread/recreate-db.test.ts` fails replay in the
+first and second batches, checks rows/head/undo rollback, then verifies full retry.
+The shared savepoint tests cover failure, defects, interruption and nesting.
+
+Exploratory local measurements covered 100 to 1,000,000 events and larger payloads.
+For one million small events, batch 100 reduced writes from 10,424,530 to 270,060.
+Batch 1,000 reduces them further to 62,276. Separate memory profiles support
+retaining 100 as a conservative internal default: for 1,000 events with an extra
+16 KiB per title, batch 1,000 saves only another 1.6% of writes while increasing
+the SQLite allocator's replay peak from 8.6 to 34.6 MiB. Small rows show a much
+better tradeoff. Whole-boot memory also includes JavaScript, snapshots and WASM
+capacity, so the SQLite peak does not imply the same increase in total memory.
+Neither batch size is a universal optimum. The exploratory benchmark is not part
+of the test suite; the unconditional write-budget regressions protect this change.
+
+Several local batch-100 profiles already exceed Cloudflare's documented memory
+ceiling when measuring used JavaScript heap plus backing storage across full boot.
+The same workloads also exceed it with the original unbatched replay module;
+the full-boot memory problem predates this change. Batch 100 adds little to the
+measured SQLite allocator peak compared with original replay.
+Free-plan compatibility with headroom is therefore not established by this PR.
+The broader capacity investigation and production validation are tracked in
+[#1612](https://github.com/livestorejs/livestore/issues/1612).

--- a/context/02-system/02-state/01-sqlite/02-schema-management/.decisions/0002-batch-replay-writes.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/.decisions/0002-batch-replay-writes.md
@@ -12,13 +12,18 @@ for 250 events and 10,140 writes for 1,000 events before batching.
 
 ## Decision
 
-Consume each existing 100-event stream chunk inside the shared `withSavepoint`
-helper. Keep materialization sequential and retain per-event progress. Commit
-application rows, the state head and undo metadata together. Keep hooks and the
-completion marker outside replay batches, in their existing order.
+Consume each eventlog page inside the shared `withSavepoint` helper. Default to
+100 events per page and allow each client runtime to select any positive integer with
+`createStore.params.stateRebuildBatchSize`. Keep materialization sequential and
+retain per-event progress. Commit application rows, the state head and undo
+metadata together. Keep hooks and the completion marker outside replay batches,
+in their existing order.
 
-Prioritize memory headroom over further write savings. Retaining 100 limits the
-batch's contribution; it is not evidence that full boot fits a Cloudflare isolate.
+Treat this as runtime tuning rather than schema identity: different clients of
+the same store can have different resource limits, and changing the value does
+not trigger a rebuild. Prioritize memory headroom over further write savings in
+the default. Retaining 100 limits the batch's contribution; it is not evidence
+that full boot fits a Cloudflare isolate.
 
 ## Alternatives
 
@@ -32,8 +37,11 @@ batch's contribution; it is not evidence that full boot fits a Cloudflare isolat
 
 The current batch rolls back on failure or interruption. Earlier batches may
 survive, but the completion protocol still requires a clean rebuild before reuse.
-Batch size bounds event count, not bytes or materializer work. No application
-configuration, live-event transaction changes or new transaction helper is needed.
+Batch size bounds event count, not bytes, materializer work, WASM capacity or
+whole-isolate memory. Lower values use smaller read/savepoint batches but perform
+more queries, savepoints and persistence writes. Higher values do the reverse.
+The setting applies to future rebuilds only. No live-event transaction changes
+or new transaction helper is needed.
 
 ## Evidence
 

--- a/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
@@ -99,14 +99,18 @@ database:
 5. Run the `post` migration hook.
 6. Insert the singleton completion row (`id = 1`) in `__livestore_rebuild`.
 
-Replay consumes the existing eventlog pages in order, with up to 100 events per
-state-database savepoint. This batch size is internal and cannot be configured by
-applications. Application rows, the state head and undo metadata commit
-together for each batch. Failure or interruption rolls back the current batch.
-Earlier batches can remain in the incomplete database, which boot discards before
-retrying. Progress still reports each processed event, not a durability boundary.
-Batching reduces repeated SQLite page writes without holding the whole replay in
-one transaction. Memory used by a batch depends on its events and materializers.
+Replay consumes eventlog pages in order, with each page committed in one
+state-database savepoint. The per-client runtime parameter
+`createStore.params.stateRebuildBatchSize` accepts positive integers and defaults
+to 100. It controls both the eventlog page and savepoint batch; it is
+not part of the state fingerprint, so changing it does not trigger a rebuild.
+Application rows, the state head and undo metadata commit together for each
+batch. Failure or interruption rolls back the current batch. Earlier batches can
+remain in the incomplete database, which boot discards before retrying. Progress
+still reports each processed event, not a durability boundary. Lower values can
+reduce per-batch resource usage at the cost of more queries, savepoints and
+persistence writes. The event count does not bound payload bytes, materializer
+work, WASM capacity or total client memory.
 
 Table existence and the state head alone do not prove completion: a materializer
 can fail partway through replay, or a hook can fail after replay reaches the tip.

--- a/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
@@ -99,6 +99,15 @@ database:
 5. Run the `post` migration hook.
 6. Insert the singleton completion row (`id = 1`) in `__livestore_rebuild`.
 
+Replay consumes the existing eventlog pages in order, with up to 100 events per
+state-database savepoint. This batch size is internal and cannot be configured by
+applications. Application rows, the state head and undo metadata commit
+together for each batch. Failure or interruption rolls back the current batch.
+Earlier batches can remain in the incomplete database, which boot discards before
+retrying. Progress still reports each processed event, not a durability boundary.
+Batching reduces repeated SQLite page writes without holding the whole replay in
+one transaction. Memory used by a batch depends on its events and materializers.
+
 Table existence and the state head alone do not prove completion: a materializer
 can fail partway through replay, or a hook can fail after replay reaches the tip.
 Boot reuses state only when all state system tables and the completion row exist.
@@ -114,7 +123,7 @@ snapshot before the session becomes available to application queries.
 
 Completion is recorded only on the successful path, never by a finalizer. Hooks
 can run again after a failed/interrupted rebuild. External hook side effects must
-tolerate retries; the marker does not make them exactly-once. Existing event
+tolerate retries; the marker does not make them exactly-once. Normal live-event
 transaction boundaries and asynchronous persistence/sync are unchanged.
 
 The marker table participates in the compound state fingerprint. Upgrading from
@@ -123,7 +132,8 @@ rebuild, including for previously complete databases. No eventlog schema or
 storage-format version changes. This protocol detects incomplete **readable**
 SQLite databases, not arbitrary file corruption or loss of the eventlog.
 
-See [the completion/recovery decision](./.decisions/0001-rebuild-completion.md).
+See [the completion/recovery decision](./.decisions/0001-rebuild-completion.md)
+and [the replay batching decision](./.decisions/0002-batch-replay-writes.md).
 
 The rebuild produces a `migrationsReport` surfaced through adapter boot info.
 On the Cloudflare Durable Object adapter, replay writes the newly materialized

--- a/context/02-system/04-runtime/02-cloudflare/spec.md
+++ b/context/02-system/04-runtime/02-cloudflare/spec.md
@@ -86,6 +86,16 @@ access. The provider side that threads `storeId` is `03-sync/03-cf`'s concern
 
 ## Open Design Questions
 
+- **LS.SYS.RT.CF-DQ2 Free-plan capacity and memory headroom.** The adapter should
+  support representative workloads on Workers Free with substantial memory
+  headroom for application state and concurrent work. The supported workload
+  envelope and regression budget are not yet established: local full-boot
+  profiles for several replay fixtures exceed the documented isolate ceiling,
+  even with 100-event replay batches. Track production-equivalent profiling,
+  allocation reduction and deployed validation in
+  [#1612](https://github.com/livestorejs/livestore/issues/1612). Account-wide
+  read/write quotas must also leave room for normal operation; batch size alone
+  cannot guarantee Free-plan compatibility.
 - **LS.SYS.RT.CF-DQ1 Flush durability scope.** The commit-loss window is
   decided (accepted; LS.SYS.RT.CF-R06). What remains platform-trust: whether
   Cloudflare's "confirmed flushed to disk" implies geo/replicated durability

--- a/context/02-system/04-runtime/02-cloudflare/spec.md
+++ b/context/02-system/04-runtime/02-cloudflare/spec.md
@@ -31,6 +31,11 @@ Inputs: `schema`, `storeId`, `clientId`, `sessionId`, the DO's own
 and `syncBackendStub` (`@livestore/sync-cf/cf-worker` RPC interface).
 `livePull: false` is the default (LS.SYS.RT.CF-R03).
 
+`createStoreDo.params.stateRebuildBatchSize` forwards the per-client rebuild
+setting. A Durable Object can choose a smaller batch than clients with more
+memory, trading lower per-batch resource use for more queries, savepoints and
+storage writes. The event-count limit is not a whole-isolate memory guarantee.
+
 Persistence keys are versioned with `liveStoreStorageFormatVersion` and the
 schema hash, so schema changes recreate state rather than migrate it in
 place.

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -44,9 +44,13 @@ contract — see
 `syncPayload` + `syncPayloadSchema` (encoded before crossing to the
 adapter), `confirmUnsavedChanges` (web `beforeunload`), `disableDevtools`
 (default `'auto'`), `params.{leaderPushBatchSize, eventQueryBatchSize,
-simulation}`, `debug.instanceId`, `shutdownDeferred`, `signal`
+stateRebuildBatchSize}`, `debug.instanceId`, `shutdownDeferred`, `signal`
 (`AbortSignal`), `logger`/`logLevel`, `unusedCacheTime` (registry, below).
 `storeId` must match `/^[a-zA-Z0-9_-]+$/` (`create-store.ts:456`).
+
+`stateRebuildBatchSize` is a per-client runtime setting rather than schema
+identity. It accepts positive integers, defaults to 100, and controls
+the number of eventlog events read and committed per state-rebuild batch.
 
 ## Commit Path
 

--- a/docs/src/content/_assets/code/reference/state/sqlite-schema/rebuild-batch-size.ts
+++ b/docs/src/content/_assets/code/reference/state/sqlite-schema/rebuild-batch-size.ts
@@ -1,0 +1,14 @@
+import { makeInMemoryAdapter } from '@livestore/adapter-web'
+import { createStorePromise } from '@livestore/livestore'
+
+import { schema } from './schema.ts'
+
+export const createAppStore = () =>
+  createStorePromise({
+    schema,
+    adapter: makeInMemoryAdapter(),
+    storeId: 'app',
+    params: {
+      stateRebuildBatchSize: 50,
+    },
+  })

--- a/docs/src/content/docs/building-with-livestore/state/sqlite-schema.mdx
+++ b/docs/src/content/docs/building-with-livestore/state/sqlite-schema.mdx
@@ -61,6 +61,8 @@ You can also provide a custom schema for a column which is used to automatically
 
 LiveStore automatically migrates the database to the newest schema and rematerializes state from the eventlog. A schema change opens a fresh state database and replays the full eventlog, even when only one table changed.
 
+Replay commits batches of up to 100 events to reduce repeated SQLite page writes, including billed row writes on Cloudflare Durable Objects. This is an internal limit, not an application setting. Events retain their original order. The savings depend on your schema and materializers.
+
 A rebuild is complete only after replay and all migration hooks finish. If a rebuild fails or is interrupted, the next boot discards incomplete derived state and retries from the eventlog. Browser fast-path startup also waits for recovery instead of exposing an incomplete snapshot. Migration hooks may run again, so any external side effects must tolerate retries. The eventlog and pending events are preserved.
 
 Upgrading from a version without rebuild-completion tracking causes a one-time rebuild, even when your application schema is unchanged. On Cloudflare Durable Objects, plan for the corresponding replay time and row writes.

--- a/docs/src/content/docs/building-with-livestore/state/sqlite-schema.mdx
+++ b/docs/src/content/docs/building-with-livestore/state/sqlite-schema.mdx
@@ -10,6 +10,7 @@ import ClientDocumentBasicSnippet from '../../../_assets/code/reference/state/sq
 import ClientDocumentKvSnippet from '../../../_assets/code/reference/state/sqlite-schema/columns/client-document-kv.tsx?snippet'
 import JsonStructSnippet from '../../../_assets/code/reference/state/sqlite-schema/columns/json-struct.ts?snippet'
 import TableBasicSnippet from '../../../_assets/code/reference/state/sqlite-schema/columns/table-basic.ts?snippet'
+import RebuildBatchSizeSnippet from '../../../_assets/code/reference/state/sqlite-schema/rebuild-batch-size.ts?snippet'
 
 LiveStore provides a schema definition language for defining your database tables and mutation definitions using explicit column configurations. LiveStore automatically migrates your database schema when you change your schema definitions.
 
@@ -61,7 +62,13 @@ You can also provide a custom schema for a column which is used to automatically
 
 LiveStore automatically migrates the database to the newest schema and rematerializes state from the eventlog. A schema change opens a fresh state database and replays the full eventlog, even when only one table changed.
 
-Replay commits batches of up to 100 events to reduce repeated SQLite page writes, including billed row writes on Cloudflare Durable Objects. This is an internal limit, not an application setting. Events retain their original order. The savings depend on your schema and materializers.
+Replay commits batches of events to reduce repeated SQLite page writes, including billed row writes on Cloudflare Durable Objects. Events retain their original order. The default batch size is 100 events.
+
+For clients with tighter resource limits, set `params.stateRebuildBatchSize` when creating the store. It accepts any positive integer:
+
+<RebuildBatchSizeSnippet />
+
+Lower values reduce the amount of replay work held by each read/savepoint batch, but perform more queries, savepoints, and persistence writes. Higher values do the reverse. The limit counts events, not payload bytes or total client memory, so measure representative rebuilds before changing it. The setting is local to each client and changing it does not trigger a rebuild; it applies the next time that client rebuilds state.
 
 A rebuild is complete only after replay and all migration hooks finish. If a rebuild fails or is interrupted, the next boot discards incomplete derived state and retries from the eventlog. Browser fast-path startup also waits for recovery instead of exposing an incomplete snapshot. Migration hooks may run again, so any external side effects must tolerate retries. The eventlog and pending events are preserved.
 

--- a/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
+++ b/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
@@ -107,6 +107,7 @@ Creates a LiveStore instance inside a Durable Object.
   - `bindingName` – Name other workers use to reach this Durable Object
 - `syncBackendStub` – Durable Object stub used to reach the sync backend
 - `livePull` – Enable real-time updates (default: `false`)
+- `params?` – Advanced per-client runtime tuning, including `stateRebuildBatchSize`
 - `resetPersistence` – Drop LiveStore state/eventlog persistence before booting (development only, default: `false`)
 - `logger?` – Optional Effect logger layer to customize formatting/output
 - `logLevel?` – Optional minimum log level (use `"None"` to disable logs)
@@ -131,6 +132,8 @@ Eviction is deliberately different: Cloudflare discards the isolate without runn
 ### Schema changes and billing
 
 Changing the state schema causes each affected store to open a fresh state database and replay its full eventlog, even if only one table changed. On Durable Objects, rebuilding the state can incur billable storage writes. Plan deployments according to the eventlog size and number of store instances.
+
+Rebuilds use 100 events per batch by default. A Durable Object can set `params: { stateRebuildBatchSize }` on `createStoreDo` or `createStoreDoPromise`; the value must be a positive integer. Lower values can reduce per-batch resource use, but require more queries, savepoints, and storage writes. This limit counts events rather than bytes and does not guarantee that the whole isolate stays within its memory limit, so profile representative data and materializers. Other clients of the same store can use different values.
 
 ## Resetting LiveStore persistence (development only)
 

--- a/packages/@livestore/adapter-cloudflare/src/create-store-do.ts
+++ b/packages/@livestore/adapter-cloudflare/src/create-store-do.ts
@@ -3,7 +3,7 @@ import type { CfTypes, HelperTypes } from '@livestore/common-cf'
 import { createStore, type LiveStoreSchema, provideOtel } from '@livestore/livestore'
 import type * as CfSyncBackend from '@livestore/sync-cf/cf-worker'
 import { makeDoRpcSync } from '@livestore/sync-cf/client'
-import { isDevEnv } from '@livestore/utils'
+import { isDevEnv, omitUndefineds } from '@livestore/utils'
 import { Effect, Layer, References, Scope } from '@livestore/utils/effect'
 
 import { makeAdapter } from './make-adapter.ts'
@@ -21,6 +21,18 @@ export type CreateStoreDoOptions<TSchema extends LiveStoreSchema, TEnv, TState> 
   clientId: string
   /** Identifier for the LiveStore session running inside the Durable Object. */
   sessionId: string
+  /** Advanced per-client runtime tuning parameters. */
+  params?: {
+    /**
+     * Number of events read and committed per batch when rebuilding SQLite state from the event log.
+     * Lower values reduce per-batch resource usage but perform more queries and savepoints.
+     * This setting applies to future rebuilds and does not change schema identity.
+     *
+     * @default 100
+     * @minimum 1
+     */
+    stateRebuildBatchSize?: number
+  }
   /** Runtime details about the Durable Object this store runs inside. Needed for sync backend to call back to this instance. */
   durableObject: {
     /** Durable Object state handle (e.g. `this.ctx`). */
@@ -107,6 +119,7 @@ export const createStoreDo = <
   livePull = false,
   resetPersistence = false,
   initialSyncOptions = { _tag: 'Blocking', timeout: 500 },
+  params,
 }: CreateStoreDoOptions<TSchema, TEnv, TState>) =>
   Effect.gen(function* () {
     const { ctx, bindingName } = durableObject
@@ -130,7 +143,12 @@ export const createStoreDo = <
       },
     })
 
-    return yield* createStore({ schema, adapter, storeId }).pipe(Scope.provide(scope), provideOtel({}))
+    return yield* createStore({
+      schema,
+      adapter,
+      storeId,
+      ...omitUndefineds({ params }),
+    }).pipe(Scope.provide(scope), provideOtel({}))
   })
 
 /**

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -46,6 +46,7 @@ export const makeAdapter =
         syncPayloadEncoded,
         syncPayloadSchema,
         schema,
+        params,
       } = adapterArgs
 
       const devtoolsOptions = { enabled: false } as DevtoolsOptions
@@ -94,6 +95,7 @@ export const makeAdapter =
           shutdownChannel,
           syncPayloadEncoded,
           syncPayloadSchema,
+          params,
         }).pipe(Layer.provide(StateHead.layer({ dbState }))),
       )
 

--- a/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
+++ b/packages/@livestore/adapter-web/src/in-memory/in-memory-adapter.ts
@@ -1,5 +1,6 @@
 import {
   type Adapter,
+  type AdapterArgs,
   ClientSessionLeaderThreadProxy,
   Devtools,
   type LockStatus,
@@ -158,6 +159,7 @@ export const makeInMemoryAdapter =
         syncOptions: options.sync,
         syncPayloadEncoded,
         syncPayloadSchema,
+        params: adapterArgs.params,
         importSnapshot: options.importSnapshot,
         devtoolsEnabled,
         sharedWorker: sharedWorkerClient === undefined ? undefined : makeWebmeshWorkerProxy(sharedWorkerClient),
@@ -217,6 +219,7 @@ export interface MakeLeaderThreadArgs {
   importSnapshot: Uint8Array<ArrayBuffer> | undefined
   devtoolsEnabled: boolean
   sharedWorker: WebmeshWorkerProxy | undefined
+  params: AdapterArgs['params']
 }
 
 const makeLeaderThread = ({
@@ -230,6 +233,7 @@ const makeLeaderThread = ({
   importSnapshot,
   devtoolsEnabled,
   sharedWorker,
+  params,
 }: MakeLeaderThreadArgs) =>
   Effect.gen(function* () {
     const services = yield* Effect.context()
@@ -275,6 +279,7 @@ const makeLeaderThread = ({
         shutdownChannel,
         syncPayloadEncoded,
         syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
+        params,
       }).pipe(Layer.provide(StateHead.layer({ dbState }))),
     )
 

--- a/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
+++ b/packages/@livestore/adapter-web/src/single-tab/single-tab-adapter.ts
@@ -149,7 +149,7 @@ export const makeSingleTabAdapter =
   (options: SingleTabAdapterOptions): Adapter =>
   (adapterArgs) =>
     Effect.gen(function* () {
-      const { schema, storeId, bootStatusQueue, shutdown, syncPayloadEncoded } = adapterArgs
+      const { schema, storeId, bootStatusQueue, shutdown, syncPayloadEncoded, params } = adapterArgs
       // Note: devtoolsEnabled is ignored in single-tab mode (devtools require SharedWorker)
 
       yield* ensureBrowserRequirements
@@ -251,6 +251,7 @@ export const makeSingleTabAdapter =
                 devtoolsEnabled: false,
                 debugInstanceId: adapterArgs.debugInstanceId,
                 syncPayloadEncoded,
+                params,
               }),
             ),
           ),

--- a/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/client-session/persisted-adapter.ts
@@ -189,6 +189,7 @@ export const makePersistedAdapter =
         shutdown,
         syncPayloadSchema: _syncPayloadSchema,
         syncPayloadEncoded,
+        params,
       } = adapterArgs
 
       // NOTE: The schema travels with the worker bundle (developers call
@@ -350,6 +351,7 @@ export const makePersistedAdapter =
               devtoolsEnabled,
               debugInstanceId,
               syncPayloadEncoded,
+              params,
             },
           })
           .pipe(

--- a/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/common/worker-schema.ts
@@ -8,7 +8,7 @@ import {
   SyncState,
   UnknownError,
 } from '@livestore/common'
-import { StreamEventsOptionsFields } from '@livestore/common/leader-thread'
+import { StateRebuildBatchSizeSchema, StreamEventsOptionsFields } from '@livestore/common/leader-thread'
 import { EventSequenceNumber, LiveStoreEvent } from '@livestore/common/schema'
 import { Rpc, RpcGroup, Schema, Transferable } from '@livestore/utils/effect'
 import * as WebmeshWorker from '@livestore/webmesh/worker'
@@ -53,6 +53,8 @@ export class LeaderWorkerOuterInitialMessage extends Rpc.make('InitialMessage', 
 
 export class LeaderWorkerOuterRpcs extends RpcGroup.make(LeaderWorkerOuterInitialMessage) {}
 
+export const LeaderWorkerParams = Schema.Struct({ stateRebuildBatchSize: StateRebuildBatchSizeSchema })
+
 // TODO unify this code with schema from node adapter
 export class LeaderWorkerInnerInitialMessage extends Rpc.make('InitialMessage', {
   payload: {
@@ -62,6 +64,7 @@ export class LeaderWorkerInnerInitialMessage extends Rpc.make('InitialMessage', 
     clientId: Schema.String,
     debugInstanceId: Schema.String,
     syncPayloadEncoded: Schema.UndefinedOr(Schema.Json),
+    params: LeaderWorkerParams,
   },
   success: Schema.Void,
   error: UnknownError,

--- a/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/leader-worker/make-leader-worker.ts
@@ -191,7 +191,7 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
 
       const leaderThreadContextOnce = yield* Effect.cached(
         Effect.gen(function* () {
-          const { storageOptions, storeId, clientId, devtoolsEnabled, debugInstanceId, syncPayloadEncoded } =
+          const { storageOptions, storeId, clientId, devtoolsEnabled, debugInstanceId, syncPayloadEncoded, params } =
             yield* RpcWorker.initialMessage(WorkerSchema.LeaderWorkerInnerInitialMessage.payloadSchema)
 
           const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
@@ -282,6 +282,7 @@ const makeWorkerRunnerInner = ({ schema, sync: syncOptions, syncPayloadSchema }:
               shutdownChannel,
               syncPayloadEncoded,
               syncPayloadSchema: syncPayloadSchema as Schema.Decoder<Schema.Json, never> | undefined,
+              params,
               ...(bootWarning !== undefined ? { bootWarning } : {}),
             }).pipe(Layer.provide(StateHead.layer({ dbState }))),
             leaderThreadScope,

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -132,13 +132,13 @@ const makeWorkerRunner = Effect.gen(function* () {
   })
 
   // Cache first-applied invariants to enforce stability across leader transitions
+  // Per-client runtime params are intentionally excluded so a new leader can apply its own tuning.
   const InvariantsSchema = Schema.Struct({
     storeId: Schema.String,
     storageOptions: WorkerSchema.StorageType,
     syncPayloadEncoded: Schema.UndefinedOr(Schema.Json),
     liveStoreVersion: Schema.Literal(liveStoreVersion),
     devtoolsEnabled: Schema.Boolean,
-    params: WorkerSchema.LeaderWorkerParams,
   })
   type Invariants = typeof InvariantsSchema.Type
   const invariantsRef = yield* Ref.make<Invariants | undefined>(undefined)
@@ -156,7 +156,6 @@ const makeWorkerRunner = Effect.gen(function* () {
           syncPayloadEncoded: initial.syncPayloadEncoded,
           liveStoreVersion: clientLiveStoreVersion,
           devtoolsEnabled: initial.devtoolsEnabled,
-          params: initial.params,
         }
         const prev = yield* Ref.get(invariantsRef)
         // Early return on mismatch to keep happy path linear

--- a/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
+++ b/packages/@livestore/adapter-web/src/web-worker/shared-worker/make-shared-worker.ts
@@ -138,6 +138,7 @@ const makeWorkerRunner = Effect.gen(function* () {
     syncPayloadEncoded: Schema.UndefinedOr(Schema.Json),
     liveStoreVersion: Schema.Literal(liveStoreVersion),
     devtoolsEnabled: Schema.Boolean,
+    params: WorkerSchema.LeaderWorkerParams,
   })
   type Invariants = typeof InvariantsSchema.Type
   const invariantsRef = yield* Ref.make<Invariants | undefined>(undefined)
@@ -148,13 +149,14 @@ const makeWorkerRunner = Effect.gen(function* () {
     // sends a new MessagePort to the shared worker which proxies messages to the new leader thread.
     UpdateMessagePort: ({ port, initial, liveStoreVersion: clientLiveStoreVersion }) =>
       Effect.gen(function* () {
-        // Enforce invariants: storeId, storageOptions, syncPayloadEncoded, liveStoreVersion must remain stable
+        // Enforce configuration stability across leader transitions.
         const invariants: Invariants = {
           storeId: initial.storeId,
           storageOptions: initial.storageOptions,
           syncPayloadEncoded: initial.syncPayloadEncoded,
           liveStoreVersion: clientLiveStoreVersion,
           devtoolsEnabled: initial.devtoolsEnabled,
+          params: initial.params,
         }
         const prev = yield* Ref.get(invariantsRef)
         // Early return on mismatch to keep happy path linear

--- a/packages/@livestore/common/src/adapter-types.ts
+++ b/packages/@livestore/common/src/adapter-types.ts
@@ -125,6 +125,10 @@ export type Adapter = (args: AdapterArgs) => Effect.Effect<ClientSession, Unknow
 export interface AdapterArgs {
   schema: LiveStoreSchema
   storeId: string
+  /** Runtime parameters resolved by `createStore` before the adapter is invoked. */
+  params: {
+    stateRebuildBatchSize: number
+  }
   devtoolsEnabled: boolean
   debugInstanceId: string
   bootStatusQueue: Queue.Queue<BootStatus>

--- a/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
+++ b/packages/@livestore/common/src/leader-thread/make-leader-thread-layer.ts
@@ -65,6 +65,7 @@ export interface MakeLeaderThreadLayerParams {
   params?: {
     localPushBatchSize?: number
     backendPushBatchSize?: number
+    stateRebuildBatchSize?: number
   }
   testing?: {
     syncProcessor?: {
@@ -185,7 +186,14 @@ export const makeLeaderThreadLayer = ({
     // This ensures all system tables exist before any queries are made
     const { migrationsReport } =
       stateNeedsRebuild === true
-        ? yield* recreateDb({ dbState, dbEventlog, schema, bootStatusQueue, materializeEvent })
+        ? yield* recreateDb({
+            dbState,
+            dbEventlog,
+            schema,
+            bootStatusQueue,
+            materializeEvent,
+            ...omitUndefineds({ stateRebuildBatchSize: params?.stateRebuildBatchSize }),
+          })
         : { migrationsReport: { migrations: [] } }
 
     const devtoolsContext =

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -14,6 +14,7 @@ import type { LiveStoreSchema } from '../schema/mod.ts'
 import { SystemTables } from '../schema/mod.ts'
 import { configureConnection, execSql } from './connection.ts'
 import type { MaterializeEvent } from './types.ts'
+import { STATE_REBUILD_BATCH_SIZE_DEFAULT } from './types.ts'
 
 export const hasCompletedState = (db: SqliteDb): boolean => {
   const tableNames = new Set(db.select<{ name: string }>('SELECT name FROM sqlite_master').map((_) => _.name))
@@ -33,12 +34,14 @@ export const recreateDb = ({
   schema,
   bootStatusQueue,
   materializeEvent,
+  stateRebuildBatchSize = STATE_REBUILD_BATCH_SIZE_DEFAULT,
 }: {
   dbState: SqliteDb
   dbEventlog: SqliteDb
   schema: LiveStoreSchema
   bootStatusQueue: Queue.Queue<BootStatus>
   materializeEvent: MaterializeEvent
+  stateRebuildBatchSize?: number
 }): Effect.Effect<{ migrationsReport: MigrationsReport }, UnknownError | MaterializeError | SqliteError> =>
   Effect.gen(function* () {
     const hooks = schema.state.sqlite.migrations.hooks
@@ -68,6 +71,7 @@ export const recreateDb = ({
       dbState,
       schema,
       materializeEvent,
+      batchSize: stateRebuildBatchSize,
       onProgress: ({ done, total }) =>
         Queue.offer(bootStatusQueue, { stage: 'rehydrating', progress: { done, total } }),
     })

--- a/packages/@livestore/common/src/leader-thread/recreate-db.ts
+++ b/packages/@livestore/common/src/leader-thread/recreate-db.ts
@@ -65,6 +65,7 @@ export const recreateDb = ({
 
     yield* rematerializeFromEventlog({
       dbEventlog,
+      dbState,
       schema,
       materializeEvent,
       onProgress: ({ done, total }) =>

--- a/packages/@livestore/common/src/leader-thread/types.ts
+++ b/packages/@livestore/common/src/leader-thread/types.ts
@@ -139,6 +139,11 @@ export type InitialBlockingSyncContext = {
 export const STREAM_EVENTS_BATCH_SIZE_DEFAULT = 100
 export const STREAM_EVENTS_BATCH_SIZE_MAX = 1_000
 
+export const STATE_REBUILD_BATCH_SIZE_DEFAULT = 100
+export const StateRebuildBatchSizeSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)).annotate({
+  title: 'stateRebuildBatchSize',
+})
+
 export const StreamEventsOptionsFields = {
   since: Schema.optional(EventSequenceNumber.Client.Composite),
   until: Schema.optional(EventSequenceNumber.Client.Composite),

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -31,7 +31,7 @@ export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerial
 }) {
   if (Schema.is(StateRebuildBatchSizeSchema)(batchSize) === false) {
     return yield* UnknownError.make({
-      cause: `Invalid stateRebuildBatchSize: ${batchSize}. Expected a positive integer.`,
+      cause: `Invalid stateRebuildBatchSize: ${String(batchSize)}. Expected a positive integer.`,
       payload: { batchSize },
     })
   }

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -5,6 +5,7 @@ import { type SqliteDb, UnknownError } from './adapter-types.ts'
 import type { MaterializeEvent } from './leader-thread/mod.ts'
 import type { EventDef, LiveStoreSchema } from './schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from './schema/mod.ts'
+import { withSavepoint } from './sqlite-db-helper.ts'
 import type { PreparedBindValues } from './util.ts'
 import { sql } from './util.ts'
 
@@ -14,13 +15,13 @@ const jsonParse = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown)
 export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerializeFromEventlog')(function* ({
   dbEventlog,
   // TODO re-use this db when bringing back the boot in-memory db implementation
-  // db,
+  dbState,
   schema,
   onProgress,
   materializeEvent,
 }: {
   dbEventlog: SqliteDb
-  // db: SqliteDb
+  dbState: SqliteDb
   schema: LiveStoreSchema
   onProgress: (_: { done: number; total: number }) => Effect.Effect<void>
   materializeEvent: MaterializeEvent
@@ -125,14 +126,19 @@ LIMIT ${CHUNK_SIZE}
     }),
   ).pipe(
     Stream.bufferArray({ capacity: 2 }),
-    Stream.tap((row) =>
-      Effect.gen(function* () {
-        yield* processEvent(row)
+    Stream.runForEachArray((rows) =>
+      Effect.forEach(
+        rows,
+        (row) =>
+          Effect.gen(function* () {
+            yield* processEvent(row)
 
-        processedEvents++
-        yield* onProgress({ done: processedEvents, total: eventsCount })
-      }),
+            processedEvents++
+            yield* onProgress({ done: processedEvents, total: eventsCount })
+          }),
+        { discard: true },
+      ).pipe(withSavepoint(dbState)),
     ),
-    Stream.runDrain,
+    Effect.ensuring(Effect.sync(() => stmt.finalize())),
   )
 }, Effect.withPerformanceMeasure('@livestore/common:rematerializeFromEventlog'))

--- a/packages/@livestore/common/src/rematerialize-from-eventlog.ts
+++ b/packages/@livestore/common/src/rematerialize-from-eventlog.ts
@@ -3,6 +3,7 @@ import { Effect, Option, ReadonlyArray as EffectArray, Schema, Stream } from '@l
 
 import { type SqliteDb, UnknownError } from './adapter-types.ts'
 import type { MaterializeEvent } from './leader-thread/mod.ts'
+import { STATE_REBUILD_BATCH_SIZE_DEFAULT, StateRebuildBatchSizeSchema } from './leader-thread/types.ts'
 import type { EventDef, LiveStoreSchema } from './schema/mod.ts'
 import { EventSequenceNumber, LiveStoreEvent, SystemTables } from './schema/mod.ts'
 import { withSavepoint } from './sqlite-db-helper.ts'
@@ -19,13 +20,22 @@ export const rematerializeFromEventlog = Effect.fn('@livestore/common:rematerial
   schema,
   onProgress,
   materializeEvent,
+  batchSize = STATE_REBUILD_BATCH_SIZE_DEFAULT,
 }: {
   dbEventlog: SqliteDb
   dbState: SqliteDb
   schema: LiveStoreSchema
   onProgress: (_: { done: number; total: number }) => Effect.Effect<void>
   materializeEvent: MaterializeEvent
+  batchSize?: number
 }) {
+  if (Schema.is(StateRebuildBatchSizeSchema)(batchSize) === false) {
+    return yield* UnknownError.make({
+      cause: `Invalid stateRebuildBatchSize: ${batchSize}. Expected a positive integer.`,
+      payload: { batchSize },
+    })
+  }
+
   const eventsCount = dbEventlog.select<{ count: number }>(
     `SELECT COUNT(*) AS count FROM ${SystemTables.EVENTLOG_META_TABLE}`,
   )[0]!.count
@@ -86,13 +96,11 @@ This likely means the schema has changed in an incompatible way.
     yield* materializeEvent(eventEncoded, { skipEventlog: true })
   })
 
-  const CHUNK_SIZE = 100
-
   const stmt = dbEventlog.prepare(sql`\
 SELECT * FROM ${SystemTables.EVENTLOG_META_TABLE} 
 WHERE seqNumGlobal > $seqNumGlobal OR (seqNumGlobal = $seqNumGlobal AND seqNumClient > $seqNumClient)
 ORDER BY seqNumGlobal ASC, seqNumClient ASC
-LIMIT ${CHUNK_SIZE}
+LIMIT $batchSize
 `)
 
   let processedEvents = 0
@@ -102,6 +110,7 @@ LIMIT ${CHUNK_SIZE}
       const rows = stmt.select<SystemTables.EventlogMetaRow>({
         $seqNumGlobal: lastId.global,
         $seqNumClient: lastId.client,
+        $batchSize: batchSize,
       } as any as PreparedBindValues)
 
       if (EffectArray.isReadonlyArrayNonEmpty(rows) === false) {

--- a/packages/@livestore/livestore/src/effect/LiveStore.ts
+++ b/packages/@livestore/livestore/src/effect/LiveStore.ts
@@ -34,6 +34,7 @@ export const makeLiveStoreContext = <
   batchUpdates,
   syncPayload,
   syncPayloadSchema,
+  params,
 }: LiveStoreContextProps<TSchema, TContext, TSyncPayloadSchema>): Effect.Effect<
   LiveStoreContextRunning['Service'],
   UnknownError | Cause.TimeoutError,
@@ -46,7 +47,7 @@ export const makeLiveStoreContext = <
         storeId,
         adapter,
         batchUpdates,
-        ...omitUndefineds({ context, boot, disableDevtools, onBootStatus, syncPayload, syncPayloadSchema }),
+        ...omitUndefineds({ context, boot, disableDevtools, onBootStatus, syncPayload, syncPayloadSchema, params }),
       })
 
       return LiveStoreContextRunning.of({ stage: 'running', store } as any as LiveStoreContextRunning['Service'])
@@ -272,6 +273,7 @@ const makeStoreTag = <TSchema extends LiveStoreSchema, TStoreId extends string>(
               onBootStatus: props.onBootStatus,
               syncPayload: props.syncPayload,
               syncPayloadSchema: props.syncPayloadSchema,
+              params: props.params,
             }),
           })
 
@@ -422,6 +424,7 @@ export const makeStoreContext =
               onBootStatus: props.onBootStatus,
               syncPayload: props.syncPayload,
               syncPayloadSchema: props.syncPayloadSchema,
+              params: props.params,
             }),
           })
 

--- a/packages/@livestore/livestore/src/store/create-store.test.ts
+++ b/packages/@livestore/livestore/src/store/create-store.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'vitest'
+
+import { type Adapter, OtelLiveDummy, UnknownError } from '@livestore/common'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect } from '@livestore/utils/effect'
+
+import { schema } from '../utils/tests/fixture.ts'
+import { createStore } from './create-store.ts'
+
+Vitest.live('validates stateRebuildBatchSize before invoking the adapter', () =>
+  Effect.gen(function* () {
+    const observedBatchSizes: number[] = []
+    const adapter: Adapter = ({ params }) => {
+      observedBatchSizes.push(params.stateRebuildBatchSize)
+      return Effect.fail(UnknownError.make({ cause: 'adapter sentinel' }))
+    }
+    const run = (stateRebuildBatchSize?: number) =>
+      createStore({
+        schema,
+        adapter,
+        storeId: 'batch-size-test',
+        ...(stateRebuildBatchSize === undefined ? {} : { params: { stateRebuildBatchSize } }),
+      }).pipe(Effect.scoped, Effect.exit)
+
+    for (const invalid of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect((yield* run(invalid))._tag).toBe('Failure')
+    }
+    expect(observedBatchSizes).toEqual([])
+
+    yield* run()
+    yield* run(1)
+    yield* run(100_000)
+    expect(observedBatchSizes).toEqual([100, 1, 100_000])
+  }).pipe(Effect.provide(OtelLiveDummy)),
+)

--- a/packages/@livestore/livestore/src/store/create-store.ts
+++ b/packages/@livestore/livestore/src/store/create-store.ts
@@ -14,6 +14,7 @@ import {
   UnknownError,
   type LogConfig,
 } from '@livestore/common'
+import { STATE_REBUILD_BATCH_SIZE_DEFAULT, StateRebuildBatchSizeSchema } from '@livestore/common/leader-thread'
 import type { LiveStoreSchema } from '@livestore/common/schema'
 import { isDevEnv, LS_DEV, omitUndefineds } from '@livestore/utils'
 import {
@@ -137,6 +138,11 @@ export type LiveStoreContextProps<
    *   useStore({ ..., syncPayloadSchema: SyncPayload, syncPayload: { authToken: '...' } })
    */
   syncPayload?: TSyncPayloadSchema['Type']
+  /** Advanced runtime tuning parameters. */
+  params?: {
+    /** Number of events read and committed per SQLite state-rebuild batch. Defaults to 100. */
+    stateRebuildBatchSize?: number
+  }
 }
 
 export interface CreateStoreOptions<
@@ -214,12 +220,21 @@ export interface CreateStoreOptions<
    * @default undefined
    */
   syncPayload?: TSyncPayloadSchema['Type']
-  /** Options provided to the Store constructor. */
+  /** Advanced runtime tuning parameters. */
   params?: {
     /** Max events pushed to the leader per write batch. */
     leaderPushBatchSize?: number
     /** Chunk size used when the stream replays confirmed events. */
     eventQueryBatchSize?: number
+    /**
+     * Number of events read and committed per batch when rebuilding SQLite state from the event log.
+     * Lower values reduce per-batch resource usage but perform more queries and savepoints.
+     * This is a per-client runtime setting and changing it does not trigger a rebuild.
+     *
+     * @default 100
+     * @minimum 1
+     */
+    stateRebuildBatchSize?: number
   }
   debug?: {
     instanceId?: string
@@ -297,6 +312,10 @@ export const createStore = <
   Scope.Scope | OtelTracer.OtelTracer
 > =>
   Effect.gen(function* () {
+    const stateRebuildBatchSize = yield* Schema.decodeUnknownEffect(StateRebuildBatchSizeSchema)(
+      params?.stateRebuildBatchSize ?? STATE_REBUILD_BATCH_SIZE_DEFAULT,
+    ).pipe(UnknownError.mapToUnknownError)
+
     const lifetimeScope = yield* Scope.make()
 
     yield* validateStoreId(storeId)
@@ -388,6 +407,7 @@ export const createStore = <
       const clientSession: ClientSession = yield* adapter({
         schema,
         storeId,
+        params: { stateRebuildBatchSize },
         devtoolsEnabled: getDevtoolsEnabled(disableDevtools),
         bootStatusQueue,
         shutdown,

--- a/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
@@ -152,6 +152,49 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
   })
 
 Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
+  for (const eventCount of [250, 1000]) {
+    Vitest.live(`schema rebuild stays within the write budget for ${eventCount} events (#1555)`, (test) =>
+      Effect.gen(function* () {
+        const server = yield* WranglerDevServer.WranglerDevServer
+        const { rebuild, rebuildEventlog, getMetrics, resetMetrics } = yield* makeStoreHelpers(
+          server.url,
+          `cf-replay-writes-${nanoid(6)}`,
+        )
+        const seeded = yield* rebuild({ seed: 'true', seedCount: String(eventCount) })
+        expect(seeded.status).toBe(200)
+        const seedBody = yield* readRebuildResponse(seeded)
+        expect(seedBody.todos).toHaveLength(eventCount)
+        expect((yield* getMetrics()).totalRowsWritten).toBeGreaterThan(0)
+        const eventlogBefore = yield* rebuildEventlog()
+        expect(eventlogBefore.events).toHaveLength(eventCount)
+
+        yield* resetMetrics()
+        const rebuilt = yield* rebuild({ post: 'complete' })
+        expect(rebuilt.status).toBe(200)
+        const rebuiltBody = yield* readRebuildResponse(rebuilt)
+        const { totalRowsWritten } = yield* getMetrics()
+        expect(rebuiltBody.todos).toEqual([{ id: 'post-hook', title: 'completed' }, ...seedBody.todos])
+        expect(rebuiltBody.attemptedEvents).toEqual(Array.from({ length: eventCount }, (_, i) => `todo-${i + 1}`))
+        expect(rebuiltBody.attemptedHooks).toEqual(['init', 'pre', 'post'])
+        expect(yield* rebuildEventlog()).toEqual(eventlogBefore)
+
+        yield* resetMetrics()
+        const reopened = yield* rebuild({ post: 'fail' })
+        expect(reopened.status).toBe(200)
+        expect(yield* readRebuildResponse(reopened)).toMatchObject({
+          todos: rebuiltBody.todos,
+          attemptedEvents: [],
+          attemptedHooks: [],
+        })
+        expect((yield* getMetrics()).totalRowsWritten).toBe(0)
+
+        yield* Effect.promise(() => test.annotate(`${totalRowsWritten} rebuild writes for ${eventCount} events`))
+        expect(totalRowsWritten).toBeGreaterThan(0)
+        expect(totalRowsWritten).toBeLessThanOrEqual(eventCount * 5)
+      }).pipe(withTestCtx(test)),
+    )
+  }
+
   Vitest.live('retries an interrupted schema rebuild instead of serving partial state (#1605)', (test) =>
     Effect.gen(function* () {
       const server = yield* WranglerDevServer.WranglerDevServer

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -14,6 +14,7 @@ import {
 } from '@livestore/sync-cf/cf-worker'
 import { handleSyncUpdateRpc } from '@livestore/sync-cf/client'
 import { shouldNeverHappen } from '@livestore/utils'
+import { Effect, Stream } from '@livestore/utils/effect'
 
 import { makeRebuildSchema } from '../rebuild-schema.ts'
 import { events, schema, tables } from '../schema.ts'
@@ -121,6 +122,7 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
     }
 
     if (url.pathname === '/store/rebuild' && request.method === 'POST') {
+      this.ensureSqlTracking()
       const seed = url.searchParams.get('seed') === 'true'
       const fixture = makeRebuildSchema({
         upgraded: seed === false,
@@ -153,9 +155,17 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
         })
         try {
           if (seed === true) {
-            for (let i = 1; i <= 5; i++) {
+            const seedCount = Number(url.searchParams.get('seedCount') ?? 5)
+            for (let i = 1; i <= seedCount; i++) {
               store.commit(fixture.events.created({ id: `todo-${i}`, title: `item ${i}` }))
             }
+            await store.syncStatusStream().pipe(
+              Stream.filter((status) => status.isSynced),
+              Stream.take(1),
+              Stream.runDrain,
+              Effect.timeout('10 seconds'),
+              Effect.runPromise,
+            )
           }
           const todos = store.query(fixture.todos.orderBy('id', 'asc'))
           return makeCfResponse(
@@ -168,7 +178,6 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
             { headers: { 'content-type': 'application/json' } },
           )
         } finally {
-          // Orderly shutdown drains admitted events to the persisted leader eventlog.
           await store.shutdownPromise()
         }
       } catch (error) {
@@ -245,8 +254,6 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
 
     if (url.pathname === '/store/metrics') {
       if (request.method === 'GET') {
-        await this.ensureStore({ storeId, resetPersistence: false })
-
         return makeCfResponse(
           JSON.stringify({
             totalRowsWritten: this.trackedSql?.totalRowsWritten ?? 0,

--- a/tests/integration/src/tests/adapter-web/adapter-web.test.ts
+++ b/tests/integration/src/tests/adapter-web/adapter-web.test.ts
@@ -10,6 +10,12 @@ import { Vitest } from '@livestore/utils-dev/node-vitest'
 import { Duration, Effect, FetchHttpClient, HttpClient, Layer, Schedule, Schema } from '@livestore/utils/effect'
 import { getFreePort, PlatformNode } from '@livestore/utils/node'
 
+declare global {
+  interface Window {
+    __adapterWebLeaderAvailable?: () => Promise<boolean>
+  }
+}
+
 /** The dev server did not become reachable within the readiness retry budget. */
 class DevServerNotReadyError extends Schema.TaggedError<DevServerNotReadyError>()('DevServerNotReadyError', {
   cause: Schema.Defect(),
@@ -147,6 +153,70 @@ Vitest.describe('adapter-web', { timeout: testTimeout }, () => {
 
       const [boot1, boot2] = yield* Effect.all([didBoot(page1), didBoot(page2)])
       expect(boot1 && boot2).toBe(true)
+    }).pipe(withTestCtx(test)),
+  )
+
+  Vitest.live('leader handoff accepts different per-client rebuild batch sizes', (test) =>
+    Effect.gen(function* () {
+      const port = yield* getFreePort.pipe(Effect.map(String))
+      yield* cmd(`./node_modules/.bin/vite --config ${viteConfigRel} dev --port ${port}`, {
+        env: { TEST_LIVESTORE_SCHEMA_PATH_JSON: undefined, LSD_DEVTOOLS_LOCAL_PREVIEW: undefined },
+      }).pipe(Effect.provide(CurrentWorkingDirectory.fromPath(integrationRoot)), Effect.forkScoped)
+      const url = `http://localhost:${port}`
+      const httpClient = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
+      yield* httpClient.head(url).pipe(
+        Effect.retry(Schedule.exponentialBackoff10Sec),
+        Effect.mapError((error) => new DevServerNotReadyError({ cause: error })),
+      )
+
+      const { browserContext } = yield* BrowserContext
+      const page1 = yield* Effect.promise(() => browserContext.newPage())
+      const page2 = yield* Effect.promise(() => browserContext.newPage())
+      const appUrl = `${url}/adapter-web/concurrent-boot`
+      const storeId = 'adapter-web-batch-size-handoff'
+
+      yield* Effect.promise(() =>
+        page1.goto(`${appUrl}?storeId=${storeId}&sessionId=a&clientId=A&stateRebuildBatchSize=1`),
+      )
+      yield* Effect.promise(() =>
+        page1.waitForSelector('text=Adapter Web Test App', { state: 'visible', timeout: 15000 }),
+      )
+      yield* Effect.promise(() =>
+        page2.goto(`${appUrl}?storeId=${storeId}&sessionId=b&clientId=B&stateRebuildBatchSize=2`),
+      )
+      yield* Effect.promise(() =>
+        page2.waitForSelector('text=Adapter Web Test App', { state: 'visible', timeout: 15000 }),
+      )
+
+      yield* Effect.promise(() => page1.close())
+      const leaderLockName = `livestore-tab-lock-${storeId}`
+      yield* Effect.promise(() =>
+        expect
+          .poll(
+            () =>
+              page2.evaluate(async (lockName) => {
+                const snapshot = await navigator.locks.query()
+                return snapshot.held?.some((lock) => lock.name === lockName) ?? false
+              }, leaderLockName),
+            { timeout: 15000 },
+          )
+          .toBe(true),
+      )
+      yield* Effect.sleep(Duration.millis(250))
+      yield* Effect.promise(() =>
+        expect
+          .poll(
+            () =>
+              page2.evaluate(() =>
+                Promise.race([
+                  window.__adapterWebLeaderAvailable?.() ?? Promise.resolve(false),
+                  new Promise<false>((resolve) => setTimeout(() => resolve(false), 1000)),
+                ]),
+              ),
+            { timeout: 15000 },
+          )
+          .toBe(true),
+      )
     }).pipe(withTestCtx(test)),
   )
 

--- a/tests/integration/src/tests/playwright/fixtures/adapter-web/Root.tsx
+++ b/tests/integration/src/tests/playwright/fixtures/adapter-web/Root.tsx
@@ -6,9 +6,16 @@ import { makePersistedAdapter } from '@livestore/adapter-web'
 import LiveStoreSharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
 import { StoreRegistry } from '@livestore/livestore'
 import { StoreRegistryProvider, useStore } from '@livestore/react'
+import { Effect } from '@livestore/utils/effect'
 
 import LiveStoreWorker from '../devtools/todomvc/livestore/livestore.worker.ts?worker'
 import { events, schema, tables } from '../devtools/todomvc/livestore/schema.ts'
+
+declare global {
+  interface Window {
+    __adapterWebLeaderAvailable?: () => Promise<boolean>
+  }
+}
 
 const ErrorFallback = <div data-webtest="error">Error</div>
 const SuspenseFallback = <div>Loading...</div>
@@ -98,12 +105,27 @@ export const Root: React.FC = () => {
 
 const AppWithStore: React.FC<{ adapter: ReturnType<typeof makePersistedAdapter>; storeId: string }> = memo(
   ({ adapter, storeId }) => {
-    const store = useStore({ storeId, schema, adapter, batchUpdates })
+    const batchSizeParam = new URLSearchParams(window.location.search).get('stateRebuildBatchSize')
+    const store = useStore({
+      storeId,
+      schema,
+      adapter,
+      batchUpdates,
+      ...(batchSizeParam === null ? {} : { params: { stateRebuildBatchSize: Number(batchSizeParam) } }),
+    })
     const todos = store.useQuery(tables.todos.orderBy('id', 'asc'))
     const addTodo = React.useCallback(
       () => store.commit(events.todoCreated({ id: 'todo-1', text: storeId })),
       [store, storeId],
     )
+
+    React.useEffect(() => {
+      window.__adapterWebLeaderAvailable = () =>
+        Effect.runPromiseExit(store.networkStatus).then((exit) => exit._tag === 'Success')
+      return () => {
+        delete window.__adapterWebLeaderAvailable
+      }
+    }, [store])
 
     return (
       <div>

--- a/tests/integration/src/tests/playwright/unit-tests/bootstatus.ts
+++ b/tests/integration/src/tests/playwright/unit-tests/bootstatus.ts
@@ -1,6 +1,7 @@
 import { makePersistedAdapter } from '@livestore/adapter-web'
 import LiveStoreSharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
 import type { BootStatus } from '@livestore/common'
+import { STATE_REBUILD_BATCH_SIZE_DEFAULT } from '@livestore/common/leader-thread'
 import { Effect, Queue, Schedule, Schema } from '@livestore/utils/effect'
 
 import { ResultBootStatus } from './bridge.ts'
@@ -18,6 +19,7 @@ export const test = () =>
     })({
       schema,
       storeId: 'default',
+      params: { stateRebuildBatchSize: STATE_REBUILD_BATCH_SIZE_DEFAULT },
       devtoolsEnabled: false,
       bootStatusQueue,
       shutdown: () => Effect.void,

--- a/tests/integration/src/tests/playwright/unit-tests/schema-migration/index.ts
+++ b/tests/integration/src/tests/playwright/unit-tests/schema-migration/index.ts
@@ -2,6 +2,7 @@ import { makePersistedAdapter } from '@livestore/adapter-web'
 import LiveStoreSharedWorker from '@livestore/adapter-web/shared-worker?sharedworker'
 import type { BootStatus } from '@livestore/common'
 import { liveStoreStorageFormatVersion, UnknownError } from '@livestore/common'
+import { STATE_REBUILD_BATCH_SIZE_DEFAULT } from '@livestore/common/leader-thread'
 import { Effect, Layer, Logger, Queue, References, Schedule, Schema, Stream } from '@livestore/utils/effect'
 import { Opfs } from '@livestore/utils/effect/browser'
 
@@ -39,6 +40,7 @@ export const testMultipleMigrations = () =>
         })({
           schema,
           storeId,
+          params: { stateRebuildBatchSize: STATE_REBUILD_BATCH_SIZE_DEFAULT },
           devtoolsEnabled: false,
           bootStatusQueue,
           shutdown: () => Effect.void,

--- a/tests/package-common/src/leader-thread/recreate-db.test.ts
+++ b/tests/package-common/src/leader-thread/recreate-db.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@livestore/utils/effect'
 import { PlatformNode } from '@livestore/utils/node'
 
-for (const failure of ['init', 'pre', 'replay', 'post', 'interrupt'] as const) {
+for (const failure of ['init', 'pre', 'replay', 'replay-after-batch', 'post', 'interrupt'] as const) {
   Vitest.live(`rebuilds surviving partial state after ${failure} failure on common leader boot (#1605)`, (test) =>
     Effect.gen(function* () {
       const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
@@ -55,10 +55,11 @@ for (const failure of ['init', 'pre', 'replay', 'post', 'interrupt'] as const) {
       })
       const events = { created: Events.synced({ name: 'created', schema: Schema.Struct({ id: Schema.String }) }) }
       const factory = EventFactory.makeFactory(events)({ client: EventFactory.clientIdentity('test') })
+      const eventIds = Array.from({ length: failure === 'replay-after-batch' ? 205 : 5 }, (_, i) => `todo-${i + 1}`)
       yield* Eventlog.initEventlogDb(dbEventlog)
-      for (let i = 1; i <= 5; i++) {
+      for (const id of eventIds) {
         const event = new LiveStoreEvent.Client.EncodedWithMeta({
-          ...LiveStoreEvent.Global.toClientEncoded(factory.created.next({ id: `todo-${i}` })),
+          ...LiveStoreEvent.Global.toClientEncoded(factory.created.next({ id })),
         })
         yield* Eventlog.insertIntoEventlog(
           event,
@@ -88,7 +89,10 @@ for (const failure of ['init', 'pre', 'replay', 'post', 'interrupt'] as const) {
           materializers: State.SQLite.materializers(events, {
             created: ({ id }) => {
               attemptedEvents.push(id)
-              if (shouldFail === true && failure === 'replay' && id === 'todo-3') {
+              if (
+                shouldFail === true &&
+                ((failure === 'replay' && id === 'todo-3') || (failure === 'replay-after-batch' && id === 'todo-103'))
+              ) {
                 throw new Error('Injected replay failure')
               }
               return todos.insert({ id })
@@ -162,7 +166,12 @@ for (const failure of ['init', 'pre', 'replay', 'post', 'interrupt'] as const) {
         const partial = yield* openState
         expect(partial.select('SELECT * FROM scratch')).not.toEqual([])
         if (failure !== 'init') expect(partial.select(SystemTables.rebuildMetaTable)).toEqual([])
-        if (failure === 'replay') expect(partial.select(todos)).toHaveLength(2)
+        if (failure === 'replay' || failure === 'replay-after-batch') {
+          const committedEvents = failure === 'replay' ? 0 : 100
+          expect(partial.select(todos)).toHaveLength(committedEvents)
+          expect(partial.select(SystemTables.sessionChangesetMetaTable)).toHaveLength(committedEvents)
+          expect((yield* StateHead.make({ dbState: partial }).get).global).toBe(committedEvents)
+        }
         if (failure === 'post' || failure === 'interrupt') expect(partial.select(todos)).toHaveLength(5)
       }).pipe(Effect.scoped)
       expect(readEventlog()).toEqual(before)
@@ -172,11 +181,11 @@ for (const failure of ['init', 'pre', 'replay', 'post', 'interrupt'] as const) {
       attemptedHooks.length = 0
       const recovered = yield* boot
       expect(recovered).toEqual({
-        todos: [{ id: 'post-hook' }, ...Array.from({ length: 5 }, (_, i) => ({ id: `todo-${i + 1}` }))],
-        pending: 5,
+        todos: [{ id: 'post-hook' }, ...eventIds.toSorted().map((id) => ({ id }))],
+        pending: eventIds.length,
         marker: [{ id: 1 }],
       })
-      expect(attemptedEvents).toEqual(['todo-1', 'todo-2', 'todo-3', 'todo-4', 'todo-5'])
+      expect(attemptedEvents).toEqual(eventIds)
       expect(attemptedHooks).toEqual(['init', 'pre', 'post'])
       expect(readEventlog()).toEqual(before)
 

--- a/tests/package-common/src/leader-thread/recreate-db.test.ts
+++ b/tests/package-common/src/leader-thread/recreate-db.test.ts
@@ -55,7 +55,7 @@ for (const failure of ['init', 'pre', 'replay', 'replay-after-batch', 'post', 'i
       })
       const events = { created: Events.synced({ name: 'created', schema: Schema.Struct({ id: Schema.String }) }) }
       const factory = EventFactory.makeFactory(events)({ client: EventFactory.clientIdentity('test') })
-      const eventIds = Array.from({ length: failure === 'replay-after-batch' ? 205 : 5 }, (_, i) => `todo-${i + 1}`)
+      const eventIds = Array.from({ length: 5 }, (_, i) => `todo-${i + 1}`)
       yield* Eventlog.initEventlogDb(dbEventlog)
       for (const id of eventIds) {
         const event = new LiveStoreEvent.Client.EncodedWithMeta({
@@ -91,7 +91,8 @@ for (const failure of ['init', 'pre', 'replay', 'replay-after-batch', 'post', 'i
               attemptedEvents.push(id)
               if (
                 shouldFail === true &&
-                ((failure === 'replay' && id === 'todo-3') || (failure === 'replay-after-batch' && id === 'todo-103'))
+                (failure === 'replay' || failure === 'replay-after-batch') &&
+                id === 'todo-3'
               ) {
                 throw new Error('Injected replay failure')
               }
@@ -150,6 +151,7 @@ for (const failure of ['init', 'pre', 'replay', 'replay-after-batch', 'post', 'i
               dbEventlog,
               devtoolsOptions: { enabled: false },
               shutdownChannel: shutdown.webChannel,
+              ...(failure === 'replay-after-batch' ? { params: { stateRebuildBatchSize: 2 } } : {}),
             }).pipe(Layer.provide(StateHead.layer({ dbState })), Layer.provide(FetchHttpClient.layer)),
           ),
         )
@@ -167,7 +169,7 @@ for (const failure of ['init', 'pre', 'replay', 'replay-after-batch', 'post', 'i
         expect(partial.select('SELECT * FROM scratch')).not.toEqual([])
         if (failure !== 'init') expect(partial.select(SystemTables.rebuildMetaTable)).toEqual([])
         if (failure === 'replay' || failure === 'replay-after-batch') {
-          const committedEvents = failure === 'replay' ? 0 : 100
+          const committedEvents = failure === 'replay' ? 0 : 2
           expect(partial.select(todos)).toHaveLength(committedEvents)
           expect(partial.select(SystemTables.sessionChangesetMetaTable)).toHaveLength(committedEvents)
           expect((yield* StateHead.make({ dbState: partial }).get).global).toBe(committedEvents)

--- a/tests/package-common/src/test-adapter.ts
+++ b/tests/package-common/src/test-adapter.ts
@@ -1,5 +1,6 @@
 import {
   type Adapter,
+  type AdapterArgs,
   ClientSessionLeaderThreadProxy,
   type LockStatus,
   type MakeSqliteDb,
@@ -69,7 +70,7 @@ export const makeTestAdapter = ({
 } = {}): Adapter =>
   ((adapterArgs) =>
     Effect.gen(function* () {
-      const { schema, storeId, syncPayloadEncoded, syncPayloadSchema } = adapterArgs
+      const { schema, storeId, syncPayloadEncoded, syncPayloadSchema, params } = adapterArgs
       const sqlite3 = yield* Effect.promise(() => loadSqlite3Wasm())
       const makeSqliteDb = yield* sqliteDbFactory({ sqlite3 })
       const shutdownChannel = yield* makeShutdownChannel(storeId)
@@ -94,6 +95,7 @@ export const makeTestAdapter = ({
         syncOptions: sync,
         syncPayloadEncoded,
         syncPayloadSchema,
+        params,
         testing,
         shutdownChannel,
       }).pipe(UnknownError.mapToUnknownError)
@@ -130,6 +132,7 @@ const makeLocalLeaderThread = ({
   syncOptions,
   syncPayloadEncoded,
   syncPayloadSchema,
+  params,
   testing,
   shutdownChannel,
 }: {
@@ -140,6 +143,7 @@ const makeLocalLeaderThread = ({
   syncOptions: SyncOptions | undefined
   syncPayloadEncoded: Schema.Json | undefined
   syncPayloadSchema: Schema.Decoder<Schema.Json> | undefined
+  params: AdapterArgs['params']
   testing?: { overrides?: TestingOverrides }
   shutdownChannel: ShutdownChannel.ShutdownChannel
 }) =>
@@ -175,6 +179,7 @@ const makeLocalLeaderThread = ({
         shutdownChannel,
         syncPayloadEncoded,
         syncPayloadSchema,
+        params,
       }).pipe(Layer.provide(StateHead.layer({ dbState }))),
     )
 


### PR DESCRIPTION
## Problem

Follow-up to #1604: stable schema fingerprints avoid unnecessary rebuilds, but real schema changes still require full eventlog replay. Derived state must remain cheap to reconstruct. Previously, replay read 100 events at a time but committed them individually, repeatedly writing the same SQLite pages and consuming Cloudflare row-write quotas (#1555).

## Solution

Reuse each eventlog page as a savepoint batch, defaulting to 100 events. Preserve event order, per-event progress, atomic rows/head/undo updates and #1610's recovery protocol. Partial final batches complete normally.

Expose `createStore.params.stateRebuildBatchSize` as a positive-integer, per-client runtime setting and forward it through the web, in-memory and Cloudflare adapters. The value is resolved and validated when `createStore` starts, remains fixed for that client session, and is only used if leader boot rebuilds state. It is not persisted or included in schema identity, so changing it does not trigger a rebuild. Different clients can choose values appropriate to their own resource limits; lower values reduce per-batch memory pressure at the cost of more queries, savepoints and writes, while larger values make the opposite trade-off. There is no arbitrary upper bound. SharedWorker leader handoff excludes this per-client setting from cross-leader invariants, so each newly elected leader applies its own resolved value.

### Benchmarks

| Events | Title payload | Original writes | Batch 100 writes (reduction) | Batch 1,000 writes (reduction) | Local seconds, original → 100 (change) |
| ---: | --- | ---: | ---: | ---: | ---: |
| 100 | Small | 1,080 | 90 (91.7%) | 90 (91.7%) | 0.052 → 0.050 (-5.3%) |
| 1,000 | Small | 10,140 | 240 (97.6%) | 120 (98.8%) | 0.245 → 0.247 (+0.5%) |
| 10,000 | Small | 102,924 | 2,480 (97.6%) | 624 (99.4%) | 2.225 → 2.092 (-6.0%) |
| 100,000 | Small | 1,039,042 | 26,310 (97.5%) | 6,000 (99.4%) | 22.591 → 19.578 (-13.3%) |
| 1,000,000 | Small | 10,424,530 | 270,060 (97.4%) | 62,276 (99.4%) | 250.292 → 217.677 (-13.0%) |
| 1,000 | Small + 4 KiB/event | 18,096 | 4,216 (76.7%) | 4,100 (77.3%) | 0.341 → 0.287 (-16.0%) |
| 10,000 | Small + 1 KiB/event | 113,942 | 8,172 (92.8%) | 6,140 (94.6%) | 2.397 → 2.039 (-14.9%) |

**Average: 93.0% fewer writes with batch 100**, the unweighted mean of the seven case reductions. Write percentages compare against the original implementation. Negative time changes mean less elapsed time; percentages use unrounded medians.

**Method:** Each case seeded a new local Durable Object eventlog and waited for synchronization, then reset the SQL counters and triggered a schema-upgrade boot that fully replayed the eventlog. Seeding was excluded. The fixture wrapped `storage.sql.exec()` and summed each cursor's `rowsWritten` immediately after execution; elapsed time covered the complete rebuild request. The original, batch-100 and batch-1,000 variants used the same fixture and payloads. Results are medians of three independent runs per case, except one run per million-event variant. Small titles are `item N`; added bytes are per event. These local timings are not production CPU measurements, and small differences are inconclusive. Benchmark code and raw artifacts remain local.

**Environment:** MacBook Pro (Mac16,7), Apple M4 Pro with 14 cores (10 performance, 4 efficiency), 48 GB unified memory, macOS 26.6.2 (25G83), Node.js 24.18.1, Wrangler 4.42.2 and workerd 1.20251008.0.

**Why 100:** for 1,000 events with 16 KiB extra payload each, batch 1,000 saves only another 1.6% of writes while raising SQLite's replay allocation peak from 8.6 to 34.6 MiB. We prioritize memory headroom. Whole-boot Cloudflare memory headroom is a separate, pre-existing problem tracked in #1612.

## Validation

- Full unit lane and TypeScript pass.
- All 12 Cloudflare tests pass. Unconditional 250/1,000-event regressions verify write budgets, replay correctness and zero-write reopen.
- Common tests verify first/second-batch rollback, complete retry and a custom batch boundary.
- Store configuration tests verify the default of 100, positive-integer validation (including rejecting 0 before adapter startup), and acceptance of values above 1,000.
- All five adapter-web integration tests pass, including leader handoff between clients with different rebuild batch sizes. Repository-wide lint and docs checks pass.
- The documented `test:run` task is unavailable; validation covers the full unit lane and affected integrations, not the entire CI matrix. Unrelated browser failure: #1609.

Stacked on #1610. Follow-up to #1604 and #1555.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core leader boot and `recreateDb`/`rematerializeFromEventlog` persistence boundaries; incorrect batch rollback could leave partial state, though existing completion protocol and expanded tests mitigate this.
> 
> **Overview**
> **Schema rebuild replay** now commits each eventlog page inside a SQLite savepoint instead of per-event writes, cutting repeated page writes (notably Cloudflare DO billed rows) while keeping event order, per-event boot progress, and incomplete-rebuild recovery.
> 
> Clients can tune future rebuilds with **`createStore.params.stateRebuildBatchSize`** (positive integer, default **100**). The value is validated at store creation, is not part of schema identity, and is forwarded through web, in-memory, and Cloudflare adapters (`createStoreDo.params`). SharedWorker leader handoff deliberately **does not** treat batch size as a cross-tab invariant so each elected leader keeps its own setting.
> 
> Docs/changelog and an ADR describe the tradeoffs; integration and unit tests cover write budgets, batch-boundary rollback, validation, and multi-tab handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ade90020bdf5fd5a2db300b3333ca9ef5296b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->