### PR TITLE
Fix store.commit callbacks by collecting events before materialization

### DIFF
--- a/.changeset/fix-commit-callback.md
+++ b/.changeset/fix-commit-callback.md
@@ -1,0 +1,7 @@
+---
+'@livestore/livestore': minor
+---
+
+Fix the documented `store.commit` callback form and its TypeScript overloads, including calls with commit options. Collect emitted events before materialization so throwing callbacks apply no events. Fixes [#1611](https://github.com/livestorejs/livestore/issues/1611).
+
+Callback return values are now ignored. Replace the undocumented `store.commit(() => [event])` form with `store.commit(event)` or emit events through the supplied callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Changed
 
+- **Store commits:** Fixed the documented callback form of `store.commit` and
+  its TypeScript overloads, including calls with commit options. Callback events
+  are collected before materialization, and throwing callbacks apply no events
+  ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
 - **Cloudflare sync:** Serialize push admission through pull publication so an
   accepted event cannot advance the backend head without notifying subscribers
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).
@@ -35,6 +39,10 @@
 
 ### Breaking Changes
 
+- **Store commit callbacks:** Callback return values are now ignored. Replace
+  the undocumented `store.commit(() => [event])` form with `store.commit(event)`
+  or `store.commit((commit) => { commit(event) })`
+  ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
 - **State schema fingerprints:** Replaced Effect-internal AST hashing with a
   LiveStore-owned canonical descriptor and a synchronous full-width SHA-256
   fingerprint. No application schema or configuration changes are required.

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -50,6 +50,14 @@ simulation}`, `debug.instanceId`, `shutdownDeferred`, `signal`
 
 ## Commit Path
 
+`store.commit` accepts events directly or a synchronous callback receiving an
+event emitter, optionally preceded by commit options. Each emitter call accepts
+one or more schema events. Events are collected in order and enter the pipeline
+only after the callback returns successfully. An empty callback is a no-op. A
+callback that throws propagates its error before entering the pipeline, discards
+the collected events, and leaves the store usable. Callback return values are
+ignored. Events must be passed to the emitter or directly to `store.commit`.
+
 The pipeline is fully synchronous, run via `Effect.runSyncWith`
 (`store.ts:945`). **This synchronicity is an invariant** (Q1, see
 [`.decisions/0001-client-session-shutdown-drain.md`](./.decisions/0001-client-session-shutdown-drain.md)):

--- a/docs/src/content/docs/building-with-livestore/store.mdx
+++ b/docs/src/content/docs/building-with-livestore/store.mdx
@@ -37,6 +37,15 @@ For how to create a store in React, see the [React integration docs](/framework-
 
 <CommitEventSnippet />
 
+For conditional batches, pass a synchronous callback to `store.commit`. The
+callback receives a `commit` function that accepts one or more events per call.
+LiveStore collects those events and applies the batch after the callback finishes.
+Queries inside the callback do not see the collected changes yet. If the callback
+throws, none of its collected events are applied and the error reaches the caller.
+An empty callback does nothing. You can pass commit options before the callback.
+Callback return values are ignored. Pass events to the supplied `commit` function
+instead of returning an array.
+
 ### Streaming events
 
 Currently only events confirmed by the sync backend are supported.

--- a/packages/@livestore/livestore/src/store/store-commit.test.ts
+++ b/packages/@livestore/livestore/src/store/store-commit.test.ts
@@ -1,0 +1,121 @@
+import { expect } from 'vitest'
+
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Effect } from '@livestore/utils/effect'
+
+import { events, makeTodoMvc, tables } from '../utils/tests/fixture.ts'
+
+Vitest.describe('Store commit API', () => {
+  Vitest.live('should materialize events emitted by the documented commit callback', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+      const firstTodo = { id: '1', text: 'Make coffee', completed: false }
+      const secondTodo = { id: '2', text: 'Buy groceries', completed: false }
+
+      // Regression for https://github.com/livestorejs/livestore/issues/1611.
+      store.commit((commit) => {
+        commit(events.todoCreated(firstTodo))
+        commit(events.todoCreated(secondTodo))
+        expect(store.query(tables.todos)).toEqual([])
+      })
+
+      expect(store.query(tables.todos.orderBy('id', 'asc'))).toEqual([firstTodo, secondTodo])
+    }).pipe(Effect.scoped),
+  )
+
+  Vitest.live('should materialize a single callback event', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+      const todo = { id: '1', text: 'Make coffee', completed: false }
+
+      store.commit((commit) => commit(events.todoCreated(todo)))
+
+      expect(store.query(tables.todos)).toEqual([todo])
+    }).pipe(Effect.scoped),
+  )
+
+  Vitest.live('should accept an empty callback', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+
+      store.commit(() => {})
+
+      expect(store.query(tables.todos)).toEqual([])
+    }).pipe(Effect.scoped),
+  )
+
+  Vitest.live('should discard collected events when the callback throws', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+      const todo = { id: '1', text: 'Make coffee', completed: false }
+      const error = new Error('Callback failed')
+
+      expect(() =>
+        store.commit((commit) => {
+          commit(events.todoCreated(todo))
+          throw error
+        }),
+      ).toThrow(error)
+
+      expect(store.query(tables.todos)).toEqual([])
+      store.commit(events.todoCreated(todo))
+      expect(store.query(tables.todos)).toEqual([todo])
+    }).pipe(Effect.scoped),
+  )
+
+  Vitest.live('should collect multiple event types in one emitter call in order', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+      const todo = { id: '1', text: 'Make coffee', completed: false }
+
+      store.commit((commit) => {
+        commit(events.todoCreated(todo), events.todoCompleted({ id: todo.id }))
+      })
+
+      expect(store.query(tables.todos)).toEqual([{ ...todo, completed: true }])
+    }).pipe(Effect.scoped),
+  )
+
+  for (const options of [{}, { label: 'Create todo' }]) {
+    Vitest.live(`should accept callback options ${JSON.stringify(options)}`, () =>
+      Effect.gen(function* () {
+        const store = yield* makeTodoMvc()
+        const todo = { id: '1', text: 'Make coffee', completed: false }
+
+        store.commit(options, (commit) => commit(events.todoCreated(todo)))
+
+        expect(store.query(tables.todos)).toEqual([todo])
+      }).pipe(Effect.scoped),
+    )
+  }
+
+  Vitest.live('should ignore callback return values and only commit emitted events', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+      const todo = { id: '1', text: 'Make coffee', completed: false }
+
+      store.commit(() => [events.todoCreated(todo)])
+      expect(store.query(tables.todos)).toEqual([])
+
+      store.commit((commit) => {
+        commit(events.todoCreated(todo))
+        return [events.todoCompleted({ id: todo.id })]
+      })
+
+      expect(store.query(tables.todos)).toEqual([todo])
+    }).pipe(Effect.scoped),
+  )
+
+  Vitest.live('should still accept direct events with options and no events', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
+      const todo = { id: '1', text: 'Make coffee', completed: false }
+
+      store.commit()
+      store.commit({ label: 'Empty commit' })
+      store.commit({ label: 'Create and complete' }, events.todoCreated(todo), events.todoCompleted({ id: todo.id }))
+
+      expect(store.query(tables.todos)).toEqual([{ ...todo, completed: true }])
+    }).pipe(Effect.scoped),
+  )
+})

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -824,6 +824,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    * For more advanced transaction scenarios, you can pass a synchronous function to `commit` which will receive a callback
    * to which you can pass multiple events to be committed in the same database transaction.
    * Under the hood this will simply collect all events and apply them in a single database transaction.
+   * The callback's return value is ignored.
    *
    * @example
    * ```ts
