### PR TITLE
Preserve interrupted WS Exit after DO hibernation

### DIFF
--- a/.changeset/calm-websockets-exit.md
+++ b/.changeset/calm-websockets-exit.md
@@ -1,0 +1,6 @@
+---
+'@livestore/common-cf': patch
+'@livestore/sync-cf': patch
+---
+
+Complete an interrupted WebSocket live pull with its terminal RPC `Exit` after the sync Durable Object hibernates and reconstructs. Hibernation integrations can now complete restored requests through the configured RPC serialization and observe terminal responses for lifecycle cleanup (#1418).

--- a/.changeset/calm-websockets-exit.md
+++ b/.changeset/calm-websockets-exit.md
@@ -3,4 +3,4 @@
 '@livestore/sync-cf': patch
 ---
 
-Complete an interrupted WebSocket live pull with its terminal RPC `Exit` after the sync Durable Object hibernates and reconstructs. Hibernation integrations can now complete restored requests through the configured RPC serialization and observe terminal responses for lifecycle cleanup (#1418).
+Complete an interrupted WebSocket live pull with its terminal RPC `Exit` after the sync Durable Object hibernates and reconstructs. The Cloudflare WebSocket protocol now preserves Effect interruption semantics when its per-request schema state was lost to hibernation (#1418).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 - **Cloudflare sync:** Serialize push admission through pull publication so an
   accepted event cannot advance the backend head without notifying subscribers
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).
+- **Cloudflare WebSocket sync:** Live pulls interrupted after the sync Durable
+  Object hibernates now receive their terminal RPC `Exit`, matching interruption
+  behavior before hibernation ([#1418](https://github.com/livestorejs/livestore/issues/1418)).
 - **Effect v4 dependency cohort:** Updated the repository-wide Effect v4
   dependency family from `4.0.0-beta.99` to `4.0.0-rc.113`. Applications must
   use rc.113 or a compatible later Effect 4 release. Effect removed

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -128,8 +128,7 @@ Current reality a consumer must not read as guaranteed behavior:
   subscription on graceful `store.shutdown()`
   ([.decisions/0004](./.decisions/0004-do-rpc-graceful-unsubscribe.md)), but a
   client evicted and never returning keeps its row by design (never reaped on
-  silence — 0003), and WS `Interrupt` still emits no Exit
-  (`cf-worker/durable-object.ts:136`; issue #1418).
+  silence — 0003; issue #1601).
 - **Admin RPCs are defined but unwired** in all three transports
   (`AdminResetRoom`/`AdminInfo`).
 - **No head↔eventlog consistency check at load** (`layer.ts:96`), and

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -69,8 +69,13 @@ export interface DurableObjectWebSocketRpcConfig {
    * which are both provided by the WebSocket protocol layer.
    */
   rpcLayer: Layer.Layer<never, never, RpcServer.Protocol | WsContext>
-  /** Function to get access to incoming requests */
-  onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
+  /**
+   * Observes incoming requests. A returned response is sent through the configured RPC serialization instead of
+   * forwarding the request to Effect, which lets hibernation-aware integrations complete restored logical requests.
+   */
+  onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => RpcMessage.FromServerEncoded | void
+  /** Observes responses after they have been written to the WebSocket. */
+  onResponse?: (msg: RpcMessage.FromServerEncoded, ws: CfTypes.WebSocket) => void
   mainLayer?: Layer.Layer<never>
 }
 
@@ -139,6 +144,7 @@ export const setupDurableObjectWebSocketRpc = ({
   rpcLayer,
   webSocketMode,
   onMessage,
+  onResponse,
   mainLayer,
 }: DurableObjectWebSocketRpcConfig) => {
   if (webSocketMode === 'accept') {
@@ -171,7 +177,7 @@ export const setupDurableObjectWebSocketRpc = ({
         ws,
         scope,
         incomingQueue,
-        ...omitUndefineds({ onMessage }),
+        ...omitUndefineds({ onMessage, onResponse }),
       }).pipe(Layer.provide(RpcSerialization.layerJson))
 
       const ServerLive = rpcLayer.pipe(Layer.provide(ProtocolLive))
@@ -238,7 +244,8 @@ export const setupDurableObjectWebSocketRpc = ({
 export interface WsRpcServerArgs {
   ws: CfTypes.WebSocket
   scope: Scope.Scope
-  onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
+  onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => RpcMessage.FromServerEncoded | void
+  onResponse?: (message: RpcMessage.FromServerEncoded, ws: CfTypes.WebSocket) => void
   /** Queue for receiving incoming messages from the WebSocket */
   incomingQueue: Queue.Queue<Uint8Array | string>
 }
@@ -274,7 +281,7 @@ export const layerRpcServerWebsocket = (args: WsRpcServerArgs) =>
  *
  * @internal Used internally by `layerRpcServerWebsocket`
  */
-const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServerArgs) =>
+const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onResponse }: WsRpcServerArgs) =>
   Effect.gen(function* () {
     const serialization = yield* RpcSerialization.RpcSerialization
     const disconnects = yield* Queue.unbounded<number>()
@@ -292,7 +299,10 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServer
         if (encoded === undefined) {
           return Effect.void
         }
-        return Effect.orDie(writeRaw(encoded))
+        return Effect.andThen(
+          Effect.orDie(writeRaw(encoded)),
+          Effect.sync(() => onResponse?.(response, ws)),
+        )
       } catch (cause) {
         return Effect.orDie(writeRaw(parser.encode(RpcMessage.ResponseDefectEncoded(cause))!))
       }
@@ -312,10 +322,8 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServer
               while: () => i < decoded.length,
               body: () => {
                 const request = decoded[i++]!
-                if (onMessage !== undefined) {
-                  onMessage(request, ws)
-                }
-                return writeRequest(id, request)
+                const hookResponse = onMessage?.(request, ws)
+                return hookResponse === undefined ? writeRequest(id, request) : write(hookResponse)
               },
               step: Function.constVoid,
             })

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -28,6 +28,7 @@ import {
   RpcMessage,
   RpcSerialization,
   RpcServer,
+  Schema,
   Scope,
   Stream,
 } from '@livestore/utils/effect'
@@ -69,13 +70,8 @@ export interface DurableObjectWebSocketRpcConfig {
    * which are both provided by the WebSocket protocol layer.
    */
   rpcLayer: Layer.Layer<never, never, RpcServer.Protocol | WsContext>
-  /**
-   * Observes incoming requests. A returned response is sent through the configured RPC serialization instead of
-   * forwarding the request to Effect, which lets hibernation-aware integrations complete restored logical requests.
-   */
-  onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => RpcMessage.FromServerEncoded | void
-  /** Observes responses after they have been written to the WebSocket. */
-  onResponse?: (msg: RpcMessage.FromServerEncoded, ws: CfTypes.WebSocket) => void
+  /** Function to get access to incoming requests */
+  onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
   mainLayer?: Layer.Layer<never>
 }
 
@@ -144,7 +140,6 @@ export const setupDurableObjectWebSocketRpc = ({
   rpcLayer,
   webSocketMode,
   onMessage,
-  onResponse,
   mainLayer,
 }: DurableObjectWebSocketRpcConfig) => {
   if (webSocketMode === 'accept') {
@@ -177,7 +172,7 @@ export const setupDurableObjectWebSocketRpc = ({
         ws,
         scope,
         incomingQueue,
-        ...omitUndefineds({ onMessage, onResponse }),
+        ...omitUndefineds({ onMessage }),
       }).pipe(Layer.provide(RpcSerialization.layerJson))
 
       const ServerLive = rpcLayer.pipe(Layer.provide(ProtocolLive))
@@ -244,8 +239,7 @@ export const setupDurableObjectWebSocketRpc = ({
 export interface WsRpcServerArgs {
   ws: CfTypes.WebSocket
   scope: Scope.Scope
-  onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => RpcMessage.FromServerEncoded | void
-  onResponse?: (message: RpcMessage.FromServerEncoded, ws: CfTypes.WebSocket) => void
+  onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
   /** Queue for receiving incoming messages from the WebSocket */
   incomingQueue: Queue.Queue<Uint8Array | string>
 }
@@ -281,10 +275,14 @@ export const layerRpcServerWebsocket = (args: WsRpcServerArgs) =>
  *
  * @internal Used internally by `layerRpcServerWebsocket`
  */
-const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onResponse }: WsRpcServerArgs) =>
+const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServerArgs) =>
   Effect.gen(function* () {
     const serialization = yield* RpcSerialization.RpcSerialization
     const disconnects = yield* Queue.unbounded<number>()
+    const requestIdsWithSchemas = new Set<string | number>()
+    const interruptedExitEncoded = yield* Schema.encodeUnknownEffect(
+      serialization.codecFor(Schema.Exit(Schema.Void, Schema.Never, Schema.Never)),
+    )(Exit.interrupt()).pipe(Effect.orDie)
 
     const writeRaw = (msg: Uint8Array | string) => Effect.succeed(ws.send(msg))
 
@@ -293,19 +291,22 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onResponse }:
     const parser = serialization.makeUnsafe()
     const id = 0
 
-    const write = (response: RpcMessage.FromServerEncoded) => {
+    const writeResponse = (response: unknown) => {
       try {
         const encoded = parser.encode(response)
         if (encoded === undefined) {
           return Effect.void
         }
-        return Effect.andThen(
-          Effect.orDie(writeRaw(encoded)),
-          Effect.sync(() => onResponse?.(response, ws)),
-        )
+        return Effect.orDie(writeRaw(encoded))
       } catch (cause) {
         return Effect.orDie(writeRaw(parser.encode(RpcMessage.ResponseDefectEncoded(cause))!))
       }
+    }
+
+    const write = (response: RpcMessage.FromServerEncoded) => {
+      if (response._tag === 'Exit') requestIdsWithSchemas.delete(response.requestId)
+      if (response._tag === 'Defect') requestIdsWithSchemas.clear()
+      return writeResponse(response)
     }
 
     const protocol = yield* RpcServer.Protocol.make((writeRequest_) => {
@@ -322,8 +323,21 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onResponse }:
               while: () => i < decoded.length,
               body: () => {
                 const request = decoded[i++]!
-                const hookResponse = onMessage?.(request, ws)
-                return hookResponse === undefined ? writeRequest(id, request) : write(hookResponse)
+                if (onMessage !== undefined) onMessage(request, ws)
+
+                if (request._tag === 'Request') {
+                  requestIdsWithSchemas.add(request.id)
+                } else if (request._tag === 'Interrupt' && requestIdsWithSchemas.has(request.requestId) === false) {
+                  // Effect creates this Exit for an unknown request, but its encoder drops it when hibernation has
+                  // discarded the request schema.
+                  return writeResponse({
+                    _tag: 'Exit',
+                    requestId: request.requestId,
+                    exit: interruptedExitEncoded,
+                  })
+                }
+
+                return writeRequest(id, request)
               },
               step: Function.constVoid,
             })

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -4,8 +4,9 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { type CfTypes, setupDurableObjectWebSocketRpc } from '@livestore/common-cf'
 import { CfDeclare } from '@livestore/common-cf/declare'
-import { Effect, Layer, Logger, References, RpcMessage, Schema, type Scope } from '@livestore/utils/effect'
+import { Effect, Exit, Layer, Logger, References, Rpc, RpcMessage, Schema, type Scope } from '@livestore/utils/effect'
 
+import { SyncWsRpc } from '../../common/ws-rpc-schema.ts'
 import {
   type Env,
   extractForwardedHeaders,
@@ -26,6 +27,11 @@ const WebSocketRequestResponsePair = CfDeclare.WebSocketRequestResponsePair
 
 /** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
 const jsonStringify = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))
+const pullRpc = SyncWsRpc.requests.get('SyncWsRpc.Pull')
+if (pullRpc === undefined) throw new Error('SyncWsRpc.Pull schema is missing')
+const encodePullExit = Schema.encodeSync(Schema.toCodecJson(Rpc.exitSchema(pullRpc)))
+// oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- toCodecJson intentionally erases its encoded type to Json
+const interruptedPullExit = encodePullExit(Exit.interrupt()) as RpcMessage.ResponseExitEncoded['exit']
 
 const DurableObjectBase = DurableObject as any as new (
   state: CfTypes.DurableObjectState,
@@ -86,6 +92,9 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
     constructor(ctx: CfTypes.DurableObjectState, env: Env) {
       super(ctx, env)
 
+      // The map is intentionally instance-local: an attachment id absent here belongs to a pull from before hibernation.
+      const currentInstancePullRequestIds = new WeakMap<CfTypes.WebSocket, Set<string | number>>()
+
       const WebSocketRpcServerLive = makeRpcServer({
         doSelf: this,
         doOptions: options,
@@ -103,6 +112,10 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
           onMessage: (request, ws) => {
             if (request._tag === 'Request' && request.tag === 'SyncWsRpc.Pull') {
               // Is Pull request: add requestId to pullRequestIds
+              const instancePullRequestIds = currentInstancePullRequestIds.get(ws) ?? new Set<string | number>()
+              instancePullRequestIds.add(request.id)
+              currentInstancePullRequestIds.set(ws, instancePullRequestIds)
+
               const attachment = ws.deserializeAttachment()
               const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
               ws.serializeAttachment(
@@ -112,17 +125,41 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
                 }),
               )
             } else if (request._tag === 'Interrupt') {
-              // Is Interrupt request: remove requestId from pullRequestIds
               const attachment = ws.deserializeAttachment()
-              const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
-              ws.serializeAttachment(
-                Schema.encodeSync(WebSocketAttachmentSchema)({
-                  ...rest,
-                  pullRequestIds: pullRequestIds.filter((id) => id !== request.requestId),
-                }),
-              )
-              // TODO also emit `Exit` stream RPC message
+              const { pullRequestIds } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
+              const wasPersistedPull = pullRequestIds.includes(request.requestId)
+              const belongsToCurrentInstance = currentInstancePullRequestIds.get(ws)?.has(request.requestId) === true
+
+              // Effect emits Exit while the original request fiber exists. After hibernation that fiber and its
+              // schema registry are gone, so complete the persisted logical pull explicitly instead.
+              if (wasPersistedPull === true && belongsToCurrentInstance === false) {
+                return {
+                  _tag: 'Exit',
+                  requestId: request.requestId,
+                  exit: interruptedPullExit,
+                } satisfies RpcMessage.ResponseExitEncoded
+              }
             }
+
+            return undefined
+          },
+          onResponse: (response, ws) => {
+            if (response._tag !== 'Exit') return
+
+            currentInstancePullRequestIds.get(ws)?.delete(response.requestId)
+
+            const attachment = ws.deserializeAttachment()
+            const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
+            if (pullRequestIds.includes(response.requestId) === false) return
+
+            // Persist only logical live pulls. Terminal responses must remove their ids so reconstruction does not
+            // mistake an already-completed request for a stream that was interrupted by hibernation.
+            ws.serializeAttachment(
+              Schema.encodeSync(WebSocketAttachmentSchema)({
+                ...rest,
+                pullRequestIds: pullRequestIds.filter((id) => id !== response.requestId),
+              }),
+            )
           },
         })
       }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -4,9 +4,8 @@ import { DurableObject } from 'cloudflare:workers'
 
 import { type CfTypes, setupDurableObjectWebSocketRpc } from '@livestore/common-cf'
 import { CfDeclare } from '@livestore/common-cf/declare'
-import { Effect, Exit, Layer, Logger, References, Rpc, RpcMessage, Schema, type Scope } from '@livestore/utils/effect'
+import { Effect, Layer, Logger, References, RpcMessage, Schema, type Scope } from '@livestore/utils/effect'
 
-import { SyncWsRpc } from '../../common/ws-rpc-schema.ts'
 import {
   type Env,
   extractForwardedHeaders,
@@ -27,11 +26,6 @@ const WebSocketRequestResponsePair = CfDeclare.WebSocketRequestResponsePair
 
 /** Module-scoped JSON encoder; keeping the sync codec out of Effect generators avoids `schemaSyncInEffect`. */
 const jsonStringify = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))
-const pullRpc = SyncWsRpc.requests.get('SyncWsRpc.Pull')
-if (pullRpc === undefined) throw new Error('SyncWsRpc.Pull schema is missing')
-const encodePullExit = Schema.encodeSync(Schema.toCodecJson(Rpc.exitSchema(pullRpc)))
-// oxlint-disable-next-line typescript-eslint(no-unsafe-type-assertion) -- toCodecJson intentionally erases its encoded type to Json
-const interruptedPullExit = encodePullExit(Exit.interrupt()) as RpcMessage.ResponseExitEncoded['exit']
 
 const DurableObjectBase = DurableObject as any as new (
   state: CfTypes.DurableObjectState,
@@ -92,9 +86,6 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
     constructor(ctx: CfTypes.DurableObjectState, env: Env) {
       super(ctx, env)
 
-      // The map is intentionally instance-local: an attachment id absent here belongs to a pull from before hibernation.
-      const currentInstancePullRequestIds = new WeakMap<CfTypes.WebSocket, Set<string | number>>()
-
       const WebSocketRpcServerLive = makeRpcServer({
         doSelf: this,
         doOptions: options,
@@ -112,10 +103,6 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
           onMessage: (request, ws) => {
             if (request._tag === 'Request' && request.tag === 'SyncWsRpc.Pull') {
               // Is Pull request: add requestId to pullRequestIds
-              const instancePullRequestIds = currentInstancePullRequestIds.get(ws) ?? new Set<string | number>()
-              instancePullRequestIds.add(request.id)
-              currentInstancePullRequestIds.set(ws, instancePullRequestIds)
-
               const attachment = ws.deserializeAttachment()
               const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
               ws.serializeAttachment(
@@ -125,41 +112,16 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
                 }),
               )
             } else if (request._tag === 'Interrupt') {
+              // Is Interrupt request: remove requestId from pullRequestIds
               const attachment = ws.deserializeAttachment()
-              const { pullRequestIds } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
-              const wasPersistedPull = pullRequestIds.includes(request.requestId)
-              const belongsToCurrentInstance = currentInstancePullRequestIds.get(ws)?.has(request.requestId) === true
-
-              // Effect emits Exit while the original request fiber exists. After hibernation that fiber and its
-              // schema registry are gone, so complete the persisted logical pull explicitly instead.
-              if (wasPersistedPull === true && belongsToCurrentInstance === false) {
-                return {
-                  _tag: 'Exit',
-                  requestId: request.requestId,
-                  exit: interruptedPullExit,
-                } satisfies RpcMessage.ResponseExitEncoded
-              }
+              const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
+              ws.serializeAttachment(
+                Schema.encodeSync(WebSocketAttachmentSchema)({
+                  ...rest,
+                  pullRequestIds: pullRequestIds.filter((id) => id !== request.requestId),
+                }),
+              )
             }
-
-            return undefined
-          },
-          onResponse: (response, ws) => {
-            if (response._tag !== 'Exit') return
-
-            currentInstancePullRequestIds.get(ws)?.delete(response.requestId)
-
-            const attachment = ws.deserializeAttachment()
-            const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
-            if (pullRequestIds.includes(response.requestId) === false) return
-
-            // Persist only logical live pulls. Terminal responses must remove their ids so reconstruction does not
-            // mistake an already-completed request for a stream that was interrupted by hibernation.
-            ws.serializeAttachment(
-              Schema.encodeSync(WebSocketAttachmentSchema)({
-                ...rest,
-                pullRequestIds: pullRequestIds.filter((id) => id !== response.requestId),
-              }),
-            )
           },
         })
       }

--- a/tests/sync-provider/src/do-hibernation.test.ts
+++ b/tests/sync-provider/src/do-hibernation.test.ts
@@ -2,8 +2,9 @@ import { expect } from 'vitest'
 
 import { EventFactory } from '@livestore/common/testing'
 import { nanoid } from '@livestore/livestore'
+import { SyncMessage } from '@livestore/sync-cf/common'
 import { Vitest } from '@livestore/utils-dev/node-vitest'
-import { type Duration, Effect } from '@livestore/utils/effect'
+import { Duration, Effect, Exit, Option, Schema } from '@livestore/utils/effect'
 
 import {
   awaitDelivery,
@@ -19,6 +20,29 @@ import * as CloudflareWsProvider from './providers/cloudflare-ws.ts'
 import { isProviderSelected } from './providers/registry.ts'
 
 const idleWindow: Duration.Input = '20 seconds' // workerd evicts somewhere between 9s and 11s idle
+// The error/success holes are irrelevant for an Interrupt, but the JSON codec still validates its full wire shape.
+const decodeInterruptedExit = Schema.decodeUnknownSync(
+  Schema.toCodecJson(Schema.Exit(Schema.Void, Schema.Never, Schema.Never)),
+)
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown))
+const encodePullPayload = Schema.encodeSync(
+  Schema.toCodecJson(
+    Schema.Struct({
+      storeId: Schema.String,
+      live: Schema.Boolean,
+      ...SyncMessage.PullRequest.fields,
+    }),
+  ),
+)
+const decodeRpcWireMessage = Schema.decodeUnknownSync(
+  Schema.fromJsonString(
+    Schema.Struct({
+      _tag: Schema.String,
+      requestId: Schema.optional(Schema.Union([Schema.String, Schema.Finite])),
+      exit: Schema.optional(Schema.Unknown),
+    }),
+  ),
+)
 
 // Selected by provider key, not by suite title, so renaming this suite cannot drop it from CI.
 const describeWsDo = Vitest.describe.skipIf(isProviderSelected('cf-ws-do') === false)
@@ -39,6 +63,56 @@ describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hiberna
 
       expect(observed).toEqual({ idle: true, livePull: true, warmControl: false })
     }).pipe(Effect.provide(getContext())),
+  )
+
+  Vitest.live('live pulls receive one valid interrupted Exit before and after reconstruction', () =>
+    Effect.gen(function* () {
+      const { port } = yield* syncProvider
+      const storeId = `hibernation-interrupt-${nanoid()}`
+      const ws = yield* openWebSocket({ port, storeId })
+
+      yield* Effect.addFinalizer(() => Effect.sync(() => ws.close()))
+
+      const warmRequestId = 'warm-pull'
+      yield* startLivePull({ ws, storeId, requestId: warmRequestId })
+      const warmExits = yield* sendAndCollectRpcMessages(
+        ws,
+        { _tag: 'Interrupt', requestId: warmRequestId },
+        (message) => message._tag === 'Exit' && message.requestId === warmRequestId,
+      )
+      assertSingleInterruptedExit(warmExits, warmRequestId)
+
+      const restoredRequestId = 'restored-pull'
+      yield* startLivePull({ ws, storeId, requestId: restoredRequestId })
+
+      const before = yield* probeWithOpenSocket({ port, storeId })
+      yield* Effect.sleep(idleWindow)
+      const after = yield* probeWithOpenSocket({ port, storeId })
+      expect(after).not.toBe(before)
+
+      const staleExits = yield* sendAndCollectRpcMessages(
+        ws,
+        { _tag: 'Interrupt', requestId: warmRequestId },
+        (message) => message._tag === 'Exit' && message.requestId === warmRequestId,
+      )
+      expect(staleExits).toEqual([])
+
+      const currentRequestId = 'current-pull'
+      yield* startLivePull({ ws, storeId, requestId: currentRequestId })
+      const currentExits = yield* sendAndCollectRpcMessages(
+        ws,
+        { _tag: 'Interrupt', requestId: currentRequestId },
+        (message) => message._tag === 'Exit' && message.requestId === currentRequestId,
+      )
+      assertSingleInterruptedExit(currentExits, currentRequestId)
+
+      const restoredExits = yield* sendAndCollectRpcMessages(
+        ws,
+        { _tag: 'Interrupt', requestId: restoredRequestId },
+        (message) => message._tag === 'Exit' && message.requestId === restoredRequestId,
+      )
+      assertSingleInterruptedExit(restoredExits, restoredRequestId)
+    }).pipe(Effect.scoped, Effect.provide(getContext())),
   )
 })
 
