### PR TITLE
feat(sync-cf): support optional Effect telemetry layers

### DIFF
--- a/.changeset/cf-telemetry-ownership.md
+++ b/.changeset/cf-telemetry-ownership.md
@@ -9,3 +9,6 @@ Existing OTLP endpoint configuration remains supported. Export finite WebSocket
 RPC spans and DO-RPC pull spans, closing finite history before live subscription
 waits. Telemetry remains opt-in and requires no Cloudflare managed export or
 Workers Paid subscription.
+
+Also accept application-supplied Effect tracer layers with per-operation resource
+scopes, and preserve queued provider flushes when an earlier export fails.

--- a/.changeset/cf-telemetry-ownership.md
+++ b/.changeset/cf-telemetry-ownership.md
@@ -6,4 +6,7 @@ Allow Cloudflare sync backends to use an optional application-supplied Effect
 tracer layer via `otel: layer`. Existing OTLP endpoint configuration remains
 supported. Finalize telemetry in the background without delaying sync
 acknowledgments, and export finite WebSocket and DO-RPC pull spans before live
-subscriptions wait. Platform-specific tracing packages stay in the application.
+subscriptions wait. Preserve sampled client context, start a backend trace when
+client context is unsampled, and keep expected sync-recovery responses out of
+boundary error telemetry. Platform-specific tracing packages stay in the
+application.

--- a/.changeset/cf-telemetry-ownership.md
+++ b/.changeset/cf-telemetry-ownership.md
@@ -1,0 +1,11 @@
+---
+'@livestore/sync-cf': minor
+---
+
+Allow Cloudflare sync backends to reuse an application-owned OpenTelemetry
+provider via `otel: provider`. Export runs in the background without delaying sync
+acknowledgments. LiveStore never registers or shuts down the injected provider.
+Existing OTLP endpoint configuration remains supported. Export finite WebSocket
+RPC spans and DO-RPC pull spans, closing finite history before live subscription
+waits. Telemetry remains opt-in and requires no Cloudflare managed export or
+Workers Paid subscription.

--- a/.changeset/cf-telemetry-ownership.md
+++ b/.changeset/cf-telemetry-ownership.md
@@ -2,13 +2,8 @@
 '@livestore/sync-cf': minor
 ---
 
-Allow Cloudflare sync backends to reuse an application-owned OpenTelemetry
-provider via `otel: provider`. Export runs in the background without delaying sync
-acknowledgments. LiveStore never registers or shuts down the injected provider.
-Existing OTLP endpoint configuration remains supported. Export finite WebSocket
-RPC spans and DO-RPC pull spans, closing finite history before live subscription
-waits. Telemetry remains opt-in and requires no Cloudflare managed export or
-Workers Paid subscription.
-
-Also accept application-supplied Effect tracer layers with per-operation resource
-scopes, and preserve queued provider flushes when an earlier export fails.
+Allow Cloudflare sync backends to use an optional application-supplied Effect
+tracer layer via `otel: layer`. Existing OTLP endpoint configuration remains
+supported. Finalize telemetry in the background without delaying sync
+acknowledgments, and export finite WebSocket and DO-RPC pull spans before live
+subscriptions wait. Platform-specific tracing packages stay in the application.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
   are collected before materialization, and throwing callbacks apply no events
   ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
 - **Cloudflare sync telemetry:** Added optional application-owned OpenTelemetry
-  providers via `otel: provider`. Export runs in the background, and finite
+  providers via `otel: provider` or Effect tracer layers via `otel: layer`.
+  Export runs in the background and preserves queued flushes after failures. Finite
   WebSocket operations and DO-RPC pull streams now emit their sync spans
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
 - **Cloudflare sync:** Serialize push admission through pull publication so an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,9 @@
   its TypeScript overloads, including calls with commit options. Callback events
   are collected before materialization, and throwing callbacks apply no events
   ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
-- **Cloudflare sync telemetry:** Added optional application-owned OpenTelemetry
-  providers via `otel: provider` or Effect tracer layers via `otel: layer`.
-  Export runs in the background and preserves queued flushes after failures. Finite
-  WebSocket operations and DO-RPC pull streams now emit their sync spans
+- **Cloudflare sync telemetry:** Added optional Effect tracer layers via `otel: layer`.
+  Telemetry cleanup runs in the background, and finite WebSocket operations and
+  DO-RPC pull streams now emit their sync spans
   ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
 - **Cloudflare sync:** Serialize push admission through pull publication so an
   accepted event cannot advance the backend head without notifying subscribers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   its TypeScript overloads, including calls with commit options. Callback events
   are collected before materialization, and throwing callbacks apply no events
   ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
