### PR TITLE
Clean up obsolete Cloudflare state using explicit file ownership

### DIFF
--- a/.changeset/cleanup-obsolete-cf-state.md
+++ b/.changeset/cleanup-obsolete-cf-state.md
@@ -2,4 +2,4 @@
 '@livestore/adapter-cloudflare': patch
 ---
 
-Remove obsolete derived state database pages after successful Cloudflare adapter boot. Preserve current state and the eventlog, and retry failed cleanup on a later boot without blocking the completed store.
+Track Cloudflare state database ownership and remove obsolete tracked files after successful boot. Preserve current state, the eventlog and untracked files, including historical orphans. Retry failed cleanup on a later boot without blocking the completed store.

--- a/.changeset/cleanup-obsolete-cf-state.md
+++ b/.changeset/cleanup-obsolete-cf-state.md
@@ -1,0 +1,5 @@
+---
+'@livestore/adapter-cloudflare': patch
+---
+
+Remove obsolete derived state database pages after successful Cloudflare adapter boot. Preserve current state and the eventlog, and retry failed cleanup on a later boot without blocking the completed store.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@
   Telemetry cleanup runs in the background, and finite WebSocket operations and
   DO-RPC pull streams now emit their sync spans
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
-- **Cloudflare adapter:** Remove obsolete derived state database pages after
-  successful boot, preserving the current state and eventlog. Failed cleanup is
-  retried on a later boot without blocking the completed store
+- **Cloudflare adapter:** Track state database ownership and remove obsolete
+  tracked state after successful boot, preserving the current state, eventlog
+  and untracked files. Failed cleanup is retried on a later boot without
+  blocking the completed store
   ([#1555](https://github.com/livestorejs/livestore/issues/1555)).
 - **Schema rebuilds:** Batched eventlog replay to reduce repeated SQLite page
   writes, including billed row writes on Cloudflare Durable Objects. Replay order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   Telemetry cleanup runs in the background, and finite WebSocket operations and
   DO-RPC pull streams now emit their sync spans
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
+- **Cloudflare adapter:** Remove obsolete derived state database pages after
+  successful boot, preserving the current state and eventlog. Failed cleanup is
+  retried on a later boot without blocking the completed store
+  ([#1555](https://github.com/livestorejs/livestore/issues/1555)).
 - **Schema rebuilds:** Batched eventlog replay to reduce repeated SQLite page
   writes, including billed row writes on Cloudflare Durable Objects. Replay order
   and recovery from incomplete rebuilds are preserved. Clients can tune the

--- a/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
@@ -31,8 +31,9 @@ rebuild by itself. The adapter-level database name is the rebuild trigger.
 
 When the web adapter opens the selected state database, it deletes other state
 database files. In development it archives up to three old files instead.
-The Cloudflare adapter removes obsolete state-file pages after successful boot,
-including completed-state reuse. Cleanup failure does not prevent serving the
+The Cloudflare adapter tracks state files it opens and removes other tracked
+state-file pages after successful boot, including completed-state reuse.
+Untracked historical files are preserved. Cleanup failure does not prevent serving the
 completed store and is retried on the next successful boot.
 
 ## State Fingerprint Contract

--- a/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
+++ b/context/02-system/02-state/01-sqlite/02-schema-management/spec.md
@@ -31,6 +31,9 @@ rebuild by itself. The adapter-level database name is the rebuild trigger.
 
 When the web adapter opens the selected state database, it deletes other state
 database files. In development it archives up to three old files instead.
+The Cloudflare adapter removes obsolete state-file pages after successful boot,
+including completed-state reuse. Cleanup failure does not prevent serving the
+completed store and is retried on the next successful boot.
 
 ## State Fingerprint Contract
 

--- a/context/02-system/04-runtime/02-cloudflare/.decisions/0002-state-file-ownership.md
+++ b/context/02-system/04-runtime/02-cloudflare/.decisions/0002-state-file-ownership.md
@@ -1,0 +1,33 @@
+# 0002 — Track state-file ownership before cleanup
+
+Status: accepted (2026-09-06), implemented in PR #1615.
+
+## Context
+
+Obsolete state files consume DO storage. Filename prefixes and even exact hash
+formats do not establish ownership of files in the shared VFS table.
+
+## Decision
+
+Record the exact path in `__livestore_state_files` before the adapter opens a
+state database. After successful boot, delete other registered files and their
+records in one native storage transaction. Keep registration and cleanup in the
+adapter's `state-files.ts` module. Do not infer ownership from filenames.
+
+## Consequences
+
+Registration adds one metadata row per selected state file, with no row writes
+when reopening an already registered file. Failed boots leave tracked files for
+later cleanup, and failed cleanup preserves the records needed to retry.
+
+Historical unregistered orphans remain untouched. An existing state file becomes
+tracked when opened normally. This avoids inspecting arbitrary databases or
+maintaining parsers for old hash formats. Cleanup consumes write quota and runs
+after boot, so storage-full recovery remains outside this change.
+
+## Evidence
+
+Cloudflare integration regressions cover unrelated files with valid state names,
+adoption of existing state without replay, registration failure before file
+creation, failed rebuilds, atomic page/registry cleanup retry, and zero-write
+completed-state reopening.

--- a/context/02-system/04-runtime/02-cloudflare/spec.md
+++ b/context/02-system/04-runtime/02-cloudflare/spec.md
@@ -61,24 +61,36 @@ behaviors versus the portable contract:
 - **`export()`/`import()` are no-ops** — `SqlStorage` has no
   serialize/deserialize; the session's initial snapshot import is therefore
   also a no-op (leader and session share the isolate anyway).
-- **`resetPersistence` spans three tables** — `vfs_pages` (state VFS),
-  `eventlog`, and `__livestore_sync_status` (direct), inside
+- **`resetPersistence` spans four tables** — `vfs_pages` (state VFS),
+  `__livestore_state_files` (adapter ownership), `eventlog`, and
+  `__livestore_sync_status` (direct), inside
   `storage.transactionSync`.
 
 ## Obsolete State Cleanup
 
-After adapter boot succeeds, delete `vfs_pages` rows for other paths in the
-adapter's `/state{fingerprint}@{storageFormatVersion}.db` namespace. Keep the
-current state file, unrelated VFS files, eventlog and sync metadata. A failed
-rebuild or migration hook must not trigger this cleanup.
+Before opening a state database, register its exact VFS path in the adapter-owned
+`__livestore_state_files` table. Registration failure stops boot before opening the
+file. Existing registrations are reused without writing rows. This registry is
+adapter metadata, separate from the eventlog and the materialized state schema.
 
-Run cleanup on completed-state reuse too, so old files from earlier releases or
-failed cleanup attempts do not require another schema change to be removed.
-Cleanup failure logs a warning and leaves the completed store available; the
-next successful boot retries. Once clean, later boots delete no rows. Deleting
-obsolete derived state means returning to an older schema rebuilds it from the
-eventlog rather than reusing its old cache. The cleanup does not compact the
-underlying Durable Object SQLite database.
+After adapter boot succeeds, remove pages belonging to other registered paths
+and their ownership records together in `storage.transactionSync`. Keep the
+current state, unregistered VFS files, eventlog and sync metadata. Failed replay
+or migration hooks retain every registered file. Cleanup failure logs a warning
+and leaves completed state available, with ownership intact for retry on the
+next successful boot. Run cleanup on completed-state reuse too.
+
+Filename shape is not proof of ownership. Old files that predate registration
+remain untouched unless the adapter subsequently opens and registers that exact
+file. Consequently this prevents new orphan accumulation without automatically
+reclaiming all historical orphans. See
+[the ownership decision](./.decisions/0002-state-file-ownership.md).
+
+Once clean, later boots write no rows for registration or cleanup. Deleting a
+previous state means returning to that schema rebuilds from the eventlog. Cleanup
+consumes billed row writes and does not explicitly compact the underlying DO
+database. Because it follows successful boot, it cannot recover a database that
+is already too full to rebuild.
 
 ## Eviction and Resume
 

--- a/context/02-system/04-runtime/02-cloudflare/spec.md
+++ b/context/02-system/04-runtime/02-cloudflare/spec.md
@@ -65,6 +65,21 @@ behaviors versus the portable contract:
   `eventlog`, and `__livestore_sync_status` (direct), inside
   `storage.transactionSync`.
 
+## Obsolete State Cleanup
+
+After adapter boot succeeds, delete `vfs_pages` rows for other paths in the
+adapter's `/state{fingerprint}@{storageFormatVersion}.db` namespace. Keep the
+current state file, unrelated VFS files, eventlog and sync metadata. A failed
+rebuild or migration hook must not trigger this cleanup.
+
+Run cleanup on completed-state reuse too, so old files from earlier releases or
+failed cleanup attempts do not require another schema change to be removed.
+Cleanup failure logs a warning and leaves the completed store available; the
+next successful boot retries. Once clean, later boots delete no rows. Deleting
+obsolete derived state means returning to an older schema rebuilds it from the
+eventlog rather than reusing its old cache. The cleanup does not compact the
+underlying Durable Object SQLite database.
+
 ## Eviction and Resume
 
 The DO adapter has no eviction-specific handling (no alarms, no hibernation

--- a/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
+++ b/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
@@ -135,6 +135,8 @@ Changing the state schema causes each affected store to open a fresh state datab
 
 Rebuilds use 100 events per batch by default. A Durable Object can set `params: { stateRebuildBatchSize }` on `createStoreDo` or `createStoreDoPromise`; the value must be a positive integer. Lower values can reduce per-batch resource use, but require more queries, savepoints, and storage writes. This limit counts events rather than bytes and does not guarantee that the whole isolate stays within its memory limit, so profile representative data and materializers. Other clients of the same store can use different values.
 
+After successful boot, the adapter removes obsolete state database pages while preserving the current database and eventlog. Failed rebuilds retain the previous state file. Cleanup failures log a warning and retry on the next successful boot, including when reusing completed state. Returning to an older schema rebuilds its state from the eventlog.
+
 ## Resetting LiveStore persistence (development only)
 
 When iterating locally, you can instruct the adapter to wipe the Durable Object’s LiveStore databases before booting by enabling `resetPersistence`. Guard this behind a protected route or admin token.

--- a/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
+++ b/docs/src/content/docs/platform-adapters/cloudflare-durable-object-adapter.mdx
@@ -135,7 +135,9 @@ Changing the state schema causes each affected store to open a fresh state datab
 
 Rebuilds use 100 events per batch by default. A Durable Object can set `params: { stateRebuildBatchSize }` on `createStoreDo` or `createStoreDoPromise`; the value must be a positive integer. Lower values can reduce per-batch resource use, but require more queries, savepoints, and storage writes. This limit counts events rather than bytes and does not guarantee that the whole isolate stays within its memory limit, so profile representative data and materializers. Other clients of the same store can use different values.
 
-After successful boot, the adapter removes obsolete state database pages while preserving the current database and eventlog. Failed rebuilds retain the previous state file. Cleanup failures log a warning and retry on the next successful boot, including when reusing completed state. Returning to an older schema rebuilds its state from the eventlog.
+The adapter tracks state files it opens. After successful boot, it removes older tracked files while preserving the current database, eventlog and untracked files. Failed rebuilds retain previous state. Cleanup failures log a warning and retry on the next successful boot, including when reusing completed state. Files from older releases remain untouched unless subsequently opened and tracked. Returning to a schema whose state was removed rebuilds it from the eventlog.
+
+Cleanup itself consumes row-write quota. It prevents new orphan accumulation, but cannot recover storage that is already too full to complete a rebuild.
 
 ## Resetting LiveStore persistence (development only)
 

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -23,6 +23,7 @@ import { loadSqlite3Wasm } from '@livestore/sqlite-wasm/load-wasm'
 import { Effect, FetchHttpClient, Layer, Queue, Schedule, SubscriptionRef, WebChannel } from '@livestore/utils/effect'
 
 import { makeSqliteDb as makeDoSqliteDb } from './make-sqlite-db.ts'
+import * as StateFiles from './state-files.ts'
 
 export const makeAdapter =
   ({
@@ -63,10 +64,13 @@ export const makeAdapter =
         yield* resetDurableObjectPersistence({ storage, storeId })
       }
 
+      const stateFileName = `${getStateDbBaseName(schema)}@${liveStoreStorageFormatVersion}.db`
+      yield* StateFiles.register(storage, stateFileName).pipe(UnknownError.mapToUnknownError)
+
       const dbState = yield* makeSqliteDb({
         _tag: 'storage',
         storage,
-        fileName: `${getStateDbBaseName(schema)}@${liveStoreStorageFormatVersion}.db`,
+        fileName: stateFileName,
         configureDb: (db) =>
           db.execute([...CF_SQL_VFS_REQUIRED_PRAGMAS, 'cache_size=-8000'].map((p) => `PRAGMA ${p}`).join(';\n')),
       }).pipe(UnknownError.mapToUnknownError)
@@ -167,13 +171,9 @@ export const makeAdapter =
         origin: undefined,
       })
 
-      // Retain previous state until boot succeeds; retry optional cleanup on the next boot if storage rejects it.
-      yield* Effect.try(() => {
-        storage.sql.exec(
-          "DELETE FROM vfs_pages WHERE file_path GLOB '/state*@*.db' AND file_path != ?",
-          `/${dbState.metadata.persistenceInfo.fileName}`,
-        )
-      }).pipe(Effect.catch((cause) => Effect.logWarning('Failed to clean up obsolete state databases', cause)))
+      yield* StateFiles.cleanup(storage, stateFileName).pipe(
+        Effect.catch((cause) => Effect.logWarning('Failed to clean up obsolete state databases', cause)),
+      )
 
       return clientSession
     }).pipe(
@@ -190,12 +190,14 @@ const resetDurableObjectPersistence = ({
 }) =>
   Effect.try({
     try: () =>
-      // All three tables live in the DO's single storage.sql database but are
+      // All four tables live in the DO's single storage.sql database but are
       // owned by different layers during normal operation:
       // - vfs_pages: written by the wa-sqlite VFS layer (backs dbState)
       // - eventlog, __livestore_sync_status: written directly by dbEventlog via storage.sql
+      // - __livestore_state_files: adapter-owned state file registry
       storage.transactionSync(() => {
         safeSqlExec(storage, 'DELETE FROM vfs_pages')
+        safeSqlExec(storage, 'DELETE FROM __livestore_state_files')
         safeSqlExec(storage, 'DELETE FROM eventlog')
         safeSqlExec(storage, 'DELETE FROM __livestore_sync_status')
       }),

--- a/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
+++ b/packages/@livestore/adapter-cloudflare/src/make-adapter.ts
@@ -167,6 +167,14 @@ export const makeAdapter =
         origin: undefined,
       })
 
+      // Retain previous state until boot succeeds; retry optional cleanup on the next boot if storage rejects it.
+      yield* Effect.try(() => {
+        storage.sql.exec(
+          "DELETE FROM vfs_pages WHERE file_path GLOB '/state*@*.db' AND file_path != ?",
+          `/${dbState.metadata.persistenceInfo.fileName}`,
+        )
+      }).pipe(Effect.catch((cause) => Effect.logWarning('Failed to clean up obsolete state databases', cause)))
+
       return clientSession
     }).pipe(
       Effect.withSpan('@livestore/adapter-cloudflare:makeAdapter', { attributes: { clientId, sessionId } }),

--- a/packages/@livestore/adapter-cloudflare/src/state-files.ts
+++ b/packages/@livestore/adapter-cloudflare/src/state-files.ts
@@ -1,0 +1,23 @@
+import type { CfTypes } from '@livestore/common-cf'
+import { Effect } from '@livestore/utils/effect'
+
+/** Record ownership before opening state so interrupted rebuilds remain eligible for cleanup. */
+export const register = (storage: CfTypes.DurableObjectStorage, fileName: string) =>
+  Effect.try(() => {
+    storage.sql.exec(`CREATE TABLE IF NOT EXISTS __livestore_state_files (file_path TEXT PRIMARY KEY) WITHOUT ROWID`)
+    storage.sql.exec('INSERT OR IGNORE INTO __livestore_state_files (file_path) VALUES (?)', `/${fileName}`)
+  })
+
+/** Keep ownership records until their pages are deleted, so failed cleanup can be retried. */
+export const cleanup = (storage: CfTypes.DurableObjectStorage, fileName: string) =>
+  Effect.try(() =>
+    storage.transactionSync(() => {
+      storage.sql.exec(
+        `DELETE FROM vfs_pages WHERE file_path IN (
+          SELECT file_path FROM __livestore_state_files WHERE file_path != ?
+        )`,
+        `/${fileName}`,
+      )
+      storage.sql.exec('DELETE FROM __livestore_state_files WHERE file_path != ?', `/${fileName}`)
+    }),
+  )

--- a/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
@@ -75,10 +75,23 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
     return {
       // Recovery tests deliberately inspect failed boot responses.
       rebuild: (params: Record<string, string>) => rawClient.post('/store/rebuild', { urlParams: params }),
-      blockCleanup: () => client.post('/store/rebuild/block-cleanup'),
+      blockCleanup: (stage: 'pages' | 'registry') =>
+        client.post('/store/rebuild/block-cleanup', { urlParams: { stage } }),
       unblockCleanup: () => client.del('/store/rebuild/block-cleanup'),
-      rebuildFiles: (seedUnrelated = false) =>
-        (seedUnrelated === true ? client.post('/store/rebuild/files') : client.get('/store/rebuild/files')).pipe(
+      blockRegistration: () => client.post('/store/rebuild/block-registration'),
+      stateFiles: () =>
+        client
+          .get('/store/rebuild/ownership')
+          .pipe(Effect.flatMap(HttpClientResponse.schemaBodyJson(Schema.Array(Schema.String)))),
+      forgetStateFileOwnership: () => client.del('/store/rebuild/ownership'),
+      rebuildFiles: (paths: ReadonlyArray<string> = []) =>
+        (paths.length === 0
+          ? client.get('/store/rebuild/files')
+          : HttpClientRequest.post('/store/rebuild/files').pipe(
+              HttpClientRequest.bodyJson(paths),
+              Effect.flatMap(client.execute),
+            )
+        ).pipe(
           Effect.flatMap(
             HttpClientResponse.schemaBodyJson(
               Schema.Array(Schema.Struct({ path: Schema.String, pages: Schema.Finite })),
@@ -166,10 +179,8 @@ Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
     Vitest.live(`removes obsolete state only after successful rebuild following ${failure} (#1555)`, (test) =>
       Effect.gen(function* () {
         const server = yield* WranglerDevServer.WranglerDevServer
-        const { rebuild, rebuildFiles, rebuildEventlog, resetMetrics, getMetrics } = yield* makeStoreHelpers(
-          server.url,
-          `cf-stale-state-${nanoid(6)}`,
-        )
+        const { rebuild, rebuildFiles, stateFiles, rebuildEventlog, resetMetrics, getMetrics } =
+          yield* makeStoreHelpers(server.url, `cf-stale-state-${nanoid(6)}`)
         const seeded = yield* rebuild({ seed: 'true' })
         expect(seeded.status).toBe(200)
         const seedBody = yield* readRebuildResponse(seeded)
@@ -178,7 +189,7 @@ Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
         expect(originalFiles).toHaveLength(1)
         const oldState = originalFiles[0]!
         const unrelated = { path: '/unrelated.db', pages: 1 }
-        yield* rebuildFiles(true)
+        yield* rebuildFiles(['/unrelated.db'])
 
         const failed = yield* rebuild(
           failure === 'replay' ? { failAt: 'todo-3' } : { post: failure === 'post' ? 'fail' : 'abort' },
@@ -187,6 +198,9 @@ Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
         const failedFiles = yield* rebuildFiles()
         expect(failedFiles).toContainEqual(oldState)
         expect(failedFiles).toContainEqual(unrelated)
+        expect(yield* stateFiles()).toEqual(
+          failedFiles.filter(({ path }) => path !== unrelated.path).map(({ path }) => path),
+        )
         expect(yield* rebuildEventlog()).toEqual(before)
 
         const recovered = yield* rebuild({ post: 'complete' })
@@ -198,6 +212,9 @@ Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
         const retainedFiles = yield* rebuildFiles()
         expect(retainedFiles).toHaveLength(2)
         expect(retainedFiles).toContainEqual(unrelated)
+        expect(yield* stateFiles()).toEqual(
+          retainedFiles.filter(({ path }) => path !== unrelated.path).map(({ path }) => path),
+        )
         expect(retainedFiles.some(({ path }) => path === oldState.path)).toBe(false)
         yield* Effect.promise(() => test.annotate(`Removed ${oldState.pages} obsolete VFS pages`))
 
@@ -215,34 +232,84 @@ Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
     )
   }
 
-  Vitest.live('retries rejected cleanup on completed-state reopen without replay (#1555)', (test) =>
+  Vitest.live('preserves untracked files even when their names match LiveStore state (#1555)', (test) =>
     Effect.gen(function* () {
       const server = yield* WranglerDevServer.WranglerDevServer
-      const { rebuild, rebuildFiles, rebuildEventlog, blockCleanup, unblockCleanup } = yield* makeStoreHelpers(
+      const { rebuild, rebuildFiles, stateFiles, forgetStateFileOwnership } = yield* makeStoreHelpers(
         server.url,
-        `cf-cleanup-retry-${nanoid(6)}`,
+        `cf-cleanup-ownership-${nanoid(6)}`,
       )
       expect((yield* rebuild({ seed: 'true' })).status).toBe(200)
-      const completed = yield* rebuild({ post: 'complete' })
-      expect(completed.status).toBe(200)
-      const { todos } = yield* readRebuildResponse(completed)
-      const files = yield* rebuildFiles()
-      const eventlog = yield* rebuildEventlog()
-      yield* blockCleanup()
+      const currentFiles = yield* rebuildFiles()
+      const untrackedPaths = [
+        '/state-cache@1.db',
+        '/state123@5.db',
+        '/stateUnLwYzVBhwzPCK5q7TrPU3q2N0dTe8m_98bud8HsAs8@6.db',
+      ]
+      yield* rebuildFiles(untrackedPaths)
+      yield* forgetStateFileOwnership()
 
-      const blocked = yield* rebuild({ post: 'fail' })
-      expect(blocked.status).toBe(200)
-      expect(yield* readRebuildResponse(blocked)).toMatchObject({ todos, attemptedEvents: [], attemptedHooks: [] })
-      expect(yield* rebuildFiles()).toContainEqual({ path: '/state-obsolete@0.db', pages: 1 })
-
-      yield* unblockCleanup()
-      const retried = yield* rebuild({ post: 'fail' })
-      expect(retried.status).toBe(200)
-      expect(yield* readRebuildResponse(retried)).toMatchObject({ todos, attemptedEvents: [], attemptedHooks: [] })
-      expect(yield* rebuildFiles()).toEqual(files)
-      expect(yield* rebuildEventlog()).toEqual(eventlog)
+      const reopened = yield* rebuild({ seed: 'true', seedCount: '0' })
+      expect(reopened.status).toBe(200)
+      expect(yield* readRebuildResponse(reopened)).toMatchObject({ attemptedEvents: [], attemptedHooks: [] })
+      expect(yield* stateFiles()).toEqual(currentFiles.map(({ path }) => path))
+      const retainedFiles = yield* rebuildFiles()
+      expect(retainedFiles).toHaveLength(currentFiles.length + untrackedPaths.length)
+      expect(retainedFiles).toEqual(
+        expect.arrayContaining([...currentFiles, ...untrackedPaths.map((path) => ({ path, pages: 1 }))]),
+      )
     }).pipe(withTestCtx(test)),
   )
+
+  Vitest.live('does not create state when recording ownership fails (#1555)', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServer.WranglerDevServer
+      const { rebuild, rebuildFiles, stateFiles, blockRegistration } = yield* makeStoreHelpers(
+        server.url,
+        `cf-registration-failure-${nanoid(6)}`,
+      )
+      expect((yield* rebuild({ seed: 'true' })).status).toBe(200)
+      const files = yield* rebuildFiles()
+      const ownedFiles = yield* stateFiles()
+      yield* blockRegistration()
+
+      expect((yield* rebuild({ post: 'complete' })).status).toBe(500)
+      expect(yield* rebuildFiles()).toEqual(files)
+      expect(yield* stateFiles()).toEqual(ownedFiles)
+    }).pipe(withTestCtx(test)),
+  )
+
+  for (const stage of ['pages', 'registry'] as const) {
+    Vitest.live(`retries rejected ${stage} cleanup on completed-state reopen without replay (#1555)`, (test) =>
+      Effect.gen(function* () {
+        const server = yield* WranglerDevServer.WranglerDevServer
+        const { rebuild, rebuildFiles, rebuildEventlog, stateFiles, blockCleanup, unblockCleanup } =
+          yield* makeStoreHelpers(server.url, `cf-cleanup-retry-${nanoid(6)}`)
+        expect((yield* rebuild({ seed: 'true' })).status).toBe(200)
+        const completed = yield* rebuild({ post: 'complete' })
+        expect(completed.status).toBe(200)
+        const { todos } = yield* readRebuildResponse(completed)
+        const files = yield* rebuildFiles()
+        const eventlog = yield* rebuildEventlog()
+        const ownedFiles = yield* stateFiles()
+        yield* blockCleanup(stage)
+
+        const blocked = yield* rebuild({ post: 'fail' })
+        expect(blocked.status).toBe(200)
+        expect(yield* readRebuildResponse(blocked)).toMatchObject({ todos, attemptedEvents: [], attemptedHooks: [] })
+        expect(yield* rebuildFiles()).toContainEqual({ path: '/previous-state.db', pages: 1 })
+        expect(yield* stateFiles()).toEqual(['/previous-state.db', ...ownedFiles])
+
+        yield* unblockCleanup()
+        const retried = yield* rebuild({ post: 'fail' })
+        expect(retried.status).toBe(200)
+        expect(yield* readRebuildResponse(retried)).toMatchObject({ todos, attemptedEvents: [], attemptedHooks: [] })
+        expect(yield* rebuildFiles()).toEqual(files)
+        expect(yield* stateFiles()).toEqual(ownedFiles)
+        expect(yield* rebuildEventlog()).toEqual(eventlog)
+      }).pipe(withTestCtx(test)),
+    )
+  }
 
   for (const eventCount of [250, 1000]) {
     Vitest.live(`schema rebuild stays within the write budget for ${eventCount} events (#1555)`, (test) =>

--- a/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/adapter-cloudflare.test.ts
@@ -75,6 +75,16 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
     return {
       // Recovery tests deliberately inspect failed boot responses.
       rebuild: (params: Record<string, string>) => rawClient.post('/store/rebuild', { urlParams: params }),
+      blockCleanup: () => client.post('/store/rebuild/block-cleanup'),
+      unblockCleanup: () => client.del('/store/rebuild/block-cleanup'),
+      rebuildFiles: (seedUnrelated = false) =>
+        (seedUnrelated === true ? client.post('/store/rebuild/files') : client.get('/store/rebuild/files')).pipe(
+          Effect.flatMap(
+            HttpClientResponse.schemaBodyJson(
+              Schema.Array(Schema.Struct({ path: Schema.String, pages: Schema.Finite })),
+            ),
+          ),
+        ),
       rebuildEventlog: () =>
         client
           .get('/store/rebuild/eventlog')
@@ -152,6 +162,88 @@ const makeStoreHelpers = (serverUrl: string, storeId: string) =>
   })
 
 Vitest.describe('adapter-cloudflare', { timeout: testTimeout }, () => {
+  for (const failure of ['replay', 'post', 'abort']) {
+    Vitest.live(`removes obsolete state only after successful rebuild following ${failure} (#1555)`, (test) =>
+      Effect.gen(function* () {
+        const server = yield* WranglerDevServer.WranglerDevServer
+        const { rebuild, rebuildFiles, rebuildEventlog, resetMetrics, getMetrics } = yield* makeStoreHelpers(
+          server.url,
+          `cf-stale-state-${nanoid(6)}`,
+        )
+        const seeded = yield* rebuild({ seed: 'true' })
+        expect(seeded.status).toBe(200)
+        const seedBody = yield* readRebuildResponse(seeded)
+        const before = yield* rebuildEventlog()
+        const originalFiles = yield* rebuildFiles()
+        expect(originalFiles).toHaveLength(1)
+        const oldState = originalFiles[0]!
+        const unrelated = { path: '/unrelated.db', pages: 1 }
+        yield* rebuildFiles(true)
+
+        const failed = yield* rebuild(
+          failure === 'replay' ? { failAt: 'todo-3' } : { post: failure === 'post' ? 'fail' : 'abort' },
+        )
+        expect(failed.status).toBe(500)
+        const failedFiles = yield* rebuildFiles()
+        expect(failedFiles).toContainEqual(oldState)
+        expect(failedFiles).toContainEqual(unrelated)
+        expect(yield* rebuildEventlog()).toEqual(before)
+
+        const recovered = yield* rebuild({ post: 'complete' })
+        expect(recovered.status).toBe(200)
+        const recoveredBody = yield* readRebuildResponse(recovered)
+        expect(recoveredBody.todos).toEqual([{ id: 'post-hook', title: 'completed' }, ...seedBody.todos])
+        expect(recoveredBody.attemptedEvents).toHaveLength(5)
+        expect(yield* rebuildEventlog()).toEqual(before)
+        const retainedFiles = yield* rebuildFiles()
+        expect(retainedFiles).toHaveLength(2)
+        expect(retainedFiles).toContainEqual(unrelated)
+        expect(retainedFiles.some(({ path }) => path === oldState.path)).toBe(false)
+        yield* Effect.promise(() => test.annotate(`Removed ${oldState.pages} obsolete VFS pages`))
+
+        yield* resetMetrics()
+        const reopened = yield* rebuild({ post: 'fail' })
+        expect(reopened.status).toBe(200)
+        expect(yield* readRebuildResponse(reopened)).toMatchObject({
+          todos: recoveredBody.todos,
+          attemptedEvents: [],
+          attemptedHooks: [],
+        })
+        expect(yield* rebuildFiles()).toEqual(retainedFiles)
+        expect((yield* getMetrics()).totalRowsWritten).toBe(0)
+      }).pipe(withTestCtx(test)),
+    )
+  }
+
+  Vitest.live('retries rejected cleanup on completed-state reopen without replay (#1555)', (test) =>
+    Effect.gen(function* () {
+      const server = yield* WranglerDevServer.WranglerDevServer
+      const { rebuild, rebuildFiles, rebuildEventlog, blockCleanup, unblockCleanup } = yield* makeStoreHelpers(
+        server.url,
+        `cf-cleanup-retry-${nanoid(6)}`,
+      )
+      expect((yield* rebuild({ seed: 'true' })).status).toBe(200)
+      const completed = yield* rebuild({ post: 'complete' })
+      expect(completed.status).toBe(200)
+      const { todos } = yield* readRebuildResponse(completed)
+      const files = yield* rebuildFiles()
+      const eventlog = yield* rebuildEventlog()
+      yield* blockCleanup()
+
+      const blocked = yield* rebuild({ post: 'fail' })
+      expect(blocked.status).toBe(200)
+      expect(yield* readRebuildResponse(blocked)).toMatchObject({ todos, attemptedEvents: [], attemptedHooks: [] })
+      expect(yield* rebuildFiles()).toContainEqual({ path: '/state-obsolete@0.db', pages: 1 })
+
+      yield* unblockCleanup()
+      const retried = yield* rebuild({ post: 'fail' })
+      expect(retried.status).toBe(200)
+      expect(yield* readRebuildResponse(retried)).toMatchObject({ todos, attemptedEvents: [], attemptedHooks: [] })
+      expect(yield* rebuildFiles()).toEqual(files)
+      expect(yield* rebuildEventlog()).toEqual(eventlog)
+    }).pipe(withTestCtx(test)),
+  )
+
   for (const eventCount of [250, 1000]) {
     Vitest.live(`schema rebuild stays within the write budget for ${eventCount} events (#1555)`, (test) =>
       Effect.gen(function* () {

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -115,12 +115,14 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
       if (request.method === 'POST') {
         this.ctx.storage.sql.exec(
           'INSERT INTO vfs_pages (file_path, page_no, page_data) VALUES (?, 0, ?)',
-          '/state-obsolete@0.db',
+          '/previous-state.db',
           new Uint8Array([1, 2, 3]),
         )
+        this.ctx.storage.sql.exec('INSERT INTO __livestore_state_files (file_path) VALUES (?)', '/previous-state.db')
+        const table = url.searchParams.get('stage') === 'registry' ? '__livestore_state_files' : 'vfs_pages'
         this.ctx.storage.sql.exec(`
-          CREATE TRIGGER reject_cleanup BEFORE DELETE ON vfs_pages
-          WHEN OLD.file_path = '/state-obsolete@0.db'
+          CREATE TRIGGER reject_cleanup BEFORE DELETE ON ${table}
+          WHEN OLD.file_path = '/previous-state.db'
           BEGIN SELECT RAISE(ABORT, 'Injected cleanup failure'); END
         `)
       } else if (request.method === 'DELETE') {
@@ -129,13 +131,39 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
       return makeCfResponse('ok')
     }
 
+    if (url.pathname === '/store/rebuild/block-registration') {
+      this.ctx.storage.sql.exec(`
+        CREATE TRIGGER reject_registration BEFORE INSERT ON __livestore_state_files
+        BEGIN SELECT RAISE(ABORT, 'Injected registration failure'); END
+      `)
+      return makeCfResponse('ok')
+    }
+
+    if (url.pathname === '/store/rebuild/ownership') {
+      if (request.method === 'DELETE') {
+        this.ctx.storage.sql.exec('DROP TABLE __livestore_state_files')
+        return makeCfResponse('ok')
+      }
+      return makeCfResponse(
+        JSON.stringify(
+          this.ctx.storage.sql
+            .exec<{ file_path: string }>('SELECT file_path FROM __livestore_state_files ORDER BY file_path')
+            .toArray()
+            .map(({ file_path }) => file_path),
+        ),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    }
+
     if (url.pathname === '/store/rebuild/files') {
       if (request.method === 'POST') {
-        this.ctx.storage.sql.exec(
-          'INSERT INTO vfs_pages (file_path, page_no, page_data) VALUES (?, 0, ?)',
-          '/unrelated.db',
-          new Uint8Array([1, 2, 3]),
-        )
+        for (const path of await request.json<string[]>()) {
+          this.ctx.storage.sql.exec(
+            'INSERT INTO vfs_pages (file_path, page_no, page_data) VALUES (?, 0, ?)',
+            path,
+            new Uint8Array([1, 2, 3]),
+          )
+        }
       }
       return makeCfResponse(
         JSON.stringify(

--- a/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
+++ b/tests/integration/src/tests/adapter-cloudflare/fixtures/worker.ts
@@ -111,6 +111,42 @@ export class TestStoreDo extends DurableObjectBase implements ClientDoWithRpcCal
       return makeCfResponse('storeId is required', { status: 400 })
     }
 
+    if (url.pathname === '/store/rebuild/block-cleanup') {
+      if (request.method === 'POST') {
+        this.ctx.storage.sql.exec(
+          'INSERT INTO vfs_pages (file_path, page_no, page_data) VALUES (?, 0, ?)',
+          '/state-obsolete@0.db',
+          new Uint8Array([1, 2, 3]),
+        )
+        this.ctx.storage.sql.exec(`
+          CREATE TRIGGER reject_cleanup BEFORE DELETE ON vfs_pages
+          WHEN OLD.file_path = '/state-obsolete@0.db'
+          BEGIN SELECT RAISE(ABORT, 'Injected cleanup failure'); END
+        `)
+      } else if (request.method === 'DELETE') {
+        this.ctx.storage.sql.exec('DROP TRIGGER reject_cleanup')
+      }
+      return makeCfResponse('ok')
+    }
+
+    if (url.pathname === '/store/rebuild/files') {
+      if (request.method === 'POST') {
+        this.ctx.storage.sql.exec(
+          'INSERT INTO vfs_pages (file_path, page_no, page_data) VALUES (?, 0, ?)',
+          '/unrelated.db',
+          new Uint8Array([1, 2, 3]),
+        )
+      }
+      return makeCfResponse(
+        JSON.stringify(
+          this.ctx.storage.sql
+            .exec('SELECT file_path AS path, COUNT(*) AS pages FROM vfs_pages GROUP BY file_path ORDER BY file_path')
+            .toArray(),
+        ),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    }
+
     if (url.pathname === '/store/rebuild/eventlog') {
       return makeCfResponse(
         JSON.stringify({


### PR DESCRIPTION
## Problem

Schema rebuilds leave obsolete Cloudflare state databases consuming storage.

## Solution

Register each state file before opening it. After successful boot, atomically remove other registered files and their ownership records. Failed cleanup rolls back and retries on a later boot.

Untracked files, including historical orphans, remain untouched. Cleanup consumes write quota and cannot recover storage already too full to rebuild.

## Validation

- 19 Cloudflare tests pass: ownership isolation, registration failure, rebuild recovery, atomic cleanup retry and zero-write reopen.
- Full unit lane, TypeScript, lint and `git diff --check` pass.

## Related issues

Addresses orphan accumulation in #1555. Stacked on #1613, following #1604 and #1610.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Durable Object persistence by deleting registered VFS state pages after boot; behavior is gated on successful boot and explicit ownership, but mistaken ownership tracking could remove wrong state until retried or rebuilt from the eventlog.
> 
> **Overview**
> The Cloudflare adapter now **tracks which VFS state databases it owns** instead of leaving schema-rebuild orphans in `vfs_pages` indefinitely.
> 
> Before opening the current state file, boot **registers** its exact path in adapter metadata table `__livestore_state_files` (registration failure aborts boot before creating state). After a **successful** boot—including completed-state reuse—it **atomically** deletes `vfs_pages` and registry rows for other **registered** paths only, while keeping the active state DB, eventlog, sync metadata, and any **untracked** VFS files (including historical orphans). Failed rebuilds keep all tracked files; cleanup errors are logged and **retried on the next successful boot** without blocking the store. Dev `resetPersistence` also clears the ownership table.
> 
> Docs, changelog, and an ADR document the ownership model. Integration tests cover post-failure cleanup, untracked-file safety, registration failure, and cleanup retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95875bbb80213cbdcaded3283751c816f880e928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->