### PR TITLE
Clean up terminal WS pull fan-out state

### DIFF
--- a/.changeset/calm-websockets-exit.md
+++ b/.changeset/calm-websockets-exit.md
@@ -3,4 +3,4 @@
 '@livestore/sync-cf': patch
 ---
 
-Complete an interrupted WebSocket live pull with its terminal RPC `Exit` after the sync Durable Object hibernates and reconstructs. The Cloudflare WebSocket protocol now preserves Effect interruption semantics when its per-request schema state was lost to hibernation (#1418).
+Complete WebSocket pull lifecycles across sync Durable Object hibernation. Interrupted live pulls now receive their terminal RPC `Exit` after reconstruction, and terminal pulls are removed from persisted fan-out state (#1418).

--- a/.changeset/calm-websockets-exit.md
+++ b/.changeset/calm-websockets-exit.md
@@ -3,4 +3,4 @@
 '@livestore/sync-cf': patch
 ---
 
-Complete WebSocket pull lifecycles across sync Durable Object hibernation. Interrupted live pulls now receive their terminal RPC `Exit` after reconstruction, and terminal pulls are removed from persisted fan-out state (#1418).
+Complete WebSocket pull lifecycles across sync Durable Object hibernation. Interrupted live pulls now receive their terminal RPC `Exit` after reconstruction, and terminal or defected pulls are removed from persisted fan-out state (#1418).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).
 - **Cloudflare WebSocket sync:** Live pulls interrupted after the sync Durable
   Object hibernates now receive their terminal RPC `Exit`, matching interruption
-  behavior before hibernation. Completed pulls are also removed from persisted
-  fan-out state ([#1418](https://github.com/livestorejs/livestore/issues/1418)).
+  behavior before hibernation. Completed and protocol-defected pulls are also
+  removed from persisted fan-out state
+  ([#1418](https://github.com/livestorejs/livestore/issues/1418)).
 - **Effect v4 dependency cohort:** Updated the repository-wide Effect v4
   dependency family from `4.0.0-beta.99` to `4.0.0-rc.113`. Applications must
   use rc.113 or a compatible later Effect 4 release. Effect removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@
   ([#1537](https://github.com/livestorejs/livestore/pull/1537)).
 - **Cloudflare WebSocket sync:** Live pulls interrupted after the sync Durable
   Object hibernates now receive their terminal RPC `Exit`, matching interruption
-  behavior before hibernation ([#1418](https://github.com/livestorejs/livestore/issues/1418)).
+  behavior before hibernation. Completed pulls are also removed from persisted
+  fan-out state ([#1418](https://github.com/livestorejs/livestore/issues/1418)).
 - **Effect v4 dependency cohort:** Updated the repository-wide Effect v4
   dependency family from `4.0.0-beta.99` to `4.0.0-rc.113`. Applications must
   use rc.113 or a compatible later Effect 4 release. Effect removed

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -48,8 +48,9 @@ arbitrates pushes and fans out live pull streams to subscribers
   attachments; hand-crafted RPC chunk frames) and DO-RPC subscriptions (a
   durable KV registry fed by live pulls). A terminal WebSocket RPC `Exit`
   removes its request ID from the attachment so later pushes target only active
-  pulls. Each DO-RPC callback carries the
-  subscription's `storeId` (`push.ts` → `emitStreamResponse` →
+  pulls; a connection-level RPC `Defect` clears all of the socket's request IDs
+  because the client terminates every outstanding request. Each DO-RPC callback
+  carries the subscription's `storeId` (`push.ts` → `emitStreamResponse` →
   `syncUpdateRpc(payload, storeId)`), so a client DO that was evicted and
   reconstructed can re-boot its store — whose boot catches up — before
   delivering, instead of dropping the update; the client-side re-boot is

--- a/context/02-system/03-sync/03-cf/spec.md
+++ b/context/02-system/03-sync/03-cf/spec.md
@@ -46,7 +46,9 @@ arbitrates pushes and fans out live pull streams to subscribers
 - **Fan-out** (`push.ts`): accepted batches are re-chunked and emitted in
   admission order to two subscriber sets — hibernatable WebSockets (per-socket `pullRequestIds`
   attachments; hand-crafted RPC chunk frames) and DO-RPC subscriptions (a
-  durable KV registry fed by live pulls). Each DO-RPC callback carries the
+  durable KV registry fed by live pulls). A terminal WebSocket RPC `Exit`
+  removes its request ID from the attachment so later pushes target only active
+  pulls. Each DO-RPC callback carries the
   subscription's `storeId` (`push.ts` → `emitStreamResponse` →
   `syncUpdateRpc(payload, storeId)`), so a client DO that was evicted and
   reconstructed can re-boot its store — whose boot catches up — before

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -307,13 +307,18 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onRequestExit
       }
     }
 
-    const write = (response: RpcMessage.FromServerEncoded) => {
-      if (response._tag === 'Exit') requestIdsWithSchemas.delete(response.requestId)
-      if (response._tag === 'Defect') requestIdsWithSchemas.clear()
-      const responseEffect = writeResponse(response)
-      return response._tag === 'Exit' && onRequestExit !== undefined
-        ? Effect.tap(responseEffect, () => Effect.sync(() => onRequestExit(response.requestId, ws)))
+    const writeExit = (requestId: string | number, exit: unknown) => {
+      requestIdsWithSchemas.delete(requestId)
+      const responseEffect = writeResponse({ _tag: 'Exit', requestId, exit })
+      return onRequestExit !== undefined
+        ? Effect.tap(responseEffect, () => Effect.sync(() => onRequestExit(requestId, ws)))
         : responseEffect
+    }
+
+    const write = (response: RpcMessage.FromServerEncoded) => {
+      if (response._tag === 'Exit') return writeExit(response.requestId, response.exit)
+      if (response._tag === 'Defect') requestIdsWithSchemas.clear()
+      return writeResponse(response)
     }
 
     const protocol = yield* RpcServer.Protocol.make((writeRequest_) => {
@@ -337,11 +342,7 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onRequestExit
                 } else if (request._tag === 'Interrupt' && requestIdsWithSchemas.has(request.requestId) === false) {
                   // Effect creates this Exit for an unknown request, but its encoder drops it when hibernation has
                   // discarded the request schema.
-                  return writeResponse({
-                    _tag: 'Exit',
-                    requestId: request.requestId,
-                    exit: interruptedExitEncoded,
-                  })
+                  return writeExit(request.requestId, interruptedExitEncoded)
                 }
 
                 return writeRequest(id, request)

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -72,6 +72,8 @@ export interface DurableObjectWebSocketRpcConfig {
   rpcLayer: Layer.Layer<never, never, RpcServer.Protocol | WsContext>
   /** Function to get access to incoming requests */
   onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
+  /** Called after a terminal RPC response has been written for a request. */
+  onRequestExit?: (requestId: string | number, ws: CfTypes.WebSocket) => void
   mainLayer?: Layer.Layer<never>
 }
 
@@ -140,6 +142,7 @@ export const setupDurableObjectWebSocketRpc = ({
   rpcLayer,
   webSocketMode,
   onMessage,
+  onRequestExit,
   mainLayer,
 }: DurableObjectWebSocketRpcConfig) => {
   if (webSocketMode === 'accept') {
@@ -172,7 +175,7 @@ export const setupDurableObjectWebSocketRpc = ({
         ws,
         scope,
         incomingQueue,
-        ...omitUndefineds({ onMessage }),
+        ...omitUndefineds({ onMessage, onRequestExit }),
       }).pipe(Layer.provide(RpcSerialization.layerJson))
 
       const ServerLive = rpcLayer.pipe(Layer.provide(ProtocolLive))
@@ -240,6 +243,7 @@ export interface WsRpcServerArgs {
   ws: CfTypes.WebSocket
   scope: Scope.Scope
   onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
+  onRequestExit?: (requestId: string | number, ws: CfTypes.WebSocket) => void
   /** Queue for receiving incoming messages from the WebSocket */
   incomingQueue: Queue.Queue<Uint8Array | string>
 }
@@ -275,7 +279,7 @@ export const layerRpcServerWebsocket = (args: WsRpcServerArgs) =>
  *
  * @internal Used internally by `layerRpcServerWebsocket`
  */
-const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServerArgs) =>
+const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onRequestExit }: WsRpcServerArgs) =>
   Effect.gen(function* () {
     const serialization = yield* RpcSerialization.RpcSerialization
     const disconnects = yield* Queue.unbounded<number>()
@@ -306,7 +310,10 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage }: WsRpcServer
     const write = (response: RpcMessage.FromServerEncoded) => {
       if (response._tag === 'Exit') requestIdsWithSchemas.delete(response.requestId)
       if (response._tag === 'Defect') requestIdsWithSchemas.clear()
-      return writeResponse(response)
+      const responseEffect = writeResponse(response)
+      return response._tag === 'Exit' && onRequestExit !== undefined
+        ? Effect.tap(responseEffect, () => Effect.sync(() => onRequestExit(response.requestId, ws)))
+        : responseEffect
     }
 
     const protocol = yield* RpcServer.Protocol.make((writeRequest_) => {

--- a/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
+++ b/packages/@livestore/common-cf/src/ws-rpc/ws-rpc-server.ts
@@ -72,8 +72,10 @@ export interface DurableObjectWebSocketRpcConfig {
   rpcLayer: Layer.Layer<never, never, RpcServer.Protocol | WsContext>
   /** Function to get access to incoming requests */
   onMessage?: (msg: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
-  /** Called after a terminal RPC response has been written for a request. */
+  /** Called after a terminal RPC response has been accepted by the serializer. */
   onRequestExit?: (requestId: string | number, ws: CfTypes.WebSocket) => void
+  /** Called after a connection-level RPC defect has been accepted by the serializer. */
+  onProtocolDefect?: (ws: CfTypes.WebSocket) => void
   mainLayer?: Layer.Layer<never>
 }
 
@@ -143,6 +145,7 @@ export const setupDurableObjectWebSocketRpc = ({
   webSocketMode,
   onMessage,
   onRequestExit,
+  onProtocolDefect,
   mainLayer,
 }: DurableObjectWebSocketRpcConfig) => {
   if (webSocketMode === 'accept') {
@@ -175,7 +178,7 @@ export const setupDurableObjectWebSocketRpc = ({
         ws,
         scope,
         incomingQueue,
-        ...omitUndefineds({ onMessage, onRequestExit }),
+        ...omitUndefineds({ onMessage, onRequestExit, onProtocolDefect }),
       }).pipe(Layer.provide(RpcSerialization.layerJson))
 
       const ServerLive = rpcLayer.pipe(Layer.provide(ProtocolLive))
@@ -244,6 +247,7 @@ export interface WsRpcServerArgs {
   scope: Scope.Scope
   onMessage?: (message: RpcMessage.FromClientEncoded, ws: CfTypes.WebSocket) => void
   onRequestExit?: (requestId: string | number, ws: CfTypes.WebSocket) => void
+  onProtocolDefect?: (ws: CfTypes.WebSocket) => void
   /** Queue for receiving incoming messages from the WebSocket */
   incomingQueue: Queue.Queue<Uint8Array | string>
 }
@@ -279,7 +283,14 @@ export const layerRpcServerWebsocket = (args: WsRpcServerArgs) =>
  *
  * @internal Used internally by `layerRpcServerWebsocket`
  */
-const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onRequestExit }: WsRpcServerArgs) =>
+const makeSocketProtocol = ({
+  incomingQueue,
+  scope,
+  ws,
+  onMessage,
+  onRequestExit,
+  onProtocolDefect,
+}: WsRpcServerArgs) =>
   Effect.gen(function* () {
     const serialization = yield* RpcSerialization.RpcSerialization
     const disconnects = yield* Queue.unbounded<number>()
@@ -288,36 +299,60 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onRequestExit
       serialization.codecFor(Schema.Exit(Schema.Void, Schema.Never, Schema.Never)),
     )(Exit.interrupt()).pipe(Effect.orDie)
 
-    const writeRaw = (msg: Uint8Array | string) => Effect.succeed(ws.send(msg))
+    const writeRaw = (msg: Uint8Array | string) => Effect.sync(() => ws.send(msg))
 
     let writeRequest!: (clientId: number, message: RpcMessage.FromClientEncoded) => Effect.Effect<void>
 
     const parser = serialization.makeUnsafe()
     const id = 0
 
-    const writeResponse = (response: unknown) => {
+    const runLifecycleHook = (name: string, hook: () => void) =>
+      Effect.sync(hook).pipe(
+        Effect.catchCause((cause) => Effect.logError(`WebSocket RPC ${name} hook failed`, { cause })),
+      )
+
+    const writeDefect = (defect: unknown) => {
       try {
-        const encoded = parser.encode(response)
-        if (encoded === undefined) {
-          return Effect.void
-        }
-        return Effect.orDie(writeRaw(encoded))
+        const encoded = parser.encode(RpcMessage.ResponseDefectEncoded(defect))
+        const responseEffect = encoded === undefined ? Effect.void : Effect.orDie(writeRaw(encoded))
+        const onAccepted = Effect.sync(() => requestIdsWithSchemas.clear()).pipe(
+          Effect.andThen(
+            onProtocolDefect !== undefined
+              ? runLifecycleHook('onProtocolDefect', () => onProtocolDefect(ws))
+              : Effect.void,
+          ),
+        )
+        return Effect.ensuring(responseEffect, onAccepted)
       } catch (cause) {
-        return Effect.orDie(writeRaw(parser.encode(RpcMessage.ResponseDefectEncoded(cause))!))
+        return Effect.die(cause)
       }
     }
 
-    const writeExit = (requestId: string | number, exit: unknown) => {
-      requestIdsWithSchemas.delete(requestId)
-      const responseEffect = writeResponse({ _tag: 'Exit', requestId, exit })
-      return onRequestExit !== undefined
-        ? Effect.tap(responseEffect, () => Effect.sync(() => onRequestExit(requestId, ws)))
-        : responseEffect
+    const writeResponse = (response: unknown, onAccepted?: Effect.Effect<void>) => {
+      try {
+        const encoded = parser.encode(response)
+        const responseEffect = encoded === undefined ? Effect.void : Effect.orDie(writeRaw(encoded))
+        return onAccepted === undefined ? responseEffect : Effect.ensuring(responseEffect, onAccepted)
+      } catch (cause) {
+        return writeDefect(cause)
+      }
     }
+
+    const writeExit = (requestId: string | number, exit: unknown) =>
+      writeResponse(
+        { _tag: 'Exit', requestId, exit },
+        Effect.sync(() => requestIdsWithSchemas.delete(requestId)).pipe(
+          Effect.andThen(
+            onRequestExit !== undefined
+              ? runLifecycleHook('onRequestExit', () => onRequestExit(requestId, ws))
+              : Effect.void,
+          ),
+        ),
+      )
 
     const write = (response: RpcMessage.FromServerEncoded) => {
       if (response._tag === 'Exit') return writeExit(response.requestId, response.exit)
-      if (response._tag === 'Defect') requestIdsWithSchemas.clear()
+      if (response._tag === 'Defect') return writeDefect(response.defect)
       return writeResponse(response)
     }
 
@@ -350,7 +385,7 @@ const makeSocketProtocol = ({ incomingQueue, scope, ws, onMessage, onRequestExit
               step: Function.constVoid,
             })
           } catch (cause) {
-            return Effect.orDie(writeRaw(parser.encode(RpcMessage.ResponseDefectEncoded(cause))!))
+            return writeDefect(cause)
           }
         }),
         Stream.runDrain,

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -102,7 +102,6 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
           // in combination with DO hibernation
           onMessage: (request, ws) => {
             if (request._tag === 'Request' && request.tag === 'SyncWsRpc.Pull') {
-              // Is Pull request: add requestId to pullRequestIds
               const attachment = ws.deserializeAttachment()
               const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
               ws.serializeAttachment(
@@ -112,17 +111,10 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
                 }),
               )
             } else if (request._tag === 'Interrupt') {
-              // Is Interrupt request: remove requestId from pullRequestIds
-              const attachment = ws.deserializeAttachment()
-              const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
-              ws.serializeAttachment(
-                Schema.encodeSync(WebSocketAttachmentSchema)({
-                  ...rest,
-                  pullRequestIds: pullRequestIds.filter((id) => id !== request.requestId),
-                }),
-              )
+              removePullRequestId(ws, request.requestId)
             }
           },
+          onRequestExit: (requestId, ws) => removePullRequestId(ws, requestId),
         })
       }
     }
@@ -233,4 +225,17 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
         Effect.runPromise,
       )
   }
+}
+
+const removePullRequestId = (ws: CfTypes.WebSocket, requestId: string | number) => {
+  const attachment = ws.deserializeAttachment()
+  const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
+  if (pullRequestIds.includes(requestId) === false) return
+
+  ws.serializeAttachment(
+    Schema.encodeSync(WebSocketAttachmentSchema)({
+      ...rest,
+      pullRequestIds: pullRequestIds.filter((id) => id !== requestId),
+    }),
+  )
 }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -113,6 +113,7 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
             }
           },
           onRequestExit: (requestId, ws) => removePullRequestId(ws, requestId),
+          onProtocolDefect: clearPullRequestIds,
         })
       }
     }