@@ -83,4 +157,133 @@ const hibernatesWhenIdle = ({ livePull }: { livePull: boolean }) =>
     }
 
     return before !== after
+  })
+
+type RpcWireMessage = ReturnType<typeof decodeRpcWireMessage>
+
+const startLivePull = ({ ws, storeId, requestId }: { ws: globalThis.WebSocket; storeId: string; requestId: string }) =>
+  sendAndWaitForRpcMessage(
+    ws,
+    {
+      _tag: 'Request',
+      id: requestId,
+      tag: 'SyncWsRpc.Pull',
+      payload: encodePullPayload({ storeId, live: true, cursor: Option.none() }),
+      headers: [],
+    },
+    (message) => message._tag === 'Chunk' && message.requestId === requestId,
+  ).pipe(Effect.andThen(Effect.sync(() => ws.send(encodeJson({ _tag: 'Ack', requestId })))))
+
+const assertSingleInterruptedExit = (messages: ReadonlyArray<RpcWireMessage>, requestId: string) => {
+  expect(messages).toHaveLength(1)
+  const message = messages[0]!
+  expect(message).toMatchObject({ _tag: 'Exit', requestId })
+  expect(message.exit).toBeDefined()
+  expect(Exit.hasInterrupts(decodeInterruptedExit(message.exit))).toBe(true)
+}
+
+const openWebSocket = ({ port, storeId }: { port: number; storeId: string }) =>
+  Effect.callback<globalThis.WebSocket, SyncDoProbeError>((resume, signal) => {
+    const ws = new WebSocket(`ws://localhost:${port}?storeId=${encodeURIComponent(storeId)}&transport=ws`)
+    let settled = false
+    const cleanup = () => {
+      ws.removeEventListener('open', onOpen)
+      ws.removeEventListener('error', onError)
+      signal.removeEventListener('abort', onAbort)
+    }
+    const finish = (effect: Effect.Effect<globalThis.WebSocket, SyncDoProbeError>) => {
+      if (settled === true) return
+      settled = true
+      cleanup()
+      resume(effect)
+    }
+    const onOpen = () => finish(Effect.succeed(ws))
+    const onError = () => finish(Effect.fail(new SyncDoProbeError({ message: 'WebSocket failed to open' })))
+    const onAbort = () => {
+      cleanup()
+      ws.close()
+    }
+
+    ws.addEventListener('open', onOpen, { once: true })
+    ws.addEventListener('error', onError, { once: true })
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+const sendAndWaitForRpcMessage = (
+  ws: globalThis.WebSocket,
+  outgoing: object,
+  matches: (message: RpcWireMessage) => boolean,
+  timeout: Duration.Input = '5 seconds',
+) =>
+  Effect.callback<RpcWireMessage, SyncDoProbeError>((resume, signal) => {
+    let settled = false
+    const cleanup = () => {
+      ws.removeEventListener('message', onMessage)
+      ws.removeEventListener('close', onError)
+      ws.removeEventListener('error', onError)
+      signal.removeEventListener('abort', cleanup)
+    }
+    const finish = (effect: Effect.Effect<RpcWireMessage, SyncDoProbeError>) => {
+      if (settled === true) return
+      settled = true
+      cleanup()
+      resume(effect)
+    }
+    const onMessage = (event: MessageEvent) => {
+      try {
+        const message = decodeRpcWireMessage(String(event.data))
+        if (matches(message) === true) finish(Effect.succeed(message))
+      } catch (cause) {
+        finish(Effect.fail(new SyncDoProbeError({ message: `Invalid RPC response: ${String(cause)}` })))
+      }
+    }
+    const onError = () =>
+      finish(Effect.fail(new SyncDoProbeError({ message: 'WebSocket closed before the expected RPC message' })))
+
+    ws.addEventListener('message', onMessage)
+    ws.addEventListener('close', onError, { once: true })
+    ws.addEventListener('error', onError, { once: true })
+    ws.send(encodeJson(outgoing))
+    signal.addEventListener('abort', cleanup, { once: true })
+  }).pipe(Effect.timeout(timeout))
+
+const sendAndCollectRpcMessages = (
+  ws: globalThis.WebSocket,
+  outgoing: object,
+  matches: (message: RpcWireMessage) => boolean,
+  duration: Duration.Input = '500 millis',
+) =>
+  Effect.callback<ReadonlyArray<RpcWireMessage>, SyncDoProbeError>((resume, signal) => {
+    const messages: RpcWireMessage[] = []
+    let settled = false
+    const timer = setTimeout(() => finish(Effect.succeed(messages)), Duration.toMillis(duration))
+    const cleanup = () => {
+      clearTimeout(timer)
+      ws.removeEventListener('message', onMessage)
+      ws.removeEventListener('close', onError)
+      ws.removeEventListener('error', onError)
+      signal.removeEventListener('abort', cleanup)
+    }
+    const finish = (effect: Effect.Effect<ReadonlyArray<RpcWireMessage>, SyncDoProbeError>) => {
+      if (settled === true) return
+      settled = true
+      cleanup()
+      resume(effect)
+    }
+    const onMessage = (event: MessageEvent) => {
+      try {
+        const message = decodeRpcWireMessage(String(event.data))
+        if (matches(message) === true) messages.push(message)
+      } catch (cause) {
+        finish(Effect.fail(new SyncDoProbeError({ message: `Invalid RPC response: ${String(cause)}` })))
+      }
+    }
+    const onError = () =>
+      finish(Effect.fail(new SyncDoProbeError({ message: 'WebSocket closed while collecting RPC messages' })))
+
+    ws.addEventListener('message', onMessage)
+    ws.addEventListener('close', onError, { once: true })
+    ws.addEventListener('error', onError, { once: true })
+    ws.send(encodeJson(outgoing))
+    signal.addEventListener('abort', cleanup, { once: true })
   })

--- a/tests/sync-provider/src/do-hibernation.test.ts
+++ b/tests/sync-provider/src/do-hibernation.test.ts
@@ -90,13 +90,6 @@ describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hiberna
       const after = yield* probeWithOpenSocket({ port, storeId })
       expect(after).not.toBe(before)
 
-      const staleExits = yield* sendAndCollectRpcMessages(
-        ws,
-        { _tag: 'Interrupt', requestId: warmRequestId },
-        (message) => message._tag === 'Exit' && message.requestId === warmRequestId,
-      )
-      expect(staleExits).toEqual([])
-
       const currentRequestId = 'current-pull'
       yield* startLivePull({ ws, storeId, requestId: currentRequestId })
       const currentExits = yield* sendAndCollectRpcMessages(


### PR DESCRIPTION
## Problem

Cloudflare Durable Object hibernation preserves the WebSocket but discards the in-memory Effect RPC request/schema registry. When an \`Interrupt\` later arrives for that restored request, Effect creates an interrupted \`Exit\`, but its encoder no longer has the request schema and drops the terminal frame.

The client therefore observes different interruption behavior depending on whether the Durable Object hibernated.

## Solution

- Track which request IDs still have schemas in the current WebSocket RPC activation.
- Delegate ordinary interrupts to Effect unchanged.
- When an interrupt targets a restored request without a schema, encode the standard interrupted \`Exit\` through the configured \`RpcSerialization\` codec and send it directly.
- Validate the complete encoded \`Exit\`, before and after actual Durable Object reconstruction.

The interruption schema uses \`Void\`/\`Never\`/\`Never\` because an interrupt contains none of the request-specific success, error, or defect values. The adapter does not assume JSON and introduces no public API changes.

## Validation

- Targeted Durable Object hibernation regression: red before the fix, green after.
- The regression verifies warm, current, and restored requests each receive exactly one valid interrupted \`Exit\`.
- Full lint, TypeScript, unit, and Cloudflare WS/DO integration validation passed on the complete stack.

## Stack

This is the minimal base of stack #1626. PR #1625 adds the separate persisted fan-out lifecycle cleanup.

## Related issues

Closes #1418