@@ -855,21 +856,12 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    */
   commit: {
     <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(...list: TCommitArg): void
-    (
-      txn: <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(
-        ...list: TCommitArg
-      ) => void,
-    ): void
+    (txn: CommitCallback<TSchema>): void
     <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(
       options: StoreCommitOptions,
       ...list: TCommitArg
     ): void
-    (
-      options: StoreCommitOptions,
-      txn: <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(
-        ...list: TCommitArg
-      ) => void,
-    ): void
+    (options: StoreCommitOptions, txn: CommitCallback<TSchema>): void
   } = (firstEventOrTxnFnOrOptions: any, ...restEvents: any[]) => {
     this.checkShutdown('commit')
 
@@ -1277,27 +1269,38 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     events: LiveStoreEvent.Input.ForSchema<TSchema>[]
     options: StoreCommitOptions | undefined
   } => {
-    let events: LiveStoreEvent.Input.ForSchema<TSchema>[]
+    let events: LiveStoreEvent.Input.ForSchema<TSchema>[] = []
     let options: StoreCommitOptions | undefined
+    let commitArgs = [firstEventOrTxnFnOrOptions, ...restEvents]
 
-    if (typeof firstEventOrTxnFnOrOptions === 'function') {
-      // TODO ensure that function is synchronous and isn't called in a async way (also write tests for this)
-      events = firstEventOrTxnFnOrOptions((arg: any) => events.push(arg))
-    } else if (
+    if (
       firstEventOrTxnFnOrOptions?.label !== undefined ||
       firstEventOrTxnFnOrOptions?.skipRefresh !== undefined ||
       firstEventOrTxnFnOrOptions?.otelContext !== undefined ||
-      firstEventOrTxnFnOrOptions?.spanLinks !== undefined
+      firstEventOrTxnFnOrOptions?.spanLinks !== undefined ||
+      typeof restEvents[0] === 'function'
     ) {
       options = firstEventOrTxnFnOrOptions
-      events = restEvents
-    } else if (firstEventOrTxnFnOrOptions === undefined) {
-      // When `commit` is called with no arguments (which sometimes happens when dynamically filtering events)
-      events = []
-    } else {
-      events = [firstEventOrTxnFnOrOptions, ...restEvents]
+      commitArgs = restEvents
+    }
+
+    const firstEventOrTxnFn = commitArgs[0]
+    if (typeof firstEventOrTxnFn === 'function') {
+      // TODO ensure that function is synchronous and isn't called in an async way (also write tests for this).
+      // Collect before materializing so a throwing callback cannot commit a partial batch.
+      firstEventOrTxnFn((...args: LiveStoreEvent.Input.ForSchema<TSchema>[]) => {
+        events.push(...args)
+      })
+    } else if (firstEventOrTxnFn !== undefined) {
+      events = commitArgs
     }
 
     return { events, options }
   }
 }
+
+type CommitCallback<TSchema extends LiveStoreSchema> = (
+  commit: <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(
+    ...events: TCommitArg
+  ) => void,
+) => void


### PR DESCRIPTION
## Problem

Documented `store.commit` callbacks crash before saving any events.

## Solution

Collect callback events before materialization and correct the callback types, including commit options. Throwing callbacks save nothing.

**Breaking:** callback return values are ignored. Replace `store.commit(() => [event])` with `store.commit(event)` or emit through the callback.

## Validation

17 focused tests, the full unit suite (`test:unit`), `ts:check`, and `lint:full:fix` passed.

## Related issues

Closes #1611.