+- **Cloudflare sync telemetry:** Added optional application-owned OpenTelemetry
+  providers via `otel: provider`. Export runs in the background, and finite
+  WebSocket operations and DO-RPC pull streams now emit their sync spans
+  ([#1618](https://github.com/livestorejs/livestore/issues/1618)).
 - **Cloudflare sync:** Serialize push admission through pull publication so an
   accepted event cannot advance the backend head without notifying subscribers
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).

--- a/context/02-system/03-sync/03-cf/.decisions/0005-optional-telemetry-ownership.md
+++ b/context/02-system/03-sync/03-cf/.decisions/0005-optional-telemetry-ownership.md
@@ -19,8 +19,11 @@ and finalize its resources in the background. The integration layer defines its
 exporter lifecycle; LiveStore does not manage SDK providers or schedule flushes.
 
 Finish WebSocket telemetry scopes before the indefinite live phase. Give finite
-WebSocket work an exported span attached to the caller, and install tracing inside
-DO-RPC pull streams' separate runtime. Platform-specific packages stay in the app.
+WebSocket work an exported span attached to a sampled caller; start a backend root
+when the caller has no sampled context so backend-only telemetry remains visible.
+Install tracing inside DO-RPC pull streams' separate runtime. Expected sync
+recovery results remain typed failures without marking the RPC boundary as an
+OpenTelemetry error. Platform-specific packages stay in the app.
 
 ## Alternatives
 
@@ -39,6 +42,8 @@ because Durable Objects provide no eviction or hibernation shutdown callback.
 ## Evidence
 
 `packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts` covers opt-out,
-independent operation scopes, span parentage, finite-history finalization, and
-acknowledgment while the OTLP collector is blocked. The disposable Cloudflare
-demo verified existing LiveStore spans through `effect-cf` on the Free plan.
+independent operation scopes, sampled and unsampled span parentage, expected
+recovery status, real WebSocket and DO-RPC transport composition,
+finite-history finalization, and acknowledgment while the OTLP collector is
+blocked. The disposable Cloudflare demo verified existing LiveStore spans
+through `effect-cf` on the Free plan.

--- a/context/02-system/03-sync/03-cf/.decisions/0005-optional-telemetry-ownership.md
+++ b/context/02-system/03-sync/03-cf/.decisions/0005-optional-telemetry-ownership.md
@@ -1,0 +1,53 @@
+# 0005 — Keep sync telemetry optional and scope exporter ownership to bounded work
+
+Status: accepted (user confirmation, 2026-09-08, to implement optional telemetry injection
+and explicit lifecycle ownership while preserving Cloudflare Free support).
+
+## Context
+
+The store accepts an application tracer, while the Cloudflare sync backend only
+accepted an OTLP endpoint and constructed its own exporter. Applications could
+not reuse their tracing setup there. WebSocket subscriptions deliberately remain
+open across hibernation, making connection shutdown an unsuitable export boundary.
+
+## Decision
+
+Accept an application-owned OTel provider directly, with no additional flush options.
+Use its optional `forceFlush()` method in the background after finite sync work.
+Install the Effect bridge locally without registering or shutting down a global
+provider. Preserve endpoint-based configuration as a mutually exclusive convenience.
+Finish telemetry scopes around WebSocket pushes and finite pull history before
+entering the live subscription phase. Explicit finite WebSocket boundaries attach
+to the caller rather than an unexported Effect RPC envelope. Wrap DO-RPC pull
+streams inside their separate execution runtime, as well as the outer handler.
+
+Cloudflare-native tracing and managed export remain optional deployment features.
+They are not dependencies of this integration. Platform-neutral OTel injection
+preserves the application's choice of exporter and destination.
+
+## Alternatives
+
+- Requiring Cloudflare's managed drain would exclude Workers Free and couple
+  library instrumentation to a platform beta.
+- Owning the application's provider would risk shutting down unrelated traces.
+- A connection-wide exporter scope would retain timers across idle subscriptions
+  or depend on shutdown callbacks the runtime does not provide.
+
+## Consequences
+
+Export runs in the background and flush failures do not change sync outcomes.
+LiveStore bounds its wait to three seconds but cannot cancel app-owned promises.
+Only one provider flush runs per DO instance at a time; completions during a flush
+request a trailing pass, including when a slow flush eventually settles.
+Delivery is best-effort rather than a durable telemetry queue. Application-owned
+providers manage their own resources; LiveStore-owned endpoint exporters close
+in separate scopes so their shutdown cannot delay acknowledgments.
+
+## Evidence
+
+`packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts` verifies
+opt-out, injected parentage, ownership, flush error isolation, acknowledgment
+while export is blocked, slow flush coalescing, and
+finite-history cleanup before a never-ending live stream.
+Cloudflare documents the absence of shutdown hooks and the effect of timers on
+hibernation in its [DO lifecycle reference](https://developers.cloudflare.com/durable-objects/concepts/durable-object-lifecycle/).

--- a/context/02-system/03-sync/03-cf/.decisions/0005-optional-telemetry-ownership.md
+++ b/context/02-system/03-sync/03-cf/.decisions/0005-optional-telemetry-ownership.md
@@ -1,53 +1,44 @@
 # 0005 — Keep sync telemetry optional and scope exporter ownership to bounded work
 
-Status: accepted (user confirmation, 2026-09-08, to implement optional telemetry injection
-and explicit lifecycle ownership while preserving Cloudflare Free support).
+Status: accepted (user confirmation, 2026-09-08, including simplification to an
+Effect-layer integration).
 
 ## Context
 
-The store accepts an application tracer, while the Cloudflare sync backend only
-accepted an OTLP endpoint and constructed its own exporter. Applications could
-not reuse their tracing setup there. WebSocket subscriptions deliberately remain
-open across hibernation, making connection shutdown an unsuitable export boundary.
+The Cloudflare sync backend only accepted an OTLP endpoint and constructed its
+own exporter. Applications need to supply their tracing integration, including
+Cloudflare-native tracing, without making telemetry mandatory or delaying sync.
+WebSocket subscriptions remain open across hibernation, so their closure is not
+a suitable export boundary.
 
 ## Decision
 
-Accept an application-owned OTel provider directly, with no additional flush options.
-Use its optional `forceFlush()` method in the background after finite sync work.
-Install the Effect bridge locally without registering or shutting down a global
-provider. Preserve endpoint-based configuration as a mutually exclusive convenience.
-Finish telemetry scopes around WebSocket pushes and finite pull history before
-entering the live subscription phase. Explicit finite WebSocket boundaries attach
-to the caller rather than an unexported Effect RPC envelope. Wrap DO-RPC pull
-streams inside their separate execution runtime, as well as the outer handler.
+Accept an optional Effect tracer layer. Preserve the existing endpoint shorthand
+by converting it to an Effect OTLP layer. Build the layer per finite operation
+and finalize its resources in the background. The integration layer defines its
+exporter lifecycle; LiveStore does not manage SDK providers or schedule flushes.
 
-Cloudflare-native tracing and managed export remain optional deployment features.
-They are not dependencies of this integration. Platform-neutral OTel injection
-preserves the application's choice of exporter and destination.
+Finish WebSocket telemetry scopes before the indefinite live phase. Give finite
+WebSocket work an exported span attached to the caller, and install tracing inside
+DO-RPC pull streams' separate runtime. Platform-specific packages stay in the app.
 
 ## Alternatives
 
-- Requiring Cloudflare's managed drain would exclude Workers Free and couple
-  library instrumentation to a platform beta.
-- Owning the application's provider would risk shutting down unrelated traces.
-- A connection-wide exporter scope would retain timers across idle subscriptions
-  or depend on shutdown callbacks the runtime does not provide.
+- Direct SDK-provider injection requires additional flush scheduling, concurrency
+  guards, and failure recovery. It is unnecessary when apps supply Effect layers.
+- Plain scoped layer provision would wait for exporter cleanup before acknowledging.
+- A connection-wide scope can retain exporter timers across idle subscriptions.
 
 ## Consequences
 
-Export runs in the background and flush failures do not change sync outcomes.
-LiveStore bounds its wait to three seconds but cannot cancel app-owned promises.
-Only one provider flush runs per DO instance at a time; completions during a flush
-request a trailing pass, including when a slow flush eventually settles.
-Delivery is best-effort rather than a durable telemetry queue. Application-owned
-providers manage their own resources; LiveStore-owned endpoint exporters close
-in separate scopes so their shutdown cannot delay acknowledgments.
+Export cleanup cannot delay sync acknowledgments. Layer construction still runs
+on the operation path, and a supplied layer must not shut down a shared provider.
+The endpoint exporter uses Effect's shutdown timeout. Delivery is best-effort
+because Durable Objects provide no eviction or hibernation shutdown callback.
 
 ## Evidence
 
-`packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts` verifies
-opt-out, injected parentage, ownership, flush error isolation, acknowledgment
-while export is blocked, slow flush coalescing, and
-finite-history cleanup before a never-ending live stream.
-Cloudflare documents the absence of shutdown hooks and the effect of timers on
-hibernation in its [DO lifecycle reference](https://developers.cloudflare.com/durable-objects/concepts/durable-object-lifecycle/).
+`packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts` covers opt-out,
+independent operation scopes, span parentage, finite-history finalization, and
+acknowledgment while the OTLP collector is blocked. The disposable Cloudflare
+demo verified existing LiveStore spans through `effect-cf` on the Free plan.

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -89,9 +89,9 @@ Object hosting a store) is `04-runtime/`'s adapter concern
 
 ## Optional telemetry
 
-`makeDurableObject` accepts an optional Effect tracer layer as `otel: layer`.
-The existing `{ baseUrl, serviceName? }` endpoint configuration creates an Effect
-OTLP exporter layer. Omit `otel` to avoid creating an exporter or sending telemetry.
+The existing `makeDurableObject` option `otel` accepts either an Effect tracer
+layer or a `{ baseUrl, serviceName? }` endpoint configuration. The latter creates
+an Effect OTLP exporter layer. Omit `otel` to avoid creating an exporter or sending telemetry.
 Applications choose the integration and destination; no Cloudflare-specific
 tracer package or paid feature is required by the library.
 

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -87,6 +87,34 @@ Server-side embedding of a LiveStore client inside Cloudflare (Durable
 Object hosting a store) is `04-runtime/`'s adapter concern
 (`adapter-cloudflare`), not part of this provider node.
 
+## Optional telemetry
+
+`makeDurableObject` leaves telemetry export disabled unless `otel` is supplied.
+Applications can pass an OpenTelemetry provider directly as `otel: provider`, or
+retain the `baseUrl`/`serviceName` convenience exporter. Neither requires Cloudflare
+native tracing, managed telemetry destinations, or a Workers Paid subscription.
+
+The injected provider remains application-owned: LiveStore does not register it
+globally or shut it down. After finite sync work, LiveStore calls `forceFlush()`
+when the provider supports it. Export runs in the background and failures do not
+change sync results. There is one outstanding flush per DO instance; concurrent
+completions request a trailing flush. LiveStore stops waiting after 3000 ms but
+cannot cancel app-owned SDK promises; a queued flush still runs if a slow promise
+eventually settles. Owned endpoint exporters close in the background with a
+3000 ms shutdown timeout.
+
+WebSocket pushes and finite pull history receive exported RPC boundary spans
+attached directly to the caller, bypassing Effect RPC's unexported subscription
+envelope. DO-RPC pull streams receive tracing inside their separate execution
+runtime. Finite history closes before waiting for live updates, so the endpoint
+exporter does not retain timers for the lifetime of an idle subscription.
+
+Export remains best-effort. A DO has no shutdown callback on hibernation or
+eviction, and an injected provider's own timers/I/O remain the app's
+responsibility. This integration does not join Cloudflare-native trace IDs to
+LiveStore traces or change the sync protocol. See
+[decision 0005](.decisions/0005-optional-telemetry-ownership.md).
+
 ## Known Gaps (Non-Obligations)
 
 Current reality a consumer must not read as guaranteed behavior:

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -94,11 +94,19 @@ Applications can pass an OpenTelemetry provider directly as `otel: provider`, or
 retain the `baseUrl`/`serviceName` convenience exporter. Neither requires Cloudflare
 native tracing, managed telemetry destinations, or a Workers Paid subscription.
 
+Applications can also supply an Effect tracer layer as `otel: layer`. LiveStore
+builds it with a fresh scope per sync operation and finalizes its acquired
+resources afterwards. Layer construction runs on the operation path; only
+finalization runs in the background. A layer must not attach a shutdown finalizer to a shared
+application-owned provider. Platform-specific tracer dependencies stay in the
+application; the library does not select a platform tracer.
+
 The injected provider remains application-owned: LiveStore does not register it
 globally or shut it down. After finite sync work, LiveStore calls `forceFlush()`
 when the provider supports it. Export runs in the background and failures do not
 change sync results. There is one outstanding flush per DO instance; concurrent
-completions request a trailing flush. LiveStore stops waiting after 3000 ms but
+completions request a trailing flush, including when the current flush fails.
+A failure alone does not schedule a retry. LiveStore stops waiting after 3000 ms but
 cannot cancel app-owned SDK promises; a queued flush still runs if a slow promise
 eventually settles. Owned endpoint exporters close in the background with a
 3000 ms shutdown timeout.

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -103,10 +103,14 @@ its exporter lifecycle. LiveStore does not manage SDK providers or schedule thei
 The built-in endpoint exporter uses Effect's three-second shutdown timeout.
 
 WebSocket pushes and finite pull history receive exported RPC boundary spans
-attached directly to the caller, bypassing Effect RPC's unexported subscription
-envelope. DO-RPC pull streams receive tracing inside their separate execution
-runtime. Finite history closes before waiting for live updates, so the endpoint
-exporter does not retain timers for the lifetime of an idle subscription.
+attached directly to a sampled caller, bypassing Effect RPC's unexported
+subscription envelope. When the caller has no sampled context, the boundary
+starts a backend root so server-side telemetry remains independently observable.
+Expected `ServerAheadError` and `BackendIdMismatchError` recovery results remain
+typed failures without marking these RPC boundaries as OpenTelemetry errors.
+DO-RPC pull streams receive tracing inside their separate execution runtime.
+Finite history closes before waiting for live updates, so the endpoint exporter
+does not retain timers for the lifetime of an idle subscription.
 
 Delivery remains best-effort: Durable Objects have no shutdown callback on
 hibernation or eviction. This integration does not join Cloudflare-native trace

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -89,27 +89,18 @@ Object hosting a store) is `04-runtime/`'s adapter concern
 
 ## Optional telemetry
 
-`makeDurableObject` leaves telemetry export disabled unless `otel` is supplied.
-Applications can pass an OpenTelemetry provider directly as `otel: provider`, or
-retain the `baseUrl`/`serviceName` convenience exporter. Neither requires Cloudflare
-native tracing, managed telemetry destinations, or a Workers Paid subscription.
+`makeDurableObject` accepts an optional Effect tracer layer as `otel: layer`.
+The existing `{ baseUrl, serviceName? }` endpoint configuration creates an Effect
+OTLP exporter layer. Omit `otel` to avoid creating an exporter or sending telemetry.
+Applications choose the integration and destination; no Cloudflare-specific
+tracer package or paid feature is required by the library.
 
-Applications can also supply an Effect tracer layer as `otel: layer`. LiveStore
-builds it with a fresh scope per sync operation and finalizes its acquired
-resources afterwards. Layer construction runs on the operation path; only
-finalization runs in the background. A layer must not attach a shutdown finalizer to a shared
-application-owned provider. Platform-specific tracer dependencies stay in the
-application; the library does not select a platform tracer.
-
-The injected provider remains application-owned: LiveStore does not register it
-globally or shut it down. After finite sync work, LiveStore calls `forceFlush()`
-when the provider supports it. Export runs in the background and failures do not
-change sync results. There is one outstanding flush per DO instance; concurrent
-completions request a trailing flush, including when the current flush fails.
-A failure alone does not schedule a retry. LiveStore stops waiting after 3000 ms but
-cannot cancel app-owned SDK promises; a queued flush still runs if a slow promise
-eventually settles. Owned endpoint exporters close in the background with a
-3000 ms shutdown timeout.
+LiveStore builds the layer in a fresh scope per sync operation. Construction runs
+on the operation path; resource finalization runs in the background so export
+cleanup cannot delay acknowledgments or change sync outcomes. The layer defines
+its exporter lifecycle. LiveStore does not manage SDK providers or schedule their
+`forceFlush()` calls. A supplied layer must not shut down a shared provider.
+The built-in endpoint exporter uses Effect's three-second shutdown timeout.
 
 WebSocket pushes and finite pull history receive exported RPC boundary spans
 attached directly to the caller, bypassing Effect RPC's unexported subscription
@@ -117,10 +108,9 @@ envelope. DO-RPC pull streams receive tracing inside their separate execution
 runtime. Finite history closes before waiting for live updates, so the endpoint
 exporter does not retain timers for the lifetime of an idle subscription.
 
-Export remains best-effort. A DO has no shutdown callback on hibernation or
-eviction, and an injected provider's own timers/I/O remain the app's
-responsibility. This integration does not join Cloudflare-native trace IDs to
-LiveStore traces or change the sync protocol. See
+Delivery remains best-effort: Durable Objects have no shutdown callback on
+hibernation or eviction. This integration does not join Cloudflare-native trace
+IDs to external traces or change the sync protocol. See
 [decision 0005](.decisions/0005-optional-telemetry-ownership.md).
 
 ## Known Gaps (Non-Obligations)

--- a/context/02-system/06-observability/spec.md
+++ b/context/02-system/06-observability/spec.md
@@ -20,7 +20,10 @@ Draft.
   `makeDurableObject({ otel: layer })`. LiveStore builds it per sync operation and
   finalizes its resources in the background. The application selects the tracer
   integration and destination. The existing endpoint configuration supplies an
-  Effect OTLP layer instead. See the
+  Effect OTLP layer instead. Sampled caller context is preserved at RPC
+  boundaries; otherwise the backend starts an independently observable trace.
+  Expected sync-recovery failures retain their typed error channel without an
+  error status on the boundary span. See the
   [Cloudflare provider spec](../03-sync/03-cf/spec.md) for transport boundaries
   and best-effort cleanup.
 - `utils/src/NoopTracer.ts` is the default when no tracer is provided

--- a/context/02-system/06-observability/spec.md
+++ b/context/02-system/06-observability/spec.md
@@ -16,17 +16,13 @@ Draft.
 - `common/src/otel.ts` centralizes tracer/span-context plumbing into the
   Store (`StoreOtel`); `createStore`/`provideOtel` inject the app tracer
   (LS.SYS.OBS-R03).
-- The Cloudflare sync backend accepts an app-owned provider through
-  `makeDurableObject({ otel: provider })`. LiveStore installs the Effect bridge
-  locally and never registers or shuts down the injected provider. The app
-  controls exporters, sampling, credentials, and destinations. Provider
-  `forceFlush()`, when available, runs in the background after finite sync work;
-  failures do not change sync outcomes. The existing `otel.baseUrl` convenience
-  configuration creates operation-scoped exporters instead. An application can
-  alternatively supply an Effect tracer layer, built and finalized per sync
-  operation, without adding a platform-specific library dependency. See the
-  [Cloudflare provider spec](../03-sync/03-cf/spec.md) for transport boundaries,
-  coalescing, and best-effort shutdown limits.
+- The Cloudflare sync backend accepts an optional Effect tracer layer through
+  `makeDurableObject({ otel: layer })`. LiveStore builds it per sync operation and
+  finalizes its resources in the background. The application selects the tracer
+  integration and destination. The existing endpoint configuration supplies an
+  Effect OTLP layer instead. See the
+  [Cloudflare provider spec](../03-sync/03-cf/spec.md) for transport boundaries
+  and best-effort cleanup.
 - `utils/src/NoopTracer.ts` is the default when no tracer is provided
   (LS.SYS.OBS-R02). It is cheap but not free: each span allocates a span
   object and returns OpenTelemetry's shared invalid span context. A zero-allocation no-op path on

--- a/context/02-system/06-observability/spec.md
+++ b/context/02-system/06-observability/spec.md
@@ -22,7 +22,9 @@ Draft.
   controls exporters, sampling, credentials, and destinations. Provider
   `forceFlush()`, when available, runs in the background after finite sync work;
   failures do not change sync outcomes. The existing `otel.baseUrl` convenience
-  configuration creates operation-scoped exporters instead. See the
+  configuration creates operation-scoped exporters instead. An application can
+  alternatively supply an Effect tracer layer, built and finalized per sync
+  operation, without adding a platform-specific library dependency. See the
   [Cloudflare provider spec](../03-sync/03-cf/spec.md) for transport boundaries,
   coalescing, and best-effort shutdown limits.
 - `utils/src/NoopTracer.ts` is the default when no tracer is provided

--- a/context/02-system/06-observability/spec.md
+++ b/context/02-system/06-observability/spec.md
@@ -16,6 +16,15 @@ Draft.
 - `common/src/otel.ts` centralizes tracer/span-context plumbing into the
   Store (`StoreOtel`); `createStore`/`provideOtel` inject the app tracer
   (LS.SYS.OBS-R03).
+- The Cloudflare sync backend accepts an app-owned provider through
+  `makeDurableObject({ otel: provider })`. LiveStore installs the Effect bridge
+  locally and never registers or shuts down the injected provider. The app
+  controls exporters, sampling, credentials, and destinations. Provider
+  `forceFlush()`, when available, runs in the background after finite sync work;
+  failures do not change sync outcomes. The existing `otel.baseUrl` convenience
+  configuration creates operation-scoped exporters instead. See the
+  [Cloudflare provider spec](../03-sync/03-cf/spec.md) for transport boundaries,
+  coalescing, and best-effort shutdown limits.
 - `utils/src/NoopTracer.ts` is the default when no tracer is provided
   (LS.SYS.OBS-R02). It is cheap but not free: each span allocates a span
   object and returns OpenTelemetry's shared invalid span context. A zero-allocation no-op path on

--- a/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
+++ b/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
@@ -12,15 +12,9 @@ import WorkerSnippet from '../../_assets/code/reference/opentelemetry/livestore.
 
 LiveStore has built-in support for OpenTelemetry.
 
-Telemetry export is optional. Without an application-provided tracer, the store
-uses a no-op tracer and sends no telemetry. When enabled, your application owns
-the tracer provider, exporter, sampling, and destination. Effect instrumentation
-and LiveStore's direct OpenTelemetry spans use the supplied tracer.
+Telemetry export is optional. Without an application-provided tracer, the store uses a no-op tracer and sends no telemetry. When enabled, your application owns the tracer provider, exporter, sampling, and destination. Effect instrumentation and LiveStore's direct OpenTelemetry spans use the supplied tracer.
 
-Configure a tracer separately in each runtime that should report telemetry,
-including browser workers. The [Cloudflare sync backend](/sync-providers/cloudflare/#server-api-reference)
-uses the optional `otel` setting for either an Effect tracer layer (`otel: tracingLayer`)
-or an OTLP endpoint (`otel: { baseUrl: 'https://collector.example.com' }`).
+Configure a tracer separately in each runtime that should report telemetry, including browser workers. The [Cloudflare sync backend](/sync-providers/cloudflare/#server-api-reference) uses the optional `otel` setting for either an Effect tracer layer (`otel: tracingLayer`) or an OTLP endpoint (`otel: { baseUrl: 'https://collector.example.com' }`).
 
 ## Usage with React
 

--- a/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
+++ b/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
@@ -12,6 +12,17 @@ import WorkerSnippet from '../../_assets/code/reference/opentelemetry/livestore.
 
 LiveStore has built-in support for OpenTelemetry.
 
+Telemetry export is optional. Without an application-provided tracer, the store
+uses a no-op tracer and sends no telemetry. When enabled, your application owns
+the tracer provider, exporter, sampling, and destination. Effect instrumentation
+and LiveStore's direct OpenTelemetry spans use the supplied tracer.
+
+Configure a tracer separately in each runtime that should report telemetry,
+including browser workers. The [Cloudflare sync backend](/sync-providers/cloudflare/#server-api-reference)
+accepts your provider directly as `otel: provider` and flushes in the background
+when it supports `forceFlush()`. This does not
+require Cloudflare's native tracing beta or a paid telemetry feature.
+
 ## Usage with React
 
 <Tabs>

--- a/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
+++ b/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
@@ -19,9 +19,8 @@ and LiveStore's direct OpenTelemetry spans use the supplied tracer.
 
 Configure a tracer separately in each runtime that should report telemetry,
 including browser workers. The [Cloudflare sync backend](/sync-providers/cloudflare/#server-api-reference)
-accepts an optional Effect tracer layer as `otel: layer`. LiveStore builds it per
-sync operation and finalizes its resources in the background. Your application
-chooses the integration and destination; Cloudflare-native tracing is optional.
+uses the optional `otel` setting for either an Effect tracer layer (`otel: tracingLayer`)
+or an OTLP endpoint (`otel: { baseUrl: 'https://collector.example.com' }`).
 
 ## Usage with React
 

--- a/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
+++ b/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
@@ -21,7 +21,8 @@ Configure a tracer separately in each runtime that should report telemetry,
 including browser workers. The [Cloudflare sync backend](/sync-providers/cloudflare/#server-api-reference)
 accepts your provider directly as `otel: provider` and flushes in the background
 when it supports `forceFlush()`. This does not
-require Cloudflare's native tracing beta or a paid telemetry feature.
+require Cloudflare's native tracing beta or a paid telemetry feature. You can also
+supply an Effect tracer layer as `otel: layer`, built and finalized per sync operation.
 
 ## Usage with React
 

--- a/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
+++ b/docs/src/content/docs/building-with-livestore/opentelemetry.mdx
@@ -19,10 +19,9 @@ and LiveStore's direct OpenTelemetry spans use the supplied tracer.
 
 Configure a tracer separately in each runtime that should report telemetry,
 including browser workers. The [Cloudflare sync backend](/sync-providers/cloudflare/#server-api-reference)
-accepts your provider directly as `otel: provider` and flushes in the background
-when it supports `forceFlush()`. This does not
-require Cloudflare's native tracing beta or a paid telemetry feature. You can also
-supply an Effect tracer layer as `otel: layer`, built and finalized per sync operation.
+accepts an optional Effect tracer layer as `otel: layer`. LiveStore builds it per
+sync operation and finalizes its resources in the background. Your application
+chooses the integration and destination; Cloudflare-native tracing is optional.
 
 ## Usage with React
 

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -191,31 +191,22 @@ Creates a sync backend Durable Object class.
 - `onPullRes?` - Callback for pull responses: `(message) => void | Promise<void>`
 - `storage?` - Storage engine: `{ _tag: 'do-sqlite' } | { _tag: 'd1', binding: string }` (default: `do-sqlite`)
 - `enabledTransports?` - Set of enabled transports: `Set<'http' | 'ws' | 'do-rpc'>`
-- `otel?` - Pass your OpenTelemetry provider directly: `otel: provider`.
-  Alternatively, supply an Effect tracer layer as `otel: layer`.
+- `otel?` - Supply an Effect tracer layer: `otel: layer`.
   The existing `{ baseUrl, serviceName? }` OTLP/HTTP JSON exporter is also supported.
 
-Without `otel`, LiveStore creates no telemetry exporter. The provider and endpoint modes work without
-Cloudflare native tracing or managed telemetry export and do not require Workers
-Paid. Your exporter destination and normal Cloudflare resource limits still apply.
+Omit `otel` to avoid creating an exporter or sending telemetry. Your application
+chooses the integration and destination. Cloudflare-native tracing and managed
+export are optional; LiveStore does not require Workers Paid.
 
-Your application owns the provider, exporter, sampling, and authentication.
-LiveStore neither registers a global provider nor shuts yours down. If the
-provider supports `forceFlush()`, LiveStore calls it in the background after
-finite sync work. Export does not delay sync acknowledgments, and flush failures
-do not fail synchronization. Concurrent requests are coalesced per Durable Object.
-LiveStore stops waiting after three seconds; it cannot cancel the provider's own
-I/O. If a slow flush eventually settles, queued work gets a trailing flush.
+LiveStore builds the layer per sync operation and finalizes its resources in the
+background, so exporter cleanup cannot delay sync acknowledgments. Construction
+runs on the operation path. The layer defines exporter setup and cleanup; do not
+attach a shutdown finalizer to a shared provider.
 
-For `otel: layer`, LiveStore builds the layer per sync operation and finalizes its
-resources in the background. Construction runs on the operation path. A layer
-must not attach a shutdown finalizer to a shared application-owned provider.
-Platform-specific tracer packages belong in the application.
-
-Choose an exporter suitable for Durable Objects: persistent timers can prevent
-hibernation, and eviction provides no shutdown hook. Delivery is best-effort.
-The endpoint-based exporter is scoped to completed work so it does not keep an
-idle WebSocket subscription alive just to run export timers.
+Finite pull history closes before the live subscription waits for updates.
+Delivery is best-effort: Durable Objects have no eviction shutdown hook, and
+exporter timers can prevent hibernation. The built-in endpoint exporter uses
+Effect's three-second shutdown timeout.
 
 <SNIPPETS.doSyncBackend />
 

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -191,22 +191,16 @@ Creates a sync backend Durable Object class.
 - `onPullRes?` - Callback for pull responses: `(message) => void | Promise<void>`
 - `storage?` - Storage engine: `{ _tag: 'do-sqlite' } | { _tag: 'd1', binding: string }` (default: `do-sqlite`)
 - `enabledTransports?` - Set of enabled transports: `Set<'http' | 'ws' | 'do-rpc'>`
-- `otel?` - Supply an Effect tracer layer: `otel: layer`.
-  The existing `{ baseUrl, serviceName? }` OTLP/HTTP JSON exporter is also supported.
+- `otel?` - Pass your Effect tracer layer with `otel: tracingLayer`, or use
+  `otel: { baseUrl: 'https://collector.example.com', serviceName: 'sync-cf' }`
+  for the built-in OTLP/HTTP JSON exporter (`serviceName` is optional).
 
-Omit `otel` to avoid creating an exporter or sending telemetry. Your application
-chooses the integration and destination. Cloudflare-native tracing and managed
-export are optional; LiveStore does not require Workers Paid.
+Omit `otel` to disable telemetry export. Your application chooses the tracing
+integration and destination; LiveStore does not require Workers Paid.
 
-LiveStore builds the layer per sync operation and finalizes its resources in the
-background, so exporter cleanup cannot delay sync acknowledgments. Construction
-runs on the operation path. The layer defines exporter setup and cleanup; do not
-attach a shutdown finalizer to a shared provider.
-
-Finite pull history closes before the live subscription waits for updates.
-Delivery is best-effort: Durable Objects have no eviction shutdown hook, and
-exporter timers can prevent hibernation. The built-in endpoint exporter uses
-Effect's three-second shutdown timeout.
+Layers are built per sync operation and cleaned up in the background. Keep setup
+lightweight, and do not shut down a shared tracer provider during cleanup.
+Telemetry delivery is best-effort.
 
 <SNIPPETS.doSyncBackend />
 

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -191,9 +191,25 @@ Creates a sync backend Durable Object class.
 - `onPullRes?` - Callback for pull responses: `(message) => void | Promise<void>`
 - `storage?` - Storage engine: `{ _tag: 'do-sqlite' } | { _tag: 'd1', binding: string }` (default: `do-sqlite`)
 - `enabledTransports?` - Set of enabled transports: `Set<'http' | 'ws' | 'do-rpc'>`
-- `otel?` - OpenTelemetry configuration:
-  - `baseUrl?` - OTEL endpoint URL
-  - `serviceName?` - Service name for traces
+- `otel?` - Pass your OpenTelemetry provider directly: `otel: provider`.
+  The existing `{ baseUrl, serviceName? }` OTLP/HTTP JSON exporter is also supported.
+
+Without `otel`, LiveStore creates no telemetry exporter. Both modes work without
+Cloudflare native tracing or managed telemetry export and do not require Workers
+Paid. Your exporter destination and normal Cloudflare resource limits still apply.
+
+Your application owns the provider, exporter, sampling, and authentication.
+LiveStore neither registers a global provider nor shuts yours down. If the
+provider supports `forceFlush()`, LiveStore calls it in the background after
+finite sync work. Export does not delay sync acknowledgments, and flush failures
+do not fail synchronization. Concurrent requests are coalesced per Durable Object.
+LiveStore stops waiting after three seconds; it cannot cancel the provider's own
+I/O. If a slow flush eventually settles, queued work gets a trailing flush.
+
+Choose an exporter suitable for Durable Objects: persistent timers can prevent
+hibernation, and eviction provides no shutdown hook. Delivery is best-effort.
+The endpoint-based exporter is scoped to completed work so it does not keep an
+idle WebSocket subscription alive just to run export timers.
 
 <SNIPPETS.doSyncBackend />
 

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -191,16 +191,11 @@ Creates a sync backend Durable Object class.
 - `onPullRes?` - Callback for pull responses: `(message) => void | Promise<void>`
 - `storage?` - Storage engine: `{ _tag: 'do-sqlite' } | { _tag: 'd1', binding: string }` (default: `do-sqlite`)
 - `enabledTransports?` - Set of enabled transports: `Set<'http' | 'ws' | 'do-rpc'>`
-- `otel?` - Pass your Effect tracer layer with `otel: tracingLayer`, or use
-  `otel: { baseUrl: 'https://collector.example.com', serviceName: 'sync-cf' }`
-  for the built-in OTLP/HTTP JSON exporter (`serviceName` is optional).
+- `otel?` - Pass your Effect tracer layer with `otel: tracingLayer`, or use `otel: { baseUrl: 'https://collector.example.com', serviceName: 'sync-cf' }` for the built-in OTLP/HTTP JSON exporter (`serviceName` is optional).
 
-Omit `otel` to disable telemetry export. Your application chooses the tracing
-integration and destination; LiveStore does not require Workers Paid.
+Omit `otel` to disable telemetry export. Your application chooses the tracing integration and destination; LiveStore does not require Workers Paid.
 
-Layers are built per sync operation and cleaned up in the background. Keep setup
-lightweight, and do not shut down a shared tracer provider during cleanup.
-Telemetry delivery is best-effort.
+Layers are built per sync operation and cleaned up in the background. Keep setup lightweight, and do not shut down a shared tracer provider during cleanup. Telemetry delivery is best-effort.
 
 <SNIPPETS.doSyncBackend />
 

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -192,9 +192,10 @@ Creates a sync backend Durable Object class.
 - `storage?` - Storage engine: `{ _tag: 'do-sqlite' } | { _tag: 'd1', binding: string }` (default: `do-sqlite`)
 - `enabledTransports?` - Set of enabled transports: `Set<'http' | 'ws' | 'do-rpc'>`
 - `otel?` - Pass your OpenTelemetry provider directly: `otel: provider`.
+  Alternatively, supply an Effect tracer layer as `otel: layer`.
   The existing `{ baseUrl, serviceName? }` OTLP/HTTP JSON exporter is also supported.
 
-Without `otel`, LiveStore creates no telemetry exporter. Both modes work without
+Without `otel`, LiveStore creates no telemetry exporter. The provider and endpoint modes work without
 Cloudflare native tracing or managed telemetry export and do not require Workers
 Paid. Your exporter destination and normal Cloudflare resource limits still apply.
 
@@ -205,6 +206,11 @@ finite sync work. Export does not delay sync acknowledgments, and flush failures
 do not fail synchronization. Concurrent requests are coalesced per Durable Object.
 LiveStore stops waiting after three seconds; it cannot cancel the provider's own
 I/O. If a slow flush eventually settles, queued work gets a trailing flush.
+
+For `otel: layer`, LiveStore builds the layer per sync operation and finalizes its
+resources in the background. Construction runs on the operation path. A layer
+must not attach a shutdown finalizer to a shared application-owned provider.
+Platform-specific tracer packages belong in the application.
 
 Choose an exporter suitable for Durable Objects: persistent timers can prevent
 hibernation, and eviction provides no shutdown hook. Delivery is best-effort.

--- a/docs/src/content/docs/sync-providers/cloudflare.mdx
+++ b/docs/src/content/docs/sync-providers/cloudflare.mdx
@@ -197,6 +197,8 @@ Omit `otel` to disable telemetry export. Your application chooses the tracing in
 
 Layers are built per sync operation and cleaned up in the background. Keep setup lightweight, and do not shut down a shared tracer provider during cleanup. Telemetry delivery is best-effort.
 
+Sampled client RPC context is preserved. When the client has no sampled context, backend spans start a new trace so server telemetry remains independently observable. Expected sync-recovery responses remain typed errors without marking the RPC boundary as a tracing error.
+
 <SNIPPETS.doSyncBackend />
 
 ### `makeWorker(options)`

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -4,17 +4,7 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { type CfTypes, setupDurableObjectWebSocketRpc } from '@livestore/common-cf'
 import { CfDeclare } from '@livestore/common-cf/declare'
-import {
-  Effect,
-  FetchHttpClient,
-  Layer,
-  Logger,
-  Otlp,
-  References,
-  RpcMessage,
-  Schema,
-  type Scope,
-} from '@livestore/utils/effect'
+import { Effect, Layer, Logger, References, RpcMessage, Schema, type Scope } from '@livestore/utils/effect'
 
 import {
   type Env,
@@ -25,6 +15,7 @@ import {
   WebSocketAttachmentSchema,
 } from '../shared.ts'
 import * as DoCtx from './layer.ts'
+import { makeObservability } from './observability.ts'
 import { createDoRpcHandler } from './transport/do-rpc-server.ts'
 import { createHttpRpcHandler } from './transport/http-rpc-server.ts'
 import { makeRpcServer } from './transport/ws-rpc-server.ts'
@@ -88,24 +79,18 @@ export type MakeDurableObjectClass = (options?: MakeDurableObjectClassOptions) =
 export const makeDurableObject: MakeDurableObjectClass = (options) => {
   const enabledTransports = options?.enabledTransports ?? new Set(['http', 'ws', 'do-rpc'])
 
-  const Observability: Layer.Layer<never> =
-    options?.otel?.baseUrl !== undefined
-      ? Otlp.layerJson({
-          baseUrl: options.otel.baseUrl,
-          tracerExportInterval: 50,
-          resource: {
-            serviceName: options.otel.serviceName ?? 'sync-cf-do',
-          },
-        }).pipe(Layer.provide(FetchHttpClient.layer))
-      : Layer.empty
-
   return class SyncBackendDOBase extends DurableObjectBase implements SyncBackendRpcInterface {
     __DURABLE_OBJECT_BRAND = 'SyncBackendDOBase' as never
+    private readonly observability = makeObservability(options?.otel)
 
     constructor(ctx: CfTypes.DurableObjectState, env: Env) {
       super(ctx, env)
 
-      const WebSocketRpcServerLive = makeRpcServer({ doSelf: this, doOptions: options })
+      const WebSocketRpcServerLive = makeRpcServer({
+        doSelf: this,
+        doOptions: options,
+        observability: this.observability,
+      })
 
       // This registers the `webSocketMessage` and `webSocketClose` handlers
       if (enabledTransports.has('ws') === true) {
@@ -139,7 +124,6 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
               // TODO also emit `Exit` stream RPC message
             }
           },
-          mainLayer: Observability,
         })
       }
     }
@@ -219,10 +203,11 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
         throw new Error('Do RPC transport is not enabled (based on `options.enabledTransports`)')
       }
 
-      return createDoRpcHandler({ payload, input: { doSelf: this, doOptions: options } }).pipe(
-        Effect.withSpan('@livestore/sync-cf:durable-object:rpc'),
-        this.runEffectAsPromise,
-      )
+      return createDoRpcHandler({
+        payload,
+        input: { doSelf: this, doOptions: options },
+        observability: this.observability,
+      }).pipe(Effect.withSpan('@livestore/sync-cf:durable-object:rpc'), this.runEffectAsPromise)
     }
 
     /**
@@ -242,13 +227,10 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
         Effect.tapCauseLogPretty,
         Effect.annotateLogs({ thread: 'SyncDo' }),
         Effect.provide(
-          Layer.mergeAll(
-            Observability,
-            Logger.layer([Logger.consoleStructured]),
-            Layer.succeed(References.MinimumLogLevel, 'Debug'),
-          ),
+          Layer.mergeAll(Logger.layer([Logger.consoleStructured]), Layer.succeed(References.MinimumLogLevel, 'Debug')),
         ),
         Effect.scoped,
+        this.observability.effect,
         Effect.runPromise,
       )
   }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
@@ -1,20 +1,51 @@
-import { ROOT_CONTEXT, trace } from '@opentelemetry/api'
+import { ROOT_CONTEXT, type SpanStatus, SpanStatusCode, trace } from '@opentelemetry/api'
 
+import { BackendIdMismatchError, UnknownError } from '@livestore/common'
+import { type CfTypes, layerProtocolDurableObject, WsContext } from '@livestore/common-cf'
 import { makeNoopSpan, makeNoopTracer } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Deferred, Effect, Fiber, Layer, OtelTracer, Stream, TestClock, Tracer } from '@livestore/utils/effect'
+import {
+  Deferred,
+  Effect,
+  FetchHttpClient,
+  Fiber,
+  Layer,
+  Option,
+  OtelTracer,
+  RpcClient,
+  RpcTest,
+  Schema,
+  Stream,
+  TestClock,
+  Tracer,
+} from '@livestore/utils/effect'
 
-import { makeObservability, rpcSpanOptions } from './observability.ts'
+import { SyncDoRpc } from '../../common/do-rpc-schema.ts'
+import { SyncWsRpc } from '../../common/ws-rpc-schema.ts'
+import { WebSocketAttachmentSchema } from '../shared.ts'
+import type * as DoCtx from './layer.ts'
+import { makeObservability, rpcSpanOptions, withRpcSpan, withRpcStreamSpan } from './observability.ts'
+import { createDoRpcHandler } from './transport/do-rpc-server.ts'
+import { makeRpcHandlers } from './transport/ws-rpc-server.ts'
 
 Vitest.describe('sync-cf telemetry ownership', () => {
   Vitest.afterEach(() => Vitest.vi.restoreAllMocks())
 
   Vitest.effect('runs sync effects and streams without exporting when telemetry is omitted', () =>
     Effect.gen(function* () {
-      const fetch = Vitest.vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}'))
+      const fetch: typeof globalThis.fetch = Vitest.vi.fn(async () => new Response('{}'))
       const observability = makeObservability(undefined)
-      const result = yield* Effect.succeed('ack').pipe(Effect.withSpan('push'), observability.effect)
-      const history = yield* Stream.make('event').pipe(Stream.withSpan('pull'), observability.stream, Stream.runCollect)
+      const result = yield* Effect.succeed('ack').pipe(
+        Effect.withSpan('push'),
+        observability.effect,
+        Effect.provideService(FetchHttpClient.Fetch, fetch),
+      )
+      const history = yield* Stream.make('event').pipe(
+        Stream.withSpan('pull'),
+        observability.stream,
+        Stream.runCollect,
+        Effect.provideService(FetchHttpClient.Fetch, fetch),
+      )
 
       yield* TestClock.adjust('4 seconds')
       Vitest.expect(result).toBe('ack')
@@ -98,13 +129,63 @@ Vitest.describe('sync-cf telemetry ownership', () => {
     }),
   )
 
-  Vitest.live('attaches a finite span to the caller across an unexported RPC envelope', () =>
+  Vitest.effect('ends WebSocket telemetry before the production handler enters its live tail', () =>
+    Effect.gen(function* () {
+      const { layer, ended } = makeRecordingTracer()
+      const finalized = yield* Deferred.make<void>()
+      const observability = makeObservability(
+        Layer.mergeAll(layer, Layer.effectDiscard(Effect.addFinalizer(() => Deferred.succeed(finalized, undefined)))),
+      )
+      const input = makeDoInput()
+      const handlers = makeRpcHandlers({ ...input, observability }).pipe(
+        Layer.provide(Layer.succeed(WsContext, WsContext.of({ ws: makeWebSocket() }))),
+      )
+      const client = yield* RpcTest.makeClient(SyncWsRpc).pipe(Effect.provide(handlers))
+      const pullFiber = yield* client['SyncWsRpc.Pull']({
+        storeId: 'store',
+        cursor: Option.none(),
+        live: true,
+      }).pipe(Stream.runDrain, Effect.forkChild)
+      yield* Effect.addFinalizer(() => Fiber.interrupt(pullFiber))
+
+      yield* Deferred.await(finalized).pipe(Effect.timeout('1 second'))
+      Vitest.expect(ended).toContain('RpcServer.SyncWsRpc.Pull')
+      Vitest.expect(pullFiber.pollUnsafe()).toBeUndefined()
+    }),
+  )
+
+  Vitest.effect('installs telemetry inside the Durable Object RPC stream runtime', () =>
+    Effect.gen(function* () {
+      const { layer, ended } = makeRecordingTracer()
+      const observability = makeObservability(layer)
+      const input = makeDoInput()
+      const protocol = layerProtocolDurableObject({
+        callerContext: { bindingName: 'TEST', durableObjectId: 'client' },
+        callRpc: (payload) =>
+          createDoRpcHandler({
+            // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- Effect RPC owns this ArrayBuffer-backed payload.
+            payload: payload as Uint8Array<ArrayBuffer>,
+            input,
+            observability,
+          }).pipe(Effect.runPromise),
+      })
+      const responses = yield* Effect.gen(function* () {
+        const client = yield* RpcClient.make(SyncDoRpc)
+        return yield* client['SyncDoRpc.Pull']({ storeId: 'store', cursor: Option.none() }).pipe(Stream.runCollect)
+      }).pipe(Effect.provide(protocol))
+
+      Vitest.expect(responses).toHaveLength(1)
+      Vitest.expect(ended).toContain('RpcServer.SyncDoRpc.Pull')
+    }),
+  )
+
+  Vitest.effect('attaches a finite span to a sampled caller across an unexported RPC envelope', () =>
     Effect.gen(function* () {
       const { layer, spans, ended } = makeRecordingTracer()
       const observability = makeObservability(layer)
       const caller = Tracer.externalSpan({ traceId: '1'.repeat(32), spanId: '2222222222222222', sampled: true })
       yield* Effect.flatMap(rpcSpanOptions, (options) =>
-        Effect.void.pipe(Effect.withSpan('push'), Effect.withSpan('finite-rpc', options)),
+        withRpcSpan(Effect.void.pipe(Effect.withSpan('push')), 'finite-rpc', options),
       ).pipe(observability.effect, Effect.withSpan('unexported-rpc-envelope'), Effect.withParentSpan(caller))
 
       Vitest.expect(spans.get('finite-rpc')?.parentId).toBe(caller.spanId)
@@ -113,12 +194,76 @@ Vitest.describe('sync-cf telemetry ownership', () => {
     }),
   )
 
+  Vitest.effect('starts a backend root when the RPC caller is unsampled', () =>
+    Effect.gen(function* () {
+      const { layer, spans, ended } = makeRecordingTracer()
+      const observability = makeObservability(layer)
+      const caller = Tracer.externalSpan({ traceId: '1'.repeat(32), spanId: '2222222222222222', sampled: false })
+      yield* Effect.flatMap(rpcSpanOptions, (options) => withRpcSpan(Effect.void, 'finite-rpc', options)).pipe(
+        observability.effect,
+        Effect.withSpan('unexported-rpc-envelope'),
+        Effect.withParentSpan(caller),
+      )
+
+      Vitest.expect(spans.get('finite-rpc')?.parentId).toBeUndefined()
+      Vitest.expect(ended).toEqual(['finite-rpc'])
+    }),
+  )
+
+  Vitest.effect('keeps anticipated RPC recovery failures out of boundary error telemetry', () =>
+    Effect.gen(function* () {
+      const { layer, statuses } = makeRecordingTracer()
+      const observability = makeObservability(layer)
+      const expected = new BackendIdMismatchError({ expected: 'backend-a', received: 'backend-b' })
+      const unexpected = new UnknownError({ cause: new Error('boom') })
+
+      const effectError = yield* withRpcSpan(Effect.fail(expected), 'expected-effect').pipe(
+        observability.effect,
+        Effect.flip,
+      )
+      const streamError = yield* Stream.fail(expected).pipe(
+        (_) => withRpcStreamSpan(_, 'expected-stream'),
+        observability.stream,
+        Stream.runDrain,
+        Effect.flip,
+      )
+      const unexpectedError = yield* withRpcSpan(Effect.fail(unexpected), 'unexpected-effect').pipe(
+        observability.effect,
+        Effect.flip,
+      )
+
+      Vitest.expect(effectError).toBe(expected)
+      Vitest.expect(streamError).toBe(expected)
+      Vitest.expect(unexpectedError).toBe(unexpected)
+      Vitest.expect(statuses.get('expected-effect')).toBe(SpanStatusCode.OK)
+      Vitest.expect(statuses.get('expected-stream')).toBe(SpanStatusCode.OK)
+      Vitest.expect(statuses.get('unexpected-effect')).toBe(SpanStatusCode.ERROR)
+    }),
+  )
+
+  Vitest.effect('forwards the operation exit to supplied layer finalizers', () =>
+    Effect.gen(function* () {
+      const released = yield* Deferred.make<string>()
+      const expected = new BackendIdMismatchError({ expected: 'backend-a', received: 'backend-b' })
+      const observability = makeObservability(
+        Layer.effectDiscard(
+          Effect.acquireRelease(Effect.void, (_, exit) => Deferred.succeed(released, exit._tag).pipe(Effect.asVoid)),
+        ),
+      )
+
+      const error = yield* Effect.fail(expected).pipe(observability.effect, Effect.flip)
+
+      Vitest.expect(error).toBe(expected)
+      Vitest.expect(yield* Deferred.await(released)).toBe('Failure')
+    }),
+  )
+
   Vitest.live('acknowledges before the owned OTLP collector responds', () =>
     Effect.gen(function* () {
       const started = Promise.withResolvers<void>()
       const gate = Promise.withResolvers<void>()
       const acknowledged = yield* Deferred.make<void>()
-      Vitest.vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      const fetch: typeof globalThis.fetch = Vitest.vi.fn(() => {
         started.resolve()
         return gate.promise.then(() => new Response('{}', { headers: { 'content-type': 'application/json' } }))
       })
@@ -128,6 +273,7 @@ Vitest.describe('sync-cf telemetry ownership', () => {
         Effect.withSpan('push'),
         observability.effect,
         Effect.andThen(Deferred.succeed(acknowledged, undefined)),
+        Effect.provideService(FetchHttpClient.Fetch, fetch),
         Effect.forkChild,
       )
       yield* Effect.promise(() => started.promise)
@@ -141,19 +287,51 @@ Vitest.describe('sync-cf telemetry ownership', () => {
 const makeRecordingTracer = () => {
   const tracer = makeNoopTracer()
   const ended: string[] = []
+  const statuses = new Map<string, SpanStatusCode>()
   const spans = new Map<string, { spanId: string; parentId: string | undefined }>()
   let nextId = 0
   Vitest.vi.spyOn(tracer, 'startSpan').mockImplementation((name, _options, context) => {
     const spanId = (++nextId).toString(16).padStart(16, '0')
     spans.set(name, { spanId, parentId: trace.getSpanContext(context ?? ROOT_CONTEXT)?.spanId })
+    const noopSpan = makeNoopSpan()
     return {
-      ...makeNoopSpan(),
+      ...noopSpan,
       spanContext: () => ({ traceId: '1'.repeat(32), spanId, traceFlags: 1 }),
+      setStatus: (status: SpanStatus) => {
+        statuses.set(name, status.code)
+        return noopSpan
+      },
       end: () => {
         ended.push(name)
       },
     }
   })
   const layer = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provide(Layer.succeed(OtelTracer.OtelTracer, tracer)))
-  return { layer, ended, spans }
+  return { layer, ended, spans, statuses }
+}
+
+/** Minimal empty SQLite-backed Durable Object boundary for transport composition tests. */
+const makeDoInput = (): Omit<DoCtx.DoCtxInput, 'from'> => {
+  const emptyCursor = Object.assign([], { toArray: () => [] })
+  const doSelf = {
+    env: {},
+    ctx: {
+      storage: {
+        sql: { exec: () => emptyCursor },
+        kv: { get: () => undefined, put: () => undefined, delete: () => undefined },
+        deleteAll: async () => undefined,
+      },
+    },
+  }
+
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- The test intentionally stubs the narrow Worker APIs reached by an empty pull.
+  return { doSelf: doSelf as unknown as DoCtx.DoCtxInput['doSelf'], doOptions: undefined }
+}
+
+const makeWebSocket = (): CfTypes.WebSocket => {
+  const attachment = Schema.encodeSync(WebSocketAttachmentSchema)({ storeId: 'store', pullRequestIds: [] })
+  const ws = { deserializeAttachment: () => attachment, close: Vitest.vi.fn() }
+
+  // oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- The handler only reads the attachment and closes invalid sockets.
+  return ws as unknown as CfTypes.WebSocket
 }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
@@ -2,7 +2,7 @@ import { ROOT_CONTEXT, trace } from '@opentelemetry/api'
 
 import { makeNoopSpan, makeNoopTracer } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Deferred, Effect, Fiber, Stream, TestClock, Tracer } from '@livestore/utils/effect'
+import { Deferred, Effect, Fiber, Layer, Stream, TestClock, Tracer } from '@livestore/utils/effect'
 
 import { makeObservability, rpcSpanOptions } from './observability.ts'
 
@@ -20,6 +20,59 @@ Vitest.describe('sync-cf telemetry ownership', () => {
       Vitest.expect(result).toBe('ack')
       Vitest.expect(history).toEqual(['event'])
       Vitest.expect(fetch).not.toHaveBeenCalled()
+    }),
+  )
+
+  Vitest.effect('builds and finalizes a supplied layer independently for overlapping operations', () =>
+    Effect.gen(function* () {
+      const firstStarted = yield* Deferred.make<void>()
+      const secondStarted = yield* Deferred.make<void>()
+      const firstGate = yield* Deferred.make<void>()
+      const secondGate = yield* Deferred.make<void>()
+      const firstReleased = yield* Deferred.make<void>()
+      const secondReleased = yield* Deferred.make<void>()
+      const builds: string[] = []
+      const releases: string[] = []
+      const layer = Layer.effectDiscard(
+        Effect.acquireRelease(
+          Effect.currentSpan.pipe(
+            Effect.orDie,
+            Effect.tap((span) => Effect.sync(() => builds.push(span.name))),
+          ),
+          (span) =>
+            Effect.sync(() => releases.push(span.name)).pipe(
+              Effect.andThen(Deferred.succeed(span.name === 'first' ? firstReleased : secondReleased, undefined)),
+            ),
+        ),
+      )
+      const observability = makeObservability(layer)
+      const first = yield* Deferred.succeed(firstStarted, undefined).pipe(
+        Effect.andThen(Deferred.await(firstGate)),
+        observability.effect,
+        Effect.withSpan('first'),
+        Effect.forkChild,
+      )
+      yield* Deferred.await(firstStarted)
+      const second = yield* Deferred.succeed(secondStarted, undefined).pipe(
+        Effect.andThen(Deferred.await(secondGate)),
+        observability.effect,
+        Effect.withSpan('second'),
+        Effect.forkChild,
+      )
+      yield* Deferred.await(secondStarted)
+      Vitest.expect(builds).toEqual(['first', 'second'])
+      Vitest.expect(releases).toEqual([])
+
+      yield* Deferred.succeed(firstGate, undefined)
+      yield* Fiber.join(first)
+      yield* Deferred.await(firstReleased)
+      Vitest.expect(releases).toEqual(['first'])
+      Vitest.expect(second.pollUnsafe()).toBeUndefined()
+
+      yield* Deferred.succeed(secondGate, undefined)
+      yield* Fiber.join(second)
+      yield* Deferred.await(secondReleased)
+      Vitest.expect(releases).toEqual(['first', 'second'])
     }),
   )
 
@@ -46,45 +99,50 @@ Vitest.describe('sync-cf telemetry ownership', () => {
     }),
   )
 
-  Vitest.effect('acknowledges during a blocked export and drains later spans even after the wait times out', () =>
-    Effect.gen(function* () {
-      const { tracer, ended } = makeRecordingTracer()
-      // These promises model the SDK boundary. Test coordination and time remain under Effect.
-      const gate = Promise.withResolvers<void>()
-      const started = Promise.withResolvers<void>()
-      const trailingFlush = Promise.withResolvers<ReadonlyArray<string>>()
-      const acknowledged = yield* Deferred.make<void>()
-      let calls = 0
-      const forceFlush = () => {
-        calls++
-        if (calls === 1) {
-          started.resolve()
-          return gate.promise
+  Vitest.effect.each(['resolve', 'reject'] as const)(
+    'drains queued spans when a timed-out flush later settles: %s',
+    (mode) =>
+      Effect.gen(function* () {
+        const { tracer, ended } = makeRecordingTracer()
+        // These promises model the SDK boundary. Test coordination and time remain under Effect.
+        const gate = Promise.withResolvers<void>()
+        const started = Promise.withResolvers<void>()
+        const trailingFlush = Promise.withResolvers<ReadonlyArray<string>>()
+        const acknowledged = yield* Deferred.make<void>()
+        let calls = 0
+        const forceFlush = () => {
+          calls++
+          if (calls === 1) {
+            started.resolve()
+            return gate.promise
+          }
+          trailingFlush.resolve([...ended])
+          return Promise.resolve()
         }
-        trailingFlush.resolve([...ended])
-        return Promise.resolve()
-      }
-      yield* Effect.addFinalizer(() => Effect.sync(() => gate.resolve()))
-      const observability = makeObservability({ getTracer: () => tracer, forceFlush })
-      yield* Effect.void.pipe(
-        Effect.withSpan('first push'),
-        observability.effect,
-        Effect.andThen(Deferred.succeed(acknowledged, undefined)),
-        Effect.forkChild,
-      )
-      yield* Effect.promise(() => started.promise)
-      yield* Effect.yieldNow
-      Vitest.expect(yield* Deferred.isDone(acknowledged)).toBe(true)
+        yield* Effect.addFinalizer(() => Effect.sync(() => gate.resolve()))
+        const observability = makeObservability({ getTracer: () => tracer, forceFlush })
+        yield* Effect.void.pipe(
+          Effect.withSpan('first push'),
+          observability.effect,
+          Effect.andThen(Deferred.succeed(acknowledged, undefined)),
+          Effect.forkChild,
+        )
+        yield* Effect.promise(() => started.promise)
+        yield* Effect.yieldNow
+        Vitest.expect(yield* Deferred.isDone(acknowledged)).toBe(true)
 
-      // Advance the actual Effect timeout, not Date.now or wall-clock sleeps.
-      yield* TestClock.adjust('4 seconds')
-      yield* Effect.void.pipe(Effect.withSpan('second push'), observability.effect)
-      yield* TestClock.adjust(1)
-      Vitest.expect(calls).toBe(1)
+        // Advance the actual Effect timeout, not Date.now or wall-clock sleeps.
+        yield* TestClock.adjust('4 seconds')
+        yield* Effect.void.pipe(Effect.withSpan('second push'), observability.effect)
+        yield* TestClock.adjust(1)
+        Vitest.expect(calls).toBe(1)
 
-      gate.resolve()
-      Vitest.expect(yield* Effect.promise(() => trailingFlush.promise)).toEqual(['first push', 'second push'])
-    }),
+        if (mode === 'reject') gate.reject(new Error('collector unavailable'))
+        else gate.resolve()
+        Vitest.expect(yield* Effect.promise(() => trailingFlush.promise)).toEqual(['first push', 'second push'])
+        yield* TestClock.adjust('4 seconds')
+        Vitest.expect(calls).toBe(2)
+      }),
   )
 
   Vitest.live.each(['reject', 'throw'] as const)('preserves sync results and recovers after a flush %s', (mode) =>

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
@@ -1,0 +1,198 @@
+import { ROOT_CONTEXT, trace } from '@opentelemetry/api'
+
+import { makeNoopSpan, makeNoopTracer } from '@livestore/utils'
+import { Vitest } from '@livestore/utils-dev/node-vitest'
+import { Deferred, Effect, Fiber, Stream, TestClock, Tracer } from '@livestore/utils/effect'
+
+import { makeObservability, rpcSpanOptions } from './observability.ts'
+
+Vitest.describe('sync-cf telemetry ownership', () => {
+  Vitest.afterEach(() => Vitest.vi.restoreAllMocks())
+
+  Vitest.effect('runs sync effects and streams without exporting when telemetry is omitted', () =>
+    Effect.gen(function* () {
+      const fetch = Vitest.vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}'))
+      const observability = makeObservability(undefined)
+      const result = yield* Effect.succeed('ack').pipe(Effect.withSpan('push'), observability.effect)
+      const history = yield* Stream.make('event').pipe(Stream.withSpan('pull'), observability.stream, Stream.runCollect)
+
+      yield* TestClock.adjust('4 seconds')
+      Vitest.expect(result).toBe('ack')
+      Vitest.expect(history).toEqual(['event'])
+      Vitest.expect(fetch).not.toHaveBeenCalled()
+    }),
+  )
+
+  Vitest.live('exports through the supplied provider after spans end without taking provider ownership', () =>
+    Effect.gen(function* () {
+      const { tracer, spans, ended } = makeRecordingTracer()
+      const register = Vitest.vi.spyOn(trace, 'setGlobalTracerProvider')
+      const flushed = Promise.withResolvers<ReadonlyArray<string>>()
+      const provider = {
+        getTracer: () => tracer,
+        forceFlush: () => {
+          flushed.resolve([...ended])
+          return Promise.resolve()
+        },
+        shutdown: Vitest.vi.fn(),
+      }
+      const observability = makeObservability(provider)
+      yield* Effect.void.pipe(Effect.withSpan('child'), Effect.withSpan('parent'), observability.effect)
+
+      Vitest.expect(yield* Effect.promise(() => flushed.promise)).toEqual(['child', 'parent'])
+      Vitest.expect(spans.get('child')?.parentId).toBe(spans.get('parent')?.spanId)
+      Vitest.expect(register).not.toHaveBeenCalled()
+      Vitest.expect(provider.shutdown).not.toHaveBeenCalled()
+    }),
+  )
+
+  Vitest.effect('acknowledges during a blocked export and drains later spans even after the wait times out', () =>
+    Effect.gen(function* () {
+      const { tracer, ended } = makeRecordingTracer()
+      // These promises model the SDK boundary. Test coordination and time remain under Effect.
+      const gate = Promise.withResolvers<void>()
+      const started = Promise.withResolvers<void>()
+      const trailingFlush = Promise.withResolvers<ReadonlyArray<string>>()
+      const acknowledged = yield* Deferred.make<void>()
+      let calls = 0
+      const forceFlush = () => {
+        calls++
+        if (calls === 1) {
+          started.resolve()
+          return gate.promise
+        }
+        trailingFlush.resolve([...ended])
+        return Promise.resolve()
+      }
+      yield* Effect.addFinalizer(() => Effect.sync(() => gate.resolve()))
+      const observability = makeObservability({ getTracer: () => tracer, forceFlush })
+      yield* Effect.void.pipe(
+        Effect.withSpan('first push'),
+        observability.effect,
+        Effect.andThen(Deferred.succeed(acknowledged, undefined)),
+        Effect.forkChild,
+      )
+      yield* Effect.promise(() => started.promise)
+      yield* Effect.yieldNow
+      Vitest.expect(yield* Deferred.isDone(acknowledged)).toBe(true)
+
+      // Advance the actual Effect timeout, not Date.now or wall-clock sleeps.
+      yield* TestClock.adjust('4 seconds')
+      yield* Effect.void.pipe(Effect.withSpan('second push'), observability.effect)
+      yield* TestClock.adjust(1)
+      Vitest.expect(calls).toBe(1)
+
+      gate.resolve()
+      Vitest.expect(yield* Effect.promise(() => trailingFlush.promise)).toEqual(['first push', 'second push'])
+    }),
+  )
+
+  Vitest.live.each(['reject', 'throw'] as const)('preserves sync results and recovers after a flush %s', (mode) =>
+    Effect.gen(function* () {
+      const failed = Promise.withResolvers<void>()
+      const recovered = Promise.withResolvers<void>()
+      let calls = 0
+      const forceFlush = () => {
+        calls++
+        if (calls === 1) {
+          failed.resolve()
+          if (mode === 'throw') throw new Error('collector unavailable')
+          return Promise.reject(new Error('collector unavailable'))
+        }
+        recovered.resolve()
+        return Promise.resolve()
+      }
+      const observability = makeObservability({ getTracer: () => makeNoopTracer(), forceFlush })
+      Vitest.expect(yield* Effect.succeed('ack').pipe(observability.effect)).toBe('ack')
+      yield* Effect.promise(() => failed.promise)
+      yield* Effect.yieldNow
+      Vitest.expect(yield* Effect.fail('sync failed').pipe(observability.effect, Effect.flip)).toBe('sync failed')
+      yield* Effect.promise(() => recovered.promise)
+      Vitest.expect(calls).toBe(2)
+    }),
+  )
+
+  Vitest.live('exports finite history while the live subscription is still open', () =>
+    Effect.gen(function* () {
+      const { tracer, ended } = makeRecordingTracer()
+      const flushed = Promise.withResolvers<ReadonlyArray<string>>()
+      const live = yield* Deferred.make<void>()
+      const observability = makeObservability({
+        getTracer: () => tracer,
+        forceFlush: () => {
+          flushed.resolve([...ended])
+          return Promise.resolve()
+        },
+      })
+      const fiber = yield* Stream.make('history').pipe(
+        Stream.withSpan('pull-history'),
+        observability.stream,
+        Stream.concat(Stream.fromEffect(Deferred.succeed(live, undefined)).pipe(Stream.concat(Stream.never))),
+        Stream.runDrain,
+        Effect.forkChild,
+      )
+      yield* Effect.addFinalizer(() => Fiber.interrupt(fiber))
+      yield* Deferred.await(live)
+      Vitest.expect(yield* Effect.promise(() => flushed.promise)).toContain('pull-history')
+      Vitest.expect(fiber.pollUnsafe()).toBeUndefined()
+    }),
+  )
+
+  Vitest.live('attaches a finite span to the caller across an unexported RPC envelope', () =>
+    Effect.gen(function* () {
+      const { tracer, spans, ended } = makeRecordingTracer()
+      const observability = makeObservability({ getTracer: () => tracer })
+      const caller = Tracer.externalSpan({ traceId: '1'.repeat(32), spanId: '2222222222222222', sampled: true })
+      yield* Effect.flatMap(rpcSpanOptions, (options) =>
+        Effect.void.pipe(Effect.withSpan('push'), Effect.withSpan('finite-rpc', options)),
+      ).pipe(observability.effect, Effect.withSpan('unexported-rpc-envelope'), Effect.withParentSpan(caller))
+
+      Vitest.expect(spans.get('finite-rpc')?.parentId).toBe(caller.spanId)
+      Vitest.expect(spans.get('push')?.parentId).toBe(spans.get('finite-rpc')?.spanId)
+      Vitest.expect(ended).toEqual(['push', 'finite-rpc'])
+    }),
+  )
+
+  Vitest.live('acknowledges before the owned OTLP collector responds', () =>
+    Effect.gen(function* () {
+      const started = Promise.withResolvers<void>()
+      const gate = Promise.withResolvers<void>()
+      const acknowledged = yield* Deferred.make<void>()
+      Vitest.vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+        started.resolve()
+        return gate.promise.then(() => new Response('{}', { headers: { 'content-type': 'application/json' } }))
+      })
+      yield* Effect.addFinalizer(() => Effect.sync(() => gate.resolve()))
+      const observability = makeObservability({ baseUrl: 'http://collector.invalid' })
+      yield* Effect.void.pipe(
+        Effect.withSpan('push'),
+        observability.effect,
+        Effect.andThen(Deferred.succeed(acknowledged, undefined)),
+        Effect.forkChild,
+      )
+      yield* Effect.promise(() => started.promise)
+      yield* Effect.yieldNow
+      Vitest.expect(yield* Deferred.isDone(acknowledged)).toBe(true)
+    }),
+  )
+})
+
+/** Record the public OTel boundary; span IDs are compared relationally, not fixed to creation order. */
+const makeRecordingTracer = () => {
+  const tracer = makeNoopTracer()
+  const ended: string[] = []
+  const spans = new Map<string, { spanId: string; parentId: string | undefined }>()
+  let nextId = 0
+  Vitest.vi.spyOn(tracer, 'startSpan').mockImplementation((name, _options, context) => {
+    const spanId = (++nextId).toString(16).padStart(16, '0')
+    spans.set(name, { spanId, parentId: trace.getSpanContext(context ?? ROOT_CONTEXT)?.spanId })
+    return {
+      ...makeNoopSpan(),
+      spanContext: () => ({ traceId: '1'.repeat(32), spanId, traceFlags: 1 }),
+      end: () => {
+        ended.push(name)
+      },
+    }
+  })
+  return { tracer, ended, spans }
+}

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.test.ts
@@ -2,7 +2,7 @@ import { ROOT_CONTEXT, trace } from '@opentelemetry/api'
 
 import { makeNoopSpan, makeNoopTracer } from '@livestore/utils'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { Deferred, Effect, Fiber, Layer, Stream, TestClock, Tracer } from '@livestore/utils/effect'
+import { Deferred, Effect, Fiber, Layer, OtelTracer, Stream, TestClock, Tracer } from '@livestore/utils/effect'
 
 import { makeObservability, rpcSpanOptions } from './observability.ts'
 
@@ -76,112 +76,14 @@ Vitest.describe('sync-cf telemetry ownership', () => {
     }),
   )
 
