### PR TITLE
Remove retired tracker references

### DIFF
--- a/.github/workflows/ci.yml.genie.ts
+++ b/.github/workflows/ci.yml.genie.ts
@@ -429,35 +429,30 @@ export default githubWorkflow({
       defaults: bashShellDefaults,
       steps: withNixDiagnosticsOnFailure([
         ...livestoreSetupSteps,
-        // TODO(oep-bbd): Restore once root cause is fixed and diagnostics are removed.
+        // Restore the monolithic docs build once the hang's root cause is fixed and diagnostics are removed.
         // { name: 'Build docs', run: runDevenvTasksBefore('docs:build:api') },
-        // TODO(oep-bbd): Temporary phase split + hard timeouts for docs CI hang triage.
-        // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
+        // Temporary phase split and hard timeouts for docs CI hang triage; remove once the root cause is fixed.
         {
           name: 'Build docs snippets',
           run: runDevenvTasksBefore('docs:build:phase:snippets'),
         },
-        // TODO(oep-bbd): Temporary diagnostics step for docs CI hang triage.
-        // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
+        // Temporary diagnostics step for docs CI hang triage; remove once the root cause is fixed.
         {
           name: 'Build docs diagrams',
           run: runDevenvTasksBefore('docs:build:phase:diagrams'),
         },
-        // TODO(oep-bbd): Temporary heartbeat/process logging for Astro build visibility.
-        // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
+        // Temporary heartbeat/process logging for Astro build visibility; remove once the root cause is fixed.
         {
           name: 'Build Astro docs bundle',
           run: runDevenvTasksBefore('docs:build:phase:astro'),
         },
-        // TODO(oep-bbd): Temporary failure-time process dump for docs CI hang triage.
-        // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
+        // Temporary failure-time process dump for docs CI hang triage; remove once the root cause is fixed.
         {
           name: 'Collect docs build diagnostics on failure',
           if: '${{ failure() }}',
           run: runDevenvTasksBefore('docs:build:diagnostics'),
         },
-        // TODO(oep-bbd): Temporary artifact upload for docs CI diagnostics.
-        // Remove once root cause is fixed. Bead context: tasks/2026/02/refactor--genie-igor-ci/oep-bbd/problem.md
+        // Temporary artifact upload for docs CI diagnostics; remove once the root cause is fixed.
         {
           name: 'Upload docs build logs',
           if: '${{ always() }}',

--- a/.oxfmtrc.json.genie.ts
+++ b/.oxfmtrc.json.genie.ts
@@ -23,7 +23,7 @@ export default oxfmtConfig({
     // Exclude Astro-generated type definitions — Astro regenerates these in its own style
     'docs/.astro/**',
     // Exclude Netlify build artifacts — bundled .mjs files trigger oxfmt sort_imports panic (oxc#17788)
-    // TODO(oep-c28): Remove once oxfmt ≥0.24.0 lands in nixpkgs (also add **/.netlify/** to effect-utils base)
+    // Remove once oxfmt ≥0.24.0 lands in nixpkgs (also add **/.netlify/** to effect-utils base)
     'docs/.netlify/**',
     '**/playwright-report/**',
     '**/test-results/**',

--- a/.oxlintrc.json.genie.ts
+++ b/.oxlintrc.json.genie.ts
@@ -4,8 +4,8 @@ import { baseOxlintCategories, baseOxlintIgnorePatterns, baseOxlintPlugins, oxli
  * LiveStore oxlint configuration (Phase 1 — permissive).
  *
  * This introduces oxlint (replacing Biome) with a deliberately permissive rule set
- * to avoid massive code churn during the initial migration. Rules are disabled with
- * TODO references to the follow-up epic oep-1n3 for incremental re-enablement.
+ * to avoid massive code churn during the initial migration. Deferred rules retain
+ * their rationale below for incremental re-enablement.
  */
 
 // ── Active rules ────────────────────────────────────────────────────────────
@@ -45,24 +45,24 @@ const permanentlyDisabledRules = {
   'react/react-in-jsx-scope': 'off',
 } as const
 
-// ── TODO(oep-1n3): Phase 2 — re-enable after codebase-wide fixes ───────────
+// ── Phase 2 — re-enable after codebase-wide fixes ───────────────────────────
 
 const phase2Rules = {
   'func-style': 'error',
-  // TODO(oep-1n3.6): 18 violations — eliminate barrel files in favor of mod.ts
+  // 18 violations — eliminate barrel files in favor of mod.ts
   'oxc/no-barrel-file': 'off',
 
-  // TODO(oep-1n3.5): 77 violations — false positives with ?worker imports
+  // 77 violations — false positives with ?worker imports
   'import/default': 'off',
-  // TODO(oep-1n3.5): 4 violations — madge already covers circular deps
+  // 4 violations — madge already covers circular deps
   'import/no-cycle': 'off',
-  // TODO(oep-1n3.5): 15 violations — evaluate dynamic require usage
+  // 15 violations — evaluate dynamic require usage
   'import/no-dynamic-require': 'off',
-  // TODO(oep-1n3.5): 35 violations — side-effect imports are valid in some contexts
+  // 35 violations — side-effect imports are valid in some contexts
   'import/no-unassigned-import': 'off',
-  // TODO(oep-1n3.5): 2 violations — namespace import false positives
+  // 2 violations — namespace import false positives
   'import/namespace': 'off',
-  // TODO(oep-1n3.5): 2 violations — named-as-default false positives
+  // 2 violations — named-as-default false positives
   'import/no-named-as-default': 'off',
 
   'react-perf/jsx-no-new-function-as-prop': 'error',
@@ -70,27 +70,27 @@ const phase2Rules = {
   'react-perf/jsx-no-jsx-as-prop': 'error',
   'react-perf/jsx-no-new-array-as-prop': 'error',
 
-  // TODO(oep-1n3.4): 447 violations — false positives in Effect generators
+  // 447 violations — false positives in Effect generators
   'block-scoped-var': 'off',
-  // TODO(oep-1n3.4): 186 violations — sequential await is intentional in many cases
+  // 186 violations — sequential await is intentional in many cases
   'no-await-in-loop': 'off',
-  // TODO(oep-1n3.4): 141 violations — false positives with Effect pipe patterns
+  // 141 violations — false positives with Effect pipe patterns
   'no-unused-expressions': 'off',
-  // TODO(oep-1n3.4): 21 violations — false positives with Effect.fn(function* ...)
+  // 21 violations — false positives with Effect.fn(function* ...)
   'require-yield': 'off',
 
-  // TODO(oep-1n3.7): 28 violations — postMessage target origin
+  // 28 violations — postMessage target origin
   'unicorn/require-post-message-target-origin': 'off',
-  // TODO(oep-1n3.7): 28 violations — addEventListener vs onX
+  // 28 violations — addEventListener vs onX
   'unicorn/prefer-add-event-listener': 'off',
-  // TODO(oep-1n3.7): 4 violations — empty files
+  // 4 violations — empty files
   'unicorn/no-empty-file': 'off',
 
-  // TODO(oep-3632.1): ~567 violations; disable temporarily to unblock CI (https://github.com/livestorejs/livestore/issues/1057)
+  // ~567 violations; disabled temporarily to unblock CI (https://github.com/livestorejs/livestore/issues/1057)
   'typescript/no-unsafe-type-assertion': 'off',
   // Inverse of overeng/explicit-boolean-compare — must stay off
   'typescript/no-unnecessary-boolean-literal-compare': 'off',
-  // TODO(oep-1n3.16): Re-enable after tsgolint crash is fixed upstream.
+  // Re-enable after the upstream tsgolint crash is fixed.
   // Currently triggers a nil pointer panic in tsgolint/typescript-go.
   'typescript/no-unnecessary-type-arguments': 'off',
   // 72 violations, concentrated in generated clients and broad union types
@@ -100,11 +100,11 @@ const phase2Rules = {
   // 42 violations, noisy with Effect error/rendering types
   'typescript/restrict-template-expressions': 'error',
 
-  // TODO(oep-1n3.9): Temporary quick-check unblocking - re-enable after async audit
+  // Temporary quick-check unblocking; re-enable after the async audit
   // 78 violations concentrated in wa-sqlite and test surfaces
   'typescript/no-floating-promises': 'off',
 
-  // TODO(oep-1n3.8a): Re-enable low-risk style hygiene rules first
+  // Re-enable low-risk style hygiene rules first
   // 16 violations, mostly logging/debug stringification quality
   'typescript/no-base-to-string': 'error',
   // 11 violations, low-risk type hygiene noise
@@ -114,7 +114,7 @@ const phase2Rules = {
   // 4 violations, mostly Effect wrappers around void-returning APIs
   'typescript/no-meaningless-void-operator': 'error',
 
-  // TODO(oep-1n3.9): Temporary unblock for correctness-sensitive rules
+  // Temporary unblock for correctness-sensitive rules
   // Re-enable after targeted async/this-binding/prototype-safety fixes.
   'typescript/unbound-method': 'off',
   'typescript/no-misused-spread': 'off',
@@ -209,7 +209,7 @@ export const livestoreOxlintOverrides = [
     rules: {
       'func-style': 'off',
       'import/no-commonjs': 'off',
-      // TODO(oep-1n3.9): Re-enable after wa-sqlite async API audit.
+      // Re-enable after the wa-sqlite async API audit.
       'typescript/await-thenable': 'off',
       'unicorn/no-new-array': 'off',
       'unicorn/no-array-sort': 'off',

--- a/devenv.nix
+++ b/devenv.nix
@@ -377,7 +377,7 @@ in
         "docs"
         "scripts"
       ];
-      # TODO(oep-1n3.10): Keep wa-sqlite unmanaged by Genie for now.
+      # Keep wa-sqlite unmanaged by Genie for now.
       # Effect-utils now supports exclusions for the coverage check.
       genieCoverageExcludes = [ "packages/@livestore/wa-sqlite/" ];
       tsconfig = "tsconfig.dev.json";

--- a/scripts/src/commands/lint.ts
+++ b/scripts/src/commands/lint.ts
@@ -57,7 +57,7 @@ const runFormatFix = cmd(['oxfmt', '.', ...oxfmtExcludePatterns]).pipe(
 )
 
 /** Run oxlint check (uses .oxlintrc.json) */
-// TODO(oep-3632.1) enable --type-aware once remaining no-unsafe-type-assertion violations are addressed (~567 remaining)
+// Enable --type-aware once the remaining no-unsafe-type-assertion violations are addressed (~567 remaining)
 const runLintCheck = cmd(['oxlint', '--import-plugin', '--deny-warnings']).pipe(
   Effect.provide(LivestoreWorkspace.toCwd()),
   Effect.withSpan('lintCheck'),


### PR DESCRIPTION
## Problem

Current formatter, linter, CI, and development configuration comments still refer to a retired issue tracker. Those identifiers and local task-document links no longer resolve, so otherwise useful operational rationale depends on unavailable context.

## Goal

Keep the operational rationale self-contained while removing retired tracker identifiers, names, commands, and dead links from tracked content.

## Decisions

- Preserve concrete rule counts, upstream blockers, and removal conditions in place.
- Keep the existing public GitHub issue link for the unsafe-type-assertion work rather than replacing it with a new issue.
- Regenerate configuration to prove comment-only generator-source changes do not create output drift.

## Verification

- `devenv tasks run genie:run` passed; generated outputs remained unchanged.
- Tracked-content searches for retired tracker identifiers, names, task links, and CLI command forms returned zero matches.
- `git diff --check` passed.
- `CI=1 devenv tasks run check:all` passed in a named PTY with exit code 0. The gate included Genie consistency and coverage, formatting, Oxlint, Nix checks, lockfile checks, megarepo checks, and TypeScript checks.

## Complexity

No new complexity; this only makes existing rationale self-contained.

## Concerns

None.

## Friction & bottlenecks

A stale local pre-commit hook expected a configuration file this repository no longer contains; the full repository gate passed independently.

No bottlenecks encountered.

## Follow-ups

None.

## References

- Existing related public issue retained in configuration: #1057

<!-- agent-footer:begin v=2 -->
<details>
<summary>Posted on behalf of @schickling</summary>

| field | value |
| --- | --- |
| `agent_identity` | dev3.direct.omp.wndc6qug |
| `session` | dev3.wndc6qug |
| `agent_persona` | generalist |
| `agent_supervisor` | unavailable |
| `agent_tool` | OMP |
| `agent_tool_version` | 18.1.14 |
| `agent_runtime` | OMP 18.1.14 |
| `tooling_profile` | dotfiles@2cf3530 |
</details>
<!-- agent-footer:end -->