### PR TITLE
Simplify store.commit callbacks with array-returned batches

### DIFF
--- a/.changeset/fix-commit-callback.md
+++ b/.changeset/fix-commit-callback.md
@@ -2,6 +2,6 @@
 '@livestore/livestore': minor
 ---
 
-Fix the documented `store.commit` callback form and its TypeScript overloads, including calls with commit options. Collect emitted events before materialization so throwing callbacks apply no events. Fixes [#1611](https://github.com/livestorejs/livestore/issues/1611).
+Fix the `store.commit` callback form and its TypeScript overloads, including calls with commit options. A synchronous callback now returns an array describing the complete event batch, which LiveStore collects before materialization so throwing callbacks apply no events. Fixes [#1611](https://github.com/livestorejs/livestore/issues/1611) and follows up on [#1616](https://github.com/livestorejs/livestore/pull/1616).
 
-Callback return values are now ignored. Replace the undocumented `store.commit(() => [event])` form with `store.commit(event)` or emit events through the supplied callback.
+Replace `store.commit((commit) => { commit(event) })` with `store.commit(() => [event])` or `store.commit(event)`. Callback builders must be synchronous and return an array, including `[]` for an empty batch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 ### Changed
 
-- **Store commits:** Fixed the documented callback form of `store.commit` and
-  its TypeScript overloads, including calls with commit options. Callback events
-  are collected before materialization, and throwing callbacks apply no events
-  ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
+- **Store commits:** Fixed the callback form of `store.commit` and its TypeScript
+  overloads, including calls with commit options. Synchronous callbacks return
+  an event array that is collected before materialization, and throwing callbacks
+  apply no events ([#1611](https://github.com/livestorejs/livestore/issues/1611),
+  [#1616](https://github.com/livestorejs/livestore/pull/1616)).
 - **Cloudflare sync telemetry:** Added optional Effect tracer layers via `otel: layer`.
   Telemetry cleanup runs in the background, and finite WebSocket operations and
   DO-RPC pull streams now emit their sync spans
@@ -60,10 +61,11 @@
 
 ### Breaking Changes
 
-- **Store commit callbacks:** Callback return values are now ignored. Replace
-  the undocumented `store.commit(() => [event])` form with `store.commit(event)`
-  or `store.commit((commit) => { commit(event) })`
-  ([#1611](https://github.com/livestorejs/livestore/issues/1611)).
+- **Store commit callbacks:** Callbacks now synchronously return an event array.
+  Replace `store.commit((commit) => { commit(event) })` with
+  `store.commit(() => [event])` or `store.commit(event)`
+  ([#1611](https://github.com/livestorejs/livestore/issues/1611),
+  [#1616](https://github.com/livestorejs/livestore/pull/1616)).
 - **Rebuild completion tracking:** The first open after upgrading from a version
   without the completion marker rebuilds derived state once. No application
   configuration changes are needed. Cloudflare deployments should budget for

--- a/context/02-system/05-store/.decisions/0002-commit-callback-return-array.md
+++ b/context/02-system/05-store/.decisions/0002-commit-callback-return-array.md
@@ -1,0 +1,64 @@
+# 0002 — Commit callbacks return complete event arrays
+
+Status: accepted (2026-09-12, maintainer-approved follow-up to
+[#1616](https://github.com/livestorejs/livestore/pull/1616#issuecomment-5622042810))
+
+## Context
+
+`store.commit` accepts events directly and supports a callback form for building
+a conditional batch. PR #1616 fixed that callback by collecting events passed to
+an emitter before materialization, while explicitly ignoring callback return
+values. The follow-up review asked whether the API should instead support only
+callbacks that return arrays, avoiding two ways to describe the same batch.
+
+The callback does not run inside the SQLite transaction. LiveStore invokes it to
+produce the complete event batch, then validates, encodes, and materializes that
+batch after the callback returns. Queries made inside the callback therefore see
+the pre-commit state.
+
+[TypeScript permits a function returning any value](https://github.com/microsoft/TypeScript/wiki/FAQ#why-are-functions-returning-non-void-assignable-to-function-returning-void),
+including a promise, to stand in for a `void`-returning callback. An emitter
+callback typed as returning `void` consequently cannot enforce the documented
+synchronous boundary or flag an accidentally returned event array.
+
+## Options
+
+- **A. Emitter callback:** Keep `store.commit((emit) => { emit(event) })` and
+  ignore its return value. This makes imperative event collection concise, but
+  resembles an active transaction even though no event is applied in the
+  callback. Its `void` return type also accepts accidental return values and
+  asynchronous callbacks.
+- **B. Array-returning callback (chosen):** Use
+  `store.commit(() => [event])`. The callback returns the complete batch as a
+  value and its return type enforces the synchronous API in ordinary typed code.
+- **C. No callback:** Require callers to build arrays outside `store.commit` and
+  spread them into the direct event overload. This has the smallest API, but
+  removes the existing scoped, lazy form for conditional batch construction.
+
+## Decision
+
+Keep the callback overload as a synchronous batch builder and require it to
+return a `ReadonlyArray` of schema events. Do not pass it an emitter, accept a
+single returned event, or support both callback styles. Direct event arguments
+remain supported.
+
+At runtime, reject a callback result that is not an array with a focused error.
+Copy a valid returned array before it enters the commit pipeline. Exceptions
+still propagate before materialization, and an empty array remains a no-op.
+
+## Consequences
+
+- The callback shape now mirrors the implementation: it describes data that
+  LiveStore commits after the callback finishes rather than appearing to commit
+  incrementally.
+- Promises are not assignable to the callback's array return type, closing the
+  common async footgun where emissions after an `await` would be lost.
+- Array operations and helper functions compose directly into commit batches.
+  Imperative builders can use a local array and return it.
+- Existing emitter callbacks must migrate to array returns. Because the callback
+  API changed during the same unreleased version as the #1616 fix, the existing
+  changeset and unreleased changelog entry describe the final contract rather
+  than recording the intermediate emitter design.
+- A future API that exposes reads and writes inside a real transaction should be
+  introduced separately instead of changing this batch-builder callback's
+  semantics.

--- a/context/02-system/05-store/spec.md
+++ b/context/02-system/05-store/spec.md
@@ -54,13 +54,14 @@ the number of eventlog events read and committed per state-rebuild batch.
 
 ## Commit Path
 
-`store.commit` accepts events directly or a synchronous callback receiving an
-event emitter, optionally preceded by commit options. Each emitter call accepts
-one or more schema events. Events are collected in order and enter the pipeline
-only after the callback returns successfully. An empty callback is a no-op. A
-callback that throws propagates its error before entering the pipeline, discards
-the collected events, and leaves the store usable. Callback return values are
-ignored. Events must be passed to the emitter or directly to `store.commit`.
+`store.commit` accepts events directly or a synchronous callback returning a
+readonly array of schema events, optionally preceded by commit options. The
+callback describes a complete batch; LiveStore copies the returned array and
+enters the pipeline only after the callback returns successfully. An empty array
+is a no-op. A callback that throws propagates its error before entering the
+pipeline and leaves the store usable. Non-array returns, including promises,
+are rejected. The callback does not receive an event emitter
+([decision 0002](./.decisions/0002-commit-callback-return-array.md)).
 
 The pipeline is fully synchronous, run via `Effect.runSyncWith`
 (`store.ts:945`). **This synchronicity is an invariant** (Q1, see

--- a/docs/src/content/docs/building-with-livestore/store.mdx
+++ b/docs/src/content/docs/building-with-livestore/store.mdx
@@ -37,14 +37,12 @@ For how to create a store in React, see the [React integration docs](/framework-
 
 <CommitEventSnippet />
 
-For conditional batches, pass a synchronous callback to `store.commit`. The
-callback receives a `commit` function that accepts one or more events per call.
-LiveStore collects those events and applies the batch after the callback finishes.
-Queries inside the callback do not see the collected changes yet. If the callback
-throws, none of its collected events are applied and the error reaches the caller.
-An empty callback does nothing. You can pass commit options before the callback.
-Callback return values are ignored. Pass events to the supplied `commit` function
-instead of returning an array.
+For conditional batches, pass a synchronous callback returning an array of
+events to `store.commit`. LiveStore applies the returned batch after the callback
+finishes. Queries inside the callback do not see the returned changes yet. If the
+callback throws, no events are applied and the error reaches the caller. Returning
+an empty array does nothing. You can pass commit options before the callback.
+The callback must return an array and cannot be asynchronous.
 
 ### Streaming events
 

--- a/docs/src/content/docs/building-with-livestore/store.mdx
+++ b/docs/src/content/docs/building-with-livestore/store.mdx
@@ -37,12 +37,7 @@ For how to create a store in React, see the [React integration docs](/framework-
 
 <CommitEventSnippet />
 
-For conditional batches, pass a synchronous callback returning an array of
-events to `store.commit`. LiveStore applies the returned batch after the callback
-finishes. Queries inside the callback do not see the returned changes yet. If the
-callback throws, no events are applied and the error reaches the caller. Returning
-an empty array does nothing. You can pass commit options before the callback.
-The callback must return an array and cannot be asynchronous.
+For conditional batches, pass a synchronous callback returning an array of events to `store.commit`. LiveStore applies the returned batch after the callback finishes. Queries inside the callback do not see the returned changes yet. If the callback throws, no events are applied and the error reaches the caller. Returning an empty array does nothing. You can pass commit options before the callback. The callback must return an array and cannot be asynchronous.
 
 ### Streaming events
 

--- a/docs/src/content/docs/framework-integrations/react-integration.mdx
+++ b/docs/src/content/docs/framework-integrations/react-integration.mdx
@@ -151,14 +151,14 @@ Returns a store instance augmented with hooks ([`store.useQuery()`](#storeuseque
 - Default store options can be configured in [`StoreRegistry`](#new-storeregistryconfig) constructor.
 - Store options are only applied when the store is loaded. Subsequent calls with different options will not affect the store if it's already loaded and cached in the registry.
 
-### `store.commit(...events)` / `store.commit(txnFn)`
+### `store.commit(...events)` / `store.commit(buildEvents)`
 
 Commits events to the store. Supports multiple calling patterns:
 
 - `store.commit(...events)` - Commit one or more events
-- `store.commit(txnFn)` - Commit events via a transaction function
+- `store.commit(buildEvents)` - Commit an array returned by a synchronous batch builder
 - `store.commit(options, ...events)` - Commit with options
-- `store.commit(options, txnFn)` - Options with transaction function
+- `store.commit(options, buildEvents)` - Options with a synchronous batch builder
 
 Options:
 - `skipRefresh` - Skip refreshing reactive queries after commit (advanced)

--- a/packages/@livestore/livestore/src/store/store-commit.test.ts
+++ b/packages/@livestore/livestore/src/store/store-commit.test.ts
@@ -6,17 +6,16 @@ import { Effect } from '@livestore/utils/effect'
 import { events, makeTodoMvc, tables } from '../utils/tests/fixture.ts'
 
 Vitest.describe('Store commit API', () => {
-  Vitest.live('should materialize events emitted by the documented commit callback', () =>
+  Vitest.live('should materialize events returned by the commit callback', () =>
     Effect.gen(function* () {
       const store = yield* makeTodoMvc()
       const firstTodo = { id: '1', text: 'Make coffee', completed: false }
       const secondTodo = { id: '2', text: 'Buy groceries', completed: false }
 
       // Regression for https://github.com/livestorejs/livestore/issues/1611.
-      store.commit((commit) => {
-        commit(events.todoCreated(firstTodo))
-        commit(events.todoCreated(secondTodo))
+      store.commit(() => {
         expect(store.query(tables.todos)).toEqual([])
+        return [events.todoCreated(firstTodo), events.todoCreated(secondTodo)]
       })
 
       expect(store.query(tables.todos.orderBy('id', 'asc'))).toEqual([firstTodo, secondTodo])
@@ -27,8 +26,9 @@ Vitest.describe('Store commit API', () => {
     Effect.gen(function* () {
       const store = yield* makeTodoMvc()
       const todo = { id: '1', text: 'Make coffee', completed: false }
+      const batch = [events.todoCreated(todo)] as const
 
-      store.commit((commit) => commit(events.todoCreated(todo)))
+      store.commit(() => batch)
 
       expect(store.query(tables.todos)).toEqual([todo])
     }).pipe(Effect.scoped),
@@ -38,21 +38,20 @@ Vitest.describe('Store commit API', () => {
     Effect.gen(function* () {
       const store = yield* makeTodoMvc()
 
-      store.commit(() => {})
+      store.commit(() => [])
 
       expect(store.query(tables.todos)).toEqual([])
     }).pipe(Effect.scoped),
   )
 
-  Vitest.live('should discard collected events when the callback throws', () =>
+  Vitest.live('should apply no events when the callback throws', () =>
     Effect.gen(function* () {
       const store = yield* makeTodoMvc()
       const todo = { id: '1', text: 'Make coffee', completed: false }
       const error = new Error('Callback failed')
 
       expect(() =>
-        store.commit((commit) => {
-          commit(events.todoCreated(todo))
+        store.commit(() => {
           throw error
         }),
       ).toThrow(error)
@@ -63,14 +62,12 @@ Vitest.describe('Store commit API', () => {
     }).pipe(Effect.scoped),
   )
 
-  Vitest.live('should collect multiple event types in one emitter call in order', () =>
+  Vitest.live('should commit multiple returned event types in order', () =>
     Effect.gen(function* () {
       const store = yield* makeTodoMvc()
       const todo = { id: '1', text: 'Make coffee', completed: false }
 
-      store.commit((commit) => {
-        commit(events.todoCreated(todo), events.todoCompleted({ id: todo.id }))
-      })
+      store.commit(() => [events.todoCreated(todo), events.todoCompleted({ id: todo.id })])
 
       expect(store.query(tables.todos)).toEqual([{ ...todo, completed: true }])
     }).pipe(Effect.scoped),
@@ -82,27 +79,46 @@ Vitest.describe('Store commit API', () => {
         const store = yield* makeTodoMvc()
         const todo = { id: '1', text: 'Make coffee', completed: false }
 
-        store.commit(options, (commit) => commit(events.todoCreated(todo)))
+        store.commit(options, () => [events.todoCreated(todo)])
 
         expect(store.query(tables.todos)).toEqual([todo])
       }).pipe(Effect.scoped),
     )
   }
 
-  Vitest.live('should ignore callback return values and only commit emitted events', () =>
+  Vitest.live('should reject callback values that are not event arrays', () =>
     Effect.gen(function* () {
       const store = yield* makeTodoMvc()
-      const todo = { id: '1', text: 'Make coffee', completed: false }
 
-      store.commit(() => [events.todoCreated(todo)])
+      expect(() => Reflect.apply(store.commit, store, [() => undefined])).toThrow(
+        'store.commit callback must synchronously return an array of events',
+      )
+      expect(() => Reflect.apply(store.commit, store, [() => Promise.resolve([])])).toThrow(
+        'store.commit callback must synchronously return an array of events',
+      )
+
       expect(store.query(tables.todos)).toEqual([])
+    }).pipe(Effect.scoped),
+  )
 
-      store.commit((commit) => {
-        commit(events.todoCreated(todo))
-        return [events.todoCompleted({ id: todo.id })]
-      })
+  Vitest.live('should reject non-array and asynchronous callbacks at the type level', () =>
+    Effect.gen(function* () {
+      const store = yield* makeTodoMvc()
 
-      expect(store.query(tables.todos)).toEqual([todo])
+      // Keep invalid calls uninvoked so TypeScript checks the public overloads without executing them.
+      const assertRejectedCallbackTypes = () => {
+        // @ts-expect-error Commit callbacks must return an event array.
+        store.commit(() => {})
+        // @ts-expect-error Commit callbacks do not receive an event emitter.
+        store.commit((emit: () => void) => {
+          emit()
+          return []
+        })
+        // @ts-expect-error Commit callbacks must be synchronous.
+        store.commit(async () => [])
+      }
+
+      expect(assertRejectedCallbackTypes).toBeTypeOf('function')
     }).pipe(Effect.scoped),
   )
 

--- a/packages/@livestore/livestore/src/store/store.ts
+++ b/packages/@livestore/livestore/src/store/store.ts
@@ -821,20 +821,16 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    *   events.todoCompleted({ id: todoId }))
    * ```
    *
-   * For more advanced transaction scenarios, you can pass a synchronous function to `commit` which will receive a callback
-   * to which you can pass multiple events to be committed in the same database transaction.
-   * Under the hood this will simply collect all events and apply them in a single database transaction.
-   * The callback's return value is ignored.
+   * For conditional batches, you can pass a synchronous function to `commit` which returns an array of events.
+   * LiveStore evaluates the function before applying the returned events in a single database transaction.
    *
    * @example
    * ```ts
-   * store.commit((commit) => {
+   * store.commit(() => {
    *   const todoId = nanoid()
-   *   if (Math.random() > 0.5) {
-   *     commit(events.todoCreated({ id: todoId, text: 'Make coffee' }))
-   *   } else {
-   *     commit(events.todoCompleted({ id: todoId }))
-   *   }
+   *   return Math.random() > 0.5
+   *     ? [events.todoCreated({ id: todoId, text: 'Make coffee' })]
+   *     : [events.todoCompleted({ id: todoId })]
    * })
    * ```
    *
@@ -856,16 +852,16 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
    */
   commit: {
     <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(...list: TCommitArg): void
-    (txn: CommitCallback<TSchema>): void
+    (buildEvents: CommitBatchBuilder<TSchema>): void
     <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(
       options: StoreCommitOptions,
       ...list: TCommitArg
     ): void
-    (options: StoreCommitOptions, txn: CommitCallback<TSchema>): void
-  } = (firstEventOrTxnFnOrOptions: any, ...restEvents: any[]) => {
+    (options: StoreCommitOptions, buildEvents: CommitBatchBuilder<TSchema>): void
+  } = (firstEventOrBatchBuilderOrOptions: any, ...restEvents: any[]) => {
     this.checkShutdown('commit')
 
-    const { events, options } = this.getCommitArgs(firstEventOrTxnFnOrOptions, restEvents)
+    const { events, options } = this.getCommitArgs(firstEventOrBatchBuilderOrOptions, restEvents)
 
     Effect.gen({ self: this }, function* () {
       const commitsSpan = otel.trace.getSpan(this[StoreInternalsSymbol].otel.commitsSpanContext)
@@ -1263,7 +1259,7 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
     effect.pipe(Effect.tapCauseLogPretty, Effect.runPromiseWith(this[StoreInternalsSymbol].effectContext.services))
 
   private getCommitArgs = (
-    firstEventOrTxnFnOrOptions: any,
+    firstEventOrBatchBuilderOrOptions: any,
     restEvents: any[],
   ): {
     events: LiveStoreEvent.Input.ForSchema<TSchema>[]
@@ -1271,27 +1267,29 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   } => {
     let events: LiveStoreEvent.Input.ForSchema<TSchema>[] = []
     let options: StoreCommitOptions | undefined
-    let commitArgs = [firstEventOrTxnFnOrOptions, ...restEvents]
+    let commitArgs = [firstEventOrBatchBuilderOrOptions, ...restEvents]
 
     if (
-      firstEventOrTxnFnOrOptions?.label !== undefined ||
-      firstEventOrTxnFnOrOptions?.skipRefresh !== undefined ||
-      firstEventOrTxnFnOrOptions?.otelContext !== undefined ||
-      firstEventOrTxnFnOrOptions?.spanLinks !== undefined ||
+      firstEventOrBatchBuilderOrOptions?.label !== undefined ||
+      firstEventOrBatchBuilderOrOptions?.skipRefresh !== undefined ||
+      firstEventOrBatchBuilderOrOptions?.otelContext !== undefined ||
+      firstEventOrBatchBuilderOrOptions?.spanLinks !== undefined ||
       typeof restEvents[0] === 'function'
     ) {
-      options = firstEventOrTxnFnOrOptions
+      options = firstEventOrBatchBuilderOrOptions
       commitArgs = restEvents
     }
 
-    const firstEventOrTxnFn = commitArgs[0]
-    if (typeof firstEventOrTxnFn === 'function') {
-      // TODO ensure that function is synchronous and isn't called in an async way (also write tests for this).
-      // Collect before materializing so a throwing callback cannot commit a partial batch.
-      firstEventOrTxnFn((...args: LiveStoreEvent.Input.ForSchema<TSchema>[]) => {
-        events.push(...args)
-      })
-    } else if (firstEventOrTxnFn !== undefined) {
+    const firstEventOrBatchBuilder = commitArgs[0]
+    if (typeof firstEventOrBatchBuilder === 'function') {
+      const builtEvents: unknown = firstEventOrBatchBuilder()
+      if (Array.isArray(builtEvents) === false) {
+        throw new TypeError('store.commit callback must synchronously return an array of events')
+      }
+
+      // Copy the completed batch so callers cannot mutate the array while it enters the commit pipeline.
+      events = [...builtEvents]
+    } else if (firstEventOrBatchBuilder !== undefined) {
       events = commitArgs
     }
 
@@ -1299,8 +1297,4 @@ export class Store<TSchema extends LiveStoreSchema = LiveStoreSchema.Any, TConte
   }
 }
 
-type CommitCallback<TSchema extends LiveStoreSchema> = (
-  commit: <const TCommitArg extends ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>>(
-    ...events: TCommitArg
-  ) => void,
-) => void
+type CommitBatchBuilder<TSchema extends LiveStoreSchema> = () => ReadonlyArray<LiveStoreEvent.Input.ForSchema<TSchema>>


### PR DESCRIPTION
## Problem

[PR #1616](https://github.com/livestorejs/livestore/pull/1616) fixed the documented `store.commit` emitter callback by collecting its events before materialization and explicitly ignoring callback return values. The [post-merge design comment](https://github.com/livestorejs/livestore/pull/1616#issuecomment-5622042810) asked whether callbacks should instead return arrays so LiveStore supports only one callback convention for describing a batch.

The emitter shape does not match the implementation particularly well: events are not committed while the callback runs, and queries in the callback see the pre-commit state. Its `void` return type also cannot enforce the synchronous boundary because TypeScript deliberately permits non-void and async functions where a void-returning callback is expected. That leaves room for silently ignored arrays and for emissions after an `await` to be lost.

## Solution

Replace emitter callbacks with synchronous batch builders that must return a `ReadonlyArray` of schema events:

```ts
store.commit(() => [event1, event2])
```

This keeps one callback convention and models the real operation as "build the complete batch, then commit it." Array returns compose with ordinary array helpers, reject typical async callbacks at the type level, and preserve the existing all-or-nothing behavior when the builder throws. Direct `store.commit(...events)`, commit options, ordering, and empty batches remain supported.

Runtime callers using JavaScript or `any` receive a focused error for non-array results, including promises. LiveStore copies a valid returned array before it enters the commit pipeline. The store intent layer records the choice and rejected alternatives, while docs, tests, the changeset, and the unreleased changelog now describe the final contract.

The trade-off is that imperative emitter callbacks must migrate. Callers that prefer imperative construction can build a local array and return it. Removing callbacks entirely was considered, but retaining a scoped, lazy builder remains useful for conditional batches. A future API exposing reads and writes inside a real transaction should be separate from this batch builder.

## Validation

- `pnpm exec vitest run packages/@livestore/livestore/src/store/store-commit.test.ts` (10 tests passed)
- `devenv tasks run test:unit`
- `devenv tasks run ts:check`
- `pnpm exec tsc -p packages/@livestore/livestore/tsconfig.json --noEmit`
- `devenv tasks run lint:check:md-imports`
- Focused Oxlint for the modified TypeScript files (0 warnings, 0 errors)
- `devenv tasks run release:changeset:check-pr`
- `devenv tasks run release:changeset:check-bodies`
- Full docs package build and internal-link validation
- Pre-commit `check-quick`

`devenv tasks run lint:full:fix` was also run. Its formatter completed, but the aggregate task remains blocked by six pre-existing Oxlint errors in unrelated example files; the modified TypeScript files pass focused Oxlint.

### Demo

```diff
-store.commit((commit) => {
-  commit(event1)
-  commit(event2)
-})
+store.commit(() => [event1, event2])
```

## Related issues

- Original callback failure: [#1611](https://github.com/livestorejs/livestore/issues/1611)
- Previous fix: [#1616](https://github.com/livestorejs/livestore/pull/1616)
- Follow-up API discussion: [#1616 comment](https://github.com/livestorejs/livestore/pull/1616#issuecomment-5622042810)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking change to a core `store.commit` API surface; apps or libraries still on the emitter callback must migrate, though direct event commits and all-or-nothing semantics are unchanged.
> 
> **Overview**
> **`store.commit` callback batches now return event arrays** instead of using an emitter function. Callers should use `store.commit(() => [event1, event2])` (or keep direct `store.commit(...events)`); migrate away from `store.commit((commit) => { commit(event) })`.
> 
> Runtime behavior matches the new shape: the builder runs first, LiveStore **copies** the returned array, then materializes only after a successful return. Throwing still applies nothing; **`[]` is a no-op**. Non-array results (including promises) throw a focused `TypeError`. TypeScript overloads use **`CommitBatchBuilder`** so async callbacks and emitter parameters are rejected at compile time.
> 
> Docs, store spec, ADR **0002**, changeset/changelog breaking notes, and **`store-commit.test.ts`** are updated to describe and lock in the contract (follow-up to [#1616](https://github.com/livestorejs/livestore/pull/1616), fixes [#1611](https://github.com/livestorejs/livestore/issues/1611)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d2e0bd1bb9472abcc2653ad120c0da64d3d105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->