@@ -225,15 +226,27 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
   }
 }
 
-const removePullRequestId = (ws: CfTypes.WebSocket, requestId: string | number) => {
+const removePullRequestId = (ws: CfTypes.WebSocket, requestId: string | number) =>
+  updatePullRequestIds(ws, (pullRequestIds) =>
+    pullRequestIds.includes(requestId) === true ? pullRequestIds.filter((id) => id !== requestId) : pullRequestIds,
+  )
+
+const clearPullRequestIds = (ws: CfTypes.WebSocket) =>
+  updatePullRequestIds(ws, (pullRequestIds) => (pullRequestIds.length === 0 ? pullRequestIds : []))
+
+const updatePullRequestIds = (
+  ws: CfTypes.WebSocket,
+  update: (pullRequestIds: ReadonlyArray<string | number>) => ReadonlyArray<string | number>,
+) => {
   const attachment = ws.deserializeAttachment()
   const { pullRequestIds, ...rest } = Schema.decodeUnknownSync(WebSocketAttachmentSchema)(attachment)
-  if (pullRequestIds.includes(requestId) === false) return
+  const nextPullRequestIds = update(pullRequestIds)
+  if (nextPullRequestIds === pullRequestIds) return
 
   ws.serializeAttachment(
     Schema.encodeSync(WebSocketAttachmentSchema)({
       ...rest,
-      pullRequestIds: pullRequestIds.filter((id) => id !== requestId),
+      pullRequestIds: nextPullRequestIds,
     }),
   )
 }

--- a/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
+++ b/packages/@livestore/sync-cf/src/cf-worker/do/durable-object.ts
@@ -110,8 +110,6 @@ export const makeDurableObject: MakeDurableObjectClass = (options) => {
                   pullRequestIds: [...pullRequestIds, request.id],
                 }),
               )