-  Vitest.live('exports through the supplied provider after spans end without taking provider ownership', () =>
+  Vitest.effect('finalizes finite history while the live subscription is still open', () =>
     Effect.gen(function* () {
-      const { tracer, spans, ended } = makeRecordingTracer()
-      const register = Vitest.vi.spyOn(trace, 'setGlobalTracerProvider')
-      const flushed = Promise.withResolvers<ReadonlyArray<string>>()
-      const provider = {
-        getTracer: () => tracer,
-        forceFlush: () => {
-          flushed.resolve([...ended])
-          return Promise.resolve()
-        },
-        shutdown: Vitest.vi.fn(),
-      }
-      const observability = makeObservability(provider)
-      yield* Effect.void.pipe(Effect.withSpan('child'), Effect.withSpan('parent'), observability.effect)
-
-      Vitest.expect(yield* Effect.promise(() => flushed.promise)).toEqual(['child', 'parent'])
-      Vitest.expect(spans.get('child')?.parentId).toBe(spans.get('parent')?.spanId)
-      Vitest.expect(register).not.toHaveBeenCalled()
-      Vitest.expect(provider.shutdown).not.toHaveBeenCalled()
-    }),
-  )
-
-  Vitest.effect.each(['resolve', 'reject'] as const)(
-    'drains queued spans when a timed-out flush later settles: %s',
-    (mode) =>
-      Effect.gen(function* () {
-        const { tracer, ended } = makeRecordingTracer()
-        // These promises model the SDK boundary. Test coordination and time remain under Effect.
-        const gate = Promise.withResolvers<void>()
-        const started = Promise.withResolvers<void>()
-        const trailingFlush = Promise.withResolvers<ReadonlyArray<string>>()
-        const acknowledged = yield* Deferred.make<void>()
-        let calls = 0
-        const forceFlush = () => {
-          calls++
-          if (calls === 1) {
-            started.resolve()
-            return gate.promise
-          }
-          trailingFlush.resolve([...ended])
-          return Promise.resolve()
-        }
-        yield* Effect.addFinalizer(() => Effect.sync(() => gate.resolve()))
-        const observability = makeObservability({ getTracer: () => tracer, forceFlush })
-        yield* Effect.void.pipe(
-          Effect.withSpan('first push'),
-          observability.effect,
-          Effect.andThen(Deferred.succeed(acknowledged, undefined)),
-          Effect.forkChild,
-        )
-        yield* Effect.promise(() => started.promise)
-        yield* Effect.yieldNow
-        Vitest.expect(yield* Deferred.isDone(acknowledged)).toBe(true)
-
-        // Advance the actual Effect timeout, not Date.now or wall-clock sleeps.
-        yield* TestClock.adjust('4 seconds')
-        yield* Effect.void.pipe(Effect.withSpan('second push'), observability.effect)
-        yield* TestClock.adjust(1)
-        Vitest.expect(calls).toBe(1)
-
-        if (mode === 'reject') gate.reject(new Error('collector unavailable'))
-        else gate.resolve()
-        Vitest.expect(yield* Effect.promise(() => trailingFlush.promise)).toEqual(['first push', 'second push'])
-        yield* TestClock.adjust('4 seconds')
-        Vitest.expect(calls).toBe(2)
-      }),
-  )
-
-  Vitest.live.each(['reject', 'throw'] as const)('preserves sync results and recovers after a flush %s', (mode) =>
-    Effect.gen(function* () {
-      const failed = Promise.withResolvers<void>()
-      const recovered = Promise.withResolvers<void>()
-      let calls = 0
-      const forceFlush = () => {
-        calls++
-        if (calls === 1) {
-          failed.resolve()
-          if (mode === 'throw') throw new Error('collector unavailable')
-          return Promise.reject(new Error('collector unavailable'))
-        }
-        recovered.resolve()
-        return Promise.resolve()
-      }
-      const observability = makeObservability({ getTracer: () => makeNoopTracer(), forceFlush })
-      Vitest.expect(yield* Effect.succeed('ack').pipe(observability.effect)).toBe('ack')
-      yield* Effect.promise(() => failed.promise)
-      yield* Effect.yieldNow
-      Vitest.expect(yield* Effect.fail('sync failed').pipe(observability.effect, Effect.flip)).toBe('sync failed')
-      yield* Effect.promise(() => recovered.promise)
-      Vitest.expect(calls).toBe(2)
-    }),
-  )
-
-  Vitest.live('exports finite history while the live subscription is still open', () =>
-    Effect.gen(function* () {
-      const { tracer, ended } = makeRecordingTracer()
-      const flushed = Promise.withResolvers<ReadonlyArray<string>>()
+      const { layer, ended } = makeRecordingTracer()
+      const finalized = yield* Deferred.make<ReadonlyArray<string>>()
       const live = yield* Deferred.make<void>()
-      const observability = makeObservability({
-        getTracer: () => tracer,
-        forceFlush: () => {
-          flushed.resolve([...ended])
-          return Promise.resolve()
-        },
-      })
+      const observability = makeObservability(
+        Layer.mergeAll(layer, Layer.effectDiscard(Effect.addFinalizer(() => Deferred.succeed(finalized, [...ended])))),
+      )
       const fiber = yield* Stream.make('history').pipe(
         Stream.withSpan('pull-history'),
         observability.stream,
@@ -191,15 +93,15 @@ Vitest.describe('sync-cf telemetry ownership', () => {
       )
       yield* Effect.addFinalizer(() => Fiber.interrupt(fiber))
       yield* Deferred.await(live)
-      Vitest.expect(yield* Effect.promise(() => flushed.promise)).toContain('pull-history')
+      Vitest.expect(yield* Deferred.await(finalized)).toContain('pull-history')
       Vitest.expect(fiber.pollUnsafe()).toBeUndefined()
     }),
   )
 
   Vitest.live('attaches a finite span to the caller across an unexported RPC envelope', () =>
     Effect.gen(function* () {
-      const { tracer, spans, ended } = makeRecordingTracer()
-      const observability = makeObservability({ getTracer: () => tracer })
+      const { layer, spans, ended } = makeRecordingTracer()
+      const observability = makeObservability(layer)
       const caller = Tracer.externalSpan({ traceId: '1'.repeat(32), spanId: '2222222222222222', sampled: true })
       yield* Effect.flatMap(rpcSpanOptions, (options) =>
         Effect.void.pipe(Effect.withSpan('push'), Effect.withSpan('finite-rpc', options)),
@@ -252,5 +154,6 @@ const makeRecordingTracer = () => {
       },
     }
   })
-  return { tracer, ended, spans }
+  const layer = OtelTracer.layerWithoutOtelTracer.pipe(Layer.provide(Layer.succeed(OtelTracer.OtelTracer, tracer)))
+  return { layer, ended, spans }
 }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
@@ -1,28 +1,15 @@
-import {
-  Effect,
-  Exit,
-  FetchHttpClient,
-  Fiber,
-  Layer,
-  Option,
-  OtelTracer,
-  Otlp,
-  Scope,
-  Stream,
-} from '@livestore/utils/effect'
+import { Effect, Exit, FetchHttpClient, Layer, Option, Otlp, Scope, Stream } from '@livestore/utils/effect'
 
 import type { SyncBackendOtelOptions } from '../shared.ts'
 
 /** Keep exporter ownership separate from sync scopes: their finalizers must not delay acknowledgments. */
 export const makeObservability = (options: SyncBackendOtelOptions | undefined) => {
-  const provider = options !== undefined && 'getTracer' in options ? options : undefined
   const layer = makeLayer(options)
-  const flush = makeProviderFlush(provider)
 
   const backgroundLayer = Layer.effectContext(
-    Effect.acquireRelease(Scope.make(), (scope) =>
-      Scope.close(scope, Exit.void).pipe(Effect.andThen(flush), runInBackground),
-    ).pipe(Effect.flatMap((scope) => Layer.buildWithScope(layer, scope))),
+    Effect.acquireRelease(Scope.make(), (scope) => Scope.close(scope, Exit.void).pipe(runInBackground)).pipe(
+      Effect.flatMap((scope) => Layer.buildWithScope(layer, scope)),
+    ),
   )
 
   return {
@@ -44,11 +31,6 @@ export const rpcSpanOptions = Effect.currentSpan.pipe(
 
 const makeLayer = (options: SyncBackendOtelOptions | undefined): Layer.Layer<never> => {
   if (isTracerLayer(options) === true) return options
-  if (options !== undefined && 'getTracer' in options) {
-    return OtelTracer.layerWithoutOtelTracer.pipe(
-      Layer.provide(Layer.succeed(OtelTracer.OtelTracer, options.getTracer('@livestore/sync-cf'))),
-    )
-  }
   if (options?.baseUrl !== undefined) {
     return Otlp.layerJson({
       baseUrl: options.baseUrl,
@@ -58,43 +40,6 @@ const makeLayer = (options: SyncBackendOtelOptions | undefined): Layer.Layer<nev
     }).pipe(Layer.provide(FetchHttpClient.layer))
   }
   return Layer.empty
-}
-
-/** Only one provider flush runs at a time; a hung app promise cannot accumulate more flush attempts. */
-const makeProviderFlush = (provider: { forceFlush?: () => Promise<void> } | undefined) => {
-  const forceFlush = provider?.forceFlush?.bind(provider)
-  if (forceFlush === undefined) return Effect.void
-
-  let running = false
-  let requested = false
-  const drain = Effect.suspend(() => {
-    requested = false
-    return Effect.tryPromise(forceFlush)
-  }).pipe(
-    // A failed attempt must still drain work queued while its promise was pending.
-    Effect.catchCause(() => Effect.void),
-    Effect.repeat({
-      while: () => {
-        // Release the guard with the final check, so a new completion cannot be lost.
-        running = requested
-        return requested
-      },
-    }),
-  )
-
-  return Effect.suspend(() => {
-    requested = true
-    if (running === true) return Effect.void
-    running = true
-
-    // Timing out this await must not interrupt the drain: SDK promises cannot be
-    // cancelled, so its guard must survive until the actual promise settles.
-    return drain.pipe(
-      Effect.forkDetach,
-      Effect.flatMap((fiber) => Fiber.await(fiber).pipe(Effect.timeoutOption(3000))),
-      Effect.asVoid,
-    )
-  })
 }
 
 /** DOs stay active for pending work; no shutdown hook or connection-wide timer is required. */

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
@@ -1,4 +1,16 @@
-import { Effect, Exit, FetchHttpClient, Layer, Option, Otlp, Scope, Stream } from '@livestore/utils/effect'
+import type { BackendIdMismatchError, ServerAheadError, UnknownError } from '@livestore/common'
+import {
+  Effect,
+  FetchHttpClient,
+  Layer,
+  Option,
+  Otlp,
+  Ref,
+  Result,
+  Scope,
+  Stream,
+  type Tracer,
+} from '@livestore/utils/effect'
 
 import type { SyncBackendOtelOptions } from '../shared.ts'
 
@@ -7,7 +19,7 @@ export const makeObservability = (options: SyncBackendOtelOptions | undefined) =
   const layer = makeLayer(options)
 
   const backgroundLayer = Layer.effectContext(
-    Effect.acquireRelease(Scope.make(), (scope) => Scope.close(scope, Exit.void).pipe(runInBackground)).pipe(
+    Effect.acquireRelease(Scope.make(), (scope, exit) => Scope.close(scope, exit).pipe(runInBackground)).pipe(
       Effect.flatMap((scope) => Layer.buildWithScope(layer, scope)),
     ),
   )
@@ -22,12 +34,64 @@ export const makeObservability = (options: SyncBackendOtelOptions | undefined) =
 
 /**
  * Effect RPC's envelope lives until a live subscription closes and may never be exported.
- * Give finite sync work its own exported boundary, attached directly to the envelope's caller.
+ * Give finite sync work its own exported boundary, attached to a sampled caller or a new backend root.
  */
 export const rpcSpanOptions = Effect.currentSpan.pipe(
-  Effect.map((span) => ({ parent: Option.getOrUndefined(span.parent), root: true })),
+  Effect.map((span) => makeRpcSpanOptions(span.parent)),
   Effect.catchTag('NoSuchElementError', () => Effect.succeed({ root: true })),
 )
+
+export const makeRpcSpanOptions = (parent: Option.Option<Tracer.AnySpan>): Tracer.SpanOptions => ({
+  // Client runtimes use an unsampled no-op span by default. Parenting to it would suppress backend-only telemetry.
+  parent: parent.pipe(
+    Option.filter((span) => span.sampled),
+    Option.getOrUndefined,
+  ),
+  root: true,
+})
+
+/** Keep expected sync-recovery results out of error telemetry while preserving the typed failure for RPC callers. */
+export const withRpcSpan = <A, E extends SyncRpcError, R>(
+  effect: Effect.Effect<A, E, R>,
+  name: string,
+  options?: Tracer.SpanOptions,
+): Effect.Effect<A, E, R> =>
+  effect.pipe(
+    Effect.map(Result.succeed),
+    Effect.catchIf(isExpectedSyncError, (error) => Effect.succeed(Result.fail(error))),
+    Effect.withSpan(name, options),
+    Effect.flatMap(resultToEffect),
+  )
+
+/** Stream equivalent of `withRpcSpan`; expected failures are restored after the boundary span ends successfully. */
+export const withRpcStreamSpan = <A, E extends SyncRpcError, R>(
+  stream: Stream.Stream<A, E, R>,
+  name: string,
+  options?: Tracer.SpanOptions,
+): Stream.Stream<A, E, R> =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const expectedError = yield* Ref.make(Option.none<E>())
+      const instrumented = stream.pipe(
+        Stream.catchIf(isExpectedSyncError, (error) =>
+          Stream.fromEffect(Ref.set(expectedError, Option.some(error))).pipe(Stream.drain),
+        ),
+        Stream.withSpan(name, options),
+      )
+      const restoreExpectedError = Stream.fromEffect(Ref.get(expectedError)).pipe(
+        Stream.flatMap(
+          Option.match({
+            onNone: () => Stream.empty,
+            onSome: Stream.fail,
+          }),
+        ),
+      )
+
+      return instrumented.pipe(Stream.concat(restoreExpectedError))
+    }),
+  )
+
+type SyncRpcError = UnknownError | ServerAheadError | BackendIdMismatchError
 
 const makeLayer = (options: SyncBackendOtelOptions | undefined): Layer.Layer<never> => {
   if (isTracerLayer(options) === true) return options
@@ -54,3 +118,9 @@ const runInBackground = (effect: Effect.Effect<void>) =>
 /** Preserve the known Layer requirements when narrowing the configuration union. */
 const isTracerLayer = (options: SyncBackendOtelOptions | undefined): options is Layer.Layer<never> =>
   Layer.isLayer(options)
+
+const isExpectedSyncError = (error: SyncRpcError): boolean =>
+  error._tag === 'ServerAheadError' || error._tag === 'BackendIdMismatchError'
+
+const resultToEffect = <A, E>(result: Result.Result<A, E>): Effect.Effect<A, E> =>
+  Result.isSuccess(result) === true ? Effect.succeed(result.success) : Effect.fail(result.failure)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
@@ -1,0 +1,108 @@
+import {
+  Effect,
+  Exit,
+  FetchHttpClient,
+  Fiber,
+  Layer,
+  Option,
+  OtelTracer,
+  Otlp,
+  Scope,
+  Stream,
+} from '@livestore/utils/effect'
+
+import type { SyncBackendOtelOptions } from '../shared.ts'
+
+/** Keep exporter ownership separate from sync scopes: their finalizers must not delay acknowledgments. */
+export const makeObservability = (options: SyncBackendOtelOptions | undefined) => {
+  const provider = options !== undefined && 'getTracer' in options ? options : undefined
+  const layer = makeLayer(options)
+  const flush = makeProviderFlush(provider)
+
+  const backgroundLayer = Layer.effectContext(
+    Effect.acquireRelease(Scope.make(), (scope) =>
+      Scope.close(scope, Exit.void).pipe(Effect.andThen(flush), runInBackground),
+    ).pipe(Effect.flatMap((scope) => Layer.buildWithScope(layer, scope))),
+  )
+
+  return {
+    effect: <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+      options === undefined ? effect : effect.pipe(Effect.provide(backgroundLayer, { local: true })),
+    stream: <A, E, R>(stream: Stream.Stream<A, E, R>) =>
+      options === undefined ? stream : stream.pipe(Stream.provide(backgroundLayer, { local: true })),
+  }
+}
+
+/**
+ * Effect RPC's envelope lives until a live subscription closes and may never be exported.
+ * Give finite sync work its own exported boundary, attached directly to the envelope's caller.
+ */
+export const rpcSpanOptions = Effect.currentSpan.pipe(
+  Effect.map((span) => ({ parent: Option.getOrUndefined(span.parent), root: true })),
+  Effect.catchTag('NoSuchElementError', () => Effect.succeed({ root: true })),
+)
+
+const makeLayer = (options: SyncBackendOtelOptions | undefined): Layer.Layer<never> => {
+  if (options !== undefined && 'getTracer' in options) {
+    return OtelTracer.layerWithoutOtelTracer.pipe(
+      Layer.provide(Layer.succeed(OtelTracer.OtelTracer, options.getTracer('@livestore/sync-cf'))),
+    )
+  }
+  if (options?.baseUrl !== undefined) {
+    return Otlp.layerJson({
+      baseUrl: options.baseUrl,
+      tracerExportInterval: 50,
+      shutdownTimeout: 3000,
+      resource: { serviceName: options.serviceName ?? 'sync-cf-do' },
+    }).pipe(Layer.provide(FetchHttpClient.layer))
+  }
+  return Layer.empty
+}
+
+/** Only one provider flush runs at a time; a hung app promise cannot accumulate more flush attempts. */
+const makeProviderFlush = (provider: { forceFlush?: () => Promise<void> } | undefined) => {
+  const forceFlush = provider?.forceFlush?.bind(provider)
+  if (forceFlush === undefined) return Effect.void
+
+  let running = false
+  let requested = false
+  const drain = Effect.suspend(() => {
+    requested = false
+    return Effect.tryPromise(forceFlush)
+  }).pipe(
+    Effect.repeat({
+      while: () => {
+        // Release the guard with the final check, so a new completion cannot be lost.
+        running = requested
+        return requested
+      },
+    }),
+    Effect.catchCause(() => {
+      running = false
+      return Effect.void
+    }),
+  )
+
+  return Effect.suspend(() => {
+    requested = true
+    if (running === true) return Effect.void
+    running = true
+
+    // Timing out this await must not interrupt the drain: SDK promises cannot be
+    // cancelled, so its guard must survive until the actual promise settles.
+    return drain.pipe(
+      Effect.forkDetach,
+      Effect.flatMap((fiber) => Fiber.await(fiber).pipe(Effect.timeoutOption(3000))),
+      Effect.asVoid,
+    )
+  })
+}
+
+/** DOs stay active for pending work; no shutdown hook or connection-wide timer is required. */
+const runInBackground = (effect: Effect.Effect<void>) =>
+  effect.pipe(
+    Effect.catchCause(() => Effect.void),
+    Effect.withTracerEnabled(false),
+    Effect.forkDetach,
+    Effect.asVoid,
+  )

--- a/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/observability.ts
@@ -43,6 +43,7 @@ export const rpcSpanOptions = Effect.currentSpan.pipe(
 )
 
 const makeLayer = (options: SyncBackendOtelOptions | undefined): Layer.Layer<never> => {
+  if (isTracerLayer(options) === true) return options
   if (options !== undefined && 'getTracer' in options) {
     return OtelTracer.layerWithoutOtelTracer.pipe(
       Layer.provide(Layer.succeed(OtelTracer.OtelTracer, options.getTracer('@livestore/sync-cf'))),
@@ -70,16 +71,14 @@ const makeProviderFlush = (provider: { forceFlush?: () => Promise<void> } | unde
     requested = false
     return Effect.tryPromise(forceFlush)
   }).pipe(
+    // A failed attempt must still drain work queued while its promise was pending.
+    Effect.catchCause(() => Effect.void),
     Effect.repeat({
       while: () => {
         // Release the guard with the final check, so a new completion cannot be lost.
         running = requested
         return requested
       },
-    }),
-    Effect.catchCause(() => {
-      running = false
-      return Effect.void
     }),
   )
 
@@ -106,3 +105,7 @@ const runInBackground = (effect: Effect.Effect<void>) =>
     Effect.forkDetach,
     Effect.asVoid,
   )
+
+/** Preserve the known Layer requirements when narrowing the configuration union. */
+const isTracerLayer = (options: SyncBackendOtelOptions | undefined): options is Layer.Layer<never> =>
+  Layer.isLayer(options)

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -5,7 +5,7 @@ import { Effect, Headers, Option, Stream } from '@livestore/utils/effect'
 import { SyncDoRpc } from '../../../common/do-rpc-schema.ts'
 import { rpcSubscriptionKeyPrefix, type RpcSubscription } from '../../shared.ts'
 import * as DoCtx from '../layer.ts'
-import type { makeObservability } from '../observability.ts'
+import { makeRpcSpanOptions, type makeObservability, withRpcStreamSpan } from '../observability.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
 
@@ -75,7 +75,7 @@ export const createDoRpcHandler = (
           ),
           Stream.tapCause(Effect.log),
           // The bridge runs this stream in a separate runtime. Install telemetry there too.
-          Stream.withSpan('RpcServer.SyncDoRpc.Pull', { parent: Option.getOrUndefined(parent), root: true }),
+          (_) => withRpcStreamSpan(_, 'RpcServer.SyncDoRpc.Pull', makeRpcSpanOptions(parent)),
           observability.stream,
         ),
       'SyncDoRpc.Push': (req) =>

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/do-rpc-server.ts
@@ -5,12 +5,14 @@ import { Effect, Headers, Option, Stream } from '@livestore/utils/effect'
 import { SyncDoRpc } from '../../../common/do-rpc-schema.ts'
 import { rpcSubscriptionKeyPrefix, type RpcSubscription } from '../../shared.ts'
 import * as DoCtx from '../layer.ts'
+import type { makeObservability } from '../observability.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
 
 export interface DoRpcHandlerOptions {
   payload: Uint8Array<ArrayBuffer>
   input: Omit<DoCtx.DoCtxInput, 'from'>
+  observability: ReturnType<typeof makeObservability>
 }
 
 /**
@@ -32,7 +34,8 @@ export const createDoRpcHandler = (
   options: DoRpcHandlerOptions,
 ): Effect.Effect<Uint8Array<ArrayBuffer> | CfTypes.ReadableStream> =>
   Effect.gen({ self: this }, function* () {
-    const { payload, input } = options
+    const { payload, input, observability } = options
+    const parent = yield* Effect.currentParentSpan.pipe(Effect.option)
 
     // TODO add admin RPCs
     const RpcLive = SyncDoRpc.toLayer({
@@ -71,6 +74,9 @@ export const createDoRpcHandler = (
               : new UnknownError({ cause }),
           ),
           Stream.tapCause(Effect.log),
+          // The bridge runs this stream in a separate runtime. Install telemetry there too.
+          Stream.withSpan('RpcServer.SyncDoRpc.Pull', { parent: Option.getOrUndefined(parent), root: true }),
+          observability.stream,
         ),
       'SyncDoRpc.Push': (req) =>
         Effect.gen({ self: this }, function* () {

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -5,42 +5,58 @@ import { Effect, identity, Layer, Result, RpcServer, Schema, Stream } from '@liv
 import { SyncWsRpc } from '../../../common/ws-rpc-schema.ts'
 import { headersRecordToMap, WebSocketAttachmentSchema } from '../../shared.ts'
 import * as DoCtx from '../layer.ts'
+import { type makeObservability, rpcSpanOptions } from '../observability.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
 
-export const makeRpcServer = ({ doSelf, doOptions }: Omit<DoCtx.DoCtxInput, 'from'>) => {
+export const makeRpcServer = ({
+  doSelf,
+  doOptions,
+  observability,
+}: Omit<DoCtx.DoCtxInput, 'from'> & { observability: ReturnType<typeof makeObservability> }) => {
   const handlersLayer = SyncWsRpc.toLayer({
     'SyncWsRpc.Pull': (req) =>
       Effect.gen(function* () {
+        const spanOptions = yield* rpcSpanOptions
         const headers = yield* getForwardedHeaders
         return makeEndingPullStream({ req, payload: req.payload, headers }).pipe(
-          // Needed to keep the stream alive on the client side for phase 2 (i.e. not send the `Exit` stream RPC message)
-          req.live === true ? Stream.concat(Stream.never) : identity,
           Stream.provide(DoCtx.layer({ doSelf, doOptions, from: { storeId: req.storeId } })),
           Stream.mapError((cause) =>
             cause._tag === 'UnknownError' || cause._tag === 'BackendIdMismatchError'
               ? cause
               : new UnknownError({ cause }),
           ),
+          Stream.withSpan('RpcServer.SyncWsRpc.Pull', spanOptions),
         )
-      }).pipe(Stream.unwrap),
-    'SyncWsRpc.Push': (req) =>
-      Effect.gen(function* () {
-        const { doOptions, storeId, ctx, env } = yield* DoCtx.DoCtx
-        const headers = yield* getForwardedHeaders
-
-        const push = makePush({ options: doOptions, storeId, payload: req.payload, headers, ctx, env })
-
-        return yield* push(req)
       }).pipe(
-        Effect.provide(DoCtx.layer({ doSelf, doOptions, from: { storeId: req.storeId } })),
-        Effect.mapError((cause) =>
-          cause._tag === 'UnknownError' || cause._tag === 'ServerAheadError' || cause._tag === 'BackendIdMismatchError'
-            ? cause
-            : new UnknownError({ cause }),
-        ),
-        Effect.tapCauseLogPretty,
+        Stream.unwrap,
+        // Drain finite history before entering the live phase, which survives DO hibernation.
+        observability.stream,
+        // Keep the client subscription open without retaining an exporter scope or timer.
+        req.live === true ? Stream.concat(Stream.never) : identity,
       ),
+    'SyncWsRpc.Push': (req) =>
+      Effect.flatMap(rpcSpanOptions, (spanOptions) =>
+        Effect.gen(function* () {
+          const { doOptions, storeId, ctx, env } = yield* DoCtx.DoCtx
+          const headers = yield* getForwardedHeaders
+
+          const push = makePush({ options: doOptions, storeId, payload: req.payload, headers, ctx, env })
+
+          return yield* push(req)
+        }).pipe(
+          Effect.provide(DoCtx.layer({ doSelf, doOptions, from: { storeId: req.storeId } })),
+          Effect.mapError((cause) =>
+            cause._tag === 'UnknownError' ||
+            cause._tag === 'ServerAheadError' ||
+            cause._tag === 'BackendIdMismatchError'
+              ? cause
+              : new UnknownError({ cause }),
+          ),
+          Effect.tapCauseLogPretty,
+          Effect.withSpan('RpcServer.SyncWsRpc.Push', spanOptions),
+        ),
+      ).pipe(observability.effect),
   })
 
   return RpcServer.layer(SyncWsRpc).pipe(Layer.provide(handlersLayer))

--- a/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/transport/ws-rpc-server.ts
@@ -5,7 +5,7 @@ import { Effect, identity, Layer, Result, RpcServer, Schema, Stream } from '@liv
 import { SyncWsRpc } from '../../../common/ws-rpc-schema.ts'
 import { headersRecordToMap, WebSocketAttachmentSchema } from '../../shared.ts'
 import * as DoCtx from '../layer.ts'
-import { type makeObservability, rpcSpanOptions } from '../observability.ts'
+import { type makeObservability, rpcSpanOptions, withRpcSpan, withRpcStreamSpan } from '../observability.ts'
 import { makeEndingPullStream } from '../pull.ts'
 import { makePush } from '../push.ts'
 
@@ -14,7 +14,18 @@ export const makeRpcServer = ({
   doOptions,
   observability,
 }: Omit<DoCtx.DoCtxInput, 'from'> & { observability: ReturnType<typeof makeObservability> }) => {
-  const handlersLayer = SyncWsRpc.toLayer({
+  const handlersLayer = makeRpcHandlers({ doSelf, doOptions, observability })
+
+  return RpcServer.layer(SyncWsRpc).pipe(Layer.provide(handlersLayer))
+}
+
+/** Production handler layer, exported so transport tests can exercise the exact RPC composition in memory. */
+export const makeRpcHandlers = ({
+  doSelf,
+  doOptions,
+  observability,
+}: Omit<DoCtx.DoCtxInput, 'from'> & { observability: ReturnType<typeof makeObservability> }) =>
+  SyncWsRpc.toLayer({
     'SyncWsRpc.Pull': (req) =>
       Effect.gen(function* () {
         const spanOptions = yield* rpcSpanOptions
@@ -26,7 +37,7 @@ export const makeRpcServer = ({
               ? cause
               : new UnknownError({ cause }),
           ),
-          Stream.withSpan('RpcServer.SyncWsRpc.Pull', spanOptions),
+          (_) => withRpcStreamSpan(_, 'RpcServer.SyncWsRpc.Pull', spanOptions),
         )
       }).pipe(
         Stream.unwrap,
@@ -54,13 +65,10 @@ export const makeRpcServer = ({
               : new UnknownError({ cause }),
           ),
           Effect.tapCauseLogPretty,
-          Effect.withSpan('RpcServer.SyncWsRpc.Push', spanOptions),
+          (_) => withRpcSpan(_, 'RpcServer.SyncWsRpc.Push', spanOptions),
         ),
       ).pipe(observability.effect),
   })
-
-  return RpcServer.layer(SyncWsRpc).pipe(Layer.provide(handlersLayer))
-}
 
 /** Extracts forwarded headers from the WebSocket attachment */
 const getForwardedHeaders = Effect.gen(function* () {

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -2,7 +2,7 @@ import type { TracerProvider } from '@opentelemetry/api'
 
 import type { UnknownError } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
-import type { Effect } from '@livestore/utils/effect'
+import type { Effect, Layer } from '@livestore/utils/effect'
 import { Result, Schema } from '@livestore/utils/effect'
 
 import type { SearchParams } from '../common/mod.ts'
@@ -114,6 +114,8 @@ export type MakeDurableObjectClassOptions = {
 }
 
 export type SyncBackendOtelOptions =
+  /** Application-supplied tracer layer; LiveStore builds and finalizes its resources per sync operation. */
+  | Layer.Layer<never>
   /** Pass your existing OTel provider directly. LiveStore never registers or shuts it down. */
   | (TracerProvider & {
       /** Standard SDK providers expose this. LiveStore invokes it in the background after sync work. */

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -1,5 +1,3 @@
-import type { TracerProvider } from '@opentelemetry/api'
-
 import type { UnknownError } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
 import type { Effect, Layer } from '@livestore/utils/effect'
@@ -116,11 +114,6 @@ export type MakeDurableObjectClassOptions = {
 export type SyncBackendOtelOptions =
   /** Application-supplied tracer layer; LiveStore builds and finalizes its resources per sync operation. */
   | Layer.Layer<never>
-  /** Pass your existing OTel provider directly. LiveStore never registers or shuts it down. */
-  | (TracerProvider & {
-      /** Standard SDK providers expose this. LiveStore invokes it in the background after sync work. */
-      forceFlush?: () => Promise<void>
-    })
   | {
       /** Convenience OTLP/HTTP JSON exporter owned by LiveStore for each operation. */
       baseUrl?: string

--- a/packages/@livestore/sync-cf/src/cf-worker/shared.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/shared.ts
@@ -1,3 +1,5 @@
+import type { TracerProvider } from '@opentelemetry/api'
+
 import type { UnknownError } from '@livestore/common'
 import type { CfTypes } from '@livestore/common-cf'
 import type { Effect } from '@livestore/utils/effect'
@@ -107,11 +109,21 @@ export type MakeDurableObjectClassOptions = {
     responseHeaders?: Record<string, string>
   }
 
-  otel?: {
-    baseUrl?: string
-    serviceName?: string
-  }
+  /** Optional telemetry. Omit to avoid creating an exporter or sending telemetry. */
+  otel?: SyncBackendOtelOptions
 }
+
+export type SyncBackendOtelOptions =
+  /** Pass your existing OTel provider directly. LiveStore never registers or shuts it down. */
+  | (TracerProvider & {
+      /** Standard SDK providers expose this. LiveStore invokes it in the background after sync work. */
+      forceFlush?: () => Promise<void>
+    })
+  | {
+      /** Convenience OTLP/HTTP JSON exporter owned by LiveStore for each operation. */
+      baseUrl?: string
+      serviceName?: string
+    }
 
 export type StoreId = string
 export type DurableObjectId = string


### PR DESCRIPTION
## Problem

Cloudflare sync already had tracing, but apps could only configure an OTLP endpoint—not plug in their own Effect tracer.

## Solution

Accept an optional `otel: layer`, preserving endpoint configuration. Fix tracer lifetimes so successive WebSocket requests use the correct context, pull traces are recorded, and spans connect to sampled callers. When caller context is absent or unsampled, the backend starts an independently observable trace. Expected sync-recovery failures remain typed without marking the RPC boundary as an OpenTelemetry error, and exporter cleanup runs in the background with the operation's actual exit.

These changes are confined to Cloudflare sync. Telemetry remains optional; client tracing is unchanged.

## Validation

Eight local comparisons confirmed the lifecycle fixes are needed beyond the configuration hook (Cloudflare API simulated). Telemetry tests, types, lint, unit, integration, and performance checks passed; DevTools retains its existing quarantine (#1489). After the public-doc formatting cleanup, `devenv tasks run lint:full:fix` and `devenv shell -- env DEVENV_TASK_PASSTHROUGH=1 mono docs build` passed; Astro reported zero diagnostics and valid internal links. After rebasing onto `main`, lint, repository-wide TypeScript checks, unit tests, and five Cloudflare sync-provider integration variants passed. The Effect-idiom follow-up added sampled/unsampled parentage, typed-recovery status, real WebSocket/DO-RPC transport, and finalizer-exit coverage. After rebasing again over #1606's Effect rc.113 and SchemaBinary migration, all 10 focused telemetry tests and all 8 intent-layer checks pass, along with `lint:full`, the `sync-cf` package type-check, and repository-wide `ts:check`; no compatibility source changes were needed. CI covers the remaining matrix. Telemetry-on/off latency has not been benchmarked.

## Demo

**Backend: Cloudflare Observability, Free plan**, using `effect-cf@0.38.0` through `otel: layer`.

![LiveStore backend spans in Cloudflare](https://livestore-pr1619-todo-evidence.bohdanptyts.workers.dev/pr-evidence/backend-cloudflare.png)

**Browser: Jaeger**, using existing client tracing with an app-owned OpenTelemetry SDK exporter.

![LiveStore browser commit spans in Jaeger](https://livestore-pr1619-todo-evidence.bohdanptyts.workers.dev/pr-evidence/client-jaeger.png)

Separate traces. Demo code and `effect-cf` are excluded from the PR.

## Contributor sync questions

- **Can browser/UI telemetry drain into Cloudflare tracing so client and server traces use the same destination?** Not currently as faithful OTLP traces. Cloudflare accepts native Worker and custom spans but does not expose arbitrary OTLP ingestion into Trace Explorer; recreating uploaded browser spans would lose their original identity, timing, and parentage. A shared external OTLP backend remains the viable unified destination, so client export is outside this PR.
- **How is Cloudflare tracing billed?** As of September 11, 2026, Workers tracing is still in open beta and free within its quotas. Cloudflare plans to begin billing on October 1, 2026: Free includes 200,000 observability events per day with three-day retention; Paid includes 20 million events per month, then charges $0.60 per additional million, with seven-day retention. Each stored span counts as an event and shares the quota with logs; sampling controls volume. See [Workers tracing limits and pricing](https://developers.cloudflare.com/workers/observability/traces/#limits--pricing).

## Related issues

Closes #1618. Related: #556, #426.