-            } else if (request._tag === 'Interrupt') {
-              removePullRequestId(ws, request.requestId)
             }
           },
           onRequestExit: (requestId, ws) => removePullRequestId(ws, requestId),

--- a/tests/sync-provider/src/do-hibernation.test.ts
+++ b/tests/sync-provider/src/do-hibernation.test.ts
@@ -106,6 +106,9 @@ describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hiberna
         (message) => message._tag === 'Exit' && message.requestId === restoredRequestId,
       )
       assertSingleInterruptedExit(restoredExits, restoredRequestId)
+
+      const probe = yield* probeSyncDo({ port, storeId })
+      expect(probe.pullRequestIds).toEqual([])
     }).pipe(Effect.scoped, Effect.provide(getContext())),
   )
 

--- a/tests/sync-provider/src/do-hibernation.test.ts
+++ b/tests/sync-provider/src/do-hibernation.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'vitest'
 
+import { EventSequenceNumber } from '@livestore/common/schema'
 import { EventFactory } from '@livestore/common/testing'
 import { nanoid } from '@livestore/livestore'
 import { SyncMessage } from '@livestore/sync-cf/common'
@@ -107,6 +108,28 @@ describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hiberna
       assertSingleInterruptedExit(restoredExits, restoredRequestId)
     }).pipe(Effect.scoped, Effect.provide(getContext())),
   )
+
+  Vitest.live('terminal pull exits remove persisted fan-out request ids', () =>
+    Effect.gen(function* () {
+      const { port } = yield* syncProvider
+      const storeId = `pull-exit-cleanup-${nanoid()}`
+      const ws = yield* openWebSocket({ port, storeId })
+
+      yield* Effect.addFinalizer(() => Effect.sync(() => ws.close()))
+
+      yield* runPullToExit({ ws, storeId, requestId: 'completed-pull', live: false, cursor: Option.none() })
+      yield* runPullToExit({
+        ws,
+        storeId,
+        requestId: 'failed-pull',
+        live: true,
+        cursor: Option.some({ backendId: 'stale-backend', eventSequenceNumber: EventSequenceNumber.Global.make(0) }),
+      })
+
+      const probe = yield* probeSyncDo({ port, storeId })
+      expect(probe.pullRequestIds).toEqual([])
+    }).pipe(Effect.scoped, Effect.provide(getContext())),
+  )
 })
 
 const eventClient = EventFactory.clientIdentity('hibernation-client', 'hibernation-session')
@@ -167,6 +190,38 @@ const startLivePull = ({ ws, storeId, requestId }: { ws: globalThis.WebSocket; s
     (message) => message._tag === 'Chunk' && message.requestId === requestId,
   ).pipe(Effect.andThen(Effect.sync(() => ws.send(encodeJson({ _tag: 'Ack', requestId })))))
 
+const runPullToExit = ({
+  ws,
+  storeId,
+  requestId,
+  live,
+  cursor,
+}: {
+  ws: globalThis.WebSocket
+  storeId: string
+  requestId: string
+  live: boolean
+  cursor: SyncMessage.PullRequest['cursor']
+}) =>
+  sendAndWaitForRpcMessage(
+    ws,
+    {
+      _tag: 'Request',
+      id: requestId,
+      tag: 'SyncWsRpc.Pull',
+      payload: encodePullPayload({ storeId, live, cursor }),
+      headers: [],
+    },
+    (message) => message._tag === 'Exit' && message.requestId === requestId,
+    {
+      onMessage: (message) => {
+        if (message._tag === 'Chunk' && message.requestId === requestId) {
+          ws.send(encodeJson({ _tag: 'Ack', requestId }))
+        }
+      },
+    },
+  )
+
 const assertSingleInterruptedExit = (messages: ReadonlyArray<RpcWireMessage>, requestId: string) => {
   expect(messages).toHaveLength(1)
   const message = messages[0]!
@@ -206,7 +261,10 @@ const sendAndWaitForRpcMessage = (
   ws: globalThis.WebSocket,
   outgoing: object,
   matches: (message: RpcWireMessage) => boolean,
-  timeout: Duration.Input = '5 seconds',
+  options?: {
+    timeout?: Duration.Input
+    onMessage?: (message: RpcWireMessage) => void
+  },
 ) =>
   Effect.callback<RpcWireMessage, SyncDoProbeError>((resume, signal) => {
     let settled = false
@@ -225,6 +283,7 @@ const sendAndWaitForRpcMessage = (
     const onMessage = (event: MessageEvent) => {
       try {
         const message = decodeRpcWireMessage(String(event.data))
+        options?.onMessage?.(message)
         if (matches(message) === true) finish(Effect.succeed(message))
       } catch (cause) {
         finish(Effect.fail(new SyncDoProbeError({ message: `Invalid RPC response: ${String(cause)}` })))
@@ -238,7 +297,7 @@ const sendAndWaitForRpcMessage = (
     ws.addEventListener('error', onError, { once: true })
     ws.send(encodeJson(outgoing))
     signal.addEventListener('abort', cleanup, { once: true })
-  }).pipe(Effect.timeout(timeout))
+  }).pipe(Effect.timeout(options?.timeout ?? '5 seconds'))
 
 const sendAndCollectRpcMessages = (
   ws: globalThis.WebSocket,

--- a/tests/sync-provider/src/do-hibernation.test.ts
+++ b/tests/sync-provider/src/do-hibernation.test.ts
@@ -100,6 +100,9 @@ describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hiberna
       )
       assertSingleInterruptedExit(currentExits, currentRequestId)
 
+      const restoredProbe = yield* probeSyncDo({ port, storeId })
+      expect(restoredProbe.pullRequestIds).toEqual([restoredRequestId])
+
       const restoredExits = yield* sendAndCollectRpcMessages(
         ws,
         { _tag: 'Interrupt', requestId: restoredRequestId },
@@ -128,6 +131,30 @@ describeWsDo(`${CloudflareWsProvider.doSqlite.name} sync provider — DO hiberna
         live: true,
         cursor: Option.some({ backendId: 'stale-backend', eventSequenceNumber: EventSequenceNumber.Global.make(0) }),
       })
+
+      const probe = yield* probeSyncDo({ port, storeId })
+      expect(probe.pullRequestIds).toEqual([])
+    }).pipe(Effect.scoped, Effect.provide(getContext())),
+  )
+
+  Vitest.live('protocol defects clear restored fan-out request ids', () =>
+    Effect.gen(function* () {
+      const { port } = yield* syncProvider
+      const storeId = `pull-defect-cleanup-${nanoid()}`
+      const ws = yield* openWebSocket({ port, storeId })
+
+      yield* Effect.addFinalizer(() => Effect.sync(() => ws.close()))
+      yield* startLivePull({ ws, storeId, requestId: 'restored-pull' })
+
+      const before = yield* probeWithOpenSocket({ port, storeId })
+      yield* Effect.sleep(idleWindow)
+      const after = yield* probeWithOpenSocket({ port, storeId })
+      expect(after).not.toBe(before)
+
+      const restoredProbe = yield* probeSyncDo({ port, storeId })
+      expect(restoredProbe.pullRequestIds).toEqual(['restored-pull'])
+
+      yield* sendAndWaitForRpcMessage(ws, '{', (message) => message._tag === 'Defect')
 
       const probe = yield* probeSyncDo({ port, storeId })
       expect(probe.pullRequestIds).toEqual([])
@@ -183,13 +210,13 @@ type RpcWireMessage = ReturnType<typeof decodeRpcWireMessage>
 const startLivePull = ({ ws, storeId, requestId }: { ws: globalThis.WebSocket; storeId: string; requestId: string }) =>
   sendAndWaitForRpcMessage(
     ws,
-    {
+    encodeJson({
       _tag: 'Request',
       id: requestId,
       tag: 'SyncWsRpc.Pull',
       payload: encodePullPayload({ storeId, live: true, cursor: Option.none() }),
       headers: [],
-    },
+    }),
     (message) => message._tag === 'Chunk' && message.requestId === requestId,
   ).pipe(Effect.andThen(Effect.sync(() => ws.send(encodeJson({ _tag: 'Ack', requestId })))))
 
@@ -208,13 +235,13 @@ const runPullToExit = ({
 }) =>
   sendAndWaitForRpcMessage(
     ws,
-    {
+    encodeJson({
       _tag: 'Request',
       id: requestId,
       tag: 'SyncWsRpc.Pull',
       payload: encodePullPayload({ storeId, live, cursor }),
       headers: [],
-    },
+    }),
     (message) => message._tag === 'Exit' && message.requestId === requestId,
     {
       onMessage: (message) => {
@@ -262,7 +289,7 @@ const openWebSocket = ({ port, storeId }: { port: number; storeId: string }) =>
 
 const sendAndWaitForRpcMessage = (
   ws: globalThis.WebSocket,
-  outgoing: object,
+  outgoing: string,
   matches: (message: RpcWireMessage) => boolean,
   options?: {
     timeout?: Duration.Input
@@ -298,7 +325,7 @@ const sendAndWaitForRpcMessage = (
     ws.addEventListener('message', onMessage)
     ws.addEventListener('close', onError, { once: true })
     ws.addEventListener('error', onError, { once: true })
-    ws.send(encodeJson(outgoing))
+    ws.send(outgoing)
     signal.addEventListener('abort', cleanup, { once: true })
   }).pipe(Effect.timeout(options?.timeout ?? '5 seconds'))
 

--- a/tests/sync-provider/src/do-idle-helpers.ts
+++ b/tests/sync-provider/src/do-idle-helpers.ts
@@ -59,7 +59,11 @@ export const syncProvider = Effect.gen(function* () {
 export const probeSyncDo = ({ port, storeId }: { port: number; storeId: string }) =>
   Effect.promise(() =>
     fetch(`http://localhost:${port}/instance/sync?storeId=${storeId}`).then((res) => res.json()),
-  ).pipe(Effect.map((json) => json as { instanceId: string; webSocketCount: number }))
+  ).pipe(
+    Effect.map(
+      (json) => json as { instanceId: string; webSocketCount: number; pullRequestIds: ReadonlyArray<string | number> },
+    ),
+  )
 
 /** Forks a scoped live pull that records every delivered event id into the returned array. */
 export const collectReceivedIds = (backend: SyncBackend.SyncBackend) =>

--- a/tests/sync-provider/src/providers/cloudflare/test-worker.ts
+++ b/tests/sync-provider/src/providers/cloudflare/test-worker.ts
@@ -14,6 +14,7 @@ import {
   matchSyncRequest,
   rpcSubscriptionKeyPrefix,
   type SyncBackendRpcInterface,
+  WebSocketAttachmentSchema,
 } from '@livestore/sync-cf/cf-worker'
 import { handleSyncUpdateRpc, makeDoRpcSync } from '@livestore/sync-cf/client'
 import {
@@ -46,7 +47,11 @@ const jsonParse = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown)
 const observedPushPayloads = new Map<string, Schema.Json | undefined>()
 
 interface SyncDoProbe {
-  getHibernationProbe(): { instanceId: string; webSocketCount: number }
+  getHibernationProbe(): {
+    instanceId: string
+    webSocketCount: number
+    pullRequestIds: ReadonlyArray<string | number>
+  }
   getPushProbe(storeId: string): { observed: boolean; payload: Schema.Json | null }
   getRpcSubscriptionCount(storeId: string): number
 }
@@ -89,8 +94,16 @@ export class SyncBackendDO extends makeDurableObject({
     this.#state = state
   }
 
-  getHibernationProbe(): { instanceId: string; webSocketCount: number } {
-    return { instanceId: this.instanceId, webSocketCount: this.#state.getWebSockets().length }
+  getHibernationProbe(): {
+    instanceId: string
+    webSocketCount: number
+    pullRequestIds: ReadonlyArray<string | number>
+  } {
+    const webSockets = this.#state.getWebSockets()
+    const pullRequestIds = webSockets.flatMap(
+      (ws) => Schema.decodeUnknownSync(WebSocketAttachmentSchema)(ws.deserializeAttachment()).pullRequestIds,
+    )
+    return { instanceId: this.instanceId, webSocketCount: webSockets.length, pullRequestIds }
   }
 
   getPushProbe(storeId: string): { observed: boolean; payload: Schema.Json | null } {


### PR DESCRIPTION
## Problem

The sync Durable Object persists live pull request IDs in each WebSocket attachment for manual push fan-out. It previously removed IDs only when an \`Interrupt\` arrived.

Consequently, finite completion and typed failure left terminal request IDs in the attachment. A connection-level RPC \`Defect\` also terminates every request on Effect's client while leaving all persisted fan-out IDs behind. Later pushes could continue sending \`Chunk\` frames to requests the client had already ended.

## Solution

- Add a narrow per-request \`onRequestExit\` lifecycle hook to the common Cloudflare WebSocket RPC adapter.
- Add a narrow connection-level \`onProtocolDefect\` hook for the global terminal case.
- Route ordinary and reconstructed exits through one exit writer.
- Route Effect, parsing, and encoding defects through one defect writer.
- Remove one persisted pull ID after \`Exit\`; clear all IDs after \`Defect\`.
- Run lifecycle cleanup for buffered serializer output and failed socket writes.
- Catch and log hook failures so callbacks cannot change the protocol result.

Both cleanup paths share one idempotent WebSocket attachment updater.

## API impact

\`DurableObjectWebSocketRpcConfig\` gains two additive optional callbacks:

- \`onRequestExit(requestId, ws)\`
- \`onProtocolDefect(ws)\`

Existing users require no changes. The hooks expose only terminal lifecycle events, and a protocol defect does not force a socket reconnect.

## Validation

- \`devenv tasks run lint:full:fix\`
- \`devenv tasks run ts:check\`
- \`devenv tasks run test:unit\`
- \`devenv tasks run test:integration:sync-provider:cf-ws-do\`
- Targeted hibernated-defect regression: failed with \`['restored-pull']\` before the fix and passed with \`[]\` after.
- Intent-layer invariant suite.
- Independent adversarial subagent review found no remaining blocker.

The regressions establish that restored IDs exist before testing removal, cover normal completion and typed failure, and force a protocol defect after actual Durable Object reconstruction.

## Stack

Depends on #1624, which contains only the hibernated \`Interrupt → Exit\` correction and closes #1418.

## Related issues

Follow-up to #1624 and #1418. No separate existing issue matched this lifecycle cleanup.